### PR TITLE
cdist: Fix incorrect logic in reduce

### DIFF
--- a/src/ATen/native/xpu/sycl/DistanceKernels.cpp
+++ b/src/ATen/native/xpu/sycl/DistanceKernels.cpp
@@ -179,6 +179,8 @@ static inline scalar_t group_reduce_agg_without_broadcast(
   do {
     agg = subgroup_reduce_agg_without_broadcast<scalar_t, F, nd_item>(
         item, agg, sg_size);
+    if (num_active_sg == 1)
+      return agg;
     item.barrier(sycl_local_fence);
     if (0 == lane_id) {
       local_shared_mem[sg_id] = agg;
@@ -186,14 +188,13 @@ static inline scalar_t group_reduce_agg_without_broadcast(
     item.barrier(sycl_local_fence);
     agg =
         local_id < num_active_sg ? local_shared_mem[local_id] : (scalar_t)0.0f;
-    num_active_sg = (num_active_sg + sg_size - 1) / sg_size;
+    if (num_active_sg > sg_size)
+      num_active_sg = (num_active_sg + sg_size - 1) / sg_size;
   } while (num_active_sg > sg_size);
 
   // num of active sgs < sg_size
   item.barrier(sycl_local_fence);
   if (0 == sg_id) {
-    agg =
-        local_id < num_active_sg ? local_shared_mem[local_id] : (scalar_t)0.0f;
     agg = subgroup_reduce_agg_without_broadcast<scalar_t, F, nd_item>(
         item, agg, sg_size);
   }


### PR DESCRIPTION
The original logic only covers cases, 1) num of active sgs == 1, 2) num of active sgs > sg_size.
But doesn't cover case, num of active sgs > 1 and <= sg_size. The PR complements the logic.