### PR TITLE
Fix abs complex to float issue

### DIFF
--- a/src/aten/UnaryOps.cpp
+++ b/src/aten/UnaryOps.cpp
@@ -1,31 +1,118 @@
 #include <ATen/ScalarOps.h>
 #include <ATen/XPUNativeFunctions.h>
 #include <ATen/core/Tensor.h>
+#include <ATen/native/Resize.h>
 #include <ATen/native/TensorIterator.h>
-#include <torch/library.h>
-
 #include <aten/sycl/UnaryKernels.h>
 #include <aten/sycl/UnaryLogKernels.h>
+#include <torch/library.h>
 
 namespace at {
 
+template <typename Stub>
+static inline Tensor& unary_op_impl_out(
+    Tensor& result,
+    const Tensor& self,
+    Stub& stub) {
+  auto iter = TensorIterator::unary_op(result, self);
+  stub(iter);
+  return result;
+}
+
+template <typename Stub, typename... Args>
+static inline Tensor& unary_op_impl_float_out(
+    Tensor& result,
+    const Tensor& self,
+    Stub& stub,
+    Args... args) {
+  auto iter = TensorIterator::unary_float_op(result, self);
+  stub(iter, args...);
+  iter.cast_outputs();
+  return result;
+}
+
+template <typename Stub>
+static inline Tensor& unary_op_impl_with_complex_to_float_out(
+    Tensor& result,
+    const Tensor& self,
+    Stub& stub,
+    bool promotes_integer_to_float) {
+  if (self.is_complex() && !result.is_complex()) {
+    // Checks if the corresponding float type can be cast to the desired dtype
+    const auto float_type = c10::toRealValueType(self.scalar_type());
+    TORCH_CHECK(
+        canCast(float_type, result.scalar_type()),
+        "result type ",
+        float_type,
+        " can't be cast to the desired output type ",
+        result.scalar_type());
+
+    // Runs the function complex->complex, as TensorIterator expects
+    Tensor complex_result = at::empty({0}, self.options());
+    auto iter = TensorIterator::unary_op(complex_result, self);
+    stub(iter);
+
+    // Copies the complex result to the actual result and returns it
+    at::native::resize_output(result, complex_result.sizes());
+    result.copy_(at::real(complex_result));
+    return result;
+  }
+
+  if (promotes_integer_to_float) {
+    return unary_op_impl_float_out(result, self, stub);
+  }
+
+  return unary_op_impl_out(result, self, stub);
+}
+
+// out_impl passed into unary_op_impl and unary_op_impl_  must go through at::
+// device dispatch otherwise it won't dispatch to out-of-source devices like
+// XLA. For example it must be at::bitwise_not_out instead of
+// bitwise_not_out(which is at::native!).
+template <typename OutImpl>
+static inline Tensor unary_op_impl(const Tensor& self, OutImpl& out_impl) {
+  Tensor result = at::empty({0}, self.options());
+  return out_impl(result, self);
+}
+
+// An alternate version of unary_op_impl that follows the same pattern
+// for non-complex inputs, but returns a floating point tensor
+// for complex inputs by default.
+template <typename OutImpl>
+static inline Tensor unary_op_impl_with_complex_to_float(
+    const Tensor& self,
+    OutImpl& out_impl) {
+  if (self.is_complex()) {
+    const auto float_type = c10::toRealValueType(self.scalar_type());
+    Tensor result = at::empty_like(self, self.options().dtype(float_type));
+    return out_impl(result, self);
+  }
+
+  Tensor result = at::empty({0}, self.options());
+  return out_impl(result, self);
+}
+
+template <typename OutImpl>
+static inline Tensor& unary_op_impl_(Tensor& self, OutImpl& out_impl) {
+  return out_impl(self, self);
+}
+
 Tensor XPUNativeFunctions::abs(const Tensor& self) {
-  Tensor out;
-  auto iter = TensorIterator::unary_op(out, self);
-  native::xpu::abs_kernel(iter);
-  return iter.output();
+  return unary_op_impl_with_complex_to_float(self, at::abs_out);
 }
 
 Tensor& XPUNativeFunctions::abs_(Tensor& self) {
-  auto iter = TensorIterator::unary_op(self, self);
-  native::xpu::abs_kernel(iter);
-  return self;
+  TORCH_CHECK(
+      !self.is_complex(), "In-place abs is not supported for complex tensors.");
+  return unary_op_impl_(self, at::abs_out);
 }
 
 Tensor& XPUNativeFunctions::abs_out(const Tensor& self, Tensor& out) {
-  auto iter = TensorIterator::unary_op(out, self);
-  native::xpu::abs_kernel(iter);
-  return out;
+  return unary_op_impl_with_complex_to_float_out(
+      out,
+      self,
+      native::xpu::abs_kernel,
+      /*promotes_integer_to_float=*/false);
 }
 
 Tensor XPUNativeFunctions::sin(const Tensor& self) {


### PR DESCRIPTION
 Note [Complex abs and angle] Complex inputs to abs and angle return float results by default. abs and angle, in both NumPy and C++, returns a float result when given a complex input. This makes sense mathematically since the absolute value and angle of a complex number has no imaginary part.
