### PR TITLE
Add skip cases

### DIFF
--- a/test/xpu/run_test_with_skip.py
+++ b/test/xpu/run_test_with_skip.py
@@ -763,6 +763,8 @@ skip_list = (
     "test_variant_consistency_eager_svd_lowrank_xpu_complex64",
     "test_conj_view_pca_lowrank_xpu_complex64",
     "test_conj_view_svd_lowrank_xpu_complex64",
+    "test_neg_conj_view_pca_lowrank_xpu_complex128",
+    "test_neg_conj_view_svd_lowrank_xpu_complex128",
     ### Error #1 in TestMathBitsXPU , RuntimeError: could not create a primitive descriptor for a deconvolution forward propagation primitive
     # https://github.com/intel/torch-xpu-ops/issues/253
     "test_conj_view_nn_functional_conv_transpose2d_xpu_complex64",


### PR DESCRIPTION
RuntimeError: Double and complex datatype matmul is not supported in oneDNN