### PR TITLE
Export EmptyTensor.h to public

### DIFF
--- a/src/ATen/CMakeLists.txt
+++ b/src/ATen/CMakeLists.txt
@@ -1,5 +1,6 @@
 # ATen XPU sources
 
+file(GLOB xpu_h "xpu/*.h")
 file(GLOB xpu_cpp "xpu/*.cpp")
 file(GLOB xpu_native_cpp "native/xpu/*.cpp" "native/sparse/*.cpp")
 file(GLOB xpu_sycl "native/xpu/sycl/*.cpp")
@@ -11,3 +12,7 @@ list(APPEND ATen_XPU_SYCL_SRCS ${xpu_sycl})
 set(ATen_XPU_CPP_SRCS ${ATen_XPU_CPP_SRCS} PARENT_SCOPE)
 set(ATen_XPU_NATIVE_CPP_SRCS ${ATen_XPU_NATIVE_CPP_SRCS} PARENT_SCOPE)
 set(ATen_XPU_SYCL_SRCS ${ATen_XPU_SYCL_SRCS} PARENT_SCOPE)
+
+foreach(HEADER  ${xpu_h})
+  install(FILES ${HEADER} DESTINATION "${AT_INSTALL_INCLUDE_DIR}/ATen/xpu")
+endforeach()


### PR DESCRIPTION
(cherry picked from commit 0173fcffed14e2440612b7f4f01112de70058f10)
As synced with @EikanWang , it is not a critical issue to release 2.5. But it is happy to cherry pick to 2.5 branch and unnecessary to update torch-xpu-ops pin specifically for this fix.