### PR TITLE
Add UT for test_autograd_fallback.py

### DIFF
--- a/test/xpu/run_test.py
+++ b/test/xpu/run_test.py
@@ -721,6 +721,8 @@ skip_list = (
 )
 res += launch_test("test_binary_ufuncs_xpu.py", skip_list)
 
+res += launch_test("test_autograd_fallback.py")
+
 # test_foreach
 # Too slow to run all case on CPU. Add white list.
 execute_list = (

--- a/test/xpu/test_autograd_fallback.py
+++ b/test/xpu/test_autograd_fallback.py
@@ -1,0 +1,18 @@
+# Owner(s): ["module: intel"]
+
+from torch.testing._internal.common_utils import run_tests, instantiate_parametrized_tests
+
+try:
+    from xpu_test_utils import XPUPatchForImport
+except Exception as e:
+    from .xpu_test_utils import XPUPatchForImport
+
+with XPUPatchForImport(False):
+    from test_autograd_fallback import TestAutogradFallback
+
+instantiate_parametrized_tests(TestAutogradFallback)
+
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/xpu/xpu_test_utils.py
+++ b/test/xpu/xpu_test_utils.py
@@ -4,7 +4,7 @@ import copy
 import os
 import sys
 
-import torch
+from torch.testing._internal import common_device_type, common_utils
 
 
 def get_wrapped_fn(fn):
@@ -27,28 +27,31 @@ class XPUPatchForImport:
         )
         self.patch_test_case = patch_test_case
         self.original_path = sys.path.copy()
-        self.test_case_cls = torch.testing._internal.common_utils.TestCase
-        self.only_cuda_fn = torch.testing._internal.common_device_type.onlyCUDA
+        self.test_case_cls = common_utils.TestCase
+        self.only_cuda_fn = common_device_type.onlyCUDA
         self.only_native_device_types_fn = (
-            torch.testing._internal.common_device_type.onlyNativeDeviceTypes
+            common_device_type.onlyNativeDeviceTypes
         )
         self.instantiate_device_type_tests_fn = (
-            torch.testing._internal.common_device_type.instantiate_device_type_tests
+            common_device_type.instantiate_device_type_tests
         )
 
     def __enter__(self):
         # Monkey patch until we have a fancy way
-        torch.testing._internal.common_device_type.onlyCUDA = (
-            torch.testing._internal.common_device_type.onlyXPU
+        common_device_type.onlyCUDA = (
+            common_device_type.onlyXPU
         )
-        torch.testing._internal.common_device_type.onlyNativeDeviceTypes = (
-            torch.testing._internal.common_device_type.onlyXPU
+        common_device_type.onlyNativeDeviceTypes = (
+            common_device_type.onlyXPU
         )
         if self.patch_test_case:
-            torch.testing._internal.common_utils.TestCase = (
-                torch.testing._internal.common_utils.NoTest
+            common_utils.TestCase = (
+                common_utils.NoTest
             )
-        torch.testing._internal.common_device_type.instantiate_device_type_tests = (
+        common_device_type.instantiate_device_type_tests = (
+            DO_NOTHING
+        )
+        common_utils.instantiate_parametrized_tests = (
             DO_NOTHING
         )
         sys.path.append(self.test_package)
@@ -56,14 +59,14 @@ class XPUPatchForImport:
 
     def __exit__(self, exc_type, exc_value, traceback):
         sys.path = self.original_path
-        torch.testing._internal.common_device_type.onlyCUDA = self.only_cuda_fn
-        torch.testing._internal.common_device_type.onlyNativeDeviceTypes = (
+        common_device_type.onlyCUDA = self.only_cuda_fn
+        common_device_type.onlyNativeDeviceTypes = (
             self.only_native_device_types_fn
         )
-        torch.testing._internal.common_device_type.instantiate_device_type_tests = (
+        common_device_type.instantiate_device_type_tests = (
             self.instantiate_device_type_tests_fn
         )
-        torch.testing._internal.common_utils.TestCase = self.test_case_cls
+        common_utils.TestCase = self.test_case_cls
 
 
 # Copy the test cases from generic_base_class to generic_test_class.


### PR DESCRIPTION
Enabled test_reducations.py and test_autograd_fallback.py to run with XPU patch. Updated XPU patch for instantiate_parametrized_tests().
We did not enable skiplist in order to report failures in log. 