### PR TITLE
Export EmptyTensor.h to public

### DIFF
--- a/src/ATen/CMakeLists.txt
+++ b/src/ATen/CMakeLists.txt
@@ -1,5 +1,6 @@
 # ATen XPU sources
 
+file(GLOB xpu_h "xpu/*.h")
 file(GLOB xpu_cpp "xpu/*.cpp")
 file(GLOB xpu_native_cpp "native/xpu/*.cpp" "native/sparse/*.cpp")
 file(GLOB xpu_sycl "native/xpu/sycl/*.cpp")
@@ -11,3 +12,7 @@ list(APPEND ATen_XPU_SYCL_SRCS ${xpu_sycl})
 set(ATen_XPU_CPP_SRCS ${ATen_XPU_CPP_SRCS} PARENT_SCOPE)
 set(ATen_XPU_NATIVE_CPP_SRCS ${ATen_XPU_NATIVE_CPP_SRCS} PARENT_SCOPE)
 set(ATen_XPU_SYCL_SRCS ${ATen_XPU_SYCL_SRCS} PARENT_SCOPE)
+
+foreach(HEADER  ${xpu_h})
+  install(FILES ${HEADER} DESTINATION "${AT_INSTALL_INCLUDE_DIR}/ATen/xpu")
+endforeach()


### PR DESCRIPTION
# Motivation
Export `<ATen/xpu/EmptyTensor.h>` to public (the counterpart location of CUDA is `${AT_INSTALL_INCLUDE_DIR}/ATen/cuda`） as it is used in codegen, refer to https://github.com/pytorch/pytorch/pull/130082/files#r1696016201
Otherwise, IPEX finds it hard to reuse this codegen due to the non-exist file of `<ATen/xpu/EmptyTensor.h>`.
The same reason applies to libtorch, which is one pure C++ code.