### PR TITLE
FIx bugs of "name 'Sequence' is not defined" in test suit

### DIFF
--- a/test/xpu/test_ops.py
+++ b/test/xpu/test_ops.py
@@ -2,6 +2,7 @@
 
 import sys
 import unittest
+from collections.abc import Sequence
 
 import torch
 from torch.testing._internal.common_dtype import (
@@ -116,7 +117,6 @@ _xpu_all_ops = [op for op in ops_and_refs if op.name in _xpu_all_op_list]
 _xpu_not_test_dtype_op_list = [
     "resize_",  # Skipped by CPU
     "resize_as_",  # Skipped by CPU
-    "abs",  # Not aligned dtype
 ]
 _xpu_float_only_op_list = [
     "reciprocal", # Align with CUDA impl. Only float and complex supported in CUDA native.


### PR DESCRIPTION
1. Fix bugs of "name 'Sequence' is not defined" in test suite.
2. Retrieve abs in testing list.