### PR TITLE
[Pytorch update breaks XPU] Revert checkIndexTensorTypes usage due to…

### DIFF
--- a/src/ATen/native/xpu/sycl/IndexingUtils.h
+++ b/src/ATen/native/xpu/sycl/IndexingUtils.h
@@ -99,7 +99,7 @@ static std::tuple<Tensor, int64_t, int64_t, int64_t> computeLinearIndex(
 static std::
     tuple<Tensor, Tensor, int64_t, int64_t, int64_t, std::vector<int64_t>>
     makeLinearIndex(Tensor self, IOptTensorListRef orig, bool check_range) {
-  checkIndexTensorTypes(orig);
+  checkIndexTensorTypes(orig, /*allow_int*/ true);
   // first expand BoolTensor (masks) or ByteTensor (masks) into 1 or more
   // LongTensors
   auto indices = expandTensors(self, orig);

--- a/test/xpu/run_test_with_skip.py
+++ b/test/xpu/run_test_with_skip.py
@@ -1380,11 +1380,6 @@ skip_list = (
     # https://github.com/intel/torch-xpu-ops/issues/461
     "test_index_put_src_datatype_xpu_float8_e5m2",
     "test_index_put_src_datatype_xpu_float8_e4m3fn",
-
-    # Regression after PyTorch update
-    # http://github.com/intel/torch-xpu-ops/issues/549
-    # IndexError: tensors used as indices must be long, byte or bool tensors.
-    "test_index_ind_dtype_xpu",
 )
 res += launch_test("test_indexing_xpu.py", skip_list)
 


### PR DESCRIPTION
… the change of API reverted in PyTorch