### PR TITLE
build: fix -Wunused-function warning

### DIFF
--- a/src/ATen/native/xpu/XPUFallback.template
+++ b/src/ATen/native/xpu/XPUFallback.template
@@ -109,10 +109,6 @@ static void xpu_lazy_registration_or_error_fallback(
   }
 }
 
-static void xpu_force_fallback(
-    const c10::OperatorHandle& op,
-    torch::jit::Stack* stack) {}
-
 TORCH_LIBRARY_IMPL(_, XPU, m) {
   static const char* enable_xpu_fallback =
       getenv("PYTORCH_ENABLE_XPU_FALLBACK");


### PR DESCRIPTION
PyTorch enforced unused-function and unused-variable compilation options recently. It leads to torch-xpu-ops building failure with -Werror.
Fixing: https://github.com/pytorch/pytorch/pull/130084
```
build/aten/src/ATen/xpu/RegisterXPU.cpp:5452:13: warning: ‘void at::xpu_force_fallback(const c10::OperatorHandle&, torch::jit::Stack*)’ defined but not used
```

cc: @fengyuan14 