### PR TITLE
Support XPU ABI=0 build

### DIFF
--- a/cmake/BuildFlags.cmake
+++ b/cmake/BuildFlags.cmake
@@ -59,10 +59,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"
     set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -fno-approx-func)
     set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -Wno-absolute-value)
     set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -no-ftz)
+    # Equivalent to build option -fpreview-breaking-changes for SYCL compiler.
+    set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -D__INTEL_PREVIEW_BREAKING_CHANGES)
+    set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -D_GLIBCXX_USE_CXX11_ABI=${GLIBCXX_USE_CXX11_ABI})
   endif()
-  # TODO: Align with PyTorch and switch to ABI=0 eventually, after
-  # resolving incompatible implementation in SYCL runtime.
-  set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -D_GLIBCXX_USE_CXX11_ABI=1)
   set(SYCL_FLAGS ${SYCL_FLAGS} ${SYCL_KERNEL_OPTIONS})
 
   set(TORCH_XPU_OPS_FLAGS ${SYCL_HOST_FLAGS})

--- a/cmake/Modules/FindSYCL.cmake
+++ b/cmake/Modules/FindSYCL.cmake
@@ -407,7 +407,6 @@ macro(SYCL_LINK_DEVICE_OBJECTS output_file sycl_target)
       OUTPUT ${output_file}
       DEPENDS ${object_files}
       COMMAND ${SYCL_EXECUTABLE}
-      -fsycl
       ${SYCL_device_link_flags}
       -fsycl-link ${object_files}
       -Xs "\"${SYCL_OFFLINE_COMPILER_FLAGS}\""
@@ -471,7 +470,7 @@ macro(SYCL_ADD_LIBRARY sycl_target)
   target_link_libraries(
     ${sycl_target}
     ${SYCL_LINK_LIBRARIES_KEYWORD}
-    ${SYCL_LIBRARIES})
+    ${SYCL_LIBRARY})
 
   set_target_properties(${sycl_target}
     PROPERTIES
@@ -530,7 +529,7 @@ macro(SYCL_ADD_EXECUTABLE sycl_target)
   target_link_libraries(
     ${sycl_target}
     ${SYCL_LINK_LIBRARIES_KEYWORD}
-    ${SYCL_LIBRARIES})
+    ${SYCL_LIBRARY})
 
   set_target_properties(${sycl_target}
     PROPERTIES

--- a/cmake/SYCL.cmake
+++ b/cmake/SYCL.cmake
@@ -25,24 +25,6 @@ if(NOT SYCL_VERSION)
   return()
 endif()
 
-find_library(SYCL_LIBRARIES sycl HINTS ${SYCL_LIBRARY_DIR})
-# On Windows, currently there's no sycl.lib. Only sycl7.lib with version suffix,
-# where the current version of the SYCL runtime is 7.
-# Until oneAPI adds support to sycl.lib without the version suffix,
-# sycl_runtime_version needs to be hardcoded and uplifted when SYCL runtime version uplifts.
-# TODO: remove this when sycl.lib is supported on Windows
-if(WIN32)
-  set(sycl_runtime_version 7)
-  find_library(
-    SYCL_LIBRARIES
-    NAMES "sycl${sycl_runtime_version}"
-    HINTS ${SYCL_LIBRARY_DIR}
-  )
-  if(SYCL_LIBRARIES STREQUAL "SYCL_LIBRARIES-NOTFOUND")
-    message(FATAL_ERROR "Cannot find a SYCL library on Windows")
-  endif()
-endif()
-
 set(SYCL_COMPILER_VERSION)
 file(READ ${SYCL_VERSION} version_contents)
 string(REGEX MATCHALL "__SYCL_COMPILER_VERSION +[0-9]+" VERSION_LINE "${version_contents}")

--- a/src/ATen/CMakeLists.txt
+++ b/src/ATen/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ATen XPU sources
 
-file(GLOB xpu_cpp "xpu/*.cpp", "native/xpu/*.cpp", "native/sparse/*.cpp")
+file(GLOB xpu_cpp "xpu/*.cpp" "native/xpu/*.cpp" "native/sparse/*.cpp")
 file(GLOB xpu_sycl "native/xpu/sycl/*.cpp")
 
 list(APPEND ATen_XPU_CPP_SRCS ${xpu_cpp})

--- a/src/ATen/native/xpu/sycl/AmpKernels.cpp
+++ b/src/ATen/native/xpu/sycl/AmpKernels.cpp
@@ -102,9 +102,9 @@ void amp_foreach_non_finite_check_and_unscale_kernel(
 }
 
 struct AmpUpdateScaleKernelFunctor {
-  void operator()(sycl::item<1> item) const {
+  void operator()(sycl::nd_item<1> item) const {
     // There is only single item/task scheduled.
-    if (item.get_linear_id() != 0)
+    if (item.get_global_linear_id() != 0)
       return;
 
     if (*found_inf_) {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,7 +82,7 @@ foreach(lib ${TORCH_XPU_OPS_LIBRARIES})
   target_include_directories(${lib} PUBLIC ${ATen_XPU_INCLUDE_DIRS})
   target_include_directories(${lib} PUBLIC ${SYCL_INCLUDE_DIR})
 
-  target_link_libraries(${lib} PUBLIC ${SYCL_LIBRARIES})
+  target_link_libraries(${lib} PUBLIC ${SYCL_LIBRARY})
 endforeach()
 
 include(${TORCH_XPU_OPS_ROOT}/cmake/ClangFormat.cmake)

--- a/test/sycl/CMakeLists.txt
+++ b/test/sycl/CMakeLists.txt
@@ -42,7 +42,7 @@ add_dependencies(test_sycl_build_archive sycl_simple_kernel_test)
 # Instead, we use explicit linkage option '--whole-archive', which is required
 # by linkage of device object modules archived in the static library. Then
 # explicit linkage configuration of SYCL runtime library is required.
-target_link_libraries(test_sycl_build_archive ${SYCL_LIBRARIES})
+target_link_libraries(test_sycl_build_archive ${SYCL_LIBRARY})
 
 if(INSTALL_TEST)
   install(TARGETS test_sycl_build_archive DESTINATION bin)


### PR DESCRIPTION
# Motivation
Support XPU ABI neutral build.
Starting from compiler 2025.0, `libsycl.so` is ABI-neutral lib. Before this, the `libsycl-preview.so` is ABI-neutral.

refer to https://github.com/pytorch/pytorch/pull/130110