### PR TITLE
Fix histogram ut failure caused by incorrect threshold settings

### DIFF
--- a/test/xpu/xpu_test_utils.py
+++ b/test/xpu/xpu_test_utils.py
@@ -359,7 +359,7 @@ _xpu_tolerance_override = {
         }
     },
     "histogram": {
-        ("TestCommonXPU", "test_out"):{
+        ("TestCommon", "test_out"):{
             torch.float32: tol(atol=3e-5, rtol=5e-5),
         }
     }


### PR DESCRIPTION
Fix histogram ut failure caused by incorrect threshold settings.