### PR TITLE
Add skip case

### DIFF
--- a/test/xpu/extended/run_test_with_skip.py
+++ b/test/xpu/extended/run_test_with_skip.py
@@ -82,6 +82,11 @@ skip_list = (
     "test_compare_cpu_nn_functional_embedding_bag_xpu_float64",
     "test_view_replay_nn_functional_embedding_bag_xpu_float32",
 
+    # Not implemented operators, aten::_embedding_bag_backward.
+    # To retrieve cases when the operators are supported.
+    # https://github.com/intel/torch-xpu-ops/issues/536
+    "test_backward_nn_functional_embedding_bag_xpu_float32",
+
     #Double and complex datatype matmul is not supported in oneDNN
     "test_compare_cpu_cdist_xpu_float64",
 


### PR DESCRIPTION
 Not implemented operators, aten::_embedding_bag_backward.
 To retrieve cases when the operators are supported.
 https://github.com/intel/torch-xpu-ops/issues/536
"test_backward_nn_functional_embedding_bag_xpu_float32",