### PR TITLE
Register operator's implementation lazily.

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -53,9 +53,6 @@ jobs:
           xpu-smi discovery
           source /opt/intel/oneapi/compiler/latest/env/vars.sh
           source activate xpu_op_${ZE_AFFINITY_MASK}
-          # Some examples are ported from PyTorch test cases. These cases
-          # require CPU fallback
-          export PYTORCH_ENABLE_XPU_FALLBACK=1
           cd examples
           timeout 8000 pytest -v
       - name: Run XPU OP UT

--- a/examples/test_torchvision_roi_align.py
+++ b/examples/test_torchvision_roi_align.py
@@ -1,0 +1,18 @@
+import torch
+from torch.testing._internal.common_utils import TestCase
+import torchvision
+
+class TestTorchVisionMethod(TestCase):
+    def test_roi_align(self):
+        a_ref = torch.zeros([4, 256, 296, 304]).requires_grad_(True)
+        b_ref = torch.zeros([2292, 5]).requires_grad_(True)
+
+        a_xpu = torch.zeros([4, 256, 296, 304], device=torch.device("xpu")).requires_grad_(True)
+        b_xpu = torch.zeros([2292, 5], device=torch.device("xpu")).requires_grad_(True)
+
+        ref = torch.ops.torchvision.roi_align(a_ref, b_ref, 0.25, 7, 7, 2, False)
+        res = torch.ops.torchvision.roi_align(a_xpu, b_xpu, 0.25, 7, 7, 2, False)
+        ref.sum().backward()
+        res.sum().backward()
+        self.assertEqual(ref, res.cpu())
+        self.assertEqual(a_ref.grad, a_xpu.grad.cpu())

--- a/src/aten/NMS.cpp
+++ b/src/aten/NMS.cpp
@@ -76,8 +76,4 @@ Tensor nms(const Tensor& dets, const Tensor& scores, double iou_threshold_) {
            .to(order_t.device(), keep.scalar_type())});
 }
 
-TORCH_LIBRARY_IMPL(torchvision, XPU, m) {
-  m.impl(TORCH_SELECTIVE_NAME("torchvision::nms"), TORCH_FN(nms));
-}
-
 } // namespace at::native::xpu

