### PR TITLE
Fixed cuda hardcode for autograd UT and skip unsupport UT for xpu

### DIFF
--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -1606,8 +1606,8 @@ skip_dict = {
         "test_triangular_solve_xpu_complex128",
         "test_triangular_solve_xpu_complex64",
         "test_triangular_solve_xpu_float64",
-        # https://github.com/intel/torch-xpu-ops/issues/317
-        # addmm.out, addmv.out, linalg_lstsq, vdot&dot lack XPU support and fallback to CPU
+        # https://github.com/intel/torch-xpu-ops/issues/821
+        # addmm.out, addmv.out, linalg_lstsq, vdot&dot, _int_mm lack XPU support and fallback to CPU
         "test_addmm_sizes_xpu_complex128",
         "test_addmm_sizes_xpu_complex64",
         "test_blas_alpha_beta_empty_xpu_complex128",
@@ -1618,6 +1618,7 @@ skip_dict = {
         "test_linalg_lstsq_input_checks_xpu_float64",
         "test_dot_invalid_args_xpu",
         "test_vdot_invalid_args_xpu",
+        "test__int_mm_errors_xpu",
         # https://github.com/intel/torch-xpu-ops/issues/821
         # RuntimeError: Fail to enable Kineto Profiler on XPU due to error code: 200
         "test_norm_fused_type_promotion_xpu_bfloat16",
@@ -1628,6 +1629,7 @@ skip_dict = {
         "test_matmul_small_brute_force_tunableop_xpu_float16",
         "test_matmul_small_brute_force_tunableop_xpu_float32",
         "test_matmul_small_brute_force_tunableop_xpu_float64",
+        "test_matmul_offline_tunableop_xpu_float16",
         # XPU does not support tunable.
         "test_bmm_tunableop_rocm_xpu_float32",
         "test_numeric_check_leak_tunableop_rocm_xpu_float32",


### PR DESCRIPTION
1. Fixed cuda hardcode for autograd UT.
2. Skiped unsupport ops for XPU device.
issue report in:
https://github.com/intel/torch-xpu-ops/issues/821
https://github.com/intel/torch-xpu-ops/issues/814