### PR TITLE
Fix pow operator complex32 UT failure on Windows MTL/LNL

### DIFF
--- a/src/ATen/native/xpu/sycl/PowKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PowKernels.cpp
@@ -37,6 +37,7 @@ static inline c10::complex<T> pow_(c10::complex<T> base, c10::complex<T> exp) {
 } // namespace impl
 
 #ifdef _MSC_VER
+// Divergence for MSVC due to accuracy issue. https://github.com/intel/torch-xpu-ops/issues/842.
 template <typename scalar_t>
 struct PowTensorTensorCastFunctor {
   using opmath_t = at::opmath_type<scalar_t>;

--- a/src/ATen/native/xpu/sycl/PowKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PowKernels.cpp
@@ -36,6 +36,15 @@ static inline c10::complex<T> pow_(c10::complex<T> base, c10::complex<T> exp) {
 
 } // namespace impl
 
+#ifdef _MSC_VER
+template <typename scalar_t>
+struct PowTensorTensorCastFunctor {
+  using opmath_t = at::opmath_type<scalar_t>;
+  opmath_t operator()(opmath_t base, opmath_t exp) const {
+    return impl::pow_(base, exp);
+  }
+};
+#else
 template <typename scalar_t>
 struct PowTensorTensorCastFunctor {
   scalar_t operator()(scalar_t base, scalar_t exp) const {
@@ -43,6 +52,7 @@ struct PowTensorTensorCastFunctor {
     return impl::pow_(opmath_t{base}, opmath_t{exp});
   }
 };
+#endif
 
 template <typename scalar_t>
 struct PowTensorTensorFunctor {


### PR DESCRIPTION
(Windows only) Fix for test_binary_ufuncs_xpu.py::TestBinaryUfuncsXPU::test_pow_xpu_float16 

The previous way of casting into opmath_t leads to accuracy failure for complex half dtype on windows. This change uses memory::LoadWithCast instead which fixes the problem.

(cherry picked from commit 5955b5cd4e8ee93a7607c1cd8cc0a9acda3c891b)