### PR TITLE
revert checkIndexType() interface change, update skip list for test_s…

### DIFF
--- a/src/ATen/native/xpu/sycl/IndexingUtils.h
+++ b/src/ATen/native/xpu/sycl/IndexingUtils.h
@@ -99,7 +99,7 @@ static std::tuple<Tensor, int64_t, int64_t, int64_t> computeLinearIndex(
 static std::
     tuple<Tensor, Tensor, int64_t, int64_t, int64_t, std::vector<int64_t>>
     makeLinearIndex(Tensor self, IOptTensorListRef orig, bool check_range) {
-  checkIndexTensorTypes(orig);
+  checkIndexTensorTypes(orig, /*allow_int*/ true);
   // first expand BoolTensor (masks) or ByteTensor (masks) into 1 or more
   // LongTensors
   auto indices = expandTensors(self, orig);

--- a/test/xpu/extended/run_test_with_skip.py
+++ b/test/xpu/extended/run_test_with_skip.py
@@ -160,6 +160,7 @@ skip_list = (
     # Greatest relative difference: 0.0032501220703125 at index (2, 1, 2, 1) (up to 0.001 allowed)
     "test_compare_cpu_nn_functional_batch_norm_xpu_float16",
     "test_compare_cpu_std_mean_xpu_bfloat16",
+    # verfieid cuda also has accuracy issue with alpha -3.125, see https://github.com/intel/torch-xpu-ops/issues/549
     "test_compare_cpu_sub_xpu_float16",
     "test_compare_cpu_var_mean_xpu_bfloat16",
 

--- a/test/xpu/run_test_with_skip.py
+++ b/test/xpu/run_test_with_skip.py
@@ -1356,10 +1356,6 @@ skip_list = (
     "test_index_put_src_datatype_xpu_float8_e5m2",
     "test_index_put_src_datatype_xpu_float8_e4m3fn",
 
-    # Regression after PyTorch update
-    # http://github.com/intel/torch-xpu-ops/issues/549
-    # IndexError: tensors used as indices must be long, byte or bool tensors.
-    "test_index_ind_dtype_xpu",
 )
 res += launch_test("test_indexing_xpu.py", skip_list)
 
@@ -2999,13 +2995,7 @@ res += launch_test("nn/test_convolution_xpu.py", skip_list)
 
 # test_dynamic_shapes
 
-skip_list = (
-    # Regression after PyTorch uplift
-    # https://github.com/intel/torch-xpu-ops/issues/549
-    # AssertionError: 3 != 3.0
-    "test_symnode_hashing",
-)
-res += launch_test("test_dynamic_shapes_xpu.py", skip_list)
+res += launch_test("test_dynamic_shapes_xpu.py")
 
 # test_load_state_dict
 


### PR DESCRIPTION
test_index_ind_dtype_xpu: because checkIndexTensorTypes interface changes is reverted by
https://github.com/pytorch/pytorch/commit/fb696bf26457a60583f4c43f1a6547b16725c016. So we should also revert torch-xpu-ops https://github.com/intel/torch-xpu-ops/commit/4db0b0cd1ca51d9cfd890be2eb3527b165782220, for the 2nd parameter of checkIndexTensorTypes.

test_symnode_hashing can pass with latest code, so remove the skip
test_compare_cpu_sub_xpu_float16 is verified cuda also has the same issue, so added comments. 

