### PR TITLE
Fixed instantiate_parametrized_tests failed issue

### DIFF
--- a/test/xpu/xpu_test_utils.py
+++ b/test/xpu/xpu_test_utils.py
@@ -36,6 +36,9 @@ class XPUPatchForImport:
         self.instantiate_device_type_tests_fn = (
             common_device_type.instantiate_device_type_tests
         )
+        self.instantiate_parametrized_tests_fn = (
+            common_utils.instantiate_parametrized_tests
+        )
 
     def __enter__(self):
         # Monkey patch until we have a fancy way
@@ -66,6 +69,9 @@ class XPUPatchForImport:
         )
         common_device_type.instantiate_device_type_tests = (
             self.instantiate_device_type_tests_fn
+        )
+        common_utils.instantiate_parametrized_tests = (
+            self.instantiate_parametrized_tests_fn
         )
         common_utils.TestCase = self.test_case_cls
 


### PR DESCRIPTION
Restore the functin of instantiate_parametrized_tests in XPUPatchForImport.__exit__