### PR TITLE
Enable fp64 tmporarily

### DIFF
--- a/.github/workflows/inductor_xpu_e2e_ci.yml
+++ b/.github/workflows/inductor_xpu_e2e_ci.yml
@@ -36,7 +36,7 @@ jobs:
           cd pytorch
           # apply PRs for stock pytorch
           pip install requests
-          python ../torch-xpu-ops/.github/scripts/apply-torch-pr.py -n 122472 124709
+          python ../torch-xpu-ops/.github/scripts/apply-torch-pr.py -n 122472 124709 125587
           git status && git show -s
           git submodule sync && git submodule update --init --recursive
           rm -rf third_party/torch-xpu-ops && cp -r ../torch-xpu-ops third_party/


### PR DESCRIPTION
As oneDNN GEMM has not supported FP64 yet, we fallback the benchmark to CPU fp64