### PR TITLE
Use safe API to access Tensor data pointer

### DIFF
--- a/src/ATen/native/xpu/NMS.cpp
+++ b/src/ATen/native/xpu/NMS.cpp
@@ -55,7 +55,7 @@ Tensor nms(const Tensor& dets, const Tensor& scores, double iou_threshold_) {
 
   at::Tensor keep =
       at::empty({dets_num}, dets.options().dtype(at::kLong).device(at::kCPU));
-  int64_t* keep_out = (int64_t*)keep.data_ptr();
+  int64_t* keep_out = keep.mutable_data_ptr<int64_t>();
 
   int num_to_keep = 0;
   for (int i = 0; i < dets_num; i++) {

--- a/src/ATen/native/xpu/NMS.cpp
+++ b/src/ATen/native/xpu/NMS.cpp
@@ -48,7 +48,8 @@ Tensor nms(const Tensor& dets, const Tensor& scores, double iou_threshold_) {
   auto mask = nms_kernel(dets_sorted, iou_threshold);
 
   at::Tensor mask_cpu = mask.to(at::kCPU);
-  unsigned long long* mask_host = (unsigned long long*)mask_cpu.mutable_data_ptr();
+  unsigned long long* mask_host =
+      (unsigned long long*)mask_cpu.mutable_data_ptr();
 
   std::vector<unsigned long long> remv(col_blocks);
   memset(&remv[0], 0, sizeof(unsigned long long) * col_blocks);

--- a/src/ATen/native/xpu/NMS.cpp
+++ b/src/ATen/native/xpu/NMS.cpp
@@ -48,7 +48,7 @@ Tensor nms(const Tensor& dets, const Tensor& scores, double iou_threshold_) {
   auto mask = nms_kernel(dets_sorted, iou_threshold);
 
   at::Tensor mask_cpu = mask.to(at::kCPU);
-  unsigned long long* mask_host = (unsigned long long*)mask_cpu.data_ptr();
+  unsigned long long* mask_host = (unsigned long long*)mask_cpu.mutable_data_ptr();
 
   std::vector<unsigned long long> remv(col_blocks);
   memset(&remv[0], 0, sizeof(unsigned long long) * col_blocks);

--- a/src/ATen/native/xpu/sycl/MultiTensorApply.h
+++ b/src/ATen/native/xpu/sycl/MultiTensorApply.h
@@ -180,7 +180,7 @@ void multi_tensor_apply(
     tlAddress[t].scalar_vals = scalars[t].to<scalar_t>();
     totalWG += (numel + kChunkSize - 1) / kChunkSize;
     for (int d = 0; d < depth; ++d) {
-      tlAddress[t].addresses[d] = tensor_lists[d][t].data_ptr();
+      tlAddress[t].addresses[d] = tensor_lists[d][t].mutable_data_ptr();
     }
   }
 
@@ -249,7 +249,7 @@ void multi_tensor_apply(
       {(int)(sizeof(TLMetaForAddress<depth>) * n_tensors)},
       tensor_lists[0][0].options().dtype(at::kByte));
   auto metaAddressInput =
-      static_cast<TLMetaForAddress<depth>*>(addressStorage.data_ptr());
+      static_cast<TLMetaForAddress<depth>*>(addressStorage.mutable_data_ptr());
   TLMetaForAddress<depth>* tlAddress = nullptr;
 
   auto tlAddress_dptr =
@@ -263,7 +263,7 @@ void multi_tensor_apply(
     tlAddress[t].numel_to_tensor = numel;
     totalWG += (numel + kChunkSize - 1) / kChunkSize;
     for (int d = 0; d < depth; ++d) {
-      tlAddress[t].addresses[d] = tensor_lists[d][t].data_ptr();
+      tlAddress[t].addresses[d] = tensor_lists[d][t].mutable_data_ptr();
     }
   }
 
@@ -279,7 +279,8 @@ void multi_tensor_apply(
   auto wgMetaStorage = at::empty(
       {(int)(sizeof(TLMetaForWG) * totalWG)},
       tensor_lists[0][0].options().dtype(at::kByte));
-  auto metaWGInput = static_cast<TLMetaForWG*>(wgMetaStorage.data_ptr());
+  auto metaWGInput =
+      static_cast<TLMetaForWG*>(wgMetaStorage.mutable_data_ptr());
   TLMetaForWG* tlWGMeta = nullptr;
 
   auto tlWGMeta_dptr = at::xpu::HostAlloc(sizeof(TLMetaForWG) * totalWG);
@@ -325,8 +326,8 @@ void multi_tensor_apply_for_fused_optimizer(
   auto addressStorage = at::empty(
       {(int)(sizeof(TLFusedMetaForAddress<depth>) * n_tensors)},
       tensor_lists[0][0].options().dtype(at::kByte));
-  auto metaFusedAddressInput =
-      static_cast<TLFusedMetaForAddress<depth>*>(addressStorage.data_ptr());
+  auto metaFusedAddressInput = static_cast<TLFusedMetaForAddress<depth>*>(
+      addressStorage.mutable_data_ptr());
   TLFusedMetaForAddress<depth>* tlAddress = nullptr;
 
   auto tlAddress_dptr =
@@ -338,10 +339,10 @@ void multi_tensor_apply_for_fused_optimizer(
   for (size_t t = 0; t < n_tensors; ++t) {
     auto numel = tensor_lists[0][t].numel();
     tlAddress[t].numel_to_tensor = numel;
-    tlAddress[t].state_steps_addresses = state_steps[t].data_ptr();
+    tlAddress[t].state_steps_addresses = state_steps[t].mutable_data_ptr();
     totalWG += (numel + kChunkSize - 1) / kChunkSize;
     for (int d = 0; d < depth; ++d) {
-      tlAddress[t].addresses[d] = tensor_lists[d][t].data_ptr();
+      tlAddress[t].addresses[d] = tensor_lists[d][t].mutable_data_ptr();
     }
   }
 
@@ -357,7 +358,8 @@ void multi_tensor_apply_for_fused_optimizer(
   auto wgMetaStorage = at::empty(
       {(int)(sizeof(TLMetaForWG) * totalWG)},
       tensor_lists[0][0].options().dtype(at::kByte));
-  auto metaWGInput = static_cast<TLMetaForWG*>(wgMetaStorage.mutable_data_ptr());
+  auto metaWGInput =
+      static_cast<TLMetaForWG*>(wgMetaStorage.mutable_data_ptr());
   TLMetaForWG* tlWGMeta = nullptr;
 
   auto tlWGMeta_dptr = at::xpu::HostAlloc(sizeof(TLMetaForWG) * totalWG);

--- a/src/ATen/native/xpu/sycl/MultiTensorApply.h
+++ b/src/ATen/native/xpu/sycl/MultiTensorApply.h
@@ -164,7 +164,7 @@ void multi_tensor_apply(
       tensor_lists[0][0].options().dtype(at::kByte));
   auto metaAddressInput =
       static_cast<TLMetaForAddressScalar<scalar_vals_t, depth>*>(
-          addressStorage.data_ptr());
+          addressStorage.mutable_data_ptr());
   TLMetaForAddressScalar<scalar_vals_t, depth>* tlAddress = nullptr;
 
   auto tlAddress_dptr = at::xpu::HostAlloc(
@@ -356,7 +356,7 @@ void multi_tensor_apply_for_fused_optimizer(
   auto wgMetaStorage = at::empty(
       {(int)(sizeof(TLMetaForWG) * totalWG)},
       tensor_lists[0][0].options().dtype(at::kByte));
-  auto metaWGInput = static_cast<TLMetaForWG*>(wgMetaStorage.data_ptr());
+  auto metaWGInput = static_cast<TLMetaForWG*>(wgMetaStorage.mutable_data_ptr());
   TLMetaForWG* tlWGMeta = nullptr;
 
   auto tlWGMeta_dptr = at::xpu::HostAlloc(sizeof(TLMetaForWG) * totalWG);

--- a/src/ATen/native/xpu/sycl/MultiTensorApply.h
+++ b/src/ATen/native/xpu/sycl/MultiTensorApply.h
@@ -196,7 +196,8 @@ void multi_tensor_apply(
   auto wgMetaStorage = at::empty(
       {(int)(sizeof(TLMetaForWG) * totalWG)},
       tensor_lists[0][0].options().dtype(at::kByte));
-  auto metaWGInput = static_cast<TLMetaForWG*>(wgMetaStorage.data_ptr());
+  auto metaWGInput =
+      static_cast<TLMetaForWG*>(wgMetaStorage.mutable_data_ptr());
   TLMetaForWG* tlWGMeta = nullptr;
 
   auto tlWGMeta_dptr = at::xpu::HostAlloc(sizeof(TLMetaForWG) * totalWG);

--- a/src/ATen/native/xpu/sycl/NMSKernel.cpp
+++ b/src/ATen/native/xpu/sycl/NMSKernel.cpp
@@ -111,7 +111,7 @@ Tensor nms_kernel(const Tensor& dets_sorted, float iou_threshold) {
             (size_t)col_blocks, (size_t)col_blocks * nms_items_per_group};
         sycl::range<2> local_range{1, (size_t)nms_items_per_group};
         using acc_t = acc_type_device<scalar_t, kXPU>;
-        auto dets_sorted_ptr = (scalar_t*)dets_sorted.data_ptr();
+        auto dets_sorted_ptr = dets_sorted.const_data_ptr<scalar_t>();
         auto mask_ptr = (unsigned long long*)mask.data_ptr();
         auto caller = NMSKernelFunctor<scalar_t, acc_t>(
             dets_num, iou_threshold, dets_sorted_ptr, mask_ptr);

--- a/src/ATen/native/xpu/sycl/NMSKernel.cpp
+++ b/src/ATen/native/xpu/sycl/NMSKernel.cpp
@@ -111,8 +111,8 @@ Tensor nms_kernel(const Tensor& dets_sorted, float iou_threshold) {
             (size_t)col_blocks, (size_t)col_blocks * nms_items_per_group};
         sycl::range<2> local_range{1, (size_t)nms_items_per_group};
         using acc_t = acc_type_device<scalar_t, kXPU>;
-        auto dets_sorted_ptr = dets_sorted.const_data_ptr<scalar_t>();
-        auto mask_ptr = (unsigned long long*)mask.data_ptr();
+        auto dets_sorted_ptr = dets_sorted.data_ptr<scalar_t>();
+        auto mask_ptr = (unsigned long long*)mask.data_ptr<int64_t>();
         auto caller = NMSKernelFunctor<scalar_t, acc_t>(
             dets_num, iou_threshold, dets_sorted_ptr, mask_ptr);
         sycl_kernel_submit(

--- a/src/ATen/native/xpu/sycl/Shape.cpp
+++ b/src/ATen/native/xpu/sycl/Shape.cpp
@@ -186,7 +186,7 @@ void parallel_cat(
     int nDims) {
   // First, let's set up our kernel parameters. We start with a raw pointer to
   // the storage for the output Tensor.
-  scalar_out_t* data = static_cast<scalar_out_t*>(out.data_ptr());
+  scalar_out_t* data = static_cast<scalar_out_t*>(out.mutable_data_ptr());
 
   // Kernel Parameter
   int64_t tensorMetadataSize =
@@ -195,7 +195,7 @@ void parallel_cat(
   auto d_inputs_storage =
       at::empty({tensorMetadataSize}, out.options().dtype(at::kByte));
   auto d_inputs = static_cast<CatArrInputTensor<scalar_in_t, unsigned int>*>(
-      d_inputs_storage.data_ptr());
+      d_inputs_storage.mutable_data_ptr());
 
   OutputTensorSizeStride<unsigned int, CAT_ARRAY_MAX_INPUT_DIMS> param;
 

--- a/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
+++ b/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
@@ -1367,9 +1367,9 @@ void spatial_softmax_forward(Tensor& output, Tensor& input, int dim) {
   using vec_t = at::native::memory::aligned_vector<scalar_t, max_vec_size>;
   constexpr int align_bytes = alignof(vec_t);
   int input_start =
-      ((uint64_t)input.data_ptr()) % align_bytes / sizeof(scalar_t);
+      ((uint64_t)input.const_data_ptr()) % align_bytes / sizeof(scalar_t);
   int output_start =
-      ((uint64_t)output.data_ptr()) % align_bytes / sizeof(scalar_t);
+      ((uint64_t)output.const_data_ptr()) % align_bytes / sizeof(scalar_t);
 
   // decide indexing range: uint32_t (4GB) or uint64_t (>4GB)
   bool can_use_32bit_index =
@@ -1558,11 +1558,11 @@ void spatial_softmax_backward(
   using vec_t = at::native::memory::aligned_vector<scalar_t, max_vec_size>;
   constexpr int align_bytes = alignof(vec_t);
   int gradin_start =
-      ((uint64_t)gradInput.data_ptr()) % align_bytes / sizeof(scalar_t);
+      ((uint64_t)gradInput.const_data_ptr()) % align_bytes / sizeof(scalar_t);
   int output_start =
-      ((uint64_t)output.data_ptr()) % align_bytes / sizeof(scalar_t);
+      ((uint64_t)output.const_data_ptr()) % align_bytes / sizeof(scalar_t);
   int gradoutput_start =
-      ((uint64_t)gradOutput.data_ptr()) % align_bytes / sizeof(scalar_t);
+      ((uint64_t)gradOutput.const_data_ptr()) % align_bytes / sizeof(scalar_t);
 
   // decide indexing range: uint32_t (4GB) or uint64_t (>4GB)
   bool can_use_32bit_index = canUse32BitIndexMath(gradInput) &&

--- a/src/ATen/native/xpu/sycl/TriangularOpsKernels.cpp
+++ b/src/ATen/native/xpu/sycl/TriangularOpsKernels.cpp
@@ -83,8 +83,8 @@ void apply_triu_tril(Tensor& result, const Tensor& self, const int64_t k) {
   IndexType result_stride_0 = (IndexType)result.stride(-2);
   IndexType result_stride_1 = (IndexType)result.stride(-1);
 
-  scalar_t* result_ptr = (scalar_t*)(result.data_ptr());
-  scalar_t* self_ptr = (scalar_t*)(self.data_ptr());
+  scalar_t* result_ptr = result.data_ptr<scalar_t>();
+  scalar_t* self_ptr = self.data_ptr<scalar_t>();
 
   ApplyTriuTrilKernelFunctor<scalar_t, IndexType, upper> kfn(
       k,


### PR DESCRIPTION
The un-templated data_ptr() does not check about the type check and storage_initialized() check. Thus, it may introduce potential bugs.

By using the template data_ptr, this could throw an error like below:

```
torch._dynamo.exc.TorchRuntimeError: Failed running call_function torchvision.roi_align(*(FakeTensor(..., device='xpu:0', size=(1, 1024, 50, 75), dtype=torch.bfloat16), FakeTensor(..., device='xpu:0', size=(1000, 5), dtype=torch.bfloat16), 0.0625, 14, 14, 0, True), **{}):
The tensor has a non-zero number of elements, but its data is not allocated yet. Caffe2 uses a lazy allocation, so you will need to call mutable_data() or raw_mutable_data() to actually allocate memory.
```