### PR TITLE
Prevent building errors caused by SYCL compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 set(PROJECT_NAME "torch-xpu-ops")
 set(PROJECT_VERSION "2.3.0")
+# Avoid SYCL compiler error
+string(APPEND CMAKE_CXX_FLAGS " -Wno-error=comment")
+
 cmake_policy(SET CMP0048 NEW)
 project(${PROJECT_NAME} VERSION "${PROJECT_VERSION}" LANGUAGES C CXX)
 


### PR DESCRIPTION
Directly caused by CXX flag `-Werror`:

```bash
oneapi/compiler/2025.0/bin/compiler/../../include/sycl/detail/builtins/builtins.hpp:235:1: error: multi-line comment [-Werror=comment]
// clang++ -[DU]__SYCL_DEVICE_ONLY__ -x c++ math_functions.inc  \
```