### PR TITLE
Windows: Give default AOT targets to Windows build.

### DIFF
--- a/cmake/BuildFlags.cmake
+++ b/cmake/BuildFlags.cmake
@@ -116,7 +116,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"
   set(SYCL_OFFLINE_COMPILER_CG_OPTIONS "${SYCL_OFFLINE_COMPILER_CG_OPTIONS} -cl-fp32-correctly-rounded-divide-sqrt")
   set(SYCL_OFFLINE_COMPILER_CG_OPTIONS "-options '${SYCL_OFFLINE_COMPILER_CG_OPTIONS}'")
 
-  set(AOT_TARGETS "pvc,xe-lpg,ats-m150")
+  if(WIN32)
+    set(AOT_TARGETS "ats-m150,lnl-m,mtl-u,mtl-h")
+  else()
+    set(AOT_TARGETS "pvc,xe-lpg,ats-m150")
+  endif()
   if((DEFINED ENV{TORCH_XPU_ARCH_LIST}) AND NOT ("$ENV{TORCH_XPU_ARCH_LIST}" STREQUAL ""))
     set(AOT_TARGETS "$ENV{TORCH_XPU_ARCH_LIST}")
   endif()


### PR DESCRIPTION
Default AOT target list on Windows prefers client GPUs, including ARC, LNL and MTLs.