### PR TITLE
Adopt std::log & std::exp in softmax kernel to avoid unnecessary fp64 instructions

### DIFF
--- a/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
+++ b/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
@@ -271,7 +271,7 @@ struct DispatchSoftmaxForwardKernelFunctor
          ++i) {
 #pragma unroll(vec_size)
       for (int j = 0; j < vec_size; ++j) {
-        sum_value += ::exp(reg_in[i][j] - max_value);
+        sum_value += std::exp(reg_in[i][j] - max_value);
       }
     }
     if (local_size_ > 1) {
@@ -285,7 +285,7 @@ struct DispatchSoftmaxForwardKernelFunctor
           [](accscalar_t a, accscalar_t b) { return a + b; });
     }
     if constexpr (LogSoftMax)
-      sum_value = ::log(sum_value);
+      sum_value = std::log(sum_value);
     else if (sum_value != 0)
       sum_value = accscalar_t(1) / sum_value;
 
@@ -305,7 +305,7 @@ struct DispatchSoftmaxForwardKernelFunctor
           reg_in[i][j] = nan_;
         } else {
           reg_in[i][j] = static_cast<scalar_t>(
-              ::exp(reg_in[i][j] - max_value) * sum_value);
+              std::exp(reg_in[i][j] - max_value) * sum_value);
         }
       }
       *(reinterpret_cast<vec_t*>(out_data_ + group_offset + index)) = reg_in[i];
@@ -520,13 +520,13 @@ struct SoftmaxForwardKernelFunctor {
       for (int j = 0; j < vec_size; ++j) {
         IndexType linear_idx = i * vec_size + j - start;
         if (linear_idx >= 0 && linear_idx < dim_size_)
-          sum_value += ::exp(accscalar_t(in_val[j]) - max_value);
+          sum_value += std::exp(accscalar_t(in_val[j]) - max_value);
       }
     }
     sum_value = sycl::reduce_over_group(
         item.get_group(), sum_value, sycl::plus<accscalar_t>());
     if (LogSoftMax)
-      sum_value = ::log(sum_value);
+      sum_value = std::log(sum_value);
     else
       sum_value = accscalar_t(1) / sum_value;
 
@@ -543,7 +543,7 @@ struct SoftmaxForwardKernelFunctor {
                   in_data_[group_offset + linear_idx] - max_value - sum_value);
             else
               out_data_[group_offset + linear_idx] = static_cast<scalar_t>(
-                  ::exp(in_data_[group_offset + linear_idx] - max_value) *
+                  std::exp(in_data_[group_offset + linear_idx] - max_value) *
                   sum_value);
           }
         }
@@ -557,7 +557,7 @@ struct SoftmaxForwardKernelFunctor {
                 static_cast<scalar_t>(in_val[j] - max_value - sum_value);
           else
             in_val[j] =
-                static_cast<scalar_t>(::exp(in_val[j] - max_value) * sum_value);
+                static_cast<scalar_t>(std::exp(in_val[j] - max_value) * sum_value);
         }
         *(reinterpret_cast<vec_t*>(
             out_data_ + group_offset - start + i * vec_size)) = in_val;
@@ -670,14 +670,14 @@ struct SpatialSoftmaxForwardKernelFunctor
     value = *(reinterpret_cast<vec_t*>(in_data_ + group_offset + offset));
 #pragma unroll(vec_size)
     for (int j = 0; j < vec_size; ++j) {
-      sum_value[j] = ::exp(value[j] - max_value[j]);
+      sum_value[j] = std::exp(value[j] - max_value[j]);
     }
     for (int i = local_row_id + block_row_; i < dim_size_; i += block_row_) {
       offset = i * inner_size_ + global_col * vec_size;
       value = *(reinterpret_cast<vec_t*>(in_data_ + group_offset + offset));
 #pragma unroll(vec_size)
       for (int j = 0; j < vec_size; ++j) {
-        sum_value[j] += ::exp(value[j] - max_value[j]);
+        sum_value[j] += std::exp(value[j] - max_value[j]);
       }
     }
     if (block_row_ > 1) {
@@ -690,7 +690,7 @@ struct SpatialSoftmaxForwardKernelFunctor
 #pragma unroll(vec_size)
       for (int j = 0; j < vec_size; ++j) {
         if (LogSoftMax)
-          sum_value[j] = ::log(local_data_[0][local_col_id][j]);
+          sum_value[j] = std::log(local_data_[0][local_col_id][j]);
         else
           sum_value[j] = accscalar_t(1) / local_data_[0][local_col_id][j];
       }
@@ -698,7 +698,7 @@ struct SpatialSoftmaxForwardKernelFunctor
 #pragma unroll(vec_size)
       for (int j = 0; j < vec_size; ++j) {
         if (LogSoftMax)
-          sum_value[j] = ::log(sum_value[j]);
+          sum_value[j] = std::log(sum_value[j]);
         else
           sum_value[j] = accscalar_t(1) / sum_value[j];
       }
@@ -717,7 +717,7 @@ struct SpatialSoftmaxForwardKernelFunctor
                 static_cast<scalar_t>(in_val[j] - max_value[j] - sum_value[j]);
           else
             in_val[j] = static_cast<scalar_t>(
-                ::exp(in_val[j] - max_value[j]) * sum_value[j]);
+                std::exp(in_val[j] - max_value[j]) * sum_value[j]);
         }
         *(reinterpret_cast<vec_t*>(out_data_ + group_offset + offset)) = in_val;
       }
@@ -890,7 +890,7 @@ struct DispatchSoftmaxBackwardKernelFunctor
       for (int j = 0; j < vec_size; ++j) {
         if (LogSoftMax) {
           reg_out[i][j] = static_cast<scalar_t>(
-              reg_gradout[i][j] - ::exp(reg_out[i][j]) * sum_value);
+              reg_gradout[i][j] - std::exp(reg_out[i][j]) * sum_value);
         } else {
           reg_out[i][j] = static_cast<scalar_t>(
               reg_out[i][j] * (reg_gradout[i][j] - sum_value));
@@ -1117,7 +1117,7 @@ struct SoftmaxBackwardKernelFunctor {
             auto offset = group_offset + linear_idx;
             if (LogSoftMax) {
               gradInput_[offset] =
-                  gradOutput_[offset] - ::exp(output_[offset]) * sum_value;
+                  gradOutput_[offset] - std::exp(output_[offset]) * sum_value;
             } else {
               gradInput_[offset] =
                   output_[offset] * (gradOutput_[offset] - sum_value);
@@ -1130,7 +1130,7 @@ struct SoftmaxBackwardKernelFunctor {
 #pragma unroll(vec_size)
         for (int j = 0; j < vec_size; ++j) {
           if (LogSoftMax) {
-            out_val[j] = grad_val[j] - ::exp(out_val[j]) * sum_value;
+            out_val[j] = grad_val[j] - std::exp(out_val[j]) * sum_value;
           } else {
             out_val[j] = out_val[j] * (grad_val[j] - sum_value);
           }
@@ -1259,7 +1259,7 @@ struct SpatialSoftmaxBackwardKernelFunctor
         for (int j = 0; j < vec_size; ++j) {
           if (LogSoftMax) {
             out_val[j] = static_cast<scalar_t>(
-                gradout_val[j] - ::exp(out_val[j]) * sum_value[j]);
+                gradout_val[j] - std::exp(out_val[j]) * sum_value[j]);
           } else {
             out_val[j] = static_cast<scalar_t>(
                 out_val[j] * (gradout_val[j] - sum_value[j]));


### PR DESCRIPTION
Using `std::exp` and `std::log` to replace `::exp` and `::log` respectively.