### PR TITLE
add hook for _check_arg_device2 and freeze_rng_state to support xpu

### DIFF
--- a/test/xpu/nn/test_multihead_attention_xpu.py
+++ b/test/xpu/nn/test_multihead_attention_xpu.py
@@ -15,6 +15,17 @@ with XPUPatchForImport(False):
     import unittest
     import unittest.mock as mock
     from torch.testing._internal.common_utils import TEST_WITH_CROSSREF
+    from typing import Optional
+
+    def _check_arg_device2(x: Optional[torch.Tensor]) -> bool:
+        if x is not None:
+            return x.device.type in [
+                "cpu",
+                "cuda",
+                "xpu",
+                torch.utils.backend_registration._privateuse1_backend_name,
+            ]
+        return True
 
     @torch.no_grad()
     @unittest.skipIf(
@@ -63,6 +74,7 @@ with XPUPatchForImport(False):
                 self.assertTrue(fastpath_mock.called)
 
     TestMultiheadAttentionNNDeviceType.test_multihead_self_attn_two_masks_fast_path_mock = multihead_self_attn_two_masks_fast_path_mock
+    torch.nn.modules.activation._check_arg_device = _check_arg_device2
 
 instantiate_device_type_tests(TestMultiheadAttentionNNDeviceType, globals(), only_for='xpu', allow_xpu=True)
 instantiate_parametrized_tests(TestMultiheadAttentionNN)

--- a/test/xpu/run_test_with_skip.py
+++ b/test/xpu/run_test_with_skip.py
@@ -1381,14 +1381,7 @@ res += launch_test("nn/test_pooling_xpu.py", skip_list)
 # nn/test_dropout
 
 
-skip_list = (
-    # Cannot freeze rng state. Need enhance test infrastructure to make XPU
-    # compatible in freeze_rng_state.
-    # https://github.com/intel/torch-xpu-ops/issues/259
-    "test_Dropout1d_xpu",
-    "test_Dropout3d_xpu",
-)
-res += launch_test("nn/test_dropout_xpu.py", skip_list)
+res += launch_test("nn/test_dropout_xpu.py")
 
 # test_dataloader
 
@@ -2897,8 +2890,6 @@ skip_list = (
     "test_multihead_attn_fast_path_small_test_xpu_float64",
     "test_multihead_attn_in_proj_bias_none_xpu_float64",
     "test_multihead_attn_in_proj_weight_none_xpu_float64",
-    # issue 342
-    "test_multihead_self_attn_two_masks_fast_path_mock_xpu",
 )
 res += launch_test("nn/test_multihead_attention_xpu.py", skip_list)
 


### PR DESCRIPTION
Added hook to support xpu backend, so that test_multihead_self_attn_two_masks_fast_path_mock_xpu and test_Dropout1d_xpu and test_Dropout3d_xpu can pass. 