### PR TITLE
Distinguish run_test.py to run with skip and run with only

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -71,7 +71,12 @@ jobs:
           export PYTORCH_ENABLE_XPU_FALLBACK=1
           export PYTORCH_TEST_WITH_SLOW=1
           cd ../pytorch/third_party/torch-xpu-ops/test/xpu
-          timeout 10000 python run_test.py
+          timeout 10000 python run_test_with_skip.py
+          # Cases run with a on-demand white list, since some suites are too
+          # slow to go through all operators on CPU. So add cases on-demand
+          # when XPU implementatoin is done.
+          # test_foreach, test_decomp
+          timeout 10000 python run_test_with_only.py
       - name: Run Torch XPU UT
         run: |
           source /opt/intel/oneapi/compiler/latest/env/vars.sh

--- a/test/xpu/run_test_with_only.py
+++ b/test/xpu/run_test_with_only.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+
+# Cases in the file is too slow to run all suites on CPU. So add white list.
+
+def launch_test(test_case, skip_list=None, exe_list=None):
+    if skip_list != None:
+        skip_options = " -k 'not " + skip_list[0]
+        for skip_case in skip_list[1:]:
+            skip_option = " and not " + skip_case
+            skip_options += skip_option
+        skip_options += "'"
+        test_command = "PYTORCH_ENABLE_XPU_FALLBACK=1 PYTORCH_TEST_WITH_SLOW=1 pytest -v " + test_case
+        test_command += skip_options
+        return os.system(test_command)
+    elif exe_list != None:
+        exe_options = " -k '" + exe_list[0]
+        for exe_case in exe_list[1:]:
+            exe_option = " and " + exe_case
+            exe_options += exe_option
+        exe_options += "'"
+        test_command = "PYTORCH_ENABLE_XPU_FALLBACK=1 PYTORCH_TEST_WITH_SLOW=1 pytest -v " + test_case
+        test_command += exe_options
+        return os.system(test_command)
+    else:
+        test_command = "PYTORCH_ENABLE_XPU_FALLBACK=1 PYTORCH_TEST_WITH_SLOW=1 pytest -v " + test_case
+        return os.system(test_command)
+
+res= 0
+
+# test_foreach
+execute_list = (
+    "_foreach_add_",
+    "not slowpath",
+)
+res += launch_test("test_foreach_xpu.py", exe_list=execute_list)
+
+exit_code = os.WEXITSTATUS(res)
+sys.exit(exit_code)

--- a/test/xpu/run_test_with_skip.py
+++ b/test/xpu/run_test_with_skip.py
@@ -728,14 +728,6 @@ res += launch_test("test_binary_ufuncs_xpu.py", skip_list)
 
 res += launch_test("test_autograd_fallback.py")
 
-# test_foreach
-# Too slow to run all case on CPU. Add white list.
-execute_list = (
-    "_foreach_add_",
-    "not slowpath",
-)
-res += launch_test("test_foreach_xpu.py", exe_list=execute_list)
-
 # test_sort_and_select
 skip_list = (
     # The following isin case fails on CPU fallback, as it could be backend-specific.
@@ -746,9 +738,9 @@ skip_list = (
     "test_isin_different_devices_xpu_int64", # AssertionError: RuntimeError not raised
     "test_isin_different_devices_xpu_int8", # AssertionError: RuntimeError not raised
     "test_isin_different_devices_xpu_uint8", # AssertionError: RuntimeError not raised
-    
+
     "test_isin_different_dtypes_xpu", # RuntimeError: "isin_default_cpu" not implemented for 'Half'"
-    
+
     "test_sort_large_slice_xpu", # Hard code CUDA
 )
 res += launch_test("test_sort_and_select_xpu.py", skip_list)


### PR DESCRIPTION
Some suites are too slow to go through all operators on CPU. So add a separate script to run suites with an on-demand white list. When developers add a new operator, they can easily check whether they need add related cases in run_test_with_only.py