### PR TITLE
Enable CPU Fallback

### DIFF
--- a/src/aten/XPUFallback.cpp
+++ b/src/aten/XPUFallback.cpp
@@ -7,13 +7,11 @@ static bool DEBUG_XPU_FALLBACK = false;
 static void xpu_fallback(
     const c10::OperatorHandle& op,
     torch::jit::Stack* stack) {
-  std::string op_name = c10::toString(op.schema().operator_name());
-
   if (!DEBUG_XPU_FALLBACK) {
     TORCH_WARN_ONCE(
         "Aten Op fallback from XPU to CPU happends.",
         " This may have performance implications.",
-        " If need debug the fallback ops please set environment variable PYTORCH_DEBUG_XPU_FALLBACK=1 ");
+        " If need debug the fallback ops please set environment variable `PYTORCH_DEBUG_XPU_FALLBACK=1` ");
   } else {
     TORCH_WARN(
         "The operator '",
@@ -63,12 +61,16 @@ TORCH_LIBRARY_IMPL(_, XPU, m) {
 }
 
 /*
- * TODO:Move the following registration to the end of all XPU aten op registrations
- *
+ * TODO: Move the following registration to the end of all XPU aten op
+ * registrations
+ */
+
+/*
  * Register fallback to CPU for ops specified in env variable
  * "PYTORCH_XPU_FALLBACK_OP" eg. export
  * PYTORCH_XPU_FALLBACK_OP=abs.out,div.Scalar,div.Tensor,div_.Scalar,div_.Tensor
-
+ */
+/*
 TORCH_LIBRARY_IMPL(aten, XPU, m) {
   static const char* fallback_op_str = getenv("PYTORCH_XPU_FALLBACK_OP");
   if (!fallback_op_str) {

--- a/src/aten/XPUFallback.cpp
+++ b/src/aten/XPUFallback.cpp
@@ -1,25 +1,23 @@
 #include <ATen/native/CPUFallback.h>
-#include <ATen/core/Tensor.h>
-#include <ATen/native/TensorIterator.h>
-#include <ATen/ScalarOps.h>
-#include <torch/library.h>
 
-#include <aten/sycl/UnaryKernels.h>
 namespace at {
 
-
-
-static void xpu_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
-  TORCH_WARN_ONCE("The operator '",
-                  op.schema().operator_name(),
-                  "' is not currently supported ",
-                  "on the XPU backend and will fall back to run on the CPU.",
-                  " This may have performance implications.");
+static void xpu_fallback(
+    const c10::OperatorHandle& op,
+    torch::jit::Stack* stack) {
+  TORCH_WARN_ONCE(
+      "The operator '",
+      op.schema().operator_name(),
+      "' is not currently supported ",
+      "on the XPU backend and will fall back to run on the CPU.",
+      " This may have performance implications.");
 
   native::cpu_fallback(op, stack);
 }
 
-static void xpu_error_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
+static void xpu_error_fallback(
+    const c10::OperatorHandle& op,
+    torch::jit::Stack* stack) {
   TORCH_CHECK_NOT_IMPLEMENTED(
       false,
       "The operator '",
@@ -32,23 +30,23 @@ static void xpu_error_fallback(const c10::OperatorHandle& op, torch::jit::Stack*
       "on XPU.");
 }
 
-
-
 TORCH_LIBRARY_IMPL(_, XPU, m) {
-  static const char* enable_xpu_fallback = getenv("PYTORCH_ENABLE_XPU_FALLBACK");
+  static const char* enable_xpu_fallback =
+      getenv("PYTORCH_ENABLE_XPU_FALLBACK");
   if (!enable_xpu_fallback || std::stoi(enable_xpu_fallback) == 0) {
-    m.fallback(torch::CppFunction::makeFromBoxedFunction<&xpu_error_fallback>());
+    m.fallback(
+        torch::CppFunction::makeFromBoxedFunction<&xpu_error_fallback>());
   } else {
     m.fallback(torch::CppFunction::makeFromBoxedFunction<&xpu_fallback>());
   }
 }
 
 TORCH_LIBRARY_IMPL(aten, XPU, m) {
-  // These ops are not supported via XPU backend currently, and we fallback to run on CPU.
-  // For the rest of unsupported ops the user needs to pass 'PYTORCH_ENABLE_XPU_FALLBACK=1'
-  // to fallback on CPU, otherwise we will error out.
-  // m.impl("div.Scalar", torch::CppFunction::makeFromBoxedFunction<&xpu_fallback>());
+  // These ops are not supported via XPU backend currently, and we fallback to
+  // run on CPU. For the rest of unsupported ops the user needs to pass
+  // 'PYTORCH_ENABLE_XPU_FALLBACK=1' to fallback on CPU, otherwise we will error
+  // out. m.impl("div.Scalar",
+  // torch::CppFunction::makeFromBoxedFunction<&xpu_fallback>());
 }
-
 
 } // namespace at

--- a/src/aten/XPUFallback.cpp
+++ b/src/aten/XPUFallback.cpp
@@ -53,7 +53,7 @@ TORCH_LIBRARY_IMPL(_, XPU, m) {
   }
 
   static const char* debug_xpu_fallback = getenv("PYTORCH_DEBUG_XPU_FALLBACK");
-  if (!debug_xpu_fallback || std::stoi(enable_xpu_fallback) == 0) {
+  if (!debug_xpu_fallback || std::stoi(debug_xpu_fallback) == 0) {
     DEBUG_XPU_FALLBACK = false;
   } else {
     DEBUG_XPU_FALLBACK = true;

--- a/src/aten/XPUFallback.cpp
+++ b/src/aten/XPUFallback.cpp
@@ -1,0 +1,54 @@
+#include <ATen/native/CPUFallback.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/ScalarOps.h>
+#include <torch/library.h>
+
+#include <aten/sycl/UnaryKernels.h>
+namespace at {
+
+
+
+static void xpu_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
+  TORCH_WARN_ONCE("The operator '",
+                  op.schema().operator_name(),
+                  "' is not currently supported ",
+                  "on the XPU backend and will fall back to run on the CPU.",
+                  " This may have performance implications.");
+
+  native::cpu_fallback(op, stack);
+}
+
+static void xpu_error_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      false,
+      "The operator '",
+      op.schema().operator_name(),
+      "' is not currently implemented ",
+      "for the XPU device. If you want this op to be added in priority during the prototype ",
+      "phase of this feature, please open issue on https://github.com/intel/torch-xpu-ops/issues. ",
+      "As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_XPU_FALLBACK=1` ",
+      "to use the CPU as a fallback for this op. WARNING: this will be slower than running natively ",
+      "on XPU.");
+}
+
+
+
+TORCH_LIBRARY_IMPL(_, XPU, m) {
+  static const char* enable_xpu_fallback = getenv("PYTORCH_ENABLE_XPU_FALLBACK");
+  if (!enable_xpu_fallback || std::stoi(enable_xpu_fallback) == 0) {
+    m.fallback(torch::CppFunction::makeFromBoxedFunction<&xpu_error_fallback>());
+  } else {
+    m.fallback(torch::CppFunction::makeFromBoxedFunction<&xpu_fallback>());
+  }
+}
+
+TORCH_LIBRARY_IMPL(aten, XPU, m) {
+  // These ops are not supported via XPU backend currently, and we fallback to run on CPU.
+  // For the rest of unsupported ops the user needs to pass 'PYTORCH_ENABLE_XPU_FALLBACK=1'
+  // to fallback on CPU, otherwise we will error out.
+  // m.impl("div.Scalar", torch::CppFunction::makeFromBoxedFunction<&xpu_fallback>());
+}
+
+
+} // namespace at

--- a/src/aten/XPUFallback.cpp
+++ b/src/aten/XPUFallback.cpp
@@ -60,32 +60,4 @@ TORCH_LIBRARY_IMPL(_, XPU, m) {
   }
 }
 
-/*
- * TODO: Move the following registration to the end of all XPU aten op
- * registrations
- */
-
-/*
- * Register fallback to CPU for ops specified in env variable
- * "PYTORCH_XPU_FALLBACK_OP" eg. export
- * PYTORCH_XPU_FALLBACK_OP=abs.out,div.Scalar,div.Tensor,div_.Scalar,div_.Tensor
- */
-/*
-TORCH_LIBRARY_IMPL(aten, XPU, m) {
-  static const char* fallback_op_str = getenv("PYTORCH_XPU_FALLBACK_OP");
-  if (!fallback_op_str) {
-    return;
-  }
-  std::istringstream iss(fallback_op_str);
-  std::string op_name;
-  while (std::getline(iss, op_name, ',')) {
-    TORCH_WARN(
-        "The operator '", op_name, "' will be forced to fallback to CPU.");
-    m.impl(
-        op_name.c_str(),
-        torch::CppFunction::makeFromBoxedFunction<&xpu_fallback>());
-  }
-}
-*/
-
 } // namespace at


### PR DESCRIPTION
### 🐛 Describe the bug

With pytorch branch https://github.com/daisyden/pytorch/daisyden/torch_ops_s3  on PVC platform linux the following cases got MetadataMismatchError .
 
TestFakeTensorXPU.test_fake_autocast_linalg_pinv_xpu_float32 
TestFakeTensorXPU.test_fake_autocast_pinverse_xpu_float32
TestFakeTensorXPU.test_fake_crossref_backward_amp_nn_functional_bilinear_xpu_float32

pytest -v test_ops.py -k <case>

```
_________ TestFakeTensorXPU.test_fake_autocast_linalg_pinv_xpu_float32 _________                                                                                                                                                                    
Traceback (most recent call last):                                                                                                                                                                                                                  
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1144, in test_wrapper                                         
    return test(*args, **kwargs)                                                                                                                                                                                                                    
  File "/home/daisyden/upstream/test_ops_s1/test/test_ops.py", line 2793, in test_fake_autocast                                                                                                                                                     
    self._test_fake_helper(device, dtype, op, context_fn)                                                                                                                                                                                           
  File "/home/daisyden/upstream/test_ops_s1/test/test_ops.py", line 2721, in _test_fake_helper                                                                                                                                                      
    run_with_fake_mode_and_verify(mode)                                                                                                                                                                                                             
  File "/home/daisyden/upstream/test_ops_s1/test/test_ops.py", line 2688, in run_with_fake_mode_and_verify                                                                                                                                          
    prims.utils.compare_tensor_meta(fake_out, real_out, True)                                                                                                                                                                                       
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/_prims_common/__init__.py", line 175, in compare_tensor_meta                                                 
    raise MetadataMismatchError(msg)                                                                                                                                                                                                                
torch._subclasses.fake_tensor.MetadataMismatchError: Dtypes torch.float32 and torch.float16 are not equal!                                                                                                                                          
                                                                                                                                                                                                                                                    
The above exception was the direct cause of the following exception:                                                                                                                                                                                
                                                                                                                                                                                                                                                    
Traceback (most recent call last):                                                                                                                                                                                                                  
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 3224, in wrapper                                                    
    method(*args, **kwargs)                                                                                                                                                                                                                         
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 426, in instantiated_test                                     
    result = test(self, **param_kwargs)                                                                                                                                                                                                             
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1224, in dep_fn                                               
    return fn(slf, *args, **kwargs)                                                                                                                                                                                                                 
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 1645, in wrapper                                                    
    fn(*args, **kwargs)                                                                                                                                                                                                                             
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1156, in test_wrapper                                         
    raise e_tracked from e                                                                                                                                                                                                                          
Exception: Caused by sample input at index 0: SampleInput(input=Tensor[size=(5, 5), device="xpu:0", dtype=torch.float32], args=(), kwargs={'rtol': 'None'}, broadcasts_input=False, name='')                                                        
                                                                                                                                                                                                                                                    
To execute this test, run the following from the base repo dir:                                                                                                                                                                                     
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=0 PYTORCH_TEST_WITH_SLOW=1 python test/test_ops.py TestFakeTensorXPU.test_fake_autocast_linalg_pinv_xpu_float32                                                                                               
                                                                                                                                                                                                                                                    
This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0                                                                               

```

```
/home/daisyden/upstream/test_ops_s1/test/test_ops.py:2817: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.                                                               
  context(),                                                                                                                                                                                                                                        
/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/amp/autocast_mode.py:270: UserWarning: User provided device_type of 'cuda', but CUDA is not available. Disabling     
  warnings.warn(                                             
_ TestFakeTensorXPU.test_fake_crossref_backward_amp_nn_functional_bilinear_xpu_float32 _
Traceback (most recent call last):
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1144, in test_wrapper
    return test(*args, **kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1405, in only_fn
    return fn(slf, *args, **kwargs)
  File "/home/daisyden/upstream/test_ops_s1/test/test_ops.py", line 2846, in test_fake_crossref_backward_amp
    self._test_fake_crossref_helper(device, dtype, op, torch.cuda.amp.autocast)
  File "/home/daisyden/upstream/test_ops_s1/test/test_ops.py", line 2820, in _test_fake_crossref_helper
    composite_compliance.compute_expected_grads(
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/composite_compliance.py", line 431, in compute_expected_grads
    results = gradcheck_wrapper(op, *args, **kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/opinfo/core.py", line 831, in <lambda>
    gradcheck_wrapper: Callable = lambda op, *args, **kwargs: op(*args, **kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/_subclasses/fake_utils.py", line 274, in __torch_dispatch__
    _check_alias_info(                                       
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/_subclasses/fake_utils.py", line 56, in _check_alias_info
    raise MetadataMismatchError(
torch._subclasses.fake_tensor.MetadataMismatchError: When comparing the output of aten.view.default on FakeTensor and concrete Tensors, found mismatch in outputs_alias_inputs check False != True

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 3224, in wrapper
    method(*args, **kwargs)                                  
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 426, in instantiated_test
    result = test(self, **param_kwargs)
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_utils.py", line 1645, in wrapper
    fn(*args, **kwargs)                                      
  File "/home/daisyden/miniforge3/envs/test_ops_s1/lib/python3.10/site-packages/torch-2.9.0a0+gitd311d30-py3.10-linux-x86_64.egg/torch/testing/_internal/common_device_type.py", line 1156, in test_wrapper
    raise e_tracked from e                                   
Exception: Caused by sample input at index 5: SampleInput(input=Tensor[size=(0, 8), device="xpu:0", dtype=torch.float32], args=TensorList[Tensor[size=(0, 8), device="xpu:0", dtype=torch.float32], Tensor[size=(8, 8, 8), device="xpu:0", dtype=tor
ch.float32], Tensor[size=(8,), device="xpu:0", dtype=torch.float32]], kwargs={}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=5 PYTORCH_TEST_WITH_SLOW=1 python test/test_ops.py TestFakeTensorXPU.test_fake_crossref_backward_amp_nn_functional_bilinear_xpu_float32

```



### Versions

Collecting environment information...
PyTorch version: N/A
Is debug build: N/A
CUDA used to build PyTorch: N/A
ROCM used to build PyTorch: N/A

OS: Ubuntu 22.04.5 LTS (x86_64)
GCC version: (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
Clang version: Could not collect
CMake version: version 4.0.0
Libc version: glibc-2.35

Python version: 3.10.18 | packaged by conda-forge | (main, Jun  4 2025, 14:45:41) [GCC 13.3.0] (64-bit runtime)
Python platform: Linux-5.15.0-73-generic-x86_64-with-glibc2.35
Is CUDA available: N/A
CUDA runtime version: Could not collect
CUDA_MODULE_LOADING set to: N/A
GPU models and configuration: Could not collect
Nvidia driver version: Could not collect
cuDNN version: Could not collect
Is XPU available: N/A
HIP runtime version: N/A
MIOpen runtime version: N/A
Is XNNPACK available: N/A

CPU:
Architecture:                    x86_64
CPU op-mode(s):                  32-bit, 64-bit
Address sizes:                   46 bits physical, 57 bits virtual
Byte Order:                      Little Endian
CPU(s):                          48
On-line CPU(s) list:             0-47
Vendor ID:                       GenuineIntel
Model name:                      Intel(R) Xeon(R) Gold 6342 CPU @ 2.80GHz
CPU family:                      6
Model:                           106
Thread(s) per core:              2
Core(s) per socket:              24
Socket(s):                       1
Stepping:                        6
CPU max MHz:                     3500.0000
CPU min MHz:                     800.0000
BogoMIPS:                        5600.00
Flags:                           fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb cat_l3 invpcid_single intel_ppin ssbd mba ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid cqm rdt_a avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb intel_pt avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local split_lock_detect wbnoinvd dtherm ida arat pln pts hwp hwp_act_window hwp_epp hwp_pkg_req avx512vbmi umip pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg tme avx512_vpopcntdq la57 rdpid fsrm md_clear pconfig flush_l1d arch_capabilities
Virtualization:                  VT-x
L1d cache:                       1.1 MiB (24 instances)
L1i cache:                       768 KiB (24 instances)
L2 cache:                        30 MiB (24 instances)
L3 cache:                        36 MiB (1 instance)
NUMA node(s):                    1
NUMA node0 CPU(s):               0-47
Vulnerability Itlb multihit:     Not affected
Vulnerability L1tf:              Not affected
Vulnerability Mds:               Not affected
Vulnerability Meltdown:          Not affected
Vulnerability Mmio stale data:   Mitigation; Clear CPU buffers; SMT vulnerable
Vulnerability Retbleed:          Not affected
Vulnerability Spec store bypass: Mitigation; Speculative Store Bypass disabled via prctl and seccomp
Vulnerability Spectre v1:        Mitigation; usercopy/swapgs barriers and __user pointer sanitization
Vulnerability Spectre v2:        Mitigation; Enhanced IBRS, IBPB conditional, RSB filling, PBRSB-eIBRS SW sequence
Vulnerability Srbds:             Not affected
Vulnerability Tsx async abort:   Not affected

Versions of relevant libraries:
[pip3] flake8==6.1.0
[pip3] flake8-bugbear==23.3.23
[pip3] flake8-comprehensions==3.15.0
[pip3] flake8-executable==2.1.3
[pip3] flake8-logging-format==0.9.0
[pip3] flake8-pyi==23.3.1
[pip3] flake8-simplify==0.19.3
[pip3] mypy==1.16.0
[pip3] mypy_extensions==1.1.0
[pip3] numpy==1.26.4
[pip3] onnx==1.18.0
[pip3] onnxscript==0.2.6
[pip3] optree==0.13.0
[pip3] pytorch-triton-xpu==3.4.0+gitae324eea
[pip3] torch==2.9.0a0+gitd311d30
[conda] numpy                     1.26.4                   pypi_0    pypi
[conda] optree                    0.13.0                   pypi_0    pypi
[conda] pytorch-triton-xpu        3.4.0+gitae324eea          pypi_0    pypi
[conda] torch                     2.9.0a0+gitf6f609f          pypi_0    pypi
[conda] torchfix                  0.4.0                    pypi_0    pypi
