### PR TITLE
Use [[maybe_unused]] to suppress unsued warning

### DIFF
--- a/src/ATen/native/xpu/LayerNorm.cpp
+++ b/src/ATen/native/xpu/LayerNorm.cpp
@@ -69,8 +69,7 @@ namespace native {
   for (const auto idx : c10::irange(axis)) {
     stat_shape.push_back(input_shape[idx]);
   }
-  for (const auto idx : c10::irange(axis, input.dim())) {
-    (void)idx;
+  for ([[maybe_unused]] const auto _ : c10::irange(axis, input.dim())) {
     stat_shape.push_back(1);
   }
 

--- a/src/ATen/native/xpu/UpSample.h
+++ b/src/ATen/native/xpu/UpSample.h
@@ -12,7 +12,7 @@
 
 namespace at::native::xpu {
 
-inline std::array<int64_t, 4> upsample_2d_common_check(
+[[maybe_unused]] inline std::array<int64_t, 4> upsample_2d_common_check(
     IntArrayRef input_size,
     IntArrayRef output_size) {
   TORCH_CHECK(
@@ -228,7 +228,7 @@ static scalar_t upsample_get_value_bounded(
   return data[batch][channel][access_y][access_x];
 }
 
-inline std::array<int64_t, 3> upsample_1d_common_check(
+[[maybe_unused]] inline std::array<int64_t, 3> upsample_1d_common_check(
     IntArrayRef input_size,
     IntArrayRef output_size) {
   TORCH_CHECK(


### PR DESCRIPTION
# Motivation
Accroding to https://github.com/pytorch/pytorch/pull/138364 to use `[[maybe_unused]]` to suppress the unused warning.

Maybe it could fix the [issue](https://github.com/intel/torch-xpu-ops/issues/987) introduced by https://github.com/intel/torch-xpu-ops/pull/770/files#diff-ae810fb2aff5cf37ab1b21244fd1e172a660a8e4f4b9292f0661af64c2f92b21L15.