### PR TITLE
Enable AOT compilation

### DIFF
--- a/cmake/BuildFlags.cmake
+++ b/cmake/BuildFlags.cmake
@@ -26,6 +26,18 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   # 3. The approx-func allows certain math function calls (such as log, sqrt, pow, etc)
   # to be replaced with an approximately equivalent set of instructions or
   # alternative math function calls, which have great errors.
+  #
+  # PSEUDO of separate compilation with DPCPP compiler.
+  # 1. Kernel source compilation:
+  # icpx -fsycl -fsycl-target=${SYCL_TARGETS_OPTION} ${SYCL_FLAGS} -fsycl-host-compiler=gcc -fsycl-host-compiler-options='${CMAKE_HOST_FLAGS}' kernel.cpp -o kernel.o
+  # 2. Device code linkage:
+  # icpx -fsycl -fsycl-target=${SYCL_TARGETS_OPTION} -fsycl-link ${SYCL_DEVICE_LINK_FLAGS} -Xs '${SYCL_OFFLINE_COMPILER_FLAGS}' kernel.o -o device-code.o
+  # 3. Host only source compilation:
+  # gcc ${CMAKE_HOST_FLAGS} host.cpp -o host.o
+  # 4. Linkage:
+  # gcc -shared host.o kernel.o device-code.o -o libxxx.so
+  set(SYCL_TARGETS_OPTION -fsycl-targets=spir64_gen,spir64)
+  set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} ${SYCL_TARGETS_OPTION})
   set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -fno-sycl-unnamed-lambda)
   set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -sycl-std=2020)
   set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -fhonor-nans)
@@ -39,6 +51,23 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set(SYCL_FLAGS ${SYCL_FLAGS} ${SYCL_KERNEL_OPTIONS})
 
   set(TORCH_XPU_OPS_FLAGS ${SYCL_HOST_FLAGS})
+
+  # -- SYCL device object linkage flags
+  include(ProcessorCount)
+  ProcessorCount(proc_cnt)
+  if ((DEFINED ENV{MAX_JOBS}) AND ("$ENV{MAX_JOBS}" LESS_EQUAL ${proc_cnt}))
+    set(SYCL_MAX_PARALLEL_LINK_JOBS $ENV{MAX_JOBS})
+  else()
+    set(SYCL_MAX_PARALLEL_LINK_JOBS ${proc_cnt})
+  endif()
+  set(SYCL_DEVICE_LINK_FLAGS ${SYCL_DEVICE_LINK_FLAGS} -fsycl-max-parallel-link-jobs=${SYCL_MAX_PARALLEL_LINK_JOBS})
+  set(SYCL_DEVICE_LINK_FLAGS ${SYCL_DEVICE_LINK_FLAGS} ${SYCL_TARGETS_OPTION})
+
+  set(SYCL_OFFLINE_COMPILER_CG_OPTIONS ${SYCL_OFFLINE_COMPILER_CG_OPTIONS} "-options \"-cl-intel-enable-auto-large-GRF-mode\"")
+  set(SYCL_OFFLINE_COMPILER_CG_OPTIONS ${SYCL_OFFLINE_COMPILER_CG_OPTIONS} "-options \"-cl-poison-unsupported-fp64-kernels\"")
+  # Support PVC AOT only currently.
+  set(SYCL_OFFLINE_COMPILER_AOT_OPTIONS "-device pvc")
+  set(SYCL_OFFLINE_COMPILER_FLAGS "${SYCL_OFFLINE_COMPILER_AOT_OPTIONS} ${SYCL_OFFLINE_COMPILER_CG_OPTIONS}")
 else()
   message("Not compiling with XPU. Only support GCC compiler as CXX compiler.")
   return()

--- a/cmake/Modules/FindSYCL.cmake
+++ b/cmake/Modules/FindSYCL.cmake
@@ -16,6 +16,12 @@
 #  SYCL_HOST_FLAGS
 #  -- SYCL compiler's 3rd party host compiler (e.g. gcc) arguments .
 #
+#  SYCL_DEVICE_LINK_FLAGS
+#  -- Arguments used when linking device object.
+#
+#  SYCL_OFFLINE_COMPILER_FLAGS
+#  -- Arguments used by offline compiler at AOT compilation.
+#
 #  SYCL_INCLUDE_DIR
 #  -- Include directory for SYCL compiler/runtime headers.
 #
@@ -373,7 +379,11 @@ macro(SYCL_LINK_DEVICE_OBJECTS output_file sycl_target)
     set(SYCL_device_link_flags)
     set(important_host_flags)
     _sycl_get_important_host_flags(important_host_flags "${SYCL_HOST_FLAGS}")
-    set(SYCL_device_link_flags ${link_type_flag} ${important_host_flags} ${SYCL_FLAGS})
+    set(SYCL_device_link_flags
+        ${link_type_flag}
+        ${important_host_flags}
+        ${SYCL_FLAGS}
+        ${SYCL_DEVICE_LINK_FLAGS})
 
     file(REAL_PATH working_directory "${output_file}")
     file(RELATIVE_PATH output_file_relative_path "${CMAKE_BINARY_DIR}" "${output_file}")
@@ -395,7 +405,12 @@ macro(SYCL_LINK_DEVICE_OBJECTS output_file sycl_target)
     add_custom_command(
       OUTPUT ${output_file}
       DEPENDS ${object_files}
-      COMMAND ${SYCL_EXECUTABLE} -fsycl ${SYCL_device_link_flags} -fsycl-link ${object_files} -o ${output_file}
+      COMMAND ${SYCL_EXECUTABLE}
+      -fsycl
+      ${SYCL_device_link_flags}
+      -fsycl-link ${object_files}
+      -Xs ${SYCL_OFFLINE_COMPILER_FLAGS}
+      -o ${output_file}
       COMMENT "Building SYCL device link file ${output_file_relative_path}"
       )
   endif()


### PR DESCRIPTION
At the current stage, enable AOT compilation only for PVC. On the other platforms, JIT works with generic SPIRV.