### PR TITLE
Add aten::lerp_

### DIFF
--- a/yaml/native/native_functions.yaml
+++ b/yaml/native/native_functions.yaml
@@ -4496,6 +4496,12 @@
   structured_delegate: lerp.Scalar_out
   tags: pointwise
 
+- func: lerp_.Scalar(Tensor(a!) self, Tensor end, Scalar weight) -> Tensor(a!)
+  device_check: NoCheck   # TensorIterator
+  variants: method
+  structured_delegate: lerp.Scalar_out
+  tags: pointwise
+
 - func: lerp.Tensor(Tensor self, Tensor end, Tensor weight) -> Tensor
   device_check: NoCheck   # TensorIterator
   variants: method, function
@@ -4508,6 +4514,12 @@
   structured_inherits: TensorIteratorBase
   dispatch:
     XPU: lerp_Tensor
+  tags: pointwise
+
+- func: lerp_.Tensor(Tensor(a!) self, Tensor end, Tensor weight) -> Tensor(a!)
+  device_check: NoCheck   # TensorIterator
+  variants: method
+  structured_delegate: lerp.Tensor_out
   tags: pointwise
 
 - func: addcdiv.out(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1, Tensor(a!) out) -> Tensor(a!)


### PR DESCRIPTION
- `lerp_.Scalar`
- `lerp_.Tensor`

Delegates to structured ops `lerp.Scalar_out` and `lerp.Tensor_out` respectively. The corresponding kernels `xpu::lerp_scalar_kernel` and `xpu::lerp_tensor_kernel` are already implemented.
