### PR TITLE
Skip bfloat16 pow CPU compare test on Windows.

### DIFF
--- a/test/xpu/extended/test_ops_xpu.py
+++ b/test/xpu/extended/test_ops_xpu.py
@@ -15,6 +15,7 @@ from torch.testing._internal.common_methods_invocations import ops_and_refs
 from torch.testing._internal.common_utils import (
     IS_FBCODE,
     IS_SANDCASTLE,
+    IS_WINDOWS,
     NoTest,
     run_tests,
     suppress_warnings,
@@ -78,6 +79,8 @@ class TestCommon(TestCase):
     def test_compare_cpu(self, device, dtype, op):
         # check if supported both by CPU and XPU
         if dtype in op.dtypes and dtype in op.supported_dtypes(device):
+            if op.name=="pow" and dtype==torch.bfloat16 and IS_WINDOWS:
+                raise unittest.SkipTest(f"CPU compare test of Pow bfloat16 is disabled on Windows.")
             self.proxy = Namespace.TestCommonProxy()
             test_common_test_fn = get_wrapped_fn(Namespace.TestCommonProxy.test_compare_cpu)
             test_common_test_fn(self.proxy, device, dtype, op)


### PR DESCRIPTION
This is to skip TestCommonXPU.test_compare_cpu_pow_xpu_bfloat16 mentioned in #666 

The UT is expected to "fail" on windows due to [its different implementation](https://github.com/intel/torch-xpu-ops/blob/13955ba5c9116ee5085fb0e4840aabe3d8f2fab4/src/ATen/native/xpu/sycl/Pow.h#L22).  This implementation will cast to float first but the cpu baseline won't, which causes numeric difference.

The implementation itself is correct and also accurate. Take the previous failed case from [log](https://wiki.ith.intel.com/display/intelnervana/Meteorlake+%5BMTL%5D+0.5.3_RC1+Bundle), pow(8.8750, 1.7188), its float32 result is 42.62965, but for bfloat16:  
0 1000100 0101011 is 42.75 (this is also xpu bloat16 torch.pow output)  
0 1000100 0101010 is 42.5 (this is also cpu bloat16 torch.pow output)  
The operator actually gives accurate results (42.75 is even closer to 42.62965) and should not be marked as failed.
