### PR TITLE
Fix pow operator complex32 UT failure on Windows MTL/LNL

### DIFF
--- a/src/ATen/native/xpu/sycl/PowKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PowKernels.cpp
@@ -130,7 +130,8 @@ void pow_tensor_tensor_kernel(TensorIteratorBase& iter) {
       pow_chalf_tensor_scalar_impl(iter, exp);
     } else {
       TORCH_INTERNAL_ASSERT(!iter.is_cpu_scalar(1) && !iter.is_cpu_scalar(2));
-      auto f = PowTensorTensorCastFunctor<scalar_t>();
+      using opmath_t = at::opmath_type<scalar_t>;
+      auto f = PowTensorTensorFunctor<opmath_t>();
       gpu_kernel(iter, f);
     }
   } else {

--- a/src/ATen/native/xpu/sycl/PowKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PowKernels.cpp
@@ -36,6 +36,7 @@ static inline c10::complex<T> pow_(c10::complex<T> base, c10::complex<T> exp) {
 
 } // namespace impl
 
+#ifdef _MSC_VER
 template <typename scalar_t>
 struct PowTensorTensorCastFunctor {
   using opmath_t = at::opmath_type<scalar_t>;
@@ -43,6 +44,15 @@ struct PowTensorTensorCastFunctor {
     return impl::pow_(base, exp);
   }
 };
+#else
+template <typename scalar_t>
+struct PowTensorTensorCastFunctor {
+  scalar_t operator()(scalar_t base, scalar_t exp) const {
+    using opmath_t = at::opmath_type<scalar_t>;
+    return impl::pow_(opmath_t{base}, opmath_t{exp});
+  }
+};
+#endif
 
 template <typename scalar_t>
 struct PowTensorTensorFunctor {

--- a/src/ATen/native/xpu/sycl/PowKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PowKernels.cpp
@@ -38,9 +38,9 @@ static inline c10::complex<T> pow_(c10::complex<T> base, c10::complex<T> exp) {
 
 template <typename scalar_t>
 struct PowTensorTensorCastFunctor {
-  scalar_t operator()(scalar_t base, scalar_t exp) const {
-    using opmath_t = at::opmath_type<scalar_t>;
-    return impl::pow_(opmath_t{base}, opmath_t{exp});
+  using opmath_t = at::opmath_type<scalar_t>;
+  opmath_t operator()(opmath_t base, opmath_t exp) const {
+    return impl::pow_(base, exp);
   }
 };
 
@@ -130,8 +130,7 @@ void pow_tensor_tensor_kernel(TensorIteratorBase& iter) {
       pow_chalf_tensor_scalar_impl(iter, exp);
     } else {
       TORCH_INTERNAL_ASSERT(!iter.is_cpu_scalar(1) && !iter.is_cpu_scalar(2));
-      using opmath_t = at::opmath_type<scalar_t>;
-      auto f = PowTensorTensorFunctor<opmath_t>();
+      auto f = PowTensorTensorCastFunctor<scalar_t>();
       gpu_kernel(iter, f);
     }
   } else {


### PR DESCRIPTION
Fix for test_binary_ufuncs_xpu.py::TestBinaryUfuncsXPU::test_pow_xpu_float16
The previous way of casting into opmath_t leads to accuracy failure for complex half dtype on windows. This change uses memory::LoadWithCast instead which fixes the problem.