### PR TITLE
arc: Comment failure of test_variable_sequence_xpu_float16 with justification after evaluation

### DIFF
--- a/test/xpu/run_test_with_skip.py
+++ b/test/xpu/run_test_with_skip.py
@@ -1292,6 +1292,7 @@ skip_list = (
     # Mismatched elements: 49 / 112 (43.8%)
     # Greatest absolute difference: 0.413818359375 at index (0, 0, 3) (up to 0.01 allowed)
     # Greatest relative difference: 642.5 at index (1, 3, 3) (up to 0 allowed)
+    # reference: https://github.com/intel/torch-xpu-ops/issues/663
     "test_variable_sequence_xpu_float16",
     # AssertionError: Scalars are not close!
     "test_InstanceNorm1d_general_xpu",

--- a/test/xpu/run_test_with_skip.py
+++ b/test/xpu/run_test_with_skip.py
@@ -1285,7 +1285,12 @@ skip_list = (
     "test_rnn_fused_xpu_float64",
     "test_rnn_retain_variables_xpu_float64",
     "test_transformerencoderlayer_xpu_float64",
-    # oneDNN addmm issue: LSTMCell has invalid result from linear_ih
+    # oneDNN issue
+    # addmm: LSTMCell has invalid result from linear_ih
+    # Tensor-likes are not close!
+    # Mismatched elements: 49 / 112 (43.8%)
+    # Greatest absolute difference: 0.413818359375 at index (0, 0, 3) (up to 0.01 allowed)
+    # Greatest relative difference: 642.5 at index (1, 3, 3) (up to 0 allowed)
     "test_variable_sequence_xpu_float64",
     # AssertionError: Scalars are not close!
     "test_InstanceNorm1d_general_xpu",

--- a/test/xpu/run_test_with_skip.py
+++ b/test/xpu/run_test_with_skip.py
@@ -1285,7 +1285,7 @@ skip_list = (
     "test_rnn_fused_xpu_float64",
     "test_rnn_retain_variables_xpu_float64",
     "test_transformerencoderlayer_xpu_float64",
-    # oneDNN issue
+    # Accuracy issue of oneDNN matmul
     # addmm: LSTMCell has invalid result from linear_ih
     # Tensor-likes are not close!
     # Mismatched elements: 49 / 112 (43.8%)

--- a/test/xpu/run_test_with_skip.py
+++ b/test/xpu/run_test_with_skip.py
@@ -1285,13 +1285,14 @@ skip_list = (
     "test_rnn_fused_xpu_float64",
     "test_rnn_retain_variables_xpu_float64",
     "test_transformerencoderlayer_xpu_float64",
+    "test_variable_sequence_xpu_float64",
     # Accuracy issue of oneDNN matmul
     # addmm: LSTMCell has invalid result from linear_ih
     # Tensor-likes are not close!
     # Mismatched elements: 49 / 112 (43.8%)
     # Greatest absolute difference: 0.413818359375 at index (0, 0, 3) (up to 0.01 allowed)
     # Greatest relative difference: 642.5 at index (1, 3, 3) (up to 0 allowed)
-    "test_variable_sequence_xpu_float64",
+    "test_variable_sequence_xpu_float16",
     # AssertionError: Scalars are not close!
     "test_InstanceNorm1d_general_xpu",
     "test_InstanceNorm2d_general_xpu",

--- a/test/xpu/run_test_with_skip.py
+++ b/test/xpu/run_test_with_skip.py
@@ -1285,6 +1285,7 @@ skip_list = (
     "test_rnn_fused_xpu_float64",
     "test_rnn_retain_variables_xpu_float64",
     "test_transformerencoderlayer_xpu_float64",
+    # oneDNN addmm issue: LSTMCell has invalid result from linear_ih
     "test_variable_sequence_xpu_float64",
     # AssertionError: Scalars are not close!
     "test_InstanceNorm1d_general_xpu",


### PR DESCRIPTION
[Certain step](https://github.com/pytorch/pytorch/blob/28b0ad4f4616497e9e297d3970992aad1d3cba44/aten/src/ATen/native/RNN.cpp#L740) in current LSTM implementation returns incorrect result consistently. It is believed that the root cause should be in Op `addmm` using oneDNN matmul implementation.