### PR TITLE
enable bool for im2col and col2im according to pytorch a15aabc975

### DIFF
--- a/src/ATen/native/xpu/sycl/Col2ImKernel.cpp
+++ b/src/ATen/native/xpu/sycl/Col2ImKernel.cpp
@@ -215,6 +215,7 @@ void col2im_kernel(
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
       at::ScalarType::BFloat16,
       at::ScalarType::Half,
+      at::ScalarType::Bool,
       input.scalar_type(),
       "col2im_xpu",
       [&] {

--- a/src/ATen/native/xpu/sycl/Im2ColKernel.cpp
+++ b/src/ATen/native/xpu/sycl/Im2ColKernel.cpp
@@ -212,7 +212,7 @@ void im2col_kernel(
   output.zero_();
 
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
-      kHalf, kBFloat16, input.scalar_type(), "im2col_xpu", [&] {
+      kHalf, kBFloat16, kBool, input.scalar_type(), "im2col_xpu", [&] {
         Tensor input_n;
         Tensor output_n;
 


### PR DESCRIPTION
Expect all the "RuntimeError: "im2col_xpu" not implemented for 'Bool'" fixed with this PR.