### PR TITLE
Rebase aten::pow with creating borrowing output and using type promotion

### DIFF
--- a/src/aten/Pow.cpp
+++ b/src/aten/Pow.cpp
@@ -3,20 +3,45 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/TensorIterator.h>
-
 #include <aten/sycl/PowKernels.h>
 
 namespace at {
 
+TensorIterator pow_Tensor_Tensor_meta(
+    const Tensor& base,
+    const Tensor& exp,
+    Tensor& out) {
+  TensorIterator iter;
+  iter.build_borrowing_binary_op(out, base, exp);
+  return iter;
+}
+
+TensorIterator pow_Tensor_Scalar_meta(
+    const Tensor& base,
+    const Scalar& exp,
+    Tensor& out) {
+  // Numpy compatibility check:
+  TORCH_CHECK(
+      !(isIntegralType(base.scalar_type(), true) && exp.isIntegral(true) &&
+        exp.toLong() < 0),
+      "Integers to negative integer powers are not allowed.");
+
+  auto common_dtype = at::result_type(base, exp);
+  TensorIterator iter;
+  iter.build_output_borrowing_argument_owning_unary_op(
+      out, base.to(common_dtype));
+  return iter;
+}
+
 Tensor XPUNativeFunctions::pow(const Tensor& self, const Tensor& exponent) {
   Tensor out;
-  auto iter = TensorIterator::binary_op(out, self, exponent);
+  auto iter = pow_Tensor_Tensor_meta(self, exponent, out);
   native::xpu::pow_tensor_tensor_kernel(iter);
   return iter.output();
 }
 
 Tensor& XPUNativeFunctions::pow_(Tensor& self, const Tensor& exponent) {
-  auto iter = TensorIterator::binary_op(self, self, exponent);
+  auto iter = pow_Tensor_Tensor_meta(self, exponent, self);
   native::xpu::pow_tensor_tensor_kernel(iter);
   return self;
 }
@@ -25,24 +50,24 @@ Tensor& XPUNativeFunctions::pow_out(
     const Tensor& base,
     const Tensor& exp,
     Tensor& out) {
-  auto iter = TensorIterator::binary_op(out, base, exp);
+  auto iter = pow_Tensor_Tensor_meta(base, exp, out);
   native::xpu::pow_tensor_tensor_kernel(iter);
   return out;
 }
 
 Tensor XPUNativeFunctions::pow(const Tensor& self, const Scalar& exponent) {
   Tensor out;
-  auto iter = TensorIterator::unary_op(out, self);
+  auto iter = pow_Tensor_Scalar_meta(self, exponent, out);
   native::xpu::pow_tensor_scalar_kernel(iter, exponent);
   return iter.output();
 }
 
 Tensor& XPUNativeFunctions::pow_(Tensor& self, const Scalar& exponent) {
+  auto iter = pow_Tensor_Scalar_meta(self, exponent, self);
   if (exponent.equal(0.0) || exponent.equal(false)) {
     self.fill_(1);
   } else if (exponent.equal(1.0) || exponent.equal(true)) {
   } else {
-    auto iter = TensorIterator::unary_op(self, self);
     native::xpu::pow_tensor_scalar_kernel(iter, exponent);
   }
   return self;
@@ -52,12 +77,12 @@ Tensor& XPUNativeFunctions::pow_out(
     const Tensor& self,
     const Scalar& exponent,
     Tensor& out) {
+  auto iter = pow_Tensor_Scalar_meta(self, exponent, out);
   if (exponent.equal(0.0) || exponent.equal(false)) {
     out.fill_(1);
   } else if (exponent.equal(1.0) || exponent.equal(true)) {
     out.copy_(self);
   } else {
-    auto iter = TensorIterator::unary_op(out, self);
     native::xpu::pow_tensor_scalar_kernel(iter, exponent);
   }
   return out;

--- a/src/aten/Pow.cpp
+++ b/src/aten/Pow.cpp
@@ -7,7 +7,7 @@
 
 namespace at {
 
-TensorIterator pow_Tensor_Tensor_meta(
+TensorIterator pow_tensor_tensor_meta(
     const Tensor& base,
     const Tensor& exp,
     Tensor& out) {
@@ -16,7 +16,7 @@ TensorIterator pow_Tensor_Tensor_meta(
   return iter;
 }
 
-TensorIterator pow_Tensor_Scalar_meta(
+TensorIterator pow_tensor_scalar_meta(
     const Tensor& base,
     const Scalar& exp,
     Tensor& out) {
@@ -35,13 +35,13 @@ TensorIterator pow_Tensor_Scalar_meta(
 
 Tensor XPUNativeFunctions::pow(const Tensor& self, const Tensor& exponent) {
   Tensor out;
-  auto iter = pow_Tensor_Tensor_meta(self, exponent, out);
+  auto iter = pow_tensor_tensor_meta(self, exponent, out);
   native::xpu::pow_tensor_tensor_kernel(iter);
   return iter.output();
 }
 
 Tensor& XPUNativeFunctions::pow_(Tensor& self, const Tensor& exponent) {
-  auto iter = pow_Tensor_Tensor_meta(self, exponent, self);
+  auto iter = pow_tensor_tensor_meta(self, exponent, self);
   native::xpu::pow_tensor_tensor_kernel(iter);
   return self;
 }
@@ -50,20 +50,20 @@ Tensor& XPUNativeFunctions::pow_out(
     const Tensor& base,
     const Tensor& exp,
     Tensor& out) {
-  auto iter = pow_Tensor_Tensor_meta(base, exp, out);
+  auto iter = pow_tensor_tensor_meta(base, exp, out);
   native::xpu::pow_tensor_tensor_kernel(iter);
   return out;
 }
 
 Tensor XPUNativeFunctions::pow(const Tensor& self, const Scalar& exponent) {
   Tensor out;
-  auto iter = pow_Tensor_Scalar_meta(self, exponent, out);
+  auto iter = pow_tensor_scalar_meta(self, exponent, out);
   native::xpu::pow_tensor_scalar_kernel(iter, exponent);
   return iter.output();
 }
 
 Tensor& XPUNativeFunctions::pow_(Tensor& self, const Scalar& exponent) {
-  auto iter = pow_Tensor_Scalar_meta(self, exponent, self);
+  auto iter = pow_tensor_scalar_meta(self, exponent, self);
   if (exponent.equal(0.0) || exponent.equal(false)) {
     self.fill_(1);
   } else if (exponent.equal(1.0) || exponent.equal(true)) {
@@ -77,7 +77,7 @@ Tensor& XPUNativeFunctions::pow_out(
     const Tensor& self,
     const Scalar& exponent,
     Tensor& out) {
-  auto iter = pow_Tensor_Scalar_meta(self, exponent, out);
+  auto iter = pow_tensor_scalar_meta(self, exponent, out);
   if (exponent.equal(0.0) || exponent.equal(false)) {
     out.fill_(1);
   } else if (exponent.equal(1.0) || exponent.equal(true)) {


### PR DESCRIPTION
1. Apply type promotion for pow ops.
2. Apply borrowing output for pow ops.