### PR TITLE
Fix div ut failures caused by the ineffective type promotion

### DIFF
--- a/src/aten/BinaryOps.cpp
+++ b/src/aten/BinaryOps.cpp
@@ -174,14 +174,14 @@ Tensor XPUNativeFunctions::div(const Tensor& self, const Tensor& other) {
   Tensor out;
   TensorIterator iter;
   iter.build_borrowing_binary_float_op(out, self, other);
-  native::xpu::div_kernel(iter);
+  native::xpu::div_true_kernel(iter);
   return iter.output();
 }
 
 Tensor& XPUNativeFunctions::div_(Tensor& self, const Tensor& other) {
   TensorIterator iter;
   iter.build_borrowing_binary_float_op(self, self, other);
-  native::xpu::div_kernel(iter);
+  native::xpu::div_true_kernel(iter);
   return self;
 }
 
@@ -191,7 +191,7 @@ Tensor& XPUNativeFunctions::div_out(
     Tensor& out) {
   TensorIterator iter;
   iter.build_borrowing_binary_float_op(out, self, other);
-  native::xpu::div_kernel(iter);
+  native::xpu::div_true_kernel(iter);
   return out;
 }
 

--- a/src/aten/sycl/BinaryDivTruncKernel.cpp
+++ b/src/aten/sycl/BinaryDivTruncKernel.cpp
@@ -7,6 +7,8 @@
 #include <aten/sycl/BinaryKernels.h>
 #include <aten/sycl/Loops.h>
 
+#include <comm/XPUMathCompat.h>
+
 namespace at::native::xpu {
 
 template <typename scalar_t, typename accscalar_t>
@@ -24,7 +26,7 @@ struct DivTruncScalarFunctor {
 template <typename scalar_t>
 struct DivTruncFunctor {
   scalar_t operator()(scalar_t a, scalar_t b) const {
-    return std::trunc(a / b);
+    return c10::xpu::compat::div_trunc(a, b);
   }
 };
 

--- a/src/aten/sycl/BinaryInternal.h
+++ b/src/aten/sycl/BinaryInternal.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#include <comm/XPUMathCompat.h>
+
 namespace at::native::xpu {
 
 template <typename scalar_t>
 struct DivFunctor {
   scalar_t operator()(scalar_t a, scalar_t b) const {
-    return a / b;
+    return c10::xpu::compat::div(a, b);
   }
 };
 

--- a/src/aten/sycl/BinaryKernels.cpp
+++ b/src/aten/sycl/BinaryKernels.cpp
@@ -58,22 +58,6 @@ void mul_kernel(TensorIteratorBase& iter) {
   }
 }
 
-void div_kernel(TensorIteratorBase& iter) {
-  auto common_dtype = iter.common_dtype();
-  if (common_dtype == kComplexHalf) {
-    using scalar_t = c10::complex<c10::Half>;
-    using opmath_t = opmath_type<scalar_t>;
-    opmath_gpu_kernel_with_scalars<scalar_t>(iter, DivFunctor<opmath_t>());
-  } else {
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
-        kHalf, kBFloat16, kBool, iter.common_dtype(), "div_xpu", [&]() {
-          using opmath_t = opmath_type<scalar_t>;
-          opmath_gpu_kernel_with_scalars<scalar_t>(
-              iter, DivFunctor<opmath_t>());
-        });
-  }
-}
-
 } // namespace xpu
 } // namespace native
 } // namespace at

--- a/src/aten/sycl/BinaryKernels.h
+++ b/src/aten/sycl/BinaryKernels.h
@@ -12,8 +12,6 @@ void sub_kernel(TensorIteratorBase& iter, const Scalar& alpha);
 
 void mul_kernel(TensorIteratorBase& iter);
 
-void div_kernel(TensorIteratorBase& iter);
-
 void div_true_kernel(TensorIteratorBase& iter);
 
 void div_trunc_kernel(TensorIteratorBase& iter);

--- a/src/comm/XPUMathCompat.h
+++ b/src/comm/XPUMathCompat.h
@@ -29,4 +29,36 @@ __MATH_FUNCTIONS_DECL__ double rsqrt(double x) {
   return sycl::rsqrt(x);
 }
 
