### PR TITLE
Fix index_add issue when index is empty

### DIFF
--- a/src/aten/sycl/Indexing.cpp
+++ b/src/aten/sycl/Indexing.cpp
@@ -317,6 +317,14 @@ void index_add_kernel(
     result.copy_(self);
   }
 
+  auto numel = index.numel();
+
+  if (result.dim() > 1) {
+      if (numel == 0 || self.numel() == 0) {
+          return;
+      }
+  }
+
   // Scalars are treated as 1-d tensor
   const Tensor self_ = (result.dim() == 0) ? result.view(1) : result;
   const Tensor source_ = (source.dim() == 0) ? source.view(1) : source;


### PR DESCRIPTION
Fixed test_dim_function_empty_xpu floating point exception when index is empty. See issue https.//github.com/intel/torch-xpu-ops/issues/302. Followed cpu implementation to return directly when index is empty. 

