### PR TITLE
unique_consecutive: rebase with enabling kBFloat16

### DIFF
--- a/src/ATen/native/xpu/sycl/UniqueKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UniqueKernels.cpp
@@ -384,6 +384,7 @@ std::tuple<Tensor, Tensor, Tensor> unique_dim_consecutive_kernel(
       AT_EXPAND(AT_ALL_TYPES),
       kBool,
       kHalf,
+      kBFloat16,
       AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES));
 }
 


### PR DESCRIPTION
To fix the unique issues in https://github.com/intel/torch-xpu-ops/issues/922. 

test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_consecutive_xpu_bfloat16 PASSED                                                                                                                              [  4%]
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_consecutive_xpu_bool PASSED                                                                                                                                  [  8%] 
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_consecutive_xpu_float16 PASSED                                                                                                                               [ 13%] 
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_consecutive_xpu_float32 PASSED                                                                                                                               [ 17%] 
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_consecutive_xpu_float64 PASSED                                                                                                                               [ 21%] 
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_consecutive_xpu_int16 PASSED                                                                                                                                 [ 26%]
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_consecutive_xpu_int32 PASSED                                                                                                                                 [ 30%] 
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_consecutive_xpu_int64 PASSED                                                                                                                                 [ 34%] 
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_consecutive_xpu_int8 PASSED                                                                                                                                  [ 39%]
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_consecutive_xpu_uint8 PASSED                                                                                                                                 [ 43%] 
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_xpu_bfloat16 PASSED                                                                                                                                          [ 47%]
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_xpu_bool PASSED                                                                                                                                              [ 52%] 
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_xpu_float16 PASSED                                                                                                                                           [ 56%]
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_xpu_float32 PASSED                                                                                                                                           [ 60%] 
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_xpu_float64 PASSED                                                                                                                                           [ 65%]
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_xpu_int16 PASSED                                                                                                                                             [ 69%] 
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_xpu_int32 PASSED                                                                                                                                             [ 73%] 
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_xpu_int64 PASSED                                                                                                                                             [ 78%]
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_xpu_int8 PASSED                                                                                                                                              [ 82%]
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_xpu_uint16 PASSED                                                                                                                                            [ 86%]
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_xpu_uint32 PASSED                                                                                                                                            [ 91%]
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_xpu_uint64 PASSED                                                                                                                                            [ 95%]
test_meta_xpu.py::TestMetaXPU::test_dispatch_meta_outplace_unique_xpu_uint8 PASSED                                                                                                                                             [100%]