### PR TITLE
Enable test_method_fn_*_first_type_int_second_type_float

### DIFF
--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -2788,12 +2788,6 @@ skip_dict = {
     ),
 
     "test_dynamic_shapes_xpu.py": None, 
-    #"test_dynamic_shapes_xpu.py": (
-    #    # issue 746, new ut failures introduced by new pytorch
-    #    "test_method_fn_add_first_type_int_second_type_float",
-    #    "test_method_fn_mul_first_type_int_second_type_float",
-    #    "test_method_fn_sub_first_type_int_second_type_float",
-    #),
 
     "nn/test_load_state_dict_xpu.py": None,
 

--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -2787,12 +2787,13 @@ skip_dict = {
         "test_Conv2d_groups_nobias",
     ),
 
-    "test_dynamic_shapes_xpu.py": (
-        # issue 746, new ut failures introduced by new pytorch
-        "test_method_fn_add_first_type_int_second_type_float",
-        "test_method_fn_mul_first_type_int_second_type_float",
-        "test_method_fn_sub_first_type_int_second_type_float",
-    ),
+    "test_dynamic_shapes_xpu.py": None, 
+    #"test_dynamic_shapes_xpu.py": (
+    #    # issue 746, new ut failures introduced by new pytorch
+    #    "test_method_fn_add_first_type_int_second_type_float",
+    #    "test_method_fn_mul_first_type_int_second_type_float",
+    #    "test_method_fn_sub_first_type_int_second_type_float",
+    #),
 
     "nn/test_load_state_dict_xpu.py": None,
 


### PR DESCRIPTION
The 3 cases under https://github.com/intel/torch-xpu-ops/issues/746 can pass with latest code.
PYTORCH_TEST_WITH_SLOW=1 python test/test_dynamic_shapes.py TestSymNumberMagicMethods.test_method_fn_add_first_type_int_second_type_float
 PYTORCH_TEST_WITH_SLOW=1 python test/test_dynamic_shapes.py TestSymNumberMagicMethods.test_method_fn_mul_first_type_int_second_type_float
 PYTORCH_TEST_WITH_SLOW=1 python test/test_dynamic_shapes.py TestSymNumberMagicMethods.test_method_fn_sub_first_type_int_second_type_float