### PR TITLE
upsample_bilinear: Enabled deterministic cases

### DIFF
--- a/test/xpu/run_test_with_skip.py
+++ b/test/xpu/run_test_with_skip.py
@@ -2861,8 +2861,6 @@ skip_list = (
     "test_cuda_vitals_gpu_only_xpu",
     # torch.utils.swap_tensors AssertionError: RuntimeError not raised
     "test_swap_basic",
-    # Needs pr to enable deterministic implementation for interpolate op
-    "test_deterministic_interpolate_bilinear_xpu",
     # Precision error
     # Fail in high probability in preci.
     # Mismatched elements: 1 / 262144 (0.0%)


### PR DESCRIPTION
The feature is enabled by https://github.com/pytorch/pytorch/pull/129864.