### PR TITLE
Drop CPU fallback for aten::norm.out and aten::nextafter.out

### DIFF
--- a/src/ATen/native/xpu/XPUFallback.template
+++ b/src/ATen/native/xpu/XPUFallback.template
@@ -239,8 +239,6 @@ TORCH_LIBRARY_IMPL(aten, XPU, m) {
     "nanmedian",
     "nanmedian.dim_values",
     "nansum",
-    "norm.out",
-    "nextafter.out",
     "ormqr",
     "_pdist_backward",
     "_pdist_forward",


### PR DESCRIPTION
Fixes: #640
Fixes: 6eca394 ("Add aten::nextafter and its variants")

CC: @fengyuan14 @yucai-intel @xytintel