### PR TITLE
Fix wrong return type in div

### DIFF
--- a/src/aten/BinaryOps.cpp
+++ b/src/aten/BinaryOps.cpp
@@ -110,13 +110,13 @@ Tensor& mul_scalar_(Tensor& self, const Scalar& other) {
 
 Tensor div_tensor(const Tensor& self_arg, const Tensor& other_arg) {
   Tensor out;
-  auto iter = TensorIterator::binary_op(out, self_arg, other_arg);
+  auto iter = TensorIterator::binary_float_op(out, self_arg, other_arg);
   native::xpu::div_kernel(iter);
   return iter.output();
 }
 
 Tensor& div_tensor_(Tensor& self, const Tensor& other_arg) {
-  auto iter = TensorIterator::binary_op(self, self, other_arg);
+  auto iter = TensorIterator::binary_float_op(self, self, other_arg);
   native::xpu::div_kernel(iter);
   return self;
 }

--- a/test/python/examples/test_binary.py
+++ b/test/python/examples/test_binary.py
@@ -49,3 +49,13 @@ class TestSimpleBinary(TestCase):
         c_xpu = a_xpu / b_xpu
         c_cpu = a_cpu / b_cpu
         self.assertEqual(c_cpu, c_xpu.to(cpu_device))
+
+    def test_div_int(self, dtype=torch.float):
+        a_cpu = torch.randint(2, 3, [8, 8])
+        b_cpu = torch.randint(2, 3, [8, 8])
+        a_xpu = a_cpu.to(xpu_device)
+        b_xpu = b_cpu.to(xpu_device)
+        c_xpu = a_xpu / b_xpu
+        c_cpu = a_cpu / b_cpu
+        self.assertEqual(c_cpu.dtype, c_xpu.dtype) # assume float
+        self.assertEqual(c_cpu, c_xpu.to(cpu_device))


### PR DESCRIPTION
Correct TensorIterator usage in div
Fixing case: int64 / int64 = float