--- a/src/aten/XPUFallback.template
+++ b/src/aten/XPUFallback.template
@@ -1,7 +1,5 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/native/CPUFallback.h>
-#include <string.h>
-#include <iostream>
 
 namespace at {
 

--- a/src/aten/XPUFallback.template
+++ b/src/aten/XPUFallback.template
@@ -1,12 +1,87 @@
+#include <ATen/core/Tensor.h>
 #include <ATen/native/CPUFallback.h>
+#include <string.h>
+#include <iostream>
 
 namespace at {
 
 static bool DEBUG_XPU_FALLBACK = false;
 
+static void xpu_fallback_impl(
+    const c10::OperatorHandle& op,
+    torch::jit::Stack* stack) {
+  native::cpu_fallback(op, stack, true);
+}
+
+namespace native::xpu {
+Tensor nms(const Tensor& dets, const Tensor& scores, double iou_threshold_);
+}
+
+// Register op's implementation lazily since sometimes the op is not defined,
+// when registering implementation in PyTorch.
+
+// Change both maps table and register_func when adding a new operator
+// with lazy registration. So far, support torchvision namespace only.
+// <operator_name: string, is_cpu_fallback: bool>
+static std::map<std::string, bool> torchvision_ops_dispatching_table_ = {
+  {"torchvision::nms", false},
+  {"torchvision::roi_align", true},
+  {"torchvision::_roi_align_backward", true},
+};
+
+// Return:
+// true  - Redispatch to implementation lazily registered.
+// false - Not redispatch.
+static bool lazy_registration_and_redispatch(
+    const c10::OperatorHandle& op,
+    torch::jit::Stack* stack) {
+  auto register_func =
+      [](torch::Library& m) -> void {
+        // Register all operators of torchvision namespace, not to register op
+        // by op when the op is called. When a torchvision::op is called,
+        // suppose ops of torchvision are all defined (`import torchvision`).
+        m.impl(TORCH_SELECTIVE_NAME("torchvision::nms"), TORCH_FN(at::native::xpu::nms));
+        m.impl(
+            TORCH_SELECTIVE_NAME("torchvision::roi_align"),
+            torch::CppFunction::makeFromBoxedFunction<&xpu_fallback_impl>());
+        m.impl(
+            TORCH_SELECTIVE_NAME("torchvision::_roi_align_backward"),
+            torch::CppFunction::makeFromBoxedFunction<&xpu_fallback_impl>());
+      };
+
+  static const torch::detail::TorchLibraryInit
+      torchvision_ops_impl_lazy_registration(
+          torch::Library::IMPL,
+          register_func,
+          "torchvision",
+          c10::make_optional(c10::DispatchKey::XPU),
+          __FILE__,
+          __LINE__);
+
+  bool need_redispatch_after_lazy_registration =
+      torchvision_ops_dispatching_table_.end() != torchvision_ops_dispatching_table_.find(op.schema().operator_name().name);
+  bool is_cpu_fallback = need_redispatch_after_lazy_registration ?
+      torchvision_ops_dispatching_table_[op.schema().operator_name().name] : true;
+
+  if (need_redispatch_after_lazy_registration) {
+    if (!is_cpu_fallback) {
+      op.redispatchBoxed(c10::DispatchKeySet(c10::DispatchKey::XPU), stack);
+    } else {
+      xpu_fallback_impl(op, stack);
+    }
+    return true;
+  } else {
+    return false;
+  }
+}
+
 static void xpu_fallback(
     const c10::OperatorHandle& op,
     torch::jit::Stack* stack) {
+  if (lazy_registration_and_redispatch(op, stack)) {
+    return;
+  }
+
   if (!DEBUG_XPU_FALLBACK) {
     TORCH_WARN_ONCE(
         "Aten Op fallback from XPU to CPU happends.",
@@ -20,22 +95,24 @@ static void xpu_fallback(
   }
 
   // TODO: do Profiling if profiler.isCPUFallbackProfilingEnabled()
-  native::cpu_fallback(op, stack, true);
+  xpu_fallback_impl(op, stack);
 }
 
-static void xpu_error_fallback(
+static void xpu_lazy_registration_or_error_fallback(
     const c10::OperatorHandle& op,
     torch::jit::Stack* stack) {
-  TORCH_CHECK_NOT_IMPLEMENTED(
-      false,
-      "The operator '",
-      op.schema().operator_name(),
-      "' is not currently implemented ",
-      "for the XPU device. If you want this op to be added in priority during the prototype ",
-      "phase of this feature, please open issue on https://github.com/intel/torch-xpu-ops/issues. ",
-      "As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_XPU_FALLBACK=1` ",
-      "to use the CPU as a fallback for this op. WARNING: this will be slower than running natively ",
-      "on XPU.");
+  if (!lazy_registration_and_redispatch(op, stack)) {
+    TORCH_CHECK_NOT_IMPLEMENTED(
+        false,
+        "The operator '",
+        op.schema().operator_name(),
+        "' is not currently implemented ",
+        "for the XPU device. If you want this op to be added in priority during the prototype ",
+        "phase of this feature, please open issue on https://github.com/intel/torch-xpu-ops/issues. ",
+        "As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_XPU_FALLBACK=1` ",
+        "to use the CPU as a fallback for this op. WARNING: this will be slower than running natively ",
+        "on XPU.");
+  }
 }
 
 static void xpu_force_fallback(
@@ -47,7 +124,7 @@ TORCH_LIBRARY_IMPL(_, XPU, m) {
       getenv("PYTORCH_ENABLE_XPU_FALLBACK");
   if (!enable_xpu_fallback || std::stoi(enable_xpu_fallback) == 0) {
     m.fallback(
-        torch::CppFunction::makeFromBoxedFunction<&xpu_error_fallback>());
+        torch::CppFunction::makeFromBoxedFunction<&xpu_lazy_registration_or_error_fallback>());
   } else {
     m.fallback(torch::CppFunction::makeFromBoxedFunction<&xpu_fallback>());
   }
@@ -81,7 +158,7 @@ TORCH_LIBRARY_IMPL(aten, XPU, m) {
   }
 }
 
-/* 
+/*
  * These ops are not supported via XPU backend currently, and we fallback to run on CPU.
  */
 TORCH_LIBRARY_IMPL(aten, XPU, m) {
@@ -421,20 +498,12 @@ TORCH_LIBRARY_IMPL(aten, XPU, m) {
   for (auto& op_name : fallback_list) {
     m.impl(
         op_name.c_str(),
-        torch::CppFunction::makeFromBoxedFunction<&xpu_fallback>());
+        torch::CppFunction::makeFromBoxedFunction<&xpu_fallback_impl>());
   }
 }
 TORCH_LIBRARY_IMPL(_inductor_test, XPU, m) {
     m.impl(
         "realize",
-        torch::CppFunction::makeFromBoxedFunction<&xpu_fallback>());
-}
-TORCH_LIBRARY_IMPL(torchvision, XPU, m) {
-    m.impl(
-        "roi_align",
-        torch::CppFunction::makeFromBoxedFunction<&xpu_fallback>());
-    m.impl(
-        "_roi_align_backward",
-        torch::CppFunction::makeFromBoxedFunction<&xpu_fallback>());
+        torch::CppFunction::makeFromBoxedFunction<&xpu_fallback_impl>());
 }
 } // namespace at

--- a/src/aten/XPUFallback.template
+++ b/src/aten/XPUFallback.template
@@ -104,12 +104,9 @@ static void xpu_lazy_registration_or_error_fallback(
         false,
         "The operator '",
         op.schema().operator_name(),
-        "' is not currently implemented ",
-        "for the XPU device. If you want this op to be added in priority during the prototype ",
-        "phase of this feature, please open issue on https://github.com/intel/torch-xpu-ops/issues. ",
-        "As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_XPU_FALLBACK=1` ",
-        "to use the CPU as a fallback for this op. WARNING: this will be slower than running natively ",
-        "on XPU.");
+        "' is not currently implemented for the XPU device. Please open a feature on https://github.com/intel/torch-xpu-ops/issues. ",
+        "You can set the environment variable `PYTORCH_ENABLE_XPU_FALLBACK=1` to use the CPU implementation as a fallback for XPU unimplemented operators. "
+        "WARNING: this will bring unexpected performance compared with running natively on XPU.");
   }
 }
 


### PR DESCRIPTION
1. Avoid dangling operator's implementation (m.impl(torchvision::nms) is ahead of `import torchvision` sometime)
2. Mute debug log of explicit CPU fallback.
3. Add torchvision.roi_align/_roi_align_backward example case