### PR TITLE
[FALLBACK] Replace TORCH_WARN with std::cout because TORCH_WARN not always print out message.

### DIFF
--- a/src/aten/XPUFallback.template
+++ b/src/aten/XPUFallback.template
@@ -1,4 +1,5 @@
 #include <ATen/native/CPUFallback.h>
+#include <iostream>
 
 namespace at {
 
@@ -7,17 +8,15 @@ static bool DEBUG_XPU_FALLBACK = false;
 static void xpu_fallback(
     const c10::OperatorHandle& op,
     torch::jit::Stack* stack) {
-  if (!DEBUG_XPU_FALLBACK) {
-    TORCH_WARN_ONCE(
-        "Aten Op fallback from XPU to CPU happends.",
-        " This may have performance implications.",
-        " If need debug the fallback ops please set environment variable `PYTORCH_DEBUG_XPU_FALLBACK=1` ");
-  } else {
-    TORCH_WARN(
-        "The operator '",
-        op.schema().operator_name(),
-        " on the XPU backend is falling back to run on the CPU.");
-  }
+
+    if (!DEBUG_XPU_FALLBACK) {
+      TORCH_WARN_ONCE(
+          "Aten Op fallback from XPU to CPU happends.",
+          " This may have performance implications.",
+          " If need debug the fallback ops please set environment variable `PYTORCH_DEBUG_XPU_FALLBACK=1` ");
+    } else {
+      std::cout << "\n[XPUFallback]: " << op.schema().operator_name() << std::endl;
+    }
 
   // TODO: do Profiling if profiler.isCPUFallbackProfilingEnabled()
   native::cpu_fallback(op, stack, true);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #170

