### PR TITLE
Using std math functions (cmath) instead of C math functions (math.h)

### DIFF
--- a/src/ATen/native/xpu/Copy.cpp
+++ b/src/ATen/native/xpu/Copy.cpp
@@ -300,7 +300,9 @@ Tensor& XPUNativeFunctions::copy_(
     const Tensor& src,
     bool non_blocking) {
   if (self._is_zerotensor()) {
-    TORCH_CHECK(false, "ZeroTensors are immutable. Please materialize the tensor using `.clone()`, if you want a mutable zero tensor.");
+    TORCH_CHECK(
+        false,
+        "ZeroTensors are immutable. Please materialize the tensor using `.clone()`, if you want a mutable zero tensor.");
   }
   if (src._is_zerotensor()) {
     return self.zero_();
@@ -316,15 +318,12 @@ Tensor& XPUNativeFunctions::copy_(
   // TODO: Support quantization
 
   // Exit early if self and src are views of the same data
-  const bool is_same_data = (
-      self.is_alias_of(src) &&
-      self.storage_offset() == src.storage_offset() &&
-      self.strides().equals(src.strides()) &&
-      self.sizes().equals(src.sizes()) &&
-      self.scalar_type() == src.scalar_type() &&
-      self.is_conj() == src.is_conj() &&
-      self.is_neg() == src.is_neg()
-    );
+  const bool is_same_data =
+      (self.is_alias_of(src) && self.storage_offset() == src.storage_offset() &&
+       self.strides().equals(src.strides()) &&
+       self.sizes().equals(src.sizes()) &&
+       self.scalar_type() == src.scalar_type() &&
+       self.is_conj() == src.is_conj() && self.is_neg() == src.is_neg());
   if (is_same_data) {
     return self;
   }

--- a/src/ATen/native/xpu/Resize.cpp
+++ b/src/ATen/native/xpu/Resize.cpp
@@ -66,7 +66,8 @@ Tensor _copy_from_and_resize(const at::Tensor& self, const at::Tensor& dst) {
 // For test infrastructure
 Tensor _copy_from(const Tensor& self, const Tensor& dst, bool non_blocking) {
   dst.resize_as_(self);
-  return at::XPUNativeFunctions::copy_(const_cast<Tensor&>(dst), self, non_blocking);
+  return at::XPUNativeFunctions::copy_(
+      const_cast<Tensor&>(dst), self, non_blocking);
 }
 
 // Should not register the operator. Desc of

--- a/src/ATen/native/xpu/Sorting.cpp
+++ b/src/ATen/native/xpu/Sorting.cpp
@@ -1,12 +1,12 @@
 #include <ATen/ATen.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/core/op_registration/adaption.h>
+#include <ATen/native/ReduceOpsUtils.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/xpu/sycl/Sorting.h>
-#include <ATen/native/ReduceOpsUtils.h>
 #include <ATen/xpu/XPUNativeFunctions.h>
-#include <comm/TensorInfo.h>
 #include <comm/RegisterUtils.h>
+#include <comm/TensorInfo.h>
 
 namespace at {
 

--- a/src/ATen/native/xpu/UnaryOps.cpp
+++ b/src/ATen/native/xpu/UnaryOps.cpp
@@ -1037,7 +1037,6 @@ Tensor& XPUNativeFunctions::ceil_out(const Tensor& self, Tensor& out) {
   return out;
 }
 
-
 Tensor XPUNativeFunctions::round(const Tensor& self) {
   if (c10::isIntegralType(self.scalar_type(), /*includeBool=*/false)) {
     return self.clone();

--- a/src/ATen/native/xpu/sycl/ActivationGeluKernel.cpp
+++ b/src/ATen/native/xpu/sycl/ActivationGeluKernel.cpp
@@ -55,7 +55,7 @@ struct GeluErfFunctor {
     using opmath_t = at::opmath_type<scalar_t>;
     constexpr opmath_t kAlpha = M_SQRT1_2;
     return static_cast<opmath_t>(x) * opmath_t(0.5) *
-        (opmath_t(1) + ::erf(static_cast<opmath_t>(x) * kAlpha));
+        (opmath_t(1) + std::erf(static_cast<opmath_t>(x) * kAlpha));
   }
 };
 
@@ -66,7 +66,7 @@ struct GeluErfBackwardFunctor {
     constexpr opmath_t kBeta = M_2_SQRTPI * M_SQRT1_2 * opmath_t(0.5);
     constexpr opmath_t kAlpha = M_SQRT1_2;
     const opmath_t cdf = opmath_t(0.5) *
-        (opmath_t(1) + ::erf(static_cast<opmath_t>(x) * kAlpha));
+        (opmath_t(1) + std::erf(static_cast<opmath_t>(x) * kAlpha));
     const opmath_t pdf = c10::xpu::compat::exp(
                              opmath_t(-0.5) * static_cast<opmath_t>(x) *
                              static_cast<opmath_t>(x)) *

--- a/src/ATen/native/xpu/sycl/Atomics.h
+++ b/src/ATen/native/xpu/sycl/Atomics.h
@@ -325,9 +325,7 @@ static inline void atomicAdd(
   target.fetch_add(val);
 }
 
-static inline void atomicAdd(
-    const sycl_local_ptr<int>& address,
-    int val) {
+static inline void atomicAdd(const sycl_local_ptr<int>& address, int val) {
   sycl_atomic_ref_rlx_wg_local_t<int> target(*address);
   target.fetch_add(val);
 }

--- a/src/ATen/native/xpu/sycl/BinaryRemainderKernel.cpp
+++ b/src/ATen/native/xpu/sycl/BinaryRemainderKernel.cpp
@@ -41,7 +41,7 @@ template <typename scalar_t>
 struct FmodFloatingFunctor {
   scalar_t operator()(scalar_t a, scalar_t b) const
       __ubsan_ignore_float_divide_by_zero__ {
-    return ::fmod(a, b);
+    return std::fmod(a, b);
   }
 };
 

--- a/src/ATen/native/xpu/sycl/Math.h
+++ b/src/ATen/native/xpu/sycl/Math.h
@@ -33,7 +33,7 @@ static inline C10_HOST_DEVICE scalar_t calc_digamma(scalar_t in) {
     return std::copysign(static_cast<scalar_t>(INFINITY), -x);
   }
 
-  bool x_is_integer = x == ::trunc(x);
+  bool x_is_integer = x == std::trunc(x);
   accscalar_t result = 0;
   if (x < 0) {
     if (x_is_integer) {
@@ -47,8 +47,8 @@ static inline C10_HOST_DEVICE scalar_t calc_digamma(scalar_t in) {
     // a periodicity of pi, in practice the computation of pi * x is a source of
     // error (when |x| > 1).
     double q, r;
-    r = ::modf(static_cast<double>(x), &q);
-    result = static_cast<accscalar_t>(-PI_f64 / ::tan(PI_f64 * r));
+    r = std::modf(static_cast<double>(x), &q);
+    result = static_cast<accscalar_t>(-PI_f64 / std::tan(PI_f64 * r));
     x = 1 - x;
   }
 
@@ -72,7 +72,7 @@ static inline C10_HOST_DEVICE scalar_t calc_digamma(scalar_t in) {
   }
 
   return static_cast<scalar_t>(
-      ::log(x) - (static_cast<accscalar_t>(0.5) / x) - y + result);
+      std::log(x) - (static_cast<accscalar_t>(0.5) / x) - y + result);
 }
 
 template <typename scalar_t>
@@ -84,7 +84,7 @@ static inline C10_HOST_DEVICE scalar_t calc_trigamma(scalar_t in) {
   accscalar_t result = 0;
   if (x < 0.5f) {
     sign = -1;
-    accscalar_t sin_pi_x = ::sin(PI * x);
+    accscalar_t sin_pi_x = std::sin(PI * x);
     result -= (PI * PI) / (sin_pi_x * sin_pi_x);
     x = 1 - x;
   }
@@ -190,22 +190,22 @@ static inline C10_HOST_DEVICE scalar_t calc_i0(scalar_t _x) {
       "don't instantiate with low precision type");
   // Upcast input for numerical accuracy purposes
   // Needed for accurate results if input is bfloat16 or float16
-  scalar_t x = ::abs(_x);
+  scalar_t x = std::abs(_x);
 
   if (x <= scalar_t{8.0}) {
     auto coeff_pair = chebyshev_coefficients_i0e_A<scalar_t>();
     auto A = std::get<0>(coeff_pair);
     auto len = std::get<1>(coeff_pair);
     scalar_t y = (x / scalar_t{2.0}) - scalar_t{2.0};
-    return (::exp(x) * chbevl(y, A, len));
+    return (std::exp(x) * chbevl(y, A, len));
   }
 
   auto coeff_pair = chebyshev_coefficients_i0e_B<scalar_t>();
   auto B = std::get<0>(coeff_pair);
   auto len = std::get<1>(coeff_pair);
   return (
-      ::exp(x) * chbevl(scalar_t{32.0} / x - scalar_t{2.0}, B, len) /
-      ::sqrt(x));
+      std::exp(x) * chbevl(scalar_t{32.0} / x - scalar_t{2.0}, B, len) /
+      std::sqrt(x));
 }
 
 template <typename T>
@@ -319,13 +319,13 @@ C10_HOST_DEVICE inline typename std::
 
 template <typename scalar_t>
 static inline C10_HOST_DEVICE scalar_t calc_i1(scalar_t _x) {
-  const auto x = ::abs(_x);
+  const auto x = std::abs(_x);
   if (x <= scalar_t{8.0}) {
     auto coeff_pair = chebyshev_coefficients_i1e_A<scalar_t>();
     auto A = std::get<0>(coeff_pair);
     auto len = std::get<1>(coeff_pair);
     scalar_t y = x / scalar_t{2.0} - scalar_t{2.0};
-    const scalar_t out = ::exp(x) * x * chbevl(y, A, len);
+    const scalar_t out = std::exp(x) * x * chbevl(y, A, len);
     return (_x < scalar_t{0.0}) ? -out : out;
   }
 
@@ -333,14 +333,14 @@ static inline C10_HOST_DEVICE scalar_t calc_i1(scalar_t _x) {
   auto B = std::get<0>(coeff_pair);
   auto len = std::get<1>(coeff_pair);
   const scalar_t out =
-      (::exp(x) * chbevl(scalar_t{32.0} / x - scalar_t{2.0}, B, len)) /
-      ::sqrt(x);
+      (std::exp(x) * chbevl(scalar_t{32.0} / x - scalar_t{2.0}, B, len)) /
+      std::sqrt(x);
   return (_x < scalar_t{0.0}) ? -out : out;
 }
 
 template <typename scalar_t>
 static inline C10_HOST_DEVICE scalar_t calc_i1e(scalar_t _x) {
-  const auto x = ::abs(_x);
+  const auto x = std::abs(_x);
   if (x <= scalar_t{8.0}) {
     auto coeff_pair = chebyshev_coefficients_i1e_A<scalar_t>();
     auto A = std::get<0>(coeff_pair);
@@ -354,7 +354,7 @@ static inline C10_HOST_DEVICE scalar_t calc_i1e(scalar_t _x) {
   auto B = std::get<0>(coeff_pair);
   auto len = std::get<1>(coeff_pair);
   const scalar_t out =
-      chbevl(scalar_t{32.0} / x - scalar_t{2.0}, B, len) / ::sqrt(x);
+      chbevl(scalar_t{32.0} / x - scalar_t{2.0}, B, len) / std::sqrt(x);
   return (_x < scalar_t{0.0}) ? -out : out;
 }
 

--- a/src/ATen/native/xpu/sycl/Pow.h
+++ b/src/ATen/native/xpu/sycl/Pow.h
@@ -47,7 +47,7 @@ powI_(Base_type base, Exp_type exp) {
 #else
 template <typename Base_type, typename Exp_type>
 static inline Base_type pow_(Base_type base, Exp_type exp) {
-  return ::pow(base, exp);
+  return std::pow(base, exp);
 }
 #endif
 

--- a/src/ATen/native/xpu/sycl/PowKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PowKernels.cpp
@@ -19,7 +19,7 @@ namespace impl {
 
 template <typename Base_type, typename Exp_type>
 static inline Base_type pow_(Base_type base, Exp_type exp) {
-  return ::pow(base, exp);
+  return std::pow(base, exp);
 }
 
 template <typename T>

--- a/src/ATen/native/xpu/sycl/Reduce.h
+++ b/src/ATen/native/xpu/sycl/Reduce.h
@@ -246,9 +246,8 @@ struct ReduceConfig {
     // in side of SG. It is functional WA. We got case failures on some
     // platforms supporting SIMD8.
     // https://github.com/intel/torch-xpu-ops/issues/698
-    auto max_sg_sz = syclMinSubGroupSize() == 8
-        ? syclMinSubGroupSize()
-        : syclMaxSubGroupSize();
+    auto max_sg_sz = syclMinSubGroupSize() == 8 ? syclMinSubGroupSize()
+                                                : syclMaxSubGroupSize();
     const int max_num_items = max_wg_sz / output_vec_size;
     int dim0_pow2 = dim0 < max_num_items ? static_cast<int>(last_pow2(dim0))
                                          : max_num_items;

--- a/src/ATen/native/xpu/sycl/Sorting.cpp
+++ b/src/ATen/native/xpu/sycl/Sorting.cpp
@@ -8,8 +8,8 @@
 #include <ATen/MemoryOverlap.h>
 #include <ATen/NumericUtils.h>
 #include <ATen/core/TensorBase.h>
-#include <ATen/native/TensorIterator.h>
 #include <ATen/native/CanUse32BitIndexMath.h>
+#include <ATen/native/TensorIterator.h>
 #include <ATen/native/xpu/sycl/SortingCommon.h>
 #include <ATen/native/xpu/sycl/SortingKernels.h>
 #include <ATen/native/xpu/sycl/SortingRadixSelect.h>
@@ -205,8 +205,7 @@ std::tuple<Tensor&, Tensor&> sort_stable_kernel(
 }
 
 template <typename scalar_t, typename index_t, int Dim>
-struct GatherMedianKernelFunctor
-    : public __SYCL_KER_CONFIG_CONVENTION__ {
+struct GatherMedianKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
   void operator()(sycl::nd_item<1> item) const {
     index_t slice = item.get_group_linear_id();
 
@@ -239,9 +238,9 @@ struct GatherMedianKernelFunctor
     if (nan_count > 0) {
       atomicAdd(
           (sycl_local_ptr<index_t>)(num_nan_
-                                            .template get_multi_ptr<
-                                                sycl::access::decorated::no>()
-                                            .get()),
+                                        .template get_multi_ptr<
+                                            sycl::access::decorated::no>()
+                                        .get()),
           nan_count);
     }
     item.barrier(sycl_local_fence);
@@ -352,8 +351,8 @@ void gatherMedian(
       values_data,
       indices_data);
   int64_t local_size = syclMaxWorkGroupSize(kfn);
-  sycl_kernel_submit(numInputSlices * local_size, local_size,
-      getCurrentSYCLQueue(), kfn);
+  sycl_kernel_submit(
+      numInputSlices * local_size, local_size, getCurrentSYCLQueue(), kfn);
 }
 
 struct MedianLauncher {

--- a/src/ATen/native/xpu/sycl/SortingCommon.h
+++ b/src/ATen/native/xpu/sycl/SortingCommon.h
@@ -433,4 +433,3 @@ void run_launcher(
 }
 
 } // namespace at::native::xpu
-

--- a/src/ATen/native/xpu/sycl/SortingRadixSelect.h
+++ b/src/ATen/native/xpu/sycl/SortingRadixSelect.h
@@ -297,8 +297,8 @@ scalar_t findPattern(
   for (index_t i = local_id; i < numIterations;
        i += item_id.get_local_range(0)) {
     bool inRange = (i < sliceSize);
-    scalar_t v = inRange ? data[i * withinSliceStride]
-                         : static_cast<scalar_t>(0);
+    scalar_t v =
+        inRange ? data[i * withinSliceStride] : static_cast<scalar_t>(0);
 
     if (inRange &&
         ((TopKTypeConfig<scalar_t>::convert(v) & desiredMask) == desired)) {

--- a/test/xpu/extended/run_test_with_skip.py
+++ b/test/xpu/extended/run_test_with_skip.py
@@ -26,6 +26,7 @@ skip_list = (
     "test_compare_cpu_tanh_xpu_complex128",
     "test_compare_cpu_tanh_xpu_complex64",
     "test_compare_cpu_rsqrt_xpu_bfloat16",
+    "test_compare_cpu_pow_xpu_bfloat16",
     # cuda has the same issue on this case
     "test_compare_cpu__refs_rsub_xpu_bfloat16",
     "test_compare_cpu_add_xpu_bfloat16",


### PR DESCRIPTION
e.g. We use `std::log` instead of `::log` because `::log` always introduces FP64 instructions regardless of the input data type.