### PR TITLE
[Inductor][UT failure] Fix max_indices in embedding_bag when mode is not Max

### DIFF
--- a/src/ATen/native/xpu/sycl/DistanceKernels.cpp
+++ b/src/ATen/native/xpu/sycl/DistanceKernels.cpp
@@ -321,72 +321,69 @@ void cdist_kernel(
   const int64_t r2 = x2_expanded.size(-2);
   const int64_t m = x1_expanded.size(-1);
 
-  AT_DISPATCH_FLOATING_TYPES(
-      x1_expanded.scalar_type(),
-      "cdist_xpu",
-      [&] {
-        if (p == 0.0) {
-          launch_cdist_forward_kernel<scalar_t, DistsZero<scalar_t>, 0>(
-              result,
-              x1_expanded,
-              x2_expanded,
-              p,
-              r1,
-              r2,
-              m,
-              r1 * r2,
-              r1 * m,
-              r2 * m);
-        } else if (p == 1.0) {
-          launch_cdist_forward_kernel<scalar_t, DistsOne<scalar_t>, 1>(
-              result,
-              x1_expanded,
-              x2_expanded,
-              p,
-              r1,
-              r2,
-              m,
-              r1 * r2,
-              r1 * m,
-              r2 * m);
-        } else if (p == 2.0) {
-          launch_cdist_forward_kernel<scalar_t, DistsTwo<scalar_t>, 2>(
-              result,
-              x1_expanded,
-              x2_expanded,
-              p,
-              r1,
-              r2,
-              m,
-              r1 * r2,
-              r1 * m,
-              r2 * m);
-        } else if (std::isinf(p)) {
-          launch_cdist_forward_kernel<scalar_t, DistsInf<scalar_t>, 3>(
-              result,
-              x1_expanded,
-              x2_expanded,
-              p,
-              r1,
-              r2,
-              m,
-              r1 * r2,
-              r1 * m,
-              r2 * m);
-        } else {
-          launch_cdist_forward_kernel<scalar_t, DistsP<scalar_t>, 4>(
-              result,
-              x1_expanded,
-              x2_expanded,
-              p,
-              r1,
-              r2,
-              m,
-              r1 * r2,
-              r1 * m,
-              r2 * m);
-        }
-      });
+  AT_DISPATCH_FLOATING_TYPES(x1_expanded.scalar_type(), "cdist_xpu", [&] {
+    if (p == 0.0) {
+      launch_cdist_forward_kernel<scalar_t, DistsZero<scalar_t>, 0>(
+          result,
+          x1_expanded,
+          x2_expanded,
+          p,
+          r1,
+          r2,
+          m,
+          r1 * r2,
+          r1 * m,
+          r2 * m);
+    } else if (p == 1.0) {
+      launch_cdist_forward_kernel<scalar_t, DistsOne<scalar_t>, 1>(
+          result,
+          x1_expanded,
+          x2_expanded,
+          p,
+          r1,
+          r2,
+          m,
+          r1 * r2,
+          r1 * m,
+          r2 * m);
+    } else if (p == 2.0) {
+      launch_cdist_forward_kernel<scalar_t, DistsTwo<scalar_t>, 2>(
+          result,
+          x1_expanded,
+          x2_expanded,
+          p,
+          r1,
+          r2,
+          m,
+          r1 * r2,
+          r1 * m,
+          r2 * m);
+    } else if (std::isinf(p)) {
+      launch_cdist_forward_kernel<scalar_t, DistsInf<scalar_t>, 3>(
+          result,
+          x1_expanded,
+          x2_expanded,
+          p,
+          r1,
+          r2,
+          m,
+          r1 * r2,
+          r1 * m,
+          r2 * m);
+    } else {
+      launch_cdist_forward_kernel<scalar_t, DistsP<scalar_t>, 4>(
+          result,
+          x1_expanded,
+          x2_expanded,
+          p,
+          r1,
+          r2,
+          m,
+          r1 * r2,
+          r1 * m,
+          r2 * m);
+    }
+  });
 }
 
 } // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
+++ b/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
@@ -393,7 +393,14 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> _embedding_bag_kernel(
   auto offset2bag = at::empty({indices.size(0)}, indices.options());
   auto output = at::empty({numBags, weight.size(1)}, weight.options());
 
-  Tensor max_indices = at::empty({numBags, weight.size(1)}, indices.options());
+  Tensor max_indices;
+
+  if (mode == MODE_MAX) {
+    max_indices = at::empty({numBags, weight.size(1)}, indices.options());
+  } else {
+    // No need to allocate if we aren't doing a backwards pass
+    max_indices = at::empty({0}, indices.options());
+  }
 
 #define EXTEND_EMBBAG_TEMPLATE(mode) \
   embedding_bag_##mode##_template(   \

--- a/test/xpu/run_test_with_skip.py
+++ b/test/xpu/run_test_with_skip.py
@@ -2057,6 +2057,12 @@ skip_list=(
     "test_compile_int4_mm_m_64_k_64_n_64_xpu",
 # Short is not supported in oneDNN!
     "test_mm_empty_inputs_mixed_dtype_errors_xpu",
+
+    # AttributeError: module 'torch._C' has no attribute '_cuda_tunableop_enable'
+    "test_bmm_tunableop_rocm_xpu_float32",
+
+    # AssertionError: Torch not compiled with CUDA enabled
+    "test_numeric_check_leak_tunableop_rocm_xpu_float32",
     )
 res += launch_test("test_linalg_xpu.py", skip_list)
 


### PR DESCRIPTION
Incorrect max_indices returned when mode is sum or mean. Fixing inductor/test_torchinductor.py::GPUTests::test_embedding_bag_xpu.