### PR TITLE
Add unary ops

### DIFF
--- a/src/aten/UnaryOps.cpp
+++ b/src/aten/UnaryOps.cpp
@@ -1,4 +1,5 @@
 #include <ATen/ScalarOps.h>
+#include <ATen/XPUNativeFunctions.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/native/TensorIterator.h>
 #include <torch/library.h>
@@ -6,19 +7,157 @@
 #include <aten/sycl/UnaryKernels.h>
 
 namespace at {
-namespace native {
-namespace xpu {
 
-Tensor& abs_out(const Tensor& self, Tensor& out) {
+Tensor XPUNativeFunctions::abs(const Tensor& self) {
+  Tensor out;
+  auto iter = TensorIterator::unary_op(out, self);
+  native::xpu::abs_kernel(iter);
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::abs_(Tensor& self) {
+  auto iter = TensorIterator::unary_op(self, self);
+  native::xpu::abs_kernel(iter);
+  return self;
+}
+
+Tensor& XPUNativeFunctions::abs_out(const Tensor& self, Tensor& out) {
   auto iter = TensorIterator::unary_op(out, self);
   native::xpu::abs_kernel(iter);
   return out;
 }
 
-TORCH_LIBRARY_IMPL(aten, XPU, m) {
-  m.impl(TORCH_SELECTIVE_NAME("aten::abs.out"), TORCH_FN(abs_out));
+Tensor XPUNativeFunctions::sin(const Tensor& self) {
+  Tensor out;
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::sin_kernel(iter);
+  return iter.output();
 }
 
-} // namespace xpu
-} // namespace native
+Tensor& XPUNativeFunctions::sin_(Tensor& self) {
+  auto iter = TensorIterator::unary_float_op(self, self);
+  native::xpu::sin_kernel(iter);
+  return self;
+}
+
+Tensor& XPUNativeFunctions::sin_out(const Tensor& self, Tensor& out) {
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::sin_kernel(iter);
+  return out;
+}
+
+Tensor XPUNativeFunctions::cos(const Tensor& self) {
+  Tensor out;
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::cos_kernel(iter);
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::cos_(Tensor& self) {
+  auto iter = TensorIterator::unary_float_op(self, self);
+  native::xpu::cos_kernel(iter);
+  return self;
+}
+
+Tensor& XPUNativeFunctions::cos_out(const Tensor& self, Tensor& out) {
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::cos_kernel(iter);
+  return out;
+}
+
+Tensor XPUNativeFunctions::log(const Tensor& self) {
+  Tensor out;
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::log_kernel(iter);
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::log_(Tensor& self) {
+  auto iter = TensorIterator::unary_float_op(self, self);
+  native::xpu::log_kernel(iter);
+  return self;
+}
+
+Tensor& XPUNativeFunctions::log_out(const Tensor& self, Tensor& out) {
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::log_kernel(iter);
+  return out;
+}
+
+Tensor XPUNativeFunctions::sqrt(const Tensor& self) {
+  Tensor out;
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::sqrt_kernel(iter);
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::sqrt_(Tensor& self) {
+  auto iter = TensorIterator::unary_float_op(self, self);
+  native::xpu::sqrt_kernel(iter);
+  return self;
+}
+
+Tensor& XPUNativeFunctions::sqrt_out(const Tensor& self, Tensor& out) {
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::sqrt_kernel(iter);
+  return out;
+}
+
+Tensor XPUNativeFunctions::rsqrt(const Tensor& self) {
+  Tensor out;
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::rsqrt_kernel(iter);
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::rsqrt_(Tensor& self) {
+  auto iter = TensorIterator::unary_float_op(self, self);
+  native::xpu::rsqrt_kernel(iter);
+  return self;
+}
+
+Tensor& XPUNativeFunctions::rsqrt_out(const Tensor& self, Tensor& out) {
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::rsqrt_kernel(iter);
+  return out;
+}
+
+Tensor XPUNativeFunctions::tanh(const Tensor& self) {
+  Tensor out;
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::tanh_kernel(iter);
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::tanh_(Tensor& self) {
+  auto iter = TensorIterator::unary_float_op(self, self);
+  native::xpu::tanh_kernel(iter);
+  return self;
+}
+
+Tensor& XPUNativeFunctions::tanh_out(const Tensor& self, Tensor& out) {
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::tanh_kernel(iter);
+  return out;
+}
+
+Tensor XPUNativeFunctions::neg(const Tensor& self) {
+  Tensor out;
+  auto iter = TensorIterator::unary_op(out, self);
+  native::xpu::neg_kernel(iter);
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::neg_(Tensor& self) {
+  auto iter = TensorIterator::unary_op(self, self);
+  native::xpu::neg_kernel(iter);
+  return self;
+}
+
+Tensor& XPUNativeFunctions::neg_out(const Tensor& self, Tensor& out) {
+  auto iter = TensorIterator::unary_op(out, self);
+  native::xpu::neg_kernel(iter);
+  return out;
+}
+
 } // namespace at

--- a/src/aten/sycl/UnaryKernels.cpp
+++ b/src/aten/sycl/UnaryKernels.cpp
@@ -18,6 +18,72 @@ struct AbsFunctor {
   }
 };
 
+template <typename scalar_t>
+struct SinFunctor {
+  scalar_t operator()(const scalar_t a) const {
+    return std::sin(a);
+  }
+};
+
+template <typename scalar_t>
+struct CosFunctor {
+  scalar_t operator()(const scalar_t a) const {
+    return std::cos(a);
+  }
+};
+
+template <typename scalar_t>
+struct LogFunctor {
+  scalar_t operator()(scalar_t a) const {
+    return std::log(a);
+  }
+};
+
+template <typename scalar_t>
+struct SqrtFunctor {
+  scalar_t operator()(scalar_t a) const {
+    return std::sqrt(a);
+  }
+};
+
+template <typename scalar_t>
+struct RsqrtFunctor {
+  scalar_t operator()(scalar_t a) const {
+    return sycl::rsqrt(float(a));
+  }
+};
+
+template <>
+struct RsqrtFunctor<double> {
+  double operator()(double a) const {
+    return sycl::rsqrt(a);
+  }
+};
+
+template <typename T>
+struct RsqrtFunctor<c10::complex<T>> {
+  c10::complex<T> operator()(c10::complex<T> a) const {
+    return c10::complex<T>(1.0, 0) /
+        static_cast<c10::complex<T>>(
+               std::sqrt(static_cast<std::complex<T>>(a)));
+  }
+};
+
+template <typename scalar_t>
+struct TanhFunctor {
+  scalar_t operator()(scalar_t a) const {
+    using opmath_t = at::opmath_type<scalar_t>;
+    return std::tanh(static_cast<opmath_t>(a));
+  }
+};
+
+template <typename scalar_t>
+struct NegFunctor {
+  scalar_t operator()(scalar_t a) const {
+    return -a;
+  }
+};
+
 void abs_kernel(TensorIteratorBase& iter) {
   auto dtype = iter.dtype();
   if (at::isComplexType(dtype)) {
@@ -33,6 +99,124 @@ void abs_kernel(TensorIteratorBase& iter) {
         iter.dtype(),
         "abs_xpu",
         [&]() { gpu_kernel(iter, AbsFunctor<scalar_t>()); });
+  }
+}
+
+void sin_kernel(TensorIteratorBase& iter) {
+  auto common_dtype = iter.common_dtype();
+  if (at::isComplexType(common_dtype)) {
+    AT_DISPATCH_COMPLEX_TYPES_AND(
+        kComplexHalf, common_dtype, "sin_name", [&]() {
+          using opmath_t = at::opmath_type<scalar_t>;
+          gpu_kernel(iter, SinFunctor<opmath_t>());
+        });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        ScalarType::Half, ScalarType::BFloat16, common_dtype, "sin_xpu", [&]() {
+          gpu_kernel(iter, SinFunctor<scalar_t>());
+        });
+  }
+}
+
+void cos_kernel(TensorIteratorBase& iter) {
+  auto common_dtype = iter.common_dtype();
+  if (at::isComplexType(common_dtype)) {
+    AT_DISPATCH_COMPLEX_TYPES_AND(
+        kComplexHalf, common_dtype, "cos_name", [&]() {
+          using opmath_t = at::opmath_type<scalar_t>;
+          gpu_kernel(iter, CosFunctor<opmath_t>());
+        });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        ScalarType::Half, ScalarType::BFloat16, common_dtype, "cos_xpu", [&]() {
+          gpu_kernel(iter, CosFunctor<scalar_t>());
+        });
+  }
+}
+
+void log_kernel(TensorIteratorBase& iter) {
+  auto common_dtype = iter.common_dtype();
+  if (at::isComplexType(common_dtype)) {
+    AT_DISPATCH_COMPLEX_TYPES_AND(
+        kComplexHalf, iter.common_dtype(), "log_xpu", [&]() {
+          using opmath_t = at::opmath_type<scalar_t>;
+          gpu_kernel(iter, LogFunctor<opmath_t>());
+        });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        ScalarType::Half,
+        ScalarType::BFloat16,
+        iter.common_dtype(),
+        "log_xpu",
+        [&]() { gpu_kernel(iter, LogFunctor<scalar_t>()); });
+  }
+}
+
+void sqrt_kernel(TensorIteratorBase& iter) {
+  auto common_dtype = iter.common_dtype();
+  if (at::isComplexType(common_dtype)) {
+    AT_DISPATCH_COMPLEX_TYPES_AND(
+        kComplexHalf, common_dtype, "sqrt_xpu", [&]() {
+          using opmath_t = at::opmath_type<scalar_t>;
+          gpu_kernel(iter, SqrtFunctor<opmath_t>());
+        });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        ScalarType::Half,
+        ScalarType::BFloat16,
+        common_dtype,
+        "sqrt_xpu",
+        [&]() { gpu_kernel(iter, SqrtFunctor<scalar_t>()); });
+  }
+}
+
+void rsqrt_kernel(TensorIteratorBase& iter) {
+  auto common_dtype = iter.common_dtype();
+  if (at::isComplexType(common_dtype)) {
+    AT_DISPATCH_COMPLEX_TYPES_AND(
+        kComplexHalf, common_dtype, "rsqrt_xpu", [&]() {
+          using opmath_t = at::opmath_type<scalar_t>;
+          gpu_kernel(iter, RsqrtFunctor<opmath_t>());
+        });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        ScalarType::BFloat16,
+        ScalarType::Half,
+        iter.common_dtype(),
+        "rsqrt_xpu",
+        [&]() { gpu_kernel(iter, RsqrtFunctor<scalar_t>()); });
+  }
+}
+
+void tanh_kernel(TensorIteratorBase& iter) {
+  auto common_dtype = iter.common_dtype();
+  if (at::isComplexType(common_dtype)) {
+    AT_DISPATCH_COMPLEX_TYPES_AND(
+        kComplexHalf, common_dtype, "tanh_name", [&]() {
+          using opmath_t = at::opmath_type<scalar_t>;
+          gpu_kernel(iter, TanhFunctor<opmath_t>());
+        });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        ScalarType::Half,
+        ScalarType::BFloat16,
+        common_dtype,
+        "tanh_xpu",
+        [&]() { gpu_kernel(iter, TanhFunctor<scalar_t>()); });
+  }
+}
+
+void neg_kernel(TensorIteratorBase& iter) {
+  auto dtype = iter.dtype();
+  if (at::isComplexType(dtype)) {
+    AT_DISPATCH_COMPLEX_TYPES_AND(kComplexHalf, dtype, "neg_xpu", [&]() {
+      gpu_kernel(iter, NegFunctor<scalar_t>());
+    });
+  } else {
+    AT_DISPATCH_ALL_TYPES_AND2(
+        ScalarType::Half, ScalarType::BFloat16, dtype, "neg_xpu", [&]() {
+          gpu_kernel(iter, NegFunctor<scalar_t>());
+        });
   }
 }
 

--- a/src/aten/sycl/UnaryKernels.h
+++ b/src/aten/sycl/UnaryKernels.h
@@ -6,4 +6,18 @@ namespace at::native::xpu {
 
 void abs_kernel(TensorIteratorBase& iter);
 
+void sin_kernel(TensorIteratorBase& iter);
+
+void cos_kernel(TensorIteratorBase& iter);
+
+void log_kernel(TensorIteratorBase& iter);
+
+void sqrt_kernel(TensorIteratorBase& iter);
+
+void rsqrt_kernel(TensorIteratorBase& iter);
+
+void tanh_kernel(TensorIteratorBase& iter);
+
+void neg_kernel(TensorIteratorBase& iter);
+
 } // namespace at::native::xpu

--- a/test/python/examples/test_unary.py
+++ b/test/python/examples/test_unary.py
@@ -21,7 +21,6 @@ class Dtypes(object):
                 if dtype in self.exclude_dtypes:
                     continue
                 kwargs['dtype'] = dtype
-                print(f"TestSimpleUnary:{fn.__name__}:{dtype}", flush=True)
                 fn(*args, **kwargs)
         return fn_out
 

--- a/test/python/examples/test_unary.py
+++ b/test/python/examples/test_unary.py
@@ -1,51 +1,73 @@
 import torch
 from torch.testing._internal.common_utils import TestCase
 
-cpu_device = torch.device("cpu")
-xpu_device = torch.device("xpu")
+
+floating_types = [torch.float, torch.half, torch.bfloat16, torch.double]
+integral_types = [torch.int8, torch.uint8, torch.short, torch.int, torch.long, torch.bool]
+complex_types = [torch.cfloat, torch.cdouble]
+floating_and_complex_types = floating_types + complex_types
+all_basic_types = floating_types + integral_types
+all_basic_and_complex_types = floating_types + integral_types + complex_types
+
+
+class Dtypes(object):
+    def __init__(self, include_dtypes, exclude_dtypes=[]):
+        self.include_dtypes = include_dtypes
+        self.exclude_dtypes = exclude_dtypes
+    
+    def __call__(self, fn):
+        def fn_out(*args, **kwargs):
+            for dtype in self.include_dtypes:
+                if dtype in self.exclude_dtypes:
+                    continue
+                kwargs['dtype'] = dtype
+                print(f"TestSimpleUnary:{fn.__name__}:{dtype}", flush=True)
+                fn(*args, **kwargs)
+        return fn_out
 
 
 class TestSimpleUnary(TestCase):
-    def test_abs(self, dtype=torch.float):
-        data = [
-            [
-                -0.2911,
-                -1.3204,
-                -2.6425,
-                -2.4644,
-                -0.6018,
-                -0.0839,
-                -0.1322,
-                -0.4713,
-                -0.3586,
-                -0.8882,
-                0.0000,
-                0.0000,
-                1.1111,
-                2.2222,
-                3.3333,
-            ]
-        ]
-        excepted = [
-            [
-                0.2911,
-                1.3204,
-                2.6425,
-                2.4644,
-                0.6018,
-                0.0839,
-                0.1322,
-                0.4713,
-                0.3586,
-                0.8882,
-                0.0000,
-                0.0000,
-                1.1111,
-                2.2222,
-                3.3333,
-            ]
-        ]
-        x_dpcpp = torch.tensor(data, device=xpu_device)
-        y = torch.tensor(excepted, device=xpu_device)
-        y_dpcpp = torch.abs(x_dpcpp)
-        self.assertEqual(y.to(cpu_device), y_dpcpp.to(cpu_device))
+    def _test_unary_out_ops(self, fn_str, dtype):
+        a_cpu = (torch.randn(2049)*10).to(dtype)
+        a_xpu = a_cpu.xpu()
+        b_cpu = eval(f"torch.{fn_str}(a_cpu)")
+        b_xpu = eval(f"torch.{fn_str}(a_xpu)")
+        c_cpu = eval(f"a_cpu.{fn_str}()")
+        c_xpu = eval(f"a_xpu.{fn_str}()")
+        self.assertEqual(b_cpu, b_xpu.cpu(), atol=1e-4, rtol=1e-4)
+        self.assertEqual(c_cpu, c_xpu.cpu(), atol=1e-4, rtol=1e-4)
+        d_cpu = eval(f"torch.{fn_str}(a_cpu, out=c_cpu)")
+        d_xpu = eval(f"torch.{fn_str}(a_xpu, out=c_xpu)")
+        self.assertEqual(c_cpu, c_xpu.cpu(), atol=1e-4, rtol=1e-4)
+    
+    @Dtypes(floating_types)
+    def test_abs_out(self, dtype):
+        self._test_unary_out_ops('abs', dtype)
+    
+    @Dtypes(floating_types)
+    def test_sin_out(self, dtype):
+        self._test_unary_out_ops('sin', dtype)
+    
+    @Dtypes(floating_types)
+    def test_cos_out(self, dtype):
+        self._test_unary_out_ops('cos', dtype)
+    
+    @Dtypes(floating_types)
+    def test_log_out(self, dtype):
+        self._test_unary_out_ops('log', dtype)
+    
+    @Dtypes(floating_types)
+    def test_sqrt_out(self, dtype):
+        self._test_unary_out_ops('sqrt', dtype)
+
+    @Dtypes(floating_types)
+    def test_rsqrt_out(self, dtype):
+        self._test_unary_out_ops('rsqrt', dtype)
+    
+    @Dtypes(floating_types)
+    def test_tanh_out(self, dtype):
+        self._test_unary_out_ops('tanh', dtype)
+    
+    @Dtypes(all_basic_and_complex_types, [torch.bool])
+    def test_neg_out(self, dtype):
+        self._test_unary_out_ops('neg', dtype)

--- a/test/python/examples/test_unary.py
+++ b/test/python/examples/test_unary.py
@@ -44,27 +44,27 @@ class TestSimpleUnary(TestCase):
     def test_abs_out(self, dtype):
         self._test_unary_out_ops('abs', dtype)
     
-    @Dtypes(floating_types)
+    @Dtypes(floating_and_complex_types)
     def test_sin_out(self, dtype):
         self._test_unary_out_ops('sin', dtype)
     
-    @Dtypes(floating_types)
+    @Dtypes(floating_and_complex_types)
     def test_cos_out(self, dtype):
         self._test_unary_out_ops('cos', dtype)
     
-    @Dtypes(floating_types)
+    @Dtypes(floating_and_complex_types)
     def test_log_out(self, dtype):
         self._test_unary_out_ops('log', dtype)
     
-    @Dtypes(floating_types)
+    @Dtypes(floating_and_complex_types)
     def test_sqrt_out(self, dtype):
         self._test_unary_out_ops('sqrt', dtype)
 
-    @Dtypes(floating_types)
+    @Dtypes(floating_and_complex_types)
     def test_rsqrt_out(self, dtype):
         self._test_unary_out_ops('rsqrt', dtype)
     
-    @Dtypes(floating_types)
+    @Dtypes(floating_and_complex_types)
     def test_tanh_out(self, dtype):
         self._test_unary_out_ops('tanh', dtype)
     

--- a/yaml/xpu_functions.yaml
+++ b/yaml/xpu_functions.yaml
@@ -55,3 +55,27 @@ supported:
   - ge.Tensor
   - ge.Tensor_out
   - ge_.Tensor
+  - abs
+  - abs_
+  - abs.out
+  - sin
+  - sin_
+  - sin.out
+  - cos
+  - cos_
+  - cos.out
+  - log
+  - log_
+  - log.out
+  - sqrt
+  - sqrt_
+  - sqrt.out
+  - rsqrt
+  - rsqrt_
+  - rsqrt.out
+  - tanh
+  - tanh_
+  - tanh.out
+  - neg
+  - neg_
+  - neg.out


### PR DESCRIPTION
### 🐛 Describe the bug

Cases:
op_ut,third_party.torch-xpu-ops.test.xpu.test_ops_xpu.TestCommonXPU,test_out_triangular_solve_xpu_float32
~~op_ut,third_party.torch-xpu-ops.test.xpu.test_ops_xpu.TestCommonXPU,test_out_addmv_xpu_float32~~
op_ut,third_party.torch-xpu-ops.test.xpu.test_ops_xpu.TestCommonXPU,test_out_cholesky_inverse_xpu_float32
op_ut,third_party.torch-xpu-ops.test.xpu.test_ops_xpu.TestCommonXPU,test_out_geqrf_xpu_float32
~~op_ut,third_party.torch-xpu-ops.test.xpu.test_ops_xpu.TestCommonXPU,test_out_histc_xpu_float32~~
~~op_ut,third_party.torch-xpu-ops.test.xpu.test_ops_xpu.TestCommonXPU,test_out_mv_xpu_float32~~
op_ut,third_party.torch-xpu-ops.test.xpu.test_ops_xpu.TestCommonXPU,test_out_narrow_copy_xpu_float32
op_ut,third_party.torch-xpu-ops.test.xpu.test_ops_xpu.TestCommonXPU,test_out_ormqr_xpu_float32
~~op_ut,third_party.torch-xpu-ops.test.xpu.test_ops_xpu.TestCommonXPU,test_out__native_batch_norm_legit_xpu_float32~~

____________________________________________________________________________________ TestCommonXPU.test_out__native_batch_norm_legit_xpu_float32 _____________________________________________________________________________________
Traceback (most recent call last):                                                                                                                                                                                                    
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1144, in test_wrapper                           
    return test(*args, **kwargs)                                                                                                                                                                                                      
  File "/home/daisyden/upstream/test_ops_s1/test/test_ops.py", line 1042, in test_out                                                                                                                                                 
    _compare_out(_case_one_transform)                                                                                                                                                                                                 
  File "/home/daisyden/upstream/test_ops_s1/test/test_ops.py", line 1007, in _compare_out                                                                                                                                             
    op_out(out=out)                                                                                                                                                                                                                   
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/opinfo/core.py", line 1186, in __call__                                      
    return self.op(*args, **kwargs)                                                                                                                                                                                                   
RuntimeError: out_invstd.dim() == 1 && out_invstd.is_contiguous() && out_invstd.sizes()[0] INTERNAL ASSERT FAILED at "/home/daisyden/upstream/test_ops_s1/third_party/torch-xpu-ops/src/ATen/native/xpu/sycl/BatchNormKernels.cpp":585
, please report a bug to PyTorch.                                                                                                                                                                                                     
                                                                                                                                                                                                                                      
The above exception was the direct cause of the following exception:                                                                                                                                                                  
                                                                                                                                                                                                                                      
Traceback (most recent call last):                                                                                                                                                                                                    
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 3224, in wrapper                                      
    method(*args, **kwargs)                                                                                                                                                                                                           
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 426, in instantiated_test                       
    result = test(self, **param_kwargs)                                                                                                                                                                                               
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 1645, in wrapper                                      
    fn(*args, **kwargs)                                                                                                                                                                                                               
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1156, in test_wrapper                           
    raise e_tracked from e                                                                                                                                                                                                            
Exception: Caused by sample input at index 0: SampleInput(input=Tensor[size=(5, 5, 5), device="xpu:0", dtype=torch.float32], args=(Tensor[size=(5,), device="xpu:0", dtype=torch.float32],Tensor[size=(5,), device="xpu:0", dtype=torc
h.float32],Tensor[size=(5,), device="xpu:0", dtype=torch.float32],Tensor[size=(5,), device="xpu:0", dtype=torch.float32],True,0.5,0.6), kwargs={}, broadcasts_input=False, name='')                                                   
                                                                                                                                                                                                                                      
To execute this test, run the following from the base repo dir:                                                                                                                                                                       
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=0 PYTORCH_TEST_WITH_SLOW=1 python test/test_ops.py TestCommonXPU.test_out__native_batch_norm_legit_xpu_float32                                                                                  
                                                                                                                                                                                                                                      
This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0                                                                                                                                                            
______________________________________________________________________________________________ TestCommonXPU.test_out_addmv_xpu_float32 ______________________________________________________________________________________________
Traceback (most recent call last):                                                                                                                                                                                                    
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1144, in test_wrapper                           
    return test(*args, **kwargs)                                                                                                                                                                                                      
  File "/home/daisyden/upstream/test_ops_s1/test/test_ops.py", line 1042, in test_out                                                                                                                                                 
    _compare_out(_case_one_transform)                                                                                                                                                                                                 
  File "/home/daisyden/upstream/test_ops_s1/test/test_ops.py", line 1017, in _compare_out                                                                                                                                             
    self.assertEqual(original_strides, final_strides, msg=stride_msg)                                                                                                                                                                 
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 4179, in assertEqual                                  
    raise error_metas.pop()[0].to_error(  # type: ignore[index]                                                                                                                                                                       
AssertionError: Scalars are not equal!

Expected 1 but got 2.
Absolute difference: 1
Relative difference: 1.0

The failure occurred for item [0][0]
Strides are not the same! Original strides were ((2,),) and strides are now ((1,),)
The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 3224, in wrapper
    method(*args, **kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 426, in instantiated_test
    result = test(self, **param_kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 1645, in wrapper
    fn(*args, **kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1156, in test_wrapper
    raise e_tracked from e
Exception: Caused by sample input at index 0: SampleInput(input=Tensor[size=(5,), device="xpu:0", dtype=torch.float32], args=TensorList[Tensor[size=(5, 10), device="xpu:0", dtype=torch.float32], Tensor[size=(10,), device="xpu:0", 
dtype=torch.float32]], kwargs={'beta': '1', 'alpha': '1'}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=0 PYTORCH_TEST_WITH_SLOW=1 python test/test_ops.py TestCommonXPU.test_out_addmv_xpu_float32

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
______________________________________________________________________________________



______________________________________________________________________________________________ TestCommonXPU.test_out_histc_xpu_float32 ______________________________________________________________________________________________
Traceback (most recent call last):
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1144, in test_wrapper
    return test(*args, **kwargs)
  File "/home/daisyden/upstream/test_ops_s1/test/test_ops.py", line 1139, in test_out
    with self.assertRaises(exc_type, msg=msg_fail):
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/unittest/case.py", line 226, in __exit__
    self._raiseFailure("{} not raised".format(exc_name))
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/unittest/case.py", line 163, in _raiseFailure
    raise self.test_case.failureException(msg)
AssertionError: RuntimeError not raised : Expected RuntimeError when doing an unsafe cast from a result of dtype torch.float32 into an out= with dtype torch.long

NOTE: If your op is a factory function (i.e., it accepts TensorOptions) you should mark its OpInfo with `is_factory_function=True`.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 3224, in wrapper
    method(*args, **kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 426, in instantiated_test
    result = test(self, **param_kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 1645, in wrapper
    fn(*args, **kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1156, in test_wrapper
    raise e_tracked from e
Exception: Caused by sample input at index 0: SampleInput(input=Tensor[size=(), device="xpu:0", dtype=torch.float32], args=(), kwargs={'min': '0', 'max': '0'}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=0 PYTORCH_TEST_WITH_SLOW=1 python test/test_ops.py TestCommonXPU.test_out_histc_xpu_float32

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0


______________________________________________________________________________________________ TestCommonXPU.test_out_mean_xpu_float32 _______________________________________________________________________________________________
Traceback (most recent call last):
Traceback (most recent call last):
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1144, in test_wrapper
    return test(*args, **kwargs)
  File "/home/daisyden/upstream/test_ops_s1/test/test_ops.py", line 1139, in test_out
    with self.assertRaises(exc_type, msg=msg_fail):
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/unittest/case.py", line 226, in __exit__
    self._raiseFailure("{} not raised".format(exc_name))
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/unittest/case.py", line 163, in _raiseFailure
    raise self.test_case.failureException(msg)
AssertionError: RuntimeError not raised : Expected RuntimeError when doing an unsafe cast from a result of dtype torch.float32 into an out= with dtype torch.long

NOTE: If your op is a factory function (i.e., it accepts TensorOptions) you should mark its OpInfo with `is_factory_function=True`.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 3224, in wrapper
    method(*args, **kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 426, in instantiated_test
    result = test(self, **param_kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 1645, in wrapper
    fn(*args, **kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1156, in test_wrapper
    raise e_tracked from e
Exception: Caused by sample input at index 1: SampleInput(input=Tensor[size=(), device="xpu:0", dtype=torch.float32], args=(), kwargs={'dim': '0', 'keepdim': 'True'}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=1 PYTORCH_TEST_WITH_SLOW=1 python test/test_ops.py TestCommonXPU.test_out_mean_xpu_float32


_______________________________________________________________________________________________ TestCommonXPU.test_out_mv_xpu_float32 ________________________________________________________________________________________________
Traceback (most recent call last):
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1144, in test_wrapper
    return test(*args, **kwargs)
  File "/home/daisyden/upstream/test_ops_s1/test/test_ops.py", line 1042, in test_out
    _compare_out(_case_one_transform)
  File "/home/daisyden/upstream/test_ops_s1/test/test_ops.py", line 1017, in _compare_out
    self.assertEqual(original_strides, final_strides, msg=stride_msg)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 4179, in assertEqual
    raise error_metas.pop()[0].to_error(  # type: ignore[index]
AssertionError: Scalars are not equal!

Expected 1 but got 2.
Absolute difference: 1
Relative difference: 1.0

The failure occurred for item [0][0]
Strides are not the same! Original strides were ((2,),) and strides are now ((1,),)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 3224, in wrapper
    method(*args, **kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 426, in instantiated_test
    result = test(self, **param_kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 1645, in wrapper
    fn(*args, **kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1156, in test_wrapper
    raise e_tracked from e
Exception: Caused by sample input at index 0: SampleInput(input=Tensor[size=(5, 10), device="xpu:0", dtype=torch.float32], args=TensorList[Tensor[size=(10,), device="xpu:0", dtype=torch.float32]], kwargs={}, broadcasts_input=False
, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=0 PYTORCH_TEST_WITH_SLOW=1 python test/test_ops.py TestCommonXPU.test_out_mv_xpu_float32

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0


________________________________________________________________________________________ TestCommonXPU.test_out_native_batch_norm_xpu_float32 ________________________________________________________________________________________
Traceback (most recent call last):
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1144, in test_wrapper
    return test(*args, **kwargs)
  File "/home/daisyden/upstream/test_ops_s1/test/test_ops.py", line 1042, in test_out
    _compare_out(_case_one_transform)
  File "/home/daisyden/upstream/test_ops_s1/test/test_ops.py", line 1007, in _compare_out
    op_out(out=out)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/opinfo/core.py", line 1186, in __call__
    return self.op(*args, **kwargs)
RuntimeError: out_invstd.dim() == 1 && out_invstd.is_contiguous() && out_invstd.sizes()[0] INTERNAL ASSERT FAILED at "/home/daisyden/upstream/test_ops_s1/third_party/torch-xpu-ops/src/ATen/native/xpu/sycl/BatchNormKernels.cpp":585
, please report a bug to PyTorch. 

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 3224, in wrapper
    method(*args, **kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 426, in instantiated_test
    result = test(self, **param_kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 1645, in wrapper
    fn(*args, **kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1156, in test_wrapper
    raise e_tracked from e
Exception: Caused by sample input at index 0: SampleInput(input=Tensor[size=(5, 5, 5), device="xpu:0", dtype=torch.float32], args=(Tensor[size=(5,), device="xpu:0", dtype=torch.float32],Tensor[size=(5,), device="xpu:0", dtype=torc
h.float32],Tensor[size=(5,), device="xpu:0", dtype=torch.float32],Tensor[size=(5,), device="xpu:0", dtype=torch.float32],True,0.5,0.6), kwargs={}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=0 PYTORCH_TEST_WITH_SLOW=1 python test/test_ops.py TestCommonXPU.test_out_native_batch_norm_xpu_float32

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0


____________________________________________________________________________________ TestCommonXPU.test_out_nn_functional_avg_pool2d_xpu_float32 _____________________________________________________________________________________
Traceback (most recent call last):
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1144, in test_wrapper
    return test(*args, **kwargs)
  File "/home/daisyden/upstream/test_ops_s1/test/test_ops.py", line 1042, in test_out
    _compare_out(_case_one_transform)
  File "/home/daisyden/upstream/test_ops_s1/test/test_ops.py", line 1010, in _compare_out
    self.assertEqual(expected, out)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 4179, in assertEqual
    raise error_metas.pop()[0].to_error(  # type: ignore[index]
AssertionError: Tensor-likes are not close!

Mismatched elements: 242 / 243 (99.6%)
Greatest absolute difference: 24.93165397644043 at index (0, 0, 6, 4) (up to 1e-05 allowed)
Greatest relative difference: 730.893310546875 at index (0, 1, 7, 6) (up to 1.3e-06 allowed)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 3224, in wrapper
    method(*args, **kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 426, in instantiated_test
    result = test(self, **param_kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 1645, in wrapper
    fn(*args, **kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1156, in test_wrapper
    raise e_tracked from e
Exception: Caused by sample input at index 0: SampleInput(input=Tensor[size=(1, 3, 9, 9), device="xpu:0", dtype=torch.float32], args=(3,1,1,True,False,2), kwargs={}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=0 PYTORCH_TEST_WITH_SLOW=1 python test/test_ops.py TestCommonXPU.test_out_nn_functional_avg_pool2d_xpu_float32

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0


______________________________________________________________________________________________ TestCommonXPU.test_out_mean_xpu_float32 _____________________________________________________________________________________[235/1853]
Traceback (most recent call last):
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1144, in test_wrapper
    return test(*args, **kwargs)
  File "/home/daisyden/upstream/test_ops_s1/test/test_ops.py", line 1139, in test_out
    with self.assertRaises(exc_type, msg=msg_fail):
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/unittest/case.py", line 226, in __exit__
    self._raiseFailure("{} not raised".format(exc_name))
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/unittest/case.py", line 163, in _raiseFailure
    raise self.test_case.failureException(msg)
AssertionError: RuntimeError not raised : Expected RuntimeError when doing an unsafe cast from a result of dtype torch.float32 into an out= with dtype torch.long

NOTE: If your op is a factory function (i.e., it accepts TensorOptions) you should mark its OpInfo with `is_factory_function=True`.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 3224, in wrapper
    method(*args, **kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 426, in instantiated_test
    result = test(self, **param_kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 1645, in wrapper
    fn(*args, **kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1156, in test_wrapper
    raise e_tracked from e
Exception: Caused by sample input at index 1: SampleInput(input=Tensor[size=(), device="xpu:0", dtype=torch.float32], args=(), kwargs={'dim': '0', 'keepdim': 'True'}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=1 PYTORCH_TEST_WITH_SLOW=1 python test/test_ops.py TestCommonXPU.test_out_mean_xpu_float32


On PVC linux.

### Versions

Collecting environment information...                  
PyTorch version: N/A                                  
Is debug build: N/A                                 
CUDA used to build PyTorch: N/A   
ROCM used to build PyTorch: N/A      
                                                         
OS: Ubuntu 22.04.5 LTS (x86_64)              
GCC version: (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
Clang version: Could not collect             
CMake version: version 4.0.0                                                                                       
Libc version: glibc-2.35                     
                                                                                                                   
Python version: 3.10.18 | packaged by conda-forge | (main, Jun  4 2025, 14:45:41) [GCC 13.3.0] (64-bit runtime)
Python platform: Linux-5.15.0-73-generic-x86_64-with-glibc2.35                                                    
Is CUDA available: N/A                       
CUDA runtime version: Could not collect      
CUDA_MODULE_LOADING set to: N/A
GPU models and configuration: Could not collect
Nvidia driver version: Could not collect
cuDNN version: Could not collect
Is XPU available: N/A               
HIP runtime version: N/A       
MIOpen runtime version: N/A        
Is XNNPACK available: N/A
                                                         
CPU:               
Architecture:                    x86_64
CPU op-mode(s):                  32-bit, 64-bit
Address sizes:                   46 bits physical, 57 bits virtual
Byte Order:                      Little Endian
CPU(s):                          48
On-line CPU(s) list:             0-47       
Vendor ID:                       GenuineIntel
Model name:                      Intel(R) Xeon(R) Gold 6342 CPU @ 2.80GHz
CPU family:                      6                                                                                 
Model:                           106                                                                               
Thread(s) per core:              2                                                                                 
Core(s) per socket:              24                                                                                
Socket(s):                       1          
Stepping:                        6
CPU max MHz:                     3500.0000
CPU min MHz:                     800.0000
BogoMIPS:                        5600.00
Flags:                           fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb cat_l3 invpcid_single intel_ppin ssbd mba ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid cqm rdt_a avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb intel_pt avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local split_lock_detect wbnoinvd dtherm ida arat pln pts hwp hwp_act_window hwp_epp hwp_pkg_req avx512vbmi umip pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg tme avx512_vpopcntdq la57 rdpid fsrm md_clear pconfig flush_l1d arch_capabilities
Virtualization:                  VT-x
L1d cache:                       1.1 MiB (24 instances)
L1i cache:                       768 KiB (24 instances)
L2 cache:                        30 MiB (24 instances)
L3 cache:                        36 MiB (1 instance)
NUMA node(s):                    1
NUMA node0 CPU(s):               0-47
Vulnerability Itlb multihit:     Not affected
Vulnerability L1tf:              Not affected
Vulnerability Mds:               Not affected
Vulnerability Meltdown:          Not affected
Vulnerability Mmio stale data:   Mitigation; Clear CPU buffers; SMT vulnerable
Vulnerability Retbleed:          Not affected
Vulnerability Spec store bypass: Mitigation; Speculative Store Bypass disabled via prctl and seccomp
Vulnerability Spectre v1:        Mitigation; usercopy/swapgs barriers and __user pointer sanitization
Vulnerability Spectre v2:        Mitigation; Enhanced IBRS, IBPB conditional, RSB filling, PBRSB-eIBRS SW sequence
Vulnerability Srbds:             Not affected
Vulnerability Tsx async abort:   Not affected

Versions of relevant libraries:
[pip3] flake8==6.1.0
[pip3] flake8-bugbear==23.3.23
[pip3] flake8-comprehensions==3.15.0
[pip3] flake8-executable==2.1.3
[pip3] flake8-logging-format==0.9.0
[pip3] flake8-pyi==23.3.1
[pip3] flake8-simplify==0.19.3
[pip3] mypy==1.16.0
[pip3] mypy_extensions==1.1.0
[pip3] numpy==1.26.4
[pip3] onnx==1.18.0
[pip3] onnxscript==0.2.6
[pip3] optree==0.13.0
[pip3] pytorch-triton-xpu==3.4.0+gitae324eea
[pip3] torch==2.9.0a0+gitd311d30
[conda] numpy                     1.26.4                   pypi_0    pypi
[conda] optree                    0.13.0                   pypi_0    pypi
[conda] pytorch-triton-xpu        3.4.0+gitae324eea          pypi_0    pypi
[conda] torch                     2.9.0a0+gitd311d30          pypi_0    pypi
[conda] torchfix                  0.4.0                    pypi_0    pypi
