### PR TITLE
build: fix warning in UpSampleNearest1dKernels.cpp

### DIFF
--- a/src/ATen/native/xpu/sycl/UpSampleNearest1dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleNearest1dKernels.cpp
@@ -275,8 +275,6 @@ void upsample_nearest1d_kernel(
       input.scalar_type(),
       "upsample_nearest1d_xpu",
       [&] {
-        using accscalar_t = acc_type<scalar_t, true>;
-
         auto idata = input.data_ptr<scalar_t>();
         auto odata = output_c.data_ptr<scalar_t>();
 


### PR DESCRIPTION
Fixes: #475
Fixes: d0d350e ("Add aten::upsample_nearest series of ops (#373)")

```
src/ATen/native/xpu/sycl/UpSampleNearest1dKernels.cpp:278:15: warning: typedef ‘using accscalar_t = at::acc_type<double, true>’ locally defined but not used [-Wunused-local-typedefs]
  278 |         using accscalar_t = acc_type<scalar_t, true>;
```

CC: @chunhuanMeng, @fengyuan14