### PR TITLE
Split binary of PyTorch XPU operators into multiple libraries

### DIFF
--- a/src/ATen/native/xpu/sycl/MultinomialKernel.cpp
+++ b/src/ATen/native/xpu/sycl/MultinomialKernel.cpp
@@ -450,8 +450,11 @@ void multinomial_kernel(
             std::min(maxThreads, requiredSubGroups * SubGroupSize);
         int requiredShared = requiredThreads * sizeof(accscalar_t);
         if (n_sample == 1 && maxShared >= requiredShared) {
-          Tensor sampled =
-              at::detail::empty_xpu({numDist, n_sample}, self_v.options());
+          // Break per source build. Build every kernel source file into a so.
+          // libtorch_xpu.so which is the so of operator level depends the so
+          // of kernels. Do not depends on libtorch_xpu.so inversively. Using
+          // at::empty instead of at::detail::empty_xpu.
+          Tensor sampled = at::empty({numDist, n_sample}, self_v.options());
           at::native::uniform_(sampled, 0.0, 1.0, generator);
           int group_size = requiredThreads;
           int group_range = numDist;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,13 +10,14 @@ add_subdirectory(ATen)
 
 set(TORCH_XPU_OPS_LIBRARIES)
 set(SYCL_LINK_LIBRARIES_KEYWORD PRIVATE)
-if(BUILD_SEPARATE_OPS)
-  add_library(
-    torch_xpu_ops
-    STATIC
-    ${ATen_XPU_CPP_SRCS}
-    ${ATen_XPU_GEN_SRCS})
 
+add_library(
+  torch_xpu_ops
+  STATIC
+  ${ATen_XPU_CPP_SRCS}
+  ${ATen_XPU_GEN_SRCS})
+
+if(BUILD_SEPARATE_OPS)
   foreach(sycl_src ${ATen_XPU_SYCL_SRCS})
     get_filename_component(name ${sycl_src} NAME_WLE REALPATH)
     set(sycl_lib torch-xpu-ops-sycl-${name})
@@ -31,11 +32,27 @@ if(BUILD_SEPARATE_OPS)
     install(TARGETS ${sycl_lib} DESTINATION "${TORCH_INSTALL_LIB_DIR}")
   endforeach()
 else()
-  sycl_add_library(
-    torch_xpu_ops
-    STATIC
-    SYCL_SOURCES ${ATen_XPU_SYCL_SRCS}
-    CXX_SOURCES ${ATen_XPU_CPP_SRCS} ${ATen_XPU_GEN_SRCS})
+  # Split kernels into multiple libraries
+  list(LENGTH ATen_XPU_SYCL_SRCS NUM_SYCL_SRC)
+  math(EXPR MAX_NUM_SYCL_SRC_PER_LIB "50")
+  math(EXPR SYCL_SRC_BEGIN "0")
+  math(EXPR NUM_LIBS "(${NUM_SYCL_SRC} + ${MAX_NUM_SYCL_SRC_PER_LIB} - 1) / ${MAX_NUM_SYCL_SRC_PER_LIB}")
+  while(NUM_LIBS GREATER 0)
+    set(sycl_lib torch-xpu-ops-sycl-ker-part${NUM_LIBS})
+    list(SUBLIST ATen_XPU_SYCL_SRCS ${SYCL_SRC_BEGIN} ${MAX_NUM_SYCL_SRC_PER_LIB} sycl_src)
+    sycl_add_library(
+      ${sycl_lib}
+      SHARED
+      SYCL_SOURCES ${sycl_src})
+    target_link_libraries(torch_xpu_ops PUBLIC ${sycl_lib})
+    list(APPEND TORCH_XPU_OPS_LIBRARIES ${sycl_lib})
+
+    # Decouple with PyTorch cmake definition.
+    install(TARGETS ${sycl_lib} DESTINATION "${TORCH_INSTALL_LIB_DIR}")
+
+    math(EXPR NUM_LIBS "${NUM_LIBS} - 1")
+    math(EXPR SYCL_SRC_BEGIN "${SYCL_SRC_BEGIN} + ${MAX_NUM_SYCL_SRC_PER_LIB}")
+  endwhile()
 endif()
 set(SYCL_LINK_LIBRARIES_KEYWORD)
 


### PR DESCRIPTION
Including 1. libtorch_xpu.so (Host only, operator level) 2. libtorch-xpu-ops-sycl-ker-partx.so (Device code) libtorch-xpu-ops-sycl-ker-partx.so at most includes 50 SYCL kernel related source files, will be about 1GB.