### PR TITLE
Fix index out of range for IndexPut kernel

### DIFF
--- a/src/ATen/native/xpu/sycl/Indexing.h
+++ b/src/ATen/native/xpu/sycl/Indexing.h
@@ -804,7 +804,7 @@ struct IndexPutDeterministicKernelFunctor {
     if (accumulate_)
       acc = self_[s_gid];
     for (int64_t inner_idx = id.glb_batch;
-         sorted_indices_[inner_idx] == idx && inner_idx < cfg_.problem_batch_;
+         inner_idx < cfg_.problem_batch_ && sorted_indices_[inner_idx] == idx;
          inner_idx++) {
       int64_t idx_orig = indices_[inner_idx];
       int64_t v_gid = idx_orig * stride_ + v_stride;


### PR DESCRIPTION
We encounter an out-of-range page fault for the index put kernel. This is because the condition check order is not correct.

We should check the array index before accessing the array. The previous ScratchPage option of the driver may hide this issue.

Co-author:
@gaopengff