### PR TITLE
Add uts of  `max` and `min`

### DIFF
--- a/test/xpu/xpu_test_utils.py
+++ b/test/xpu/xpu_test_utils.py
@@ -237,6 +237,8 @@ _xpu_computation_op_list = [
     "repeat_interleave",
     "fmax",
     "fmin",
+    "max",
+    "min",
     "floor",
     "floor_divide",
     "copysign",


### PR DESCRIPTION
`max.dim` and `min.dim` have already been impelmented, but their uts have not been added to the test scope.

![image](https://github.com/user-attachments/assets/45534426-ee46-4d45-98f8-9e295e7c3aff)
![image](https://github.com/user-attachments/assets/f58d2803-b6c4-4697-9f36-3b651f00cd1d)


