### PR TITLE
Add unit test cases for parametrization

### DIFF
--- a/test/xpu/nn/test_parametrization_xpu.py
+++ b/test/xpu/nn/test_parametrization_xpu.py
@@ -1,0 +1,20 @@
+# Owner(s): ["module: intel"]
+
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import run_tests, instantiate_parametrized_tests
+
+try:
+    from .xpu_test_utils import XPUPatchForImport
+except Exception as e:
+    from ..xpu_test_utils import XPUPatchForImport
+
+with XPUPatchForImport(False):
+    from test_parametrization import TestNNParametrization, TestNNParametrizationDevice
+
+
+instantiate_device_type_tests(TestNNParametrizationDevice, globals(), only_for="xpu")
+instantiate_parametrized_tests(TestNNParametrization)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/xpu/run_test_with_only.py
+++ b/test/xpu/run_test_with_only.py
@@ -47,5 +47,8 @@ res += launch_test("test_decomp_xpu.py", exe_list=execute_list)
 # test_comparison_utils
 res += launch_test("test_comparison_utils_xpu.py")
 
+# test_comparison_utils
+res += launch_test("nn/test_parametrization_xpu.py")
+
 exit_code = os.WEXITSTATUS(res)
 sys.exit(exit_code)


### PR DESCRIPTION
18 cases skipped since the pytorch compiled without LAPACK.
TestNNParametrization::test_caching_parametrization_swap_False
TestNNParametrization::test_caching_parametrization_swap_True
TestNNParametrization::test_caching_parametrization_with_transfer_parametrizations_and_params_swap_False
TestNNParametrization::test_caching_parametrization_with_transfer_parametrizations_and_params_swap_True SKIPPED
TestNNParametrization::test_initialization_parametrization_swap_False
TestNNParametrization::test_initialization_parametrization_swap_True
TestNNParametrization::test_multiple_inputs_parametrization_swap_False
TestNNParametrization::test_multiple_inputs_parametrization_swap_True
TestNNParametrization::test_orthogonal_errors_swap_False
TestNNParametrization::test_orthogonal_errors_swap_True
TestNNParametrization::test_orthogonal_parametrization_swap_False
TestNNParametrization::test_orthogonal_parametrization_swap_True
TestNNParametrization::test_register_and_remove_parametrization_swap_False
TestNNParametrization::test_register_and_remove_parametrization_swap_True
TestNNParametrization::test_serialization_parametrization_swap_False
TestNNParametrization::test_serialization_parametrization_swap_True
TestNNParametrization::test_transfer_parametrizations_and_params_many_to_one_swap_False
TestNNParametrization::test_transfer_parametrizations_and_params_many_to_one_swap_True