### PR TITLE
Complement ATen operators' variants with `func`, `inplace` and `out`.

### DIFF
--- a/src/aten/BinaryOps.cpp
+++ b/src/aten/BinaryOps.cpp
@@ -8,10 +8,10 @@
 
 namespace at {
 
-at::Tensor XPUNativeFunctions::add(
-    const at::Tensor& self,
-    const at::Tensor& other,
-    const at::Scalar& alpha) {
+Tensor XPUNativeFunctions::add(
+    const Tensor& self,
+    const Tensor& other,
+    const Scalar& alpha) {
   Tensor out;
   auto iter = TensorIterator::binary_op(out, self, other);
   native::alpha_check(iter.dtype(), alpha);
@@ -19,30 +19,50 @@ at::Tensor XPUNativeFunctions::add(
   return iter.output();
 }
 
-at::Tensor& XPUNativeFunctions::add_(
-    at::Tensor& self,
-    const at::Tensor& other,
-    const at::Scalar& alpha) {
+Tensor& XPUNativeFunctions::add_(
+    Tensor& self,
+    const Tensor& other,
+    const Scalar& alpha) {
   auto iter = TensorIterator::binary_op(self, self, other);
   native::alpha_check(iter.dtype(), alpha);
   native::xpu::add_kernel(iter, alpha);
   return self;
 }
 
-at::Tensor XPUNativeFunctions::add(
-    const at::Tensor& self,
-    const at::Scalar& other,
-    const at::Scalar& alpha) {
+Tensor& XPUNativeFunctions::add_out(
+    const Tensor& self,
+    const Tensor& other,
+    const Scalar& alpha,
+    Tensor& out) {
+  auto iter = TensorIterator::binary_op(out, self, other);
+  native::alpha_check(iter.dtype(), alpha);
+  native::xpu::add_kernel(iter, alpha);
+  return out;
+}
+
+Tensor XPUNativeFunctions::add(
+    const Tensor& self,
+    const Scalar& other,
+    const Scalar& alpha) {
   auto wrapper = native::wrapped_scalar_tensor(other);
   return XPUNativeFunctions::add(self, wrapper, alpha);
 }
 
-at::Tensor& XPUNativeFunctions::add_(
-    at::Tensor& self,
-    const at::Scalar& other,
-    const at::Scalar& alpha) {
+Tensor& XPUNativeFunctions::add_(
+    Tensor& self,
+    const Scalar& other,
+    const Scalar& alpha) {
   auto wrapper = native::wrapped_scalar_tensor(other);
   return XPUNativeFunctions::add_(self, wrapper, alpha);
+}
+
+Tensor& XPUNativeFunctions::add_out(
+    const Tensor& self,
+    const Scalar& other,
+    const Scalar& alpha,
+    Tensor& out) {
+  auto wrapper = native::wrapped_scalar_tensor(other);
+  return XPUNativeFunctions::add_out(self, wrapper, alpha, out);
 }
 
 Tensor XPUNativeFunctions::sub(
@@ -66,6 +86,18 @@ Tensor& XPUNativeFunctions::sub_(
   native::alpha_check(iter.dtype(), alpha);
   native::xpu::sub_kernel(iter, alpha);
   return self;
+}
+
+Tensor& XPUNativeFunctions::sub_out(
+    const Tensor& self,
+    const Tensor& other,
+    const Scalar& alpha,
+    Tensor& out) {
+  native::sub_check(self, other);
+  auto iter = TensorIterator::binary_op(out, self, other);
+  native::alpha_check(iter.dtype(), alpha);
+  native::xpu::sub_kernel(iter, alpha);
+  return out;
 }
 
 Tensor XPUNativeFunctions::sub(
@@ -84,6 +116,15 @@ Tensor& XPUNativeFunctions::sub_(
   return XPUNativeFunctions::sub_(self, wrapper, alpha);
 }
 
+Tensor& XPUNativeFunctions::sub_out(
+    const Tensor& self,
+    const Scalar& other,
+    const Scalar& alpha,
+    Tensor& out) {
+  auto wrapper = native::wrapped_scalar_tensor(other);
+  return XPUNativeFunctions::sub_out(self, wrapper, alpha, out);
+}
+
 Tensor XPUNativeFunctions::mul(const Tensor& self, const Tensor& other) {
   Tensor out;
   auto iter = TensorIterator::binary_op(out, self, other);
@@ -97,6 +138,15 @@ Tensor& XPUNativeFunctions::mul_(Tensor& self, const Tensor& other) {
   return self;
 }
 
+Tensor& XPUNativeFunctions::mul_out(
+    const Tensor& self,
+    const Tensor& other,
+    Tensor& out) {
+  auto iter = TensorIterator::binary_op(out, self, other);
+  native::xpu::mul_kernel(iter);
+  return out;
+}
+
 Tensor XPUNativeFunctions::mul(const Tensor& self, const Scalar& other) {
   auto wrapper = native::wrapped_scalar_tensor(other);
   return XPUNativeFunctions::mul(self, wrapper);
@@ -105,6 +155,14 @@ Tensor XPUNativeFunctions::mul(const Tensor& self, const Scalar& other) {
 Tensor& XPUNativeFunctions::mul_(Tensor& self, const Scalar& other) {
   auto wrapper = native::wrapped_scalar_tensor(other);
   return XPUNativeFunctions::mul_(self, wrapper);
+}
+
+Tensor& XPUNativeFunctions::mul_out(
+    const Tensor& self,
+    const Scalar& other,
+    Tensor& out) {
+  auto wrapper = native::wrapped_scalar_tensor(other);
+  return XPUNativeFunctions::mul_out(self, wrapper, out);
 }
 
 Tensor XPUNativeFunctions::div(const Tensor& self, const Tensor& other) {
@@ -120,6 +178,15 @@ Tensor& XPUNativeFunctions::div_(Tensor& self, const Tensor& other) {
   return self;
 }
 
+Tensor& XPUNativeFunctions::div_out(
+    const Tensor& self,
+    const Tensor& other,
+    Tensor& out) {
+  auto iter = TensorIterator::binary_float_op(out, self, other);
+  native::xpu::div_kernel(iter);
+  return out;
+}
+
 Tensor XPUNativeFunctions::div(const Tensor& self, const Scalar& other) {
   auto wrapper = native::wrapped_scalar_tensor(other);
   return XPUNativeFunctions::div(self, wrapper);
@@ -128,6 +195,64 @@ Tensor XPUNativeFunctions::div(const Tensor& self, const Scalar& other) {
 Tensor& XPUNativeFunctions::div_(Tensor& self, const Scalar& other) {
   auto wrapper = native::wrapped_scalar_tensor(other);
   return XPUNativeFunctions::div_(self, wrapper);
+}
+
+Tensor& XPUNativeFunctions::div_out(
+    const Tensor& self,
+    const Scalar& other,
+    Tensor& out) {
+  auto wrapper = native::wrapped_scalar_tensor(other);
+  return XPUNativeFunctions::div_out(self, wrapper, out);
+}
+
+Tensor XPUNativeFunctions::rsub(
+    const Tensor& self,
+    const Tensor& other,
+    const Scalar& alpha) {
+  return XPUNativeFunctions::sub(self, other, alpha);
+}
+
+Tensor& XPUNativeFunctions::rsub_out(
+    const Tensor& self,
+    const Tensor& other,
+    const Scalar& alpha,
+    Tensor& out) {
+  return XPUNativeFunctions::sub_out(self, other, alpha, out);
+}
+
+Tensor XPUNativeFunctions::rsub(
+    const Tensor& self,
+    const Scalar& other,
+    const Scalar& alpha) {
+  return XPUNativeFunctions::sub(
+      self, native::wrapped_scalar_tensor(other), alpha);
+}
+
+Tensor& XPUNativeFunctions::rsub_out(
+    const Tensor& self,
+    const Scalar& other,
+    const Scalar& alpha,
+    Tensor& out) {
+  return XPUNativeFunctions::sub_out(
+      self, native::wrapped_scalar_tensor(other), alpha, out);
+}
+
+Tensor& XPUNativeFunctions::remainder_out(
+    const Tensor& self,
+    const Tensor& other,
+    Tensor& out) {
+  auto iter = TensorIterator::binary_op(out, self, other);
+  native::xpu::remainder_kernel(iter);
+  return out;
+}
+
+Tensor& XPUNativeFunctions::fmod_out(
+    const Tensor& self,
+    const Tensor& other,
+    Tensor& out) {
+  auto iter = TensorIterator::binary_op(out, self, other);
+  native::xpu::fmod_kernel(iter);
+  return out;
 }
 
 } // namespace at

--- a/src/aten/BinaryOps.cpp
+++ b/src/aten/BinaryOps.cpp
@@ -5,6 +5,7 @@
 #include <ATen/native/TensorIterator.h>
 
 #include <aten/sycl/BinaryKernels.h>
+#include <aten/sycl/BinaryRemainderKernel.h>
 
 namespace at {
 
@@ -237,6 +238,19 @@ Tensor& XPUNativeFunctions::rsub_out(
       self, native::wrapped_scalar_tensor(other), alpha, out);
 }
 
+Tensor XPUNativeFunctions::remainder(const Tensor& self, const Tensor& other) {
+  Tensor out;
+  auto iter = TensorIterator::binary_op(out, self, other);
+  native::xpu::remainder_kernel(iter);
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::remainder_(Tensor& self, const Tensor& other) {
+  auto iter = TensorIterator::binary_op(self, self, other);
+  native::xpu::remainder_kernel(iter);
+  return self;
+}
+
 Tensor& XPUNativeFunctions::remainder_out(
     const Tensor& self,
     const Tensor& other,
@@ -246,6 +260,50 @@ Tensor& XPUNativeFunctions::remainder_out(
   return out;
 }
 
+Tensor XPUNativeFunctions::remainder(const Tensor& self, const Scalar& other) {
+  auto wrapper = native::wrapped_scalar_tensor(other);
+  return XPUNativeFunctions::remainder(self, wrapper);
+}
+
+Tensor& XPUNativeFunctions::remainder_(Tensor& self, const Scalar& other) {
+  auto wrapper = native::wrapped_scalar_tensor(other);
+  return XPUNativeFunctions::remainder_(self, wrapper);
+}
+
+Tensor& XPUNativeFunctions::remainder_out(
+    const Tensor& self,
+    const Scalar& other,
+    Tensor& out) {
+  auto wrapper = native::wrapped_scalar_tensor(other);
+  return XPUNativeFunctions::remainder_out(self, wrapper, out);
+}
+
+Tensor XPUNativeFunctions::remainder(const Scalar& self, const Tensor& other) {
+  auto wrapper = native::wrapped_scalar_tensor(self);
+  return XPUNativeFunctions::remainder(wrapper, other);
+}
+
+Tensor& XPUNativeFunctions::remainder_out(
+    const Scalar& self,
+    const Tensor& other,
+    Tensor& out) {
+  auto wrapper = native::wrapped_scalar_tensor(self);
+  return XPUNativeFunctions::remainder_out(wrapper, other, out);
+}
+
+Tensor XPUNativeFunctions::fmod(const Tensor& self, const Tensor& other) {
+  Tensor out;
+  auto iter = TensorIterator::binary_op(out, self, other);
+  native::xpu::fmod_kernel(iter);
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::fmod_(Tensor& self, const Tensor& other) {
+  auto iter = TensorIterator::binary_op(self, self, other);
+  native::xpu::fmod_kernel(iter);
+  return self;
+}
+
 Tensor& XPUNativeFunctions::fmod_out(
     const Tensor& self,
     const Tensor& other,
@@ -253,6 +311,24 @@ Tensor& XPUNativeFunctions::fmod_out(
   auto iter = TensorIterator::binary_op(out, self, other);
   native::xpu::fmod_kernel(iter);
   return out;
+}
+
+Tensor XPUNativeFunctions::fmod(const Tensor& self, const Scalar& other) {
+  auto wrapper = native::wrapped_scalar_tensor(other);
+  return XPUNativeFunctions::fmod(self, wrapper);
+}
+
+Tensor& XPUNativeFunctions::fmod_(Tensor& self, const Scalar& other) {
+  auto wrapper = native::wrapped_scalar_tensor(other);
+  return XPUNativeFunctions::fmod_(self, wrapper);
+}
+
+Tensor& XPUNativeFunctions::fmod_out(
+    const Tensor& self,
+    const Scalar& other,
+    Tensor& out) {
+  auto wrapper = native::wrapped_scalar_tensor(other);
+  return XPUNativeFunctions::fmod_out(self, wrapper, out);
 }
 
 } // namespace at

--- a/src/aten/Pow.cpp
+++ b/src/aten/Pow.cpp
@@ -8,48 +8,80 @@
 
 namespace at {
 
-Tensor& XPUNativeFunctions::pow_out(
-    const Tensor& base,
-    const Tensor& exp,
-    Tensor& result) {
-  auto iter = TensorIterator::binary_op(result, base, exp);
+Tensor XPUNativeFunctions::pow(const Tensor& self, const Tensor& exponent) {
+  Tensor out;
+  auto iter = TensorIterator::binary_op(out, self, exponent);
   native::xpu::pow_tensor_tensor_kernel(iter);
-  return result;
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::pow_(Tensor& self, const Tensor& exponent) {
+  auto iter = TensorIterator::binary_op(self, self, exponent);
+  native::xpu::pow_tensor_tensor_kernel(iter);
+  return self;
 }
 
 Tensor& XPUNativeFunctions::pow_out(
-    const Scalar& base,
+    const Tensor& base,
     const Tensor& exp,
-    Tensor& result) {
-  if (base.isComplex() && base.toComplexDouble() == 1.0) {
-    result.resize_as_(exp).fill_(1);
-  } else if (!base.isComplex() && base.toDouble() == 1.0) {
-    result.resize_as_(exp).fill_(1);
+    Tensor& out) {
+  auto iter = TensorIterator::binary_op(out, base, exp);
+  native::xpu::pow_tensor_tensor_kernel(iter);
+  return out;
+}
+
+Tensor XPUNativeFunctions::pow(const Tensor& self, const Scalar& exponent) {
+  Tensor out;
+  auto iter = TensorIterator::unary_op(out, self);
+  native::xpu::pow_tensor_scalar_kernel(iter, exponent);
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::pow_(Tensor& self, const Scalar& exponent) {
+  if (exponent.equal(0.0) || exponent.equal(false)) {
+    self.fill_(1);
+  } else if (exponent.equal(1.0) || exponent.equal(true)) {
   } else {
-    XPUNativeFunctions::pow_out(
-        native::wrapped_scalar_tensor(base), exp, result);
+    auto iter = TensorIterator::unary_op(self, self);
+    native::xpu::pow_tensor_scalar_kernel(iter, exponent);
   }
-  return result;
+  return self;
 }
 
 Tensor& XPUNativeFunctions::pow_out(
     const Tensor& self,
     const Scalar& exponent,
-    Tensor& result) {
-  auto iter = TensorIterator::unary_op(result, self);
-  auto& base_ = iter.tensor(1);
-  if (exponent.isComplex() && (exponent.toComplexDouble() == 0.0)) {
-    result.resize_as_(base_).fill_(1);
-  } else if (exponent.isComplex() && (exponent.toComplexDouble() == 1.0)) {
-    result.resize_as_(base_).fill_(base_);
-  } else if (!exponent.isComplex() && (exponent.toDouble() == 0.0)) {
-    result.resize_as_(base_).fill_(1);
-  } else if (!exponent.isComplex() && (exponent.toDouble() == 1.0)) {
-    result.resize_as_(base_).copy_(base_);
+    Tensor& out) {
+  if (exponent.equal(0.0) || exponent.equal(false)) {
+    out.fill_(1);
+  } else if (exponent.equal(1.0) || exponent.equal(true)) {
+    out.copy_(self);
   } else {
+    auto iter = TensorIterator::unary_op(out, self);
     native::xpu::pow_tensor_scalar_kernel(iter, exponent);
   }
-  return result;
+  return out;
+}
+
+Tensor XPUNativeFunctions::pow(const Scalar& self, const Tensor& exponent) {
+  Tensor out;
+  auto iter = TensorIterator::binary_op(
+      out, native::wrapped_scalar_tensor(self), exponent);
+  native::xpu::pow_tensor_tensor_kernel(iter);
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::pow_out(
+    const Scalar& self,
+    const Tensor& exponent,
+    Tensor& out) {
+  if (self.equal(1.0)) {
+    out.fill_(1);
+  } else {
+    return XPUNativeFunctions::pow_out(
+        native::wrapped_scalar_tensor(self), exponent, out);
+  }
+  return out;
 }
 
 } // namespace at

--- a/src/aten/Pow.cpp
+++ b/src/aten/Pow.cpp
@@ -1,0 +1,55 @@
+#include <ATen/ScalarOps.h>
+#include <ATen/XPUNativeFunctions.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/native/BinaryOps.h>
+#include <ATen/native/TensorIterator.h>
+
+#include <aten/sycl/PowKernels.h>
+
+namespace at {
+
+Tensor& XPUNativeFunctions::pow_out(
+    const Tensor& base,
+    const Tensor& exp,
+    Tensor& result) {
+  auto iter = TensorIterator::binary_op(result, base, exp);
+  native::xpu::pow_tensor_tensor_kernel(iter);
+  return result;
+}
+
+Tensor& XPUNativeFunctions::pow_out(
+    const Scalar& base,
+    const Tensor& exp,
+    Tensor& result) {
+  if (base.isComplex() && base.toComplexDouble() == 1.0) {
+    result.resize_as_(exp).fill_(1);
+  } else if (!base.isComplex() && base.toDouble() == 1.0) {
+    result.resize_as_(exp).fill_(1);
+  } else {
+    XPUNativeFunctions::pow_out(
+        native::wrapped_scalar_tensor(base), exp, result);
+  }
+  return result;
+}
+
+Tensor& XPUNativeFunctions::pow_out(
+    const Tensor& self,
+    const Scalar& exponent,
+    Tensor& result) {
+  auto iter = TensorIterator::unary_op(result, self);
+  auto& base_ = iter.tensor(1);
+  if (exponent.isComplex() && (exponent.toComplexDouble() == 0.0)) {
+    result.resize_as_(base_).fill_(1);
+  } else if (exponent.isComplex() && (exponent.toComplexDouble() == 1.0)) {
+    result.resize_as_(base_).fill_(base_);
+  } else if (!exponent.isComplex() && (exponent.toDouble() == 0.0)) {
+    result.resize_as_(base_).fill_(1);
+  } else if (!exponent.isComplex() && (exponent.toDouble() == 1.0)) {
+    result.resize_as_(base_).copy_(base_);
+  } else {
+    native::xpu::pow_tensor_scalar_kernel(iter, exponent);
+  }
+  return result;
+}
+
+} // namespace at

--- a/src/aten/UnaryOps.cpp
+++ b/src/aten/UnaryOps.cpp
@@ -5,6 +5,7 @@
 #include <torch/library.h>
 
 #include <aten/sycl/UnaryKernels.h>
+#include <aten/sycl/UnaryLogKernels.h>
 
 namespace at {
 
@@ -24,75 +25,6 @@ Tensor& XPUNativeFunctions::abs_(Tensor& self) {
 Tensor& XPUNativeFunctions::abs_out(const Tensor& self, Tensor& out) {
   auto iter = TensorIterator::unary_op(out, self);
   native::xpu::abs_kernel(iter);
-  return iter.output();
-}
-
-Tensor& XPUNativeFunctions::abs_(Tensor& self) {
-  auto iter = TensorIterator::unary_op(self, self);
-  native::xpu::abs_kernel(iter);
-  return self;
-}
-
-Tensor& XPUNativeFunctions::abs_out(const Tensor& self, Tensor& out) {
-  auto iter = TensorIterator::unary_op(out, self);
-  native::xpu::abs_kernel(iter);
-  return out;
-}
-
-Tensor XPUNativeFunctions::sin(const Tensor& self) {
-  Tensor out;
-  auto iter = TensorIterator::unary_float_op(out, self);
-  native::xpu::sin_kernel(iter);
-  return iter.output();
-}
-
-Tensor& XPUNativeFunctions::sin_(Tensor& self) {
-  auto iter = TensorIterator::unary_float_op(self, self);
-  native::xpu::sin_kernel(iter);
-  return self;
-}
-
-Tensor& XPUNativeFunctions::sin_out(const Tensor& self, Tensor& out) {
-  auto iter = TensorIterator::unary_float_op(out, self);
-  native::xpu::sin_kernel(iter);
-  return out;
-}
-
-Tensor XPUNativeFunctions::cos(const Tensor& self) {
-  Tensor out;
-  auto iter = TensorIterator::unary_float_op(out, self);
-  native::xpu::cos_kernel(iter);
-  return iter.output();
-}
-
-Tensor& XPUNativeFunctions::cos_(Tensor& self) {
-  auto iter = TensorIterator::unary_float_op(self, self);
-  native::xpu::cos_kernel(iter);
-  return self;
-}
-
-Tensor& XPUNativeFunctions::cos_out(const Tensor& self, Tensor& out) {
-  auto iter = TensorIterator::unary_float_op(out, self);
-  native::xpu::cos_kernel(iter);
-  return out;
-}
-
-Tensor XPUNativeFunctions::log(const Tensor& self) {
-  Tensor out;
-  auto iter = TensorIterator::unary_float_op(out, self);
-  native::xpu::log_kernel(iter);
-  return iter.output();
-}
-
-Tensor& XPUNativeFunctions::log_(Tensor& self) {
-  auto iter = TensorIterator::unary_float_op(self, self);
-  native::xpu::log_kernel(iter);
-  return self;
-}
-
-Tensor& XPUNativeFunctions::log_out(const Tensor& self, Tensor& out) {
-  auto iter = TensorIterator::unary_float_op(out, self);
-  native::xpu::log_kernel(iter);
   return out;
 }
 

--- a/src/aten/UnaryOps.cpp
+++ b/src/aten/UnaryOps.cpp
@@ -160,4 +160,23 @@ Tensor& XPUNativeFunctions::neg_out(const Tensor& self, Tensor& out) {
   return out;
 }
 
+Tensor XPUNativeFunctions::reciprocal(const Tensor& self) {
+  Tensor out;
+  auto iter = TensorIterator::unary_op(out, self);
+  native::xpu::reciprocal_kernel(iter);
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::reciprocal_(Tensor& self) {
+  auto iter = TensorIterator::unary_op(self, self);
+  native::xpu::reciprocal_kernel(iter);
+  return self;
+}
+
+Tensor& XPUNativeFunctions::reciprocal_out(const Tensor& self, Tensor& out) {
+  auto iter = TensorIterator::unary_op(out, self);
+  native::xpu::reciprocal_kernel(iter);
+  return out;
+}
+
 } // namespace at

--- a/src/aten/UnaryOps.cpp
+++ b/src/aten/UnaryOps.cpp
@@ -1,4 +1,5 @@
 #include <ATen/ScalarOps.h>
+#include <ATen/XPUNativeFunctions.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/native/TensorIterator.h>
 #include <torch/library.h>
@@ -6,19 +7,157 @@
 #include <aten/sycl/UnaryKernels.h>
 
 namespace at {
-namespace native {
-namespace xpu {
 
-Tensor& abs_out(const Tensor& self, Tensor& out) {
+Tensor XPUNativeFunctions::abs(const Tensor& self) {
+  Tensor out;
+  auto iter = TensorIterator::unary_op(out, self);
+  native::xpu::abs_kernel(iter);
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::abs_(Tensor& self) {
+  auto iter = TensorIterator::unary_op(self, self);
+  native::xpu::abs_kernel(iter);
+  return self;
+}
+
+Tensor& XPUNativeFunctions::abs_out(const Tensor& self, Tensor& out) {
   auto iter = TensorIterator::unary_op(out, self);
   native::xpu::abs_kernel(iter);
   return out;
 }
 
-TORCH_LIBRARY_IMPL(aten, XPU, m) {
-  m.impl(TORCH_SELECTIVE_NAME("aten::abs.out"), TORCH_FN(abs_out));
+Tensor XPUNativeFunctions::sin(const Tensor& self) {
+  Tensor out;
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::sin_kernel(iter);
+  return iter.output();
 }
 
-} // namespace xpu
-} // namespace native
+Tensor& XPUNativeFunctions::sin_(Tensor& self) {
+  auto iter = TensorIterator::unary_float_op(self, self);
+  native::xpu::sin_kernel(iter);
+  return self;
+}
+
+Tensor& XPUNativeFunctions::sin_out(const Tensor& self, Tensor& out) {
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::sin_kernel(iter);
+  return out;
+}
+
+Tensor XPUNativeFunctions::cos(const Tensor& self) {
+  Tensor out;
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::cos_kernel(iter);
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::cos_(Tensor& self) {
+  auto iter = TensorIterator::unary_float_op(self, self);
+  native::xpu::cos_kernel(iter);
+  return self;
+}
+
+Tensor& XPUNativeFunctions::cos_out(const Tensor& self, Tensor& out) {
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::cos_kernel(iter);
+  return out;
+}
+
+Tensor XPUNativeFunctions::log(const Tensor& self) {
+  Tensor out;
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::log_kernel(iter);
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::log_(Tensor& self) {
+  auto iter = TensorIterator::unary_float_op(self, self);
+  native::xpu::log_kernel(iter);
+  return self;
+}
+
+Tensor& XPUNativeFunctions::log_out(const Tensor& self, Tensor& out) {
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::log_kernel(iter);
+  return out;
+}
+
+Tensor XPUNativeFunctions::sqrt(const Tensor& self) {
+  Tensor out;
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::sqrt_kernel(iter);
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::sqrt_(Tensor& self) {
+  auto iter = TensorIterator::unary_float_op(self, self);
+  native::xpu::sqrt_kernel(iter);
+  return self;
+}
+
+Tensor& XPUNativeFunctions::sqrt_out(const Tensor& self, Tensor& out) {
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::sqrt_kernel(iter);
+  return out;
+}
+
+Tensor XPUNativeFunctions::rsqrt(const Tensor& self) {
+  Tensor out;
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::rsqrt_kernel(iter);
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::rsqrt_(Tensor& self) {
+  auto iter = TensorIterator::unary_float_op(self, self);
+  native::xpu::rsqrt_kernel(iter);
+  return self;
+}
+
+Tensor& XPUNativeFunctions::rsqrt_out(const Tensor& self, Tensor& out) {
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::rsqrt_kernel(iter);
+  return out;
+}
+
+Tensor XPUNativeFunctions::tanh(const Tensor& self) {
+  Tensor out;
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::tanh_kernel(iter);
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::tanh_(Tensor& self) {
+  auto iter = TensorIterator::unary_float_op(self, self);
+  native::xpu::tanh_kernel(iter);
+  return self;
+}
+
+Tensor& XPUNativeFunctions::tanh_out(const Tensor& self, Tensor& out) {
+  auto iter = TensorIterator::unary_float_op(out, self);
+  native::xpu::tanh_kernel(iter);
+  return out;
+}
+
+Tensor XPUNativeFunctions::neg(const Tensor& self) {
+  Tensor out;
+  auto iter = TensorIterator::unary_op(out, self);
+  native::xpu::neg_kernel(iter);
+  return iter.output();
+}
+
+Tensor& XPUNativeFunctions::neg_(Tensor& self) {
+  auto iter = TensorIterator::unary_op(self, self);
+  native::xpu::neg_kernel(iter);
+  return self;
+}
+
+Tensor& XPUNativeFunctions::neg_out(const Tensor& self, Tensor& out) {
+  auto iter = TensorIterator::unary_op(out, self);
+  native::xpu::neg_kernel(iter);
+  return out;
+}
+
 } // namespace at

--- a/src/aten/sycl/BinaryKernels.cpp
+++ b/src/aten/sycl/BinaryKernels.cpp
@@ -42,7 +42,43 @@ struct DivFunctor {
   }
 };
 
-void add_kernel(TensorIterator& iter, const c10::Scalar& alpha) {
+template <typename scalar_t>
+struct RemainderIntegralFunctor {
+  scalar_t operator()(scalar_t a, scalar_t b) const {
+    scalar_t r = a % b;
+    if (r != 0 && c10::signs_differ(r, b)) {
+      r += b;
+    }
+    return r;
+  }
+};
+
+template <typename scalar_t>
+struct RemainderFloatingFunctor {
+  scalar_t operator()(scalar_t a, scalar_t b) const {
+    auto mod = std::fmod(a, b);
+    if (mod != 0 && c10::signs_differ(b, mod)) {
+      mod += b;
+    }
+    return mod;
+  }
+};
+
+template <typename scalar_t>
+struct FmodIntegralFunctor {
+  scalar_t operator()(scalar_t a, scalar_t b) const {
+    return a % b;
+  }
+};
+
+template <typename scalar_t>
+struct FmodFloatingFunctor {
+  scalar_t operator()(scalar_t a, scalar_t b) const {
+    return ::fmod(a, b);
+  }
+};
+
+void add_kernel(TensorIteratorBase& iter, const c10::Scalar& alpha) {
   auto common_dtype = iter.common_dtype();
   if (common_dtype == kComplexHalf) {
     using scalar_t = c10::complex<c10::Half>;
@@ -59,11 +95,11 @@ void add_kernel(TensorIterator& iter, const c10::Scalar& alpha) {
   }
 }
 
-void sub_kernel(TensorIterator& iter, const c10::Scalar& alpha) {
+void sub_kernel(TensorIteratorBase& iter, const c10::Scalar& alpha) {
   add_kernel(iter, -alpha);
 }
 
-void mul_kernel(TensorIterator& iter) {
+void mul_kernel(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (common_dtype == kComplexHalf) {
     using scalar_t = c10::complex<c10::Half>;
@@ -80,7 +116,7 @@ void mul_kernel(TensorIterator& iter) {
   }
 }
 
-void div_kernel(TensorIterator& iter) {
+void div_kernel(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (common_dtype == kComplexHalf) {
     using scalar_t = c10::complex<c10::Half>;
@@ -92,6 +128,32 @@ void div_kernel(TensorIterator& iter) {
           using opmath_t = opmath_type<scalar_t>;
           opmath_gpu_kernel_with_scalars<scalar_t>(
               iter, DivFunctor<opmath_t>());
+        });
+  }
+}
+
+void remainder_kernel(TensorIteratorBase& iter) {
+  if (isIntegralType(iter.common_dtype(), /*includeBool*/ false)) {
+    AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "remainder_xpu", [&]() {
+      gpu_kernel_with_scalars(iter, RemainderIntegralFunctor<scalar_t>());
+    });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        kHalf, kBFloat16, iter.common_dtype(), "remainder_xpu", [&]() {
+          gpu_kernel_with_scalars(iter, RemainderFloatingFunctor<scalar_t>());
+        });
+  }
+}
+
+void fmod_kernel(TensorIteratorBase& iter) {
+  if (isIntegralType(iter.common_dtype(), /*includeBool*/ false)) {
+    AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "fmod_xpu", [&]() {
+      gpu_kernel_with_scalars(iter, FmodIntegralFunctor<scalar_t>());
+    });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        kHalf, kBFloat16, iter.common_dtype(), "fmod_xpu", [&]() {
+          gpu_kernel_with_scalars(iter, FmodFloatingFunctor<scalar_t>());
         });
   }
 }

--- a/src/aten/sycl/BinaryKernels.h
+++ b/src/aten/sycl/BinaryKernels.h
@@ -6,13 +6,17 @@ namespace at {
 namespace native {
 namespace xpu {
 
-void add_kernel(TensorIterator& iter, const Scalar& alpha);
+void add_kernel(TensorIteratorBase& iter, const Scalar& alpha);
 
-void sub_kernel(TensorIterator& iter, const Scalar& alpha);
+void sub_kernel(TensorIteratorBase& iter, const Scalar& alpha);
 
-void mul_kernel(TensorIterator& iter);
+void mul_kernel(TensorIteratorBase& iter);
 
-void div_kernel(TensorIterator& iter);
+void div_kernel(TensorIteratorBase& iter);
+
+void remainder_kernel(TensorIteratorBase& iter);
+
+void fmod_kernel(TensorIteratorBase& iter);
 
 } // namespace xpu
 } // namespace native

--- a/src/aten/sycl/BinaryKernels.h
+++ b/src/aten/sycl/BinaryKernels.h
@@ -14,10 +14,6 @@ void mul_kernel(TensorIteratorBase& iter);
 
 void div_kernel(TensorIteratorBase& iter);
 
-void remainder_kernel(TensorIteratorBase& iter);
-
-void fmod_kernel(TensorIteratorBase& iter);
-
 } // namespace xpu
 } // namespace native
 } // namespace at

--- a/src/aten/sycl/BinaryRemainderKernel.cpp
+++ b/src/aten/sycl/BinaryRemainderKernel.cpp
@@ -1,0 +1,76 @@
+#include <ATen/ATen.h>
+#include <ATen/Dispatch.h>
+#include <ATen/native/TensorIterator.h>
+#include <aten/sycl/Loops.h>
+
+namespace at {
+namespace native {
+namespace xpu {
+
+template <typename scalar_t>
+struct RemainderIntegralFunctor {
+  scalar_t operator()(scalar_t a, scalar_t b) const {
+    scalar_t r = a % b;
+    if (r != 0 && c10::signs_differ(r, b)) {
+      r += b;
+    }
+    return r;
+  }
+};
+
+template <typename scalar_t>
+struct RemainderFloatingFunctor {
+  scalar_t operator()(scalar_t a, scalar_t b) const
+      __ubsan_ignore_float_divide_by_zero__ {
+    auto mod = std::fmod(a, b);
+    if (mod != 0 && c10::signs_differ(b, mod)) {
+      mod += b;
+    }
+    return mod;
+  }
+};
+
+template <typename scalar_t>
+struct FmodIntegralFunctor {
+  scalar_t operator()(scalar_t a, scalar_t b) const {
+    return a % b;
+  }
+};
+
+template <typename scalar_t>
+struct FmodFloatingFunctor {
+  scalar_t operator()(scalar_t a, scalar_t b) const
+      __ubsan_ignore_float_divide_by_zero__ {
+    return ::fmod(a, b);
+  }
+};
+
+void remainder_kernel(TensorIteratorBase& iter) {
+  if (isIntegralType(iter.common_dtype(), /*includeBool*/ false)) {
+    AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "remainder_xpu", [&]() {
+      gpu_kernel_with_scalars(iter, RemainderIntegralFunctor<scalar_t>());
+    });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        kHalf, kBFloat16, iter.common_dtype(), "remainder_xpu", [&]() {
+          gpu_kernel_with_scalars(iter, RemainderFloatingFunctor<scalar_t>());
+        });
+  }
+}
+
+void fmod_kernel(TensorIteratorBase& iter) {
+  if (isIntegralType(iter.common_dtype(), /*includeBool*/ false)) {
+    AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "fmod_xpu", [&]() {
+      gpu_kernel_with_scalars(iter, FmodIntegralFunctor<scalar_t>());
+    });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        kHalf, kBFloat16, iter.common_dtype(), "fmod_xpu", [&]() {
+          gpu_kernel_with_scalars(iter, FmodFloatingFunctor<scalar_t>());
+        });
+  }
+}
+
+} // namespace xpu
+} // namespace native
+} // namespace at

--- a/src/aten/sycl/BinaryRemainderKernel.h
+++ b/src/aten/sycl/BinaryRemainderKernel.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <ATen/native/TensorIterator.h>
+
+namespace at {
+namespace native {
+namespace xpu {
+
+void remainder_kernel(TensorIteratorBase& iter);
+
+void fmod_kernel(TensorIteratorBase& iter);
+
+} // namespace xpu
+} // namespace native
+} // namespace at

--- a/src/aten/sycl/PowKernels.cpp
+++ b/src/aten/sycl/PowKernels.cpp
@@ -1,0 +1,277 @@
+#include <ATen/ATen.h>
+#include <ATen/Dispatch.h>
+#include <ATen/native/TensorIterator.h>
+
+#include <aten/sycl/Loops.h>
+#include <aten/sycl/UnaryKernels.h>
+
+namespace at {
+namespace native {
+namespace xpu {
+
+void pow_tensor_scalar_kernel(
+    TensorIteratorBase& iter,
+    const Scalar& exp_scalar);
+
+template <typename T>
+inline T powi(T a, T b) {
+  T result = 1;
+  while (b) {
+    if (b & 1) {
+      result *= a;
+    }
+    b /= 2;
+    a *= a;
+  }
+  return result;
+}
+
+template <typename scalar_t>
+inline scalar_t pow_impl(scalar_t a, scalar_t b) {
+  return powi<scalar_t>(a, b);
+}
+
+template <>
+inline float pow_impl<float>(float a, float b) {
+  return std::pow(a, b);
+}
+
+template <>
+inline double pow_impl<double>(double a, double b) {
+  return std::pow(a, b);
+}
+
+template <>
+inline at::Half pow_impl<at::Half>(at::Half a, at::Half b) {
+  return std::pow(float(a), float(b));
+}
+
+template <>
+inline at::BFloat16 pow_impl<at::BFloat16>(at::BFloat16 a, at::BFloat16 b) {
+  return std::pow(float(a), float(b));
+}
+
+template <>
+inline c10::complex<float> pow_impl<c10::complex<float>>(
+    c10::complex<float> a,
+    c10::complex<float> b) {
+  return static_cast<c10::complex<float>>(std::pow(
+      static_cast<std::complex<float>>(a),
+      static_cast<std::complex<float>>(b)));
+}
+
+template <>
+inline c10::complex<double> pow_impl<c10::complex<double>>(
+    c10::complex<double> a,
+    c10::complex<double> b) {
+  return static_cast<c10::complex<double>>(std::pow(
+      static_cast<std::complex<double>>(a),
+      static_cast<std::complex<double>>(b)));
+}
+
+template <typename scalar_t>
+struct PowTensorTensorFunctor {
+  scalar_t operator()(scalar_t base, scalar_t exp) const {
+    return pow_impl<scalar_t>(base, exp);
+  }
+};
+
+template <typename scalar_t>
+struct PowScalarTensorFunctor {
+  scalar_t operator()(scalar_t exp) const {
+    return pow_impl<scalar_t>(base_, exp);
+  }
+  PowScalarTensorFunctor(scalar_t base) : base_(base) {}
+
+ private:
+  scalar_t base_;
+};
+
+template <typename T>
+struct PowScalarTensorFunctor<c10::complex<T>> {
+  c10::complex<T> operator()(c10::complex<T> exp) const {
+    return std::exp(fct_ * exp);
+  }
+  PowScalarTensorFunctor(c10::complex<T> base) {
+    fct_ = std::log(base);
+  }
+
+ private:
+  c10::complex<T> fct_;
+};
+
+template <>
+struct PowScalarTensorFunctor<c10::complex<at::Half>> {
+  using opmath_t = at::opmath_type<c10::complex<at::Half>>;
+  c10::complex<at::Half> operator()(c10::complex<at::Half> exp) const {
+    return std::exp(fct_ * opmath_t{exp});
+  }
+  PowScalarTensorFunctor(c10::complex<at::Half> base) {
+    fct_ = std::log(opmath_t{base});
+  }
+
+ private:
+  opmath_t fct_;
+};
+
+template <typename scalar_t>
+void pow_scalar_tensor_impl(TensorIteratorBase& iter, scalar_t base) {
+  auto f = PowScalarTensorFunctor<scalar_t>(base);
+  gpu_kernel(iter, f);
+}
+
+template <typename scalar_t, typename opmath_t>
+struct PowChalfTensorScalarFunctor {
+  scalar_t operator()(scalar_t base) const {
+    return std::pow(opmath_t{base}, exp_);
+  }
+  PowChalfTensorScalarFunctor(opmath_t exp) : exp_(exp) {}
+
+ private:
+  opmath_t exp_;
+};
+
+void pow_chalf_tensor_scalar_impl(
+    TensorIteratorBase& iter,
+    const Scalar& exp_scalar) {
+  using scalar_t = c10::complex<at::Half>;
+  using opmath_t = at::opmath_type<scalar_t>;
+  auto exp = exp_scalar.to<opmath_t>();
+  auto f = PowChalfTensorScalarFunctor<scalar_t, opmath_t>(exp);
+  gpu_kernel(iter, f);
+}
+
+void pow_tensor_tensor_kernel(TensorIteratorBase& iter) {
+  auto common_dtype = iter.common_dtype();
+  if (common_dtype == kComplexHalf) {
+    using scalar_t = c10::complex<at::Half>;
+    if (iter.is_cpu_scalar(1)) {
+      const auto base = iter.scalar_value<scalar_t>(1);
+      iter.remove_operand(1);
+      pow_scalar_tensor_impl(iter, base);
+    } else if (iter.is_cpu_scalar(2)) {
+      const auto exp = iter.scalar_value<scalar_t>(2);
+      iter.remove_operand(2);
+      pow_chalf_tensor_scalar_impl(iter, exp);
+    } else {
+      using opmath_t = at::opmath_type<scalar_t>;
+      TORCH_INTERNAL_ASSERT(!iter.is_cpu_scalar(1) && !iter.is_cpu_scalar(2));
+      auto f = PowTensorTensorFunctor<opmath_t>();
+      gpu_kernel(iter, f);
+    }
+  } else {
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+        kHalf, kBFloat16, iter.common_dtype(), "pow_xpu", [&] {
+          if (iter.is_cpu_scalar(1)) {
+            const auto base = iter.scalar_value<scalar_t>(1);
+            iter.remove_operand(1);
+            pow_scalar_tensor_impl(iter, base);
+          } else if (iter.is_cpu_scalar(2)) {
+            const auto exp = iter.scalar_value<scalar_t>(2);
+            iter.remove_operand(2);
+            pow_tensor_scalar_kernel(iter, exp);
+          } else {
+            gpu_kernel(iter, PowTensorTensorFunctor<scalar_t>());
+          }
+        });
+  }
+}
+
+template <typename scalar_t>
+struct PowImplUnaryFunctor1 {
+  scalar_t operator()(scalar_t base) const {
+    return base * base;
+  }
+};
+
+template <typename scalar_t>
+struct PowImplUnaryFunctor2 {
+  scalar_t operator()(scalar_t base) const {
+    return base * base * base;
+  }
+};
+
+template <typename scalar_t>
+struct PowImplUnaryFunctor3 {
+  scalar_t operator()(scalar_t base) const {
+    return 1.0 / (base * base);
+  }
+};
+
+template <typename scalar_t>
+struct PowImplUnaryFunctor4 {
+  scalar_t operator()(scalar_t base) const {
+    return 1.0 / (base * base);
+  }
+};
+
+template <typename scalar_t>
+struct PowScalarTensorFunctor2 {
+  scalar_t operator()(scalar_t base) const {
+    return pow_impl<scalar_t>(base, exp_);
+  }
+  PowScalarTensorFunctor2(scalar_t exp) : exp_(exp) {}
+
+ private:
+  scalar_t exp_;
+};
+
+template <typename Base_type, typename Exp_type>
+void pow_tensor_scalar_kernel_impl(TensorIteratorBase& iter, Exp_type exp) {
+  const auto d_exp = static_cast<double>(exp);
+  // .5 (sqrt), -.5 (rsqrt) and -1 (reciprocal) specializations are handled
+  // in pow_tensor_scalar_kernel
+  if (d_exp == 2) {
+    gpu_kernel(iter, PowImplUnaryFunctor1<Base_type>());
+  } else if (d_exp == 3) {
+    gpu_kernel(iter, PowImplUnaryFunctor2<Base_type>());
+  } else if (d_exp == -2) {
+    gpu_kernel(iter, PowImplUnaryFunctor3<Base_type>());
+  } else {
+    auto f = PowScalarTensorFunctor2<Base_type>(exp);
+    gpu_kernel(iter, f);
+  }
+}
+
+void pow_tensor_scalar_kernel(
+    TensorIteratorBase& iter,
+    const Scalar& exp_scalar) {
+  // Dispatch to fast specialization for sqrt, rsqrt and reciprocal
+  if (!exp_scalar.isComplex()) {
+    if (exp_scalar.equal(.5)) {
+      return sqrt_kernel(iter);
+    } else if (exp_scalar.equal(-0.5)) {
+      return rsqrt_kernel(iter);
+    } else if (exp_scalar.equal(-1.0)) {
+      return reciprocal_kernel(iter);
+    }
+  }
+  if (isComplexType(iter.common_dtype()) || exp_scalar.isComplex()) {
+    if (iter.common_dtype() == kComplexHalf) {
+      pow_chalf_tensor_scalar_impl(iter, exp_scalar);
+      return;
+    }
+    AT_DISPATCH_COMPLEX_TYPES(iter.common_dtype(), "pow_xpu", [&]() {
+      const auto exp = exp_scalar.to<scalar_t>();
+      gpu_kernel(iter, PowScalarTensorFunctor2<scalar_t>(exp));
+    });
+  } else if (
+      isFloatingType(iter.common_dtype()) || exp_scalar.isIntegral(false)) {
+    AT_DISPATCH_ALL_TYPES_AND2(
+        kHalf, kBFloat16, iter.common_dtype(), "pow_xpu", [&]() {
+          const auto exp = exp_scalar.to<scalar_t>();
+          pow_tensor_scalar_kernel_impl<scalar_t>(iter, exp);
+        });
+  } else {
+    TORCH_INTERNAL_ASSERT(
+        false,
+        "invalid combination of type in Pow function, common dtype:",
+        iter.common_dtype(),
+        "exp is integral?",
+        exp_scalar.isIntegral(false));
+  }
+}
+
+} // namespace xpu
+} // namespace native
+} // namespace at

--- a/src/aten/sycl/PowKernels.h
+++ b/src/aten/sycl/PowKernels.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <ATen/native/TensorIterator.h>
+
+namespace at {
+namespace native {
+namespace xpu {
+
+void pow_tensor_scalar_kernel(
+    TensorIteratorBase& iter,
+    const Scalar& exp_scalar);
+
+void pow_tensor_tensor_kernel(TensorIteratorBase& iter);
+
+} // namespace xpu
+} // namespace native
+} // namespace at

--- a/src/aten/sycl/UnaryKernels.cpp
+++ b/src/aten/sycl/UnaryKernels.cpp
@@ -146,7 +146,7 @@ void sin_kernel(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
     AT_DISPATCH_COMPLEX_TYPES_AND(
-        kComplexHalf, common_dtype, "sin_name", [&]() {
+        kComplexHalf, common_dtype, "sin_xpu", [&]() {
           using opmath_t = at::opmath_type<scalar_t>;
           gpu_kernel(iter, SinFunctor<opmath_t>());
         });

--- a/src/aten/sycl/UnaryKernels.cpp
+++ b/src/aten/sycl/UnaryKernels.cpp
@@ -84,6 +84,46 @@ struct NegFunctor {
   }
 };
 
+template <typename scalar_t>
+inline scalar_t reciprocal_wrapper(scalar_t a) {
+  return static_cast<scalar_t>(1) / a;
+}
+
+template <typename T>
+inline c10::complex<T> reciprocal_wrapper(c10::complex<T> v) {
+  // Handle extreme cases for numpy compatibility
+  auto both_inf = [](T real, T imag) {
+    return (std::isinf(real) && std::isinf(imag));
+  };
+
+  auto either_inf = [](T real, T imag) {
+    return std::isinf(real) || std::isinf(imag);
+  };
+
+  auto either_nan = [](T real, T imag) {
+    return std::isnan(real) || std::isnan(imag);
+  };
+
+  if (either_nan(v.real(), v.imag()) || both_inf(v.real(), v.imag())) {
+    // If either is Nan or both are infinite, return {nan, nan}
+    return {
+        std::numeric_limits<T>::quiet_NaN(),
+        std::numeric_limits<T>::quiet_NaN()};
+  } else if (either_inf(v.real(), v.imag())) {
+    // If either is Inf, return {0, 0}
+    return {0, 0};
+  }
+  const c10::complex<T> one = c10::complex<T>(1.0, 0);
+  return one / v;
+}
+
+template <typename scalar_t>
+struct ReciprocalFunctor {
+  scalar_t operator()(scalar_t a) const {
+    return reciprocal_wrapper<scalar_t>(a);
+  }
+};
+
 void abs_kernel(TensorIteratorBase& iter) {
   auto dtype = iter.dtype();
   if (at::isComplexType(dtype)) {
@@ -218,6 +258,15 @@ void neg_kernel(TensorIteratorBase& iter) {
           gpu_kernel(iter, NegFunctor<scalar_t>());
         });
   }
+}
+
+void reciprocal_kernel(TensorIteratorBase& iter) {
+  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
+      ScalarType::Half,
+      ScalarType::BFloat16,
+      iter.common_dtype(),
+      "reciprocal_xpu",
+      [&]() { gpu_kernel(iter, ReciprocalFunctor<scalar_t>()); });
 }
 
 } // namespace at::native::xpu

--- a/src/aten/sycl/UnaryKernels.cpp
+++ b/src/aten/sycl/UnaryKernels.cpp
@@ -18,6 +18,72 @@ struct AbsFunctor {
   }
 };
 
+template <typename scalar_t>
+struct SinFunctor {
+  scalar_t operator()(const scalar_t a) const {
+    return std::sin(a);
+  }
+};
+
+template <typename scalar_t>
+struct CosFunctor {
+  scalar_t operator()(const scalar_t a) const {
+    return std::cos(a);
+  }
+};
+
+template <typename scalar_t>
+struct LogFunctor {
+  scalar_t operator()(scalar_t a) const {
+    return std::log(a);
+  }
+};
+
+template <typename scalar_t>
+struct SqrtFunctor {
+  scalar_t operator()(scalar_t a) const {
+    return std::sqrt(a);
+  }
+};
+
+template <typename scalar_t>
+struct RsqrtFunctor {
+  scalar_t operator()(scalar_t a) const {
+    return sycl::rsqrt(float(a));
+  }
+};
+
+template <>
+struct RsqrtFunctor<double> {
+  double operator()(double a) const {
+    return sycl::rsqrt(a);
+  }
+};
+
+template <typename T>
+struct RsqrtFunctor<c10::complex<T>> {
+  c10::complex<T> operator()(c10::complex<T> a) const {
+    return c10::complex<T>(1.0, 0) /
+        static_cast<c10::complex<T>>(
+               std::sqrt(static_cast<std::complex<T>>(a)));
+  }
+};
+
+template <typename scalar_t>
+struct TanhFunctor {
+  scalar_t operator()(scalar_t a) const {
+    using opmath_t = at::opmath_type<scalar_t>;
+    return std::tanh(static_cast<opmath_t>(a));
+  }
+};
+
+template <typename scalar_t>
+struct NegFunctor {
+  scalar_t operator()(scalar_t a) const {
+    return -a;
+  }
+};
+
 void abs_kernel(TensorIteratorBase& iter) {
   auto dtype = iter.dtype();
   if (at::isComplexType(dtype)) {
@@ -33,6 +99,124 @@ void abs_kernel(TensorIteratorBase& iter) {
         iter.dtype(),
         "abs_xpu",
         [&]() { gpu_kernel(iter, AbsFunctor<scalar_t>()); });
+  }
+}
+
+void sin_kernel(TensorIteratorBase& iter) {
+  auto common_dtype = iter.common_dtype();
+  if (at::isComplexType(common_dtype)) {
+    AT_DISPATCH_COMPLEX_TYPES_AND(
+        kComplexHalf, common_dtype, "sin_name", [&]() {
+          using opmath_t = at::opmath_type<scalar_t>;
+          gpu_kernel(iter, SinFunctor<opmath_t>());
+        });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        ScalarType::Half, ScalarType::BFloat16, common_dtype, "sin_xpu", [&]() {
+          gpu_kernel(iter, SinFunctor<scalar_t>());
+        });
+  }
+}
+
+void cos_kernel(TensorIteratorBase& iter) {
+  auto common_dtype = iter.common_dtype();
+  if (at::isComplexType(common_dtype)) {
+    AT_DISPATCH_COMPLEX_TYPES_AND(
+        kComplexHalf, common_dtype, "cos_name", [&]() {
+          using opmath_t = at::opmath_type<scalar_t>;
+          gpu_kernel(iter, CosFunctor<opmath_t>());
+        });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        ScalarType::Half, ScalarType::BFloat16, common_dtype, "cos_xpu", [&]() {
+          gpu_kernel(iter, CosFunctor<scalar_t>());
+        });
+  }
+}
+
+void log_kernel(TensorIteratorBase& iter) {
+  auto common_dtype = iter.common_dtype();
+  if (at::isComplexType(common_dtype)) {
+    AT_DISPATCH_COMPLEX_TYPES_AND(
+        kComplexHalf, iter.common_dtype(), "log_xpu", [&]() {
+          using opmath_t = at::opmath_type<scalar_t>;
+          gpu_kernel(iter, LogFunctor<opmath_t>());
+        });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        ScalarType::Half,
+        ScalarType::BFloat16,
+        iter.common_dtype(),
+        "log_xpu",
+        [&]() { gpu_kernel(iter, LogFunctor<scalar_t>()); });
+  }
+}
+
+void sqrt_kernel(TensorIteratorBase& iter) {
+  auto common_dtype = iter.common_dtype();
+  if (at::isComplexType(common_dtype)) {
+    AT_DISPATCH_COMPLEX_TYPES_AND(
+        kComplexHalf, common_dtype, "sqrt_xpu", [&]() {
+          using opmath_t = at::opmath_type<scalar_t>;
+          gpu_kernel(iter, SqrtFunctor<opmath_t>());
+        });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        ScalarType::Half,
+        ScalarType::BFloat16,
+        common_dtype,
+        "sqrt_xpu",
+        [&]() { gpu_kernel(iter, SqrtFunctor<scalar_t>()); });
+  }
+}
+
+void rsqrt_kernel(TensorIteratorBase& iter) {
+  auto common_dtype = iter.common_dtype();
+  if (at::isComplexType(common_dtype)) {
+    AT_DISPATCH_COMPLEX_TYPES_AND(
+        kComplexHalf, common_dtype, "rsqrt_xpu", [&]() {
+          using opmath_t = at::opmath_type<scalar_t>;
+          gpu_kernel(iter, RsqrtFunctor<opmath_t>());
+        });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        ScalarType::BFloat16,
+        ScalarType::Half,
+        iter.common_dtype(),
+        "rsqrt_xpu",
+        [&]() { gpu_kernel(iter, RsqrtFunctor<scalar_t>()); });
+  }
+}
+
+void tanh_kernel(TensorIteratorBase& iter) {
+  auto common_dtype = iter.common_dtype();
+  if (at::isComplexType(common_dtype)) {
+    AT_DISPATCH_COMPLEX_TYPES_AND(
+        kComplexHalf, common_dtype, "tanh_name", [&]() {
+          using opmath_t = at::opmath_type<scalar_t>;
+          gpu_kernel(iter, TanhFunctor<opmath_t>());
+        });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        ScalarType::Half,
+        ScalarType::BFloat16,
+        common_dtype,
+        "tanh_xpu",
+        [&]() { gpu_kernel(iter, TanhFunctor<scalar_t>()); });
+  }
+}
+
+void neg_kernel(TensorIteratorBase& iter) {
+  auto dtype = iter.dtype();
+  if (at::isComplexType(dtype)) {
+    AT_DISPATCH_COMPLEX_TYPES_AND(kComplexHalf, dtype, "neg_xpu", [&]() {
+      gpu_kernel(iter, NegFunctor<scalar_t>());
+    });
+  } else {
+    AT_DISPATCH_ALL_TYPES_AND2(
+        ScalarType::Half, ScalarType::BFloat16, dtype, "neg_xpu", [&]() {
+          gpu_kernel(iter, NegFunctor<scalar_t>());
+        });
   }
 }
 

--- a/src/aten/sycl/UnaryKernels.cpp
+++ b/src/aten/sycl/UnaryKernels.cpp
@@ -162,7 +162,7 @@ void cos_kernel(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
     AT_DISPATCH_COMPLEX_TYPES_AND(
-        kComplexHalf, common_dtype, "cos_name", [&]() {
+        kComplexHalf, common_dtype, "cos_xpu", [&]() {
           using opmath_t = at::opmath_type<scalar_t>;
           gpu_kernel(iter, CosFunctor<opmath_t>());
         });

--- a/src/aten/sycl/UnaryKernels.cpp
+++ b/src/aten/sycl/UnaryKernels.cpp
@@ -232,7 +232,7 @@ void tanh_kernel(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
     AT_DISPATCH_COMPLEX_TYPES_AND(
-        kComplexHalf, common_dtype, "tanh_name", [&]() {
+        kComplexHalf, common_dtype, "tanh_xpu", [&]() {
           using opmath_t = at::opmath_type<scalar_t>;
           gpu_kernel(iter, TanhFunctor<opmath_t>());
         });

--- a/src/aten/sycl/UnaryKernels.cpp
+++ b/src/aten/sycl/UnaryKernels.cpp
@@ -33,13 +33,6 @@ struct CosFunctor {
 };
 
 template <typename scalar_t>
-struct LogFunctor {
-  scalar_t operator()(scalar_t a) const {
-    return std::log(a);
-  }
-};
-
-template <typename scalar_t>
 struct SqrtFunctor {
   scalar_t operator()(scalar_t a) const {
     return std::sqrt(a);
@@ -145,11 +138,10 @@ void abs_kernel(TensorIteratorBase& iter) {
 void sin_kernel(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
-    AT_DISPATCH_COMPLEX_TYPES_AND(
-        kComplexHalf, common_dtype, "sin_xpu", [&]() {
-          using opmath_t = at::opmath_type<scalar_t>;
-          gpu_kernel(iter, SinFunctor<opmath_t>());
-        });
+    AT_DISPATCH_COMPLEX_TYPES_AND(kComplexHalf, common_dtype, "sin_xpu", [&]() {
+      using opmath_t = at::opmath_type<scalar_t>;
+      gpu_kernel(iter, SinFunctor<opmath_t>());
+    });
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(
         ScalarType::Half, ScalarType::BFloat16, common_dtype, "sin_xpu", [&]() {
@@ -161,34 +153,15 @@ void sin_kernel(TensorIteratorBase& iter) {
 void cos_kernel(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
-    AT_DISPATCH_COMPLEX_TYPES_AND(
-        kComplexHalf, common_dtype, "cos_xpu", [&]() {
-          using opmath_t = at::opmath_type<scalar_t>;
-          gpu_kernel(iter, CosFunctor<opmath_t>());
-        });
+    AT_DISPATCH_COMPLEX_TYPES_AND(kComplexHalf, common_dtype, "cos_xpu", [&]() {
+      using opmath_t = at::opmath_type<scalar_t>;
+      gpu_kernel(iter, CosFunctor<opmath_t>());
+    });
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(
         ScalarType::Half, ScalarType::BFloat16, common_dtype, "cos_xpu", [&]() {
           gpu_kernel(iter, CosFunctor<scalar_t>());
         });
-  }
-}
-
-void log_kernel(TensorIteratorBase& iter) {
-  auto common_dtype = iter.common_dtype();
-  if (at::isComplexType(common_dtype)) {
-    AT_DISPATCH_COMPLEX_TYPES_AND(
-        kComplexHalf, iter.common_dtype(), "log_xpu", [&]() {
-          using opmath_t = at::opmath_type<scalar_t>;
-          gpu_kernel(iter, LogFunctor<opmath_t>());
-        });
-  } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(
-        ScalarType::Half,
-        ScalarType::BFloat16,
-        iter.common_dtype(),
-        "log_xpu",
-        [&]() { gpu_kernel(iter, LogFunctor<scalar_t>()); });
   }
 }
 

--- a/src/aten/sycl/UnaryKernels.h
+++ b/src/aten/sycl/UnaryKernels.h
@@ -20,4 +20,6 @@ void tanh_kernel(TensorIteratorBase& iter);
 
 void neg_kernel(TensorIteratorBase& iter);
 
+void reciprocal_kernel(TensorIteratorBase& iter);
+
 } // namespace at::native::xpu

--- a/src/aten/sycl/UnaryKernels.h
+++ b/src/aten/sycl/UnaryKernels.h
@@ -10,8 +10,6 @@ void sin_kernel(TensorIteratorBase& iter);
 
 void cos_kernel(TensorIteratorBase& iter);
 
-void log_kernel(TensorIteratorBase& iter);
-
 void sqrt_kernel(TensorIteratorBase& iter);
 
 void rsqrt_kernel(TensorIteratorBase& iter);

--- a/src/aten/sycl/UnaryKernels.h
+++ b/src/aten/sycl/UnaryKernels.h
@@ -6,4 +6,18 @@ namespace at::native::xpu {
 
 void abs_kernel(TensorIteratorBase& iter);
 
+void sin_kernel(TensorIteratorBase& iter);
+
+void cos_kernel(TensorIteratorBase& iter);
+
+void log_kernel(TensorIteratorBase& iter);
+
+void sqrt_kernel(TensorIteratorBase& iter);
+
+void rsqrt_kernel(TensorIteratorBase& iter);
+
+void tanh_kernel(TensorIteratorBase& iter);
+
+void neg_kernel(TensorIteratorBase& iter);
+
 } // namespace at::native::xpu

--- a/src/aten/sycl/UnaryLogKernels.cpp
+++ b/src/aten/sycl/UnaryLogKernels.cpp
@@ -1,0 +1,39 @@
+#include <ATen/ATen.h>
+
+#include <ATen/Dispatch.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/native/TensorIterator.h>
+#include <c10/core/ScalarType.h>
+
+#include <aten/sycl/CopyKernel.h>
+#include <aten/sycl/Loops.h>
+#include <comm/SYCLContext.h>
+
+namespace at::native::xpu {
+
+template <typename scalar_t>
+struct LogFunctor {
+  scalar_t operator()(scalar_t a) const {
+    return std::log(a);
+  }
+};
+
+void log_kernel(TensorIteratorBase& iter) {
+  auto common_dtype = iter.common_dtype();
+  if (at::isComplexType(common_dtype)) {
+    AT_DISPATCH_COMPLEX_TYPES_AND(
+        kComplexHalf, iter.common_dtype(), "log_xpu", [&]() {
+          using opmath_t = at::opmath_type<scalar_t>;
+          gpu_kernel(iter, LogFunctor<opmath_t>());
+        });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        ScalarType::Half,
+        ScalarType::BFloat16,
+        iter.common_dtype(),
+        "log_xpu",
+        [&]() { gpu_kernel(iter, LogFunctor<scalar_t>()); });
+  }
+}
+
+} // namespace at::native::xpu

--- a/src/aten/sycl/UnaryLogKernels.h
+++ b/src/aten/sycl/UnaryLogKernels.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <ATen/native/TensorIterator.h>
+
+namespace at::native::xpu {
+
+void log_kernel(TensorIteratorBase& iter);
+
+} // namespace at::native::xpu

--- a/test/python/examples/test_binary.py
+++ b/test/python/examples/test_binary.py
@@ -59,3 +59,230 @@ class TestSimpleBinary(TestCase):
         c_cpu = a_cpu / b_cpu
         self.assertEqual(c_cpu.dtype, c_xpu.dtype) # assume float
         self.assertEqual(c_cpu, c_xpu.to(cpu_device))
+    
+    def test_binary_div_channels_last(self, dtype=torch.float):
+        shapes = [
+            (1, 2, 3, 4),
+            (2, 2, 3, 3),
+            (4, 4, 4, 4),
+            (4, 4, 1, 1),
+            (4, 1, 4, 4),
+            (4, 1, 4, 1),
+            (4, 1, 1, 4),
+            (1, 4, 1, 4),
+            (1, 4, 4, 1),
+            (4, 1, 1, 1),
+        ]
+        for shape in shapes:
+            N, C, H, W = shape[0], shape[1], shape[2], shape[3]
+            a_cpu = torch.randn(N, C, H, W)
+            b_cpu = torch.randn(N, C, H, W)
+            a_xpu = a_cpu.to("xpu").to(memory_format=torch.contiguous_format)
+            b_xpu = b_cpu.to("xpu").to(memory_format=torch.contiguous_format)
+
+            a_cpu.div_(b_cpu)
+            a_xpu.div_(b_xpu)
+            self.assertEqual(a_cpu, a_xpu.cpu())
+            if 1 == C or (1 == H and 1 == W):
+                self.assertEqual(a_xpu.is_contiguous(), True)
+                self.assertEqual(
+                    a_xpu.is_contiguous(memory_format=torch.channels_last), True
+                )
+            else:
+                self.assertEqual(a_xpu.is_contiguous(), True)
+                self.assertEqual(
+                    a_xpu.is_contiguous(memory_format=torch.channels_last), False
+                )
+
+            a_cpu = torch.randn(N, C, H, W)
+            b_cpu = torch.randn(N, C, H, W)
+            a_xpu = a_cpu.to("xpu").to(memory_format=torch.channels_last)
+            b_xpu = b_cpu.to("xpu").to(memory_format=torch.channels_last)
+
+            a_cpu.div_(b_cpu)
+            a_xpu.div_(b_xpu)
+            self.assertEqual(a_cpu, a_xpu.cpu())
+            if 1 == C or (1 == H and 1 == W):
+                self.assertEqual(a_xpu.is_contiguous(), True)
+                self.assertEqual(
+                    a_xpu.is_contiguous(memory_format=torch.channels_last), True
+                )
+            else:
+                self.assertEqual(a_xpu.is_contiguous(), False)
+                self.assertEqual(
+                    a_xpu.is_contiguous(memory_format=torch.channels_last), True
+                )
+
+            a_cpu = torch.randn(N, C, H, W)
+            b_cpu = torch.randn(N, C, H, W)
+            a_xpu = a_cpu.to("xpu").to(memory_format=torch.channels_last)
+            b_xpu = b_cpu.to("xpu").to(memory_format=torch.contiguous_format)
+
+            a_cpu.div_(b_cpu)
+            a_xpu.div_(b_xpu)
+            self.assertEqual(a_cpu, a_xpu.cpu())
+            if 1 == C or (1 == H and 1 == W):
+                self.assertEqual(a_xpu.is_contiguous(), True)
+                self.assertEqual(
+                    a_xpu.is_contiguous(memory_format=torch.channels_last), True
+                )
+            else:
+                self.assertEqual(a_xpu.is_contiguous(), False)
+                self.assertEqual(
+                    a_xpu.is_contiguous(memory_format=torch.channels_last), True
+                )
+
+            a_cpu = torch.randn(N, C, H, W)
+            b_cpu = torch.randn(N, C, H, W)
+            a_xpu = a_cpu.to("xpu").to(memory_format=torch.contiguous_format)
+            b_xpu = b_cpu.to("xpu").to(memory_format=torch.channels_last)
+
+            a_cpu.div_(b_cpu)
+            a_xpu.div_(b_xpu)
+            self.assertEqual(a_cpu, a_xpu.cpu())
+            if 1 == C or (1 == H and 1 == W):
+                self.assertEqual(a_xpu.is_contiguous(), True)
+                self.assertEqual(
+                    a_xpu.is_contiguous(memory_format=torch.channels_last), True
+                )
+            else:
+                self.assertEqual(a_xpu.is_contiguous(), True)
+                self.assertEqual(
+                    a_xpu.is_contiguous(memory_format=torch.channels_last), False
+                )
+
+            a_cpu = torch.randn(N, C, H, W)
+            b_cpu = torch.randn(N, C, H, W)
+            y_cpu = a_cpu / b_cpu
+            a_xpu = a_cpu.to("xpu").to(memory_format=torch.contiguous_format)
+            b_xpu = b_cpu.to("xpu").to(memory_format=torch.contiguous_format)
+            y_xpu = a_xpu / b_xpu
+            self.assertEqual(y_cpu, y_xpu.cpu())
+            if 1 == C or (1 == H and 1 == W):
+                self.assertEqual(a_xpu.is_contiguous(), True)
+                self.assertEqual(
+                    a_xpu.is_contiguous(memory_format=torch.channels_last), True
+                )
+            else:
+                self.assertEqual(a_xpu.is_contiguous(), True)
+                self.assertEqual(
+                    a_xpu.is_contiguous(memory_format=torch.channels_last), False
+                )
+
+            a_cpu = torch.randn(N, C, H, W)
+            b_cpu = torch.randn(N, C, H, W)
+            y_cpu = a_cpu / b_cpu
+            a_xpu = a_cpu.to("xpu").to(memory_format=torch.channels_last)
+            b_xpu = b_cpu.to("xpu").to(memory_format=torch.channels_last)
+            y_xpu = a_xpu / b_xpu
+            self.assertEqual(y_cpu, y_xpu.cpu())
+            if 1 == C or (1 == H and 1 == W):
+                self.assertEqual(a_xpu.is_contiguous(), True)
+                self.assertEqual(
+                    a_xpu.is_contiguous(memory_format=torch.channels_last), True
+                )
+            else:
+                self.assertEqual(a_xpu.is_contiguous(), False)
+                self.assertEqual(
+                    a_xpu.is_contiguous(memory_format=torch.channels_last), True
+                )
+
+            a_cpu = torch.randn(N, C, H, W)
+            b_cpu = torch.randn(N, C, H, W)
+            y_cpu = a_cpu / b_cpu
+            a_xpu = a_cpu.to("xpu").to(memory_format=torch.channels_last)
+            b_xpu = b_cpu.to("xpu").to(memory_format=torch.contiguous_format)
+            y_xpu = a_xpu / b_xpu
+            self.assertEqual(y_cpu, y_xpu.cpu())
+            if 1 == C or (1 == H and 1 == W):
+                self.assertEqual(a_xpu.is_contiguous(), True)
+                self.assertEqual(
+                    a_xpu.is_contiguous(memory_format=torch.channels_last), True
+                )
+            else:
+                self.assertEqual(a_xpu.is_contiguous(), False)
+                self.assertEqual(
+                    a_xpu.is_contiguous(memory_format=torch.channels_last), True
+                )
+
+            a_cpu = torch.randn(N, C, H, W)
+            b_cpu = torch.randn(N, C, H, W)
+            y_cpu = a_cpu / b_cpu
+            a_xpu = a_cpu.to("xpu").to(memory_format=torch.contiguous_format)
+            b_xpu = b_cpu.to("xpu").to(memory_format=torch.channels_last)
+            y_xpu = a_xpu / b_xpu
+            self.assertEqual(y_cpu, y_xpu.cpu())
+            if 1 == C or (1 == H and 1 == W):
+                self.assertEqual(a_xpu.is_contiguous(), True)
+                self.assertEqual(
+                    a_xpu.is_contiguous(memory_format=torch.channels_last), True
+                )
+            else:
+                self.assertEqual(a_xpu.is_contiguous(), True)
+                self.assertEqual(
+                    a_xpu.is_contiguous(memory_format=torch.channels_last), False
+                )
+    
+    def test_pow(self, dtype=torch.float):
+        x_cpu = torch.tensor(([2.5, 3.1, 1.3]), dtype=torch.float, device=cpu_device)
+        x_xpu = torch.tensor(
+            ([2.5, 3.1, 1.3]), dtype=torch.float, device=xpu_device
+        )
+        y_cpu = torch.tensor(([3.0, 3.0, 3.0]), dtype=torch.float, device=cpu_device)
+        y_xpu = torch.tensor(
+            ([3.0, 3.0, 3.0]), dtype=torch.float, device=xpu_device
+        )
+        self.assertEqual(torch.pow(x_cpu, y_cpu), torch.pow(x_xpu, y_xpu).cpu())
+        self.assertEqual(x_cpu.pow(y_cpu), x_xpu.pow(y_xpu).cpu())
+        self.assertEqual(x_cpu.pow_(y_cpu), x_xpu.pow_(y_xpu).cpu())
+    
+    def test_binary_op(self, dtype=torch.float):
+        x_cpu = torch.randn(5)
+
+        x_xpu = x_cpu.to(xpu_device)
+        # y_cpu1 = x_cpu.new_ones((2, 3))
+        y_cpu1 = torch.randn(5)
+        # y_cpu2 = x_cpu.new_ones((2, 3))
+        y_cpu2 = torch.randn(5)
+
+        y_cpu1_int = torch.tensor([[3, 1, 2, 3], [2, 3, 4, 1]], dtype=torch.int32)
+        # y_cpu2 = x_cpu.new_ones((2, 3))
+        y_cpu2_int = torch.tensor([[1, 5, 2, 4], [1, 1, 5, 5]], dtype=torch.int32)
+
+        y_xpu1 = y_cpu1.to(xpu_device)
+        y_xpu2 = y_cpu2.to(xpu_device)
+        y_xpu1_int = y_cpu1_int.to(xpu_device)
+        y_xpu2_int = y_cpu2_int.to(xpu_device)
+
+        x_cpu_b_1 = torch.tensor([True, True])
+        x_cpu_b_2 = torch.tensor([False, True])
+        x_xpu_b_1 = x_cpu_b_1.to(xpu_device)
+        x_xpu_b_2 = x_cpu_b_2.to(xpu_device)
+
+        print("remainder scalar y_cpu", torch.remainder(y_cpu1, 1.5))
+        print("remainder scalar y_xpu", torch.remainder(y_xpu1, 1.5).to(cpu_device))
+        self.assertEqual(
+            torch.remainder(y_cpu1, 1.5), torch.remainder(y_xpu1, 1.5).to(cpu_device)
+        )
+
+        print("remainder tensor y_cpu", torch.remainder(y_cpu1, y_cpu2))
+        print(
+            "remainder tensor y_xpu",
+            torch.remainder(y_xpu1, y_xpu2).to(cpu_device),
+        )
+        self.assertEqual(
+            torch.remainder(y_cpu1, y_cpu2),
+            torch.remainder(y_xpu1, y_xpu2).to(cpu_device),
+        )
+
+        print("fmod scalar y_cpu", torch.fmod(y_cpu1, 1.5))
+        print("fmod scalar y_xpu", torch.fmod(y_xpu1, 1.5).to(cpu_device))
+        self.assertEqual(
+            torch.fmod(y_cpu1, 1.5), torch.fmod(y_xpu1, 1.5).to(cpu_device)
+        )
+
+        print("fmod tensor y_cpu", torch.fmod(y_cpu1, y_cpu2))
+        print("fmod tensor y_xpu", torch.fmod(y_xpu1, y_xpu2).to(cpu_device))
+        self.assertEqual(
+            torch.fmod(y_cpu1, y_cpu2), torch.fmod(y_xpu1, y_xpu2).to(cpu_device)
+        )

--- a/test/python/examples/test_unary.py
+++ b/test/python/examples/test_unary.py
@@ -71,3 +71,7 @@ class TestSimpleUnary(TestCase):
     @Dtypes(all_basic_and_complex_types, [torch.bool])
     def test_neg_out(self, dtype):
         self._test_unary_out_ops('neg', dtype)
+    
+    @Dtypes(floating_and_complex_types)
+    def test_reciprocal_out(self, dtype):
+        self._test_unary_out_ops('reciprocal', dtype)

--- a/test/python/examples/test_unary.py
+++ b/test/python/examples/test_unary.py
@@ -1,51 +1,73 @@
 import torch
 from torch.testing._internal.common_utils import TestCase
 
-cpu_device = torch.device("cpu")
-xpu_device = torch.device("xpu")
+
+floating_types = [torch.float, torch.half, torch.bfloat16, torch.double]
+integral_types = [torch.int8, torch.uint8, torch.short, torch.int, torch.long, torch.bool]
+complex_types = [torch.cfloat, torch.cdouble]
+floating_and_complex_types = floating_types + complex_types
+all_basic_types = floating_types + integral_types
+all_basic_and_complex_types = floating_types + integral_types + complex_types
+
+
+class Dtypes(object):
+    def __init__(self, include_dtypes, exclude_dtypes=[]):
+        self.include_dtypes = include_dtypes
+        self.exclude_dtypes = exclude_dtypes
+    
+    def __call__(self, fn):
+        def fn_out(*args, **kwargs):
+            for dtype in self.include_dtypes:
+                if dtype in self.exclude_dtypes:
+                    continue
+                kwargs['dtype'] = dtype
+                print(f"TestSimpleUnary:{fn.__name__}:{dtype}", flush=True)
+                fn(*args, **kwargs)
+        return fn_out
 
 
 class TestSimpleUnary(TestCase):
-    def test_abs(self, dtype=torch.float):
-        data = [
-            [
-                -0.2911,
-                -1.3204,
-                -2.6425,
-                -2.4644,
-                -0.6018,
-                -0.0839,
-                -0.1322,
-                -0.4713,
-                -0.3586,
-                -0.8882,
-                0.0000,
-                0.0000,
-                1.1111,
-                2.2222,
-                3.3333,
-            ]
-        ]
-        excepted = [
-            [
-                0.2911,
-                1.3204,
-                2.6425,
-                2.4644,
-                0.6018,
-                0.0839,
-                0.1322,
-                0.4713,
-                0.3586,
-                0.8882,
-                0.0000,
-                0.0000,
-                1.1111,
-                2.2222,
-                3.3333,
-            ]
-        ]
-        x_dpcpp = torch.tensor(data, device=xpu_device)
-        y = torch.tensor(excepted, device=xpu_device)
-        y_dpcpp = torch.abs(x_dpcpp)
-        self.assertEqual(y.to(cpu_device), y_dpcpp.to(cpu_device))
+    def _test_unary_out_ops(self, fn_str, dtype):
+        a_cpu = (torch.randn(2049)*10).to(dtype)
+        a_xpu = a_cpu.xpu()
+        b_cpu = eval(f"torch.{fn_str}(a_cpu)")
+        b_xpu = eval(f"torch.{fn_str}(a_xpu)")
+        c_cpu = eval(f"a_cpu.{fn_str}()")
+        c_xpu = eval(f"a_xpu.{fn_str}()")
+        self.assertEqual(b_cpu, b_xpu.cpu(), atol=1e-4, rtol=1e-4)
+        self.assertEqual(c_cpu, c_xpu.cpu(), atol=1e-4, rtol=1e-4)
+        d_cpu = eval(f"torch.{fn_str}(a_cpu, out=c_cpu)")
+        d_xpu = eval(f"torch.{fn_str}(a_xpu, out=c_xpu)")
+        self.assertEqual(c_cpu, c_xpu.cpu(), atol=1e-4, rtol=1e-4)
+    
+    @Dtypes(floating_types)
+    def test_abs_out(self, dtype):
+        self._test_unary_out_ops('abs', dtype)
+    
+    @Dtypes(floating_types)
+    def test_sin_out(self, dtype):
+        self._test_unary_out_ops('sin', dtype)
+    
+    @Dtypes(floating_types)
+    def test_cos_out(self, dtype):
+        self._test_unary_out_ops('cos', dtype)
+    
+    @Dtypes(floating_types)
+    def test_log_out(self, dtype):
+        self._test_unary_out_ops('log', dtype)
+    
+    @Dtypes(floating_types)
+    def test_sqrt_out(self, dtype):
+        self._test_unary_out_ops('sqrt', dtype)
+
+    @Dtypes(floating_types)
+    def test_rsqrt_out(self, dtype):
+        self._test_unary_out_ops('rsqrt', dtype)
+    
+    @Dtypes(floating_types)
+    def test_tanh_out(self, dtype):
+        self._test_unary_out_ops('tanh', dtype)
+    
+    @Dtypes(all_basic_and_complex_types, [torch.bool])
+    def test_neg_out(self, dtype):
+        self._test_unary_out_ops('neg', dtype)

--- a/test/python/examples/test_unary.py
+++ b/test/python/examples/test_unary.py
@@ -44,27 +44,27 @@ class TestSimpleUnary(TestCase):
     def test_abs_out(self, dtype):
         self._test_unary_out_ops('abs', dtype)
     
-    @Dtypes(floating_types)
+    @Dtypes(floating_and_complex_types)
     def test_sin_out(self, dtype):
         self._test_unary_out_ops('sin', dtype)
     
-    @Dtypes(floating_types)
+    @Dtypes(floating_and_complex_types)
     def test_cos_out(self, dtype):
         self._test_unary_out_ops('cos', dtype)
     
-    @Dtypes(floating_types)
+    @Dtypes(floating_and_complex_types)
     def test_log_out(self, dtype):
         self._test_unary_out_ops('log', dtype)
     
-    @Dtypes(floating_types)
+    @Dtypes(floating_and_complex_types)
     def test_sqrt_out(self, dtype):
         self._test_unary_out_ops('sqrt', dtype)
 
-    @Dtypes(floating_types)
+    @Dtypes(floating_and_complex_types)
     def test_rsqrt_out(self, dtype):
         self._test_unary_out_ops('rsqrt', dtype)
     
-    @Dtypes(floating_types)
+    @Dtypes(floating_and_complex_types)
     def test_tanh_out(self, dtype):
         self._test_unary_out_ops('tanh', dtype)
     

--- a/yaml/xpu_functions.yaml
+++ b/yaml/xpu_functions.yaml
@@ -31,8 +31,20 @@ supported:
   - rsub.Tensor_out
   - rsub.Scalar
   - rsub.Scalar_out
+  - remainder.Tensor
+  - remainder_.Tensor
   - remainder.Tensor_out
+  - remainder.Scalar
+  - remainder_.Scalar
+  - remainder.Scalar_out
+  - remainder.Scalar_Tensor
+  - remainder.Scalar_Tensor_out
+  - fmod.Tensor
+  - fmod_.Tensor
   - fmod.Tensor_out
+  - fmod.Scalar
+  - fmod_.Scalar
+  - fmod.Scalar_out
 
   - eq.Scalar
   - eq.Scalar_out
@@ -98,7 +110,12 @@ supported:
   - reciprocal
   - reciprocal_
   - reciprocal.out
-
+  
+  - pow.Tensor_Tensor
+  - pow_.Tensor
   - pow.Tensor_Tensor_out
-  - pow.Scalar_out
+  - pow.Tensor_Scalar
+  - pow_.Scalar
   - pow.Tensor_Scalar_out
+  - pow.Scalar
+  - pow.Scalar_out

--- a/yaml/xpu_functions.yaml
+++ b/yaml/xpu_functions.yaml
@@ -55,3 +55,27 @@ supported:
   - ge.Tensor
   - ge.Tensor_out
   - ge_.Tensor
+  - abs
+  - abs_
+  - abs.out
+  - sin
+  - sin_
+  - sin.out
+  - cos
+  - cos_
+  - cos.out
+  - log
+  - log_
+  - log.out
+  - sqrt
+  - sqrt_
+  - sqrt.out
+  - rsqrt
+  - rsqrt_
+  - rsqrt.out
+  - tanh
+  - tanh_
+  - tanh.out
+  - neg
+  - neg_
+  - neg.out

--- a/yaml/xpu_functions.yaml
+++ b/yaml/xpu_functions.yaml
@@ -3,22 +3,37 @@ cpp_namespace: at
 use_out_as_primary: true
 device_guard: true
 supported:
-  - add.Scalar
   - add.Tensor
-  - add_.Scalar
   - add_.Tensor
-  - sub.Scalar
+  - add.out
+  - add.Scalar
+  - add_.Scalar
+  - add.Scalar_out
   - sub.Tensor
-  - sub_.Scalar
   - sub_.Tensor
-  - mul.Scalar
+  - sub.out
+  - sub.Scalar
+  - sub_.Scalar
+  - sub.Scalar_out
   - mul.Tensor
-  - mul_.Scalar
   - mul_.Tensor
-  - div.Scalar
+  - mul.out
+  - mul.Scalar
+  - mul_.Scalar
+  - mul.Scalar_out
   - div.Tensor
-  - div_.Scalar
   - div_.Tensor
+  - div.out
+  - div.Scalar
+  - div_.Scalar
+  - div.Scalar_out
+  - rsub.Tensor
+  - rsub.Tensor_out
+  - rsub.Scalar
+  - rsub.Scalar_out
+  - remainder.Tensor_out
+  - fmod.Tensor_out
+
   - eq.Scalar
   - eq.Scalar_out
   - eq_.Scalar
@@ -55,6 +70,7 @@ supported:
   - ge.Tensor
   - ge.Tensor_out
   - ge_.Tensor
+
   - abs
   - abs_
   - abs.out
@@ -79,3 +95,10 @@ supported:
   - neg
   - neg_
   - neg.out
+  - reciprocal
+  - reciprocal_
+  - reciprocal.out
+
+  - pow.Tensor_Tensor_out
+  - pow.Scalar_out
+  - pow.Tensor_Scalar_out


### PR DESCRIPTION
1. Complement ATen operators' variants implementation.
2. Add new Binary operators, e.g. rsub, remainder, fmod, reciprocal, pow.
dep on: https://github.com/intel/torch-xpu-ops/pull/42