### PR TITLE
Add lshift to fallback list

### DIFF
--- a/src/ATen/native/xpu/XPUFallback.template
+++ b/src/ATen/native/xpu/XPUFallback.template
@@ -241,6 +241,7 @@ TORCH_LIBRARY_IMPL(aten, XPU, m) {
     "put_",
     "rrelu_with_noise",
     "__rshift__.Scalar",
+    "__lshift__.Scalar",
     "_scaled_dot_product_efficient_attention",
     "_scaled_mm",
     "segment_reduce",


### PR DESCRIPTION
As was mentioned in https://github.com/intel/torch-xpu-ops/issues/570#issuecomment-2263621964 `__rshift__.Scalar` is already in the list. Adding lshift will allow running triton unit tests without patching pytorch.