### PR TITLE
Modernize C10_UNUSED

### DIFF
--- a/src/ATen/native/xpu/LayerNorm.cpp
+++ b/src/ATen/native/xpu/LayerNorm.cpp
@@ -69,7 +69,7 @@ namespace native {
   for (const auto idx : c10::irange(axis)) {
     stat_shape.push_back(input_shape[idx]);
   }
-  for (const auto idx : c10::irange(axis, input.dim())) {
+  for (const auto & : c10::irange(axis, input.dim())) {
     stat_shape.push_back(1);
   }
 

--- a/src/ATen/native/xpu/LayerNorm.cpp
+++ b/src/ATen/native/xpu/LayerNorm.cpp
@@ -69,7 +69,8 @@ namespace native {
   for (const auto idx : c10::irange(axis)) {
     stat_shape.push_back(input_shape[idx]);
   }
-  for (const auto & : c10::irange(axis, input.dim())) {
+  for (const auto idx : c10::irange(axis, input.dim())) {
+    (void)idx;
     stat_shape.push_back(1);
   }
 

--- a/src/ATen/native/xpu/LayerNorm.cpp
+++ b/src/ATen/native/xpu/LayerNorm.cpp
@@ -69,7 +69,7 @@ namespace native {
   for (const auto idx : c10::irange(axis)) {
     stat_shape.push_back(input_shape[idx]);
   }
-  for (C10_UNUSED const auto idx : c10::irange(axis, input.dim())) {
+  for (const auto idx : c10::irange(axis, input.dim())) {
     stat_shape.push_back(1);
   }
 

--- a/src/ATen/native/xpu/LayerNorm.cpp
+++ b/src/ATen/native/xpu/LayerNorm.cpp
@@ -69,7 +69,7 @@ namespace native {
   for (const auto idx : c10::irange(axis)) {
     stat_shape.push_back(input_shape[idx]);
   }
-  for (const auto C10_UNUSED idx : c10::irange(axis, input.dim())) {
+  for (C10_UNUSED const auto idx : c10::irange(axis, input.dim())) {
     stat_shape.push_back(1);
   }
 

--- a/src/ATen/native/xpu/UpSample.h
+++ b/src/ATen/native/xpu/UpSample.h
@@ -12,7 +12,7 @@
 
 namespace at::native::xpu {
 
-inline C10_UNUSED std::array<int64_t, 4> upsample_2d_common_check(
+C10_UNUSED inline std::array<int64_t, 4> upsample_2d_common_check(
     IntArrayRef input_size,
     IntArrayRef output_size) {
   TORCH_CHECK(
@@ -228,7 +228,7 @@ static scalar_t upsample_get_value_bounded(
   return data[batch][channel][access_y][access_x];
 }
 
-static C10_UNUSED std::array<int64_t, 3> upsample_1d_common_check(
+C10_UNUSED inline std::array<int64_t, 3> upsample_1d_common_check(
     IntArrayRef input_size,
     IntArrayRef output_size) {
   TORCH_CHECK(

--- a/src/ATen/native/xpu/UpSample.h
+++ b/src/ATen/native/xpu/UpSample.h
@@ -12,7 +12,7 @@
 
 namespace at::native::xpu {
 
-C10_UNUSED inline std::array<int64_t, 4> upsample_2d_common_check(
+inline std::array<int64_t, 4> upsample_2d_common_check(
     IntArrayRef input_size,
     IntArrayRef output_size) {
   TORCH_CHECK(
@@ -228,7 +228,7 @@ static scalar_t upsample_get_value_bounded(
   return data[batch][channel][access_y][access_x];
 }
 
-C10_UNUSED inline std::array<int64_t, 3> upsample_1d_common_check(
+inline std::array<int64_t, 3> upsample_1d_common_check(
     IntArrayRef input_size,
     IntArrayRef output_size) {
   TORCH_CHECK(


### PR DESCRIPTION
[[[maybe_unused]]](https://en.cppreference.com/w/cpp/language/attributes/maybe_unused) is part of C++17 standard.
Depends on: https://github.com/pytorch/pytorch/pull/138102