+// To walk around SYCL compiler optimization on data type promotion.
+// c10::Half gets data type promotion in +-*/ operations. See
+// c10/util/Half-inl.h. XPU implementation gets worse precision on half div,
+// since SYCL compiler optimizes the pattern. To align CPU/CUDA precision,
+// we define compat div to suppress the optimization. Same as c10::BFloat16.
+template <typename T>
+inline T div(const T& a, const T& b) __ubsan_ignore_float_divide_by_zero__ {
+  return a / b;
+}
+
+template <>
+inline c10::Half div<c10::Half>(const c10::Half& a, const c10::Half& b)
+    __ubsan_ignore_float_divide_by_zero__ {
+  volatile float res = static_cast<float>(a) / static_cast<float>(b);
+  return res;
+}
+
+template <>
+inline c10::BFloat16 div<c10::BFloat16>(
+    const c10::BFloat16& a,
+    const c10::BFloat16& b) __ubsan_ignore_float_divide_by_zero__ {
+  volatile float res = static_cast<float>(a) / static_cast<float>(b);
+  return res;
+}
+
+template <typename T>
+inline T div_trunc(const T& a, const T& b) {
+  // In the SYCL compilation environment, dividing the same numbers does not
+  // equal 1.f sometimes. Therefore, additional checks are required.
+  return ((a == b) && std::isfinite(a)) ? (T)1 : (T)std::trunc(div<T>(a, b));
+}
+
 } // namespace c10::xpu::compat

--- a/test/xpu/fin_grain/run_fine_grain.py
+++ b/test/xpu/fin_grain/run_fine_grain.py
@@ -8,8 +8,6 @@ skip_list = (
     "test_compare_cpu_cumsum_xpu_bfloat16",
     "test_compare_cpu_cumsum_xpu_float16",
     "test_compare_cpu_log_softmax_xpu_bfloat16", # Need FP64 golden ref for more accurate comparison
-    "test_compare_cpu_div_floor_rounding_xpu_bfloat16",
-    "test_compare_cpu_div_trunc_rounding_xpu_float16",
     "test_compare_cpu_log_xpu_complex64",
     "test_compare_cpu_mul_xpu_complex64",
     "test_compare_cpu_native_dropout_backward_xpu_bool",
@@ -25,6 +23,11 @@ skip_list = (
     "test_compare_cpu_tanh_xpu_complex128",
     "test_compare_cpu_tanh_xpu_complex64",
     "test_non_standard_bool_values_native_dropout_backward_xpu_bool",
+
+    # CPU result is not golden reference
+    "test_compare_cpu_div_floor_rounding_xpu_bfloat16",
+    "test_compare_cpu_div_trunc_rounding_xpu_float16",
+    "test_compare_cpu_div_trunc_rounding_xpu_bfloat16",
 
     # TestCompositeCompliance
     # CPU fallback fails

--- a/test/xpu/run_test_with_skip.py
+++ b/test/xpu/run_test_with_skip.py
@@ -943,7 +943,7 @@ skip_list = (
     "jiterator", # Jiterator is only supported by CUDA
     "cuda", # Skip cuda hard-coded case
     "test_fmod_remainder_by_zero_integral_xpu_int64", # zero division is an undefined behavior: different handles on different backends
-    "test_div_rounding_numpy_xpu_float16", # CPU fail
+    "test_div_rounding_numpy_xpu_float16", # Calculation error. XPU implementation uses opmath type.
     "test_cpu_tensor_pow_cuda_scalar_tensor_xpu", # CUDA hard-coded
     "test_type_promotion_bitwise_and_xpu", # align CUDA dtype
     "test_type_promotion_bitwise_or_xpu", # align CUDA dtype
@@ -961,6 +961,8 @@ skip_list = (
     "test_logaddexp_xpu_complex64", # CPU fail
     "test_type_promotion_clamp_max_xpu", # align CUDA dtype, CUDA XFAIL
     "test_type_promotion_clamp_min_xpu", # align CUDA dtype, CUDA XFAIL
+    "test_div_rounding_nonfinite_xpu_bfloat16", # CPU result is not golden reference
+    "test_div_rounding_nonfinite_xpu_float16", # CPU result is not golden reference
 )
 res += launch_test("test_binary_ufuncs_xpu.py", skip_list)
 


### PR DESCRIPTION
Fix div ut failures caused by the ineffective type promotion.
1. Align div with mul implementation by using opmath type.
2. Fix div trunc failure when result of division between two same floating point values is not 1.f sometimes.
3. Remove unnecessary kernels.