### PR TITLE
skip cases which used CUDA graph

### DIFF
--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -2688,16 +2688,8 @@ skip_dict = {
     "nn/test_pruning_xpu.py": None,
 
     "test_foreach_xpu.py": (
-        # CPU fallback fails. Implementation difference between CPU and CUDA. Expect success on CPU and expect fail on CUDA. When we use CPU fallback and align expected fail list with CUDA, these cases fail.
-        "test_binary_op_with_scalar_self_support__foreach_pow_is_fastpath_True_xpu_bool",
-        # AssertionError: RuntimeError not raised
-        # https://github.com/intel/torch-xpu-ops/issues/784 
-        "test_0dim_tensor_overload_exception_xpu",
         # RuntimeError: Tried to instantiate dummy base class CUDAGraph
-        "test_big_num_tensors__foreach_max_use_cuda_graph_True_xpu_float32",
-        "test_big_num_tensors__foreach_max_use_cuda_graph_True_xpu_float64",
-        "test_big_num_tensors__foreach_norm_use_cuda_graph_True_xpu_float32",
-        "test_big_num_tensors__foreach_norm_use_cuda_graph_True_xpu_float64",
+        "use_cuda_graph_True",
     ),
 
     "nn/test_convolution_xpu.py": (


### PR DESCRIPTION
UT cases failed for CUDA graph：
test_foreach_xpu.py::TestForeachXPU::test_big_num_tensors__foreach_max_use_cuda_graph_True_w_empty_False_xpu_float32
test_foreach_xpu.py::TestForeachXPU::test_big_num_tensors__foreach_max_use_cuda_graph_True_w_empty_False_xpu_float64
test_foreach_xpu.py::TestForeachXPU::test_big_num_tensors__foreach_max_use_cuda_graph_True_w_empty_True_xpu_float32
test_foreach_xpu.py::TestForeachXPU::test_big_num_tensors__foreach_max_use_cuda_graph_True_w_empty_True_xpu_float64
test_foreach_xpu.py::TestForeachXPU::test_big_num_tensors__foreach_norm_use_cuda_graph_True_w_empty_False_xpu_float32
test_foreach_xpu.py::TestForeachXPU::test_big_num_tensors__foreach_norm_use_cuda_graph_True_w_empty_False_xpu_float64
test_foreach_xpu.py::TestForeachXPU::test_big_num_tensors__foreach_norm_use_cuda_graph_True_w_empty_True_xpu_float32
test_foreach_xpu.py::TestForeachXPU::test_big_num_tensors__foreach_norm_use_cuda_graph_True_w_empty_True_xpu_float64