### PR TITLE
Add aten::glu_jvp for xpu

### DIFF
--- a/src/ATen/native/xpu/GatedLinearUnit.cpp
+++ b/src/ATen/native/xpu/GatedLinearUnit.cpp
@@ -8,6 +8,7 @@
 namespace at {
 namespace native {
 REGISTER_XPU_DISPATCH(glu_stub, &xpu::glu_kernel);
+REGISTER_XPU_DISPATCH(glu_jvp_stub, &xpu::glu_jvp_kernel);
 
 Tensor& glu_backward_xpu_out(
     const Tensor& grad_output,

--- a/src/ATen/native/xpu/sycl/ActivationGluKernels.h
+++ b/src/ATen/native/xpu/sycl/ActivationGluKernels.h
@@ -5,6 +5,7 @@
 namespace at::native::xpu {
 
 TORCH_XPU_API void glu_kernel(TensorIteratorBase& iter);
+TORCH_XPU_API void glu_jvp_kernel(TensorIteratorBase& iter);
 
 TORCH_XPU_API void glu_backward_kernel(
     const TensorIteratorBase& iter,

--- a/test/xpu/extended/skip_list_common.py
+++ b/test/xpu/extended/skip_list_common.py
@@ -132,8 +132,7 @@ skip_dict = {
     "test_compare_cpu_nn_functional_interpolate_area_xpu_float16",
     # Not all operators are implemented for XPU tested in the case.
     # Retrieve it once the operator is implemented.
-    # Error: The operator 'aten::glu_jvp' is not currently implemented for the XPU device.
-    "test_forward_ad_nn_functional_glu_xpu_float32",
+
     # Precision error.
     # Mismatched elements: 1 / 812 (0.1%)
     # Greatest absolute difference: 0.03125 at index (610,) (up to 0.001 allowed)

--- a/yaml/native/native_functions.yaml
+++ b/yaml/native/native_functions.yaml
@@ -4166,6 +4166,18 @@
   dispatch:
     XPU: glu_backward_xpu
 
+- func: glu_jvp(Tensor glu, Tensor x, Tensor dx, int dim) -> Tensor
+  python_module: nn
+  dispatch:
+    XPU: glu_jvp
+  autogen: glu_jvp.out
+
+- func: glu_backward_jvp(Tensor grad_x, Tensor grad_glu, Tensor x, Tensor dgrad_glu, Tensor dx, int dim) -> Tensor
+  python_module: nn
+  dispatch:
+    XPU: glu_backward_jvp
+  autogen: glu_backward_jvp.out
+
 - func: softplus.out(Tensor self, Scalar beta=1, Scalar threshold=20, *, Tensor(a!) out) -> Tensor(a!)
   structured: True
   structured_inherits: TensorIteratorBase


### PR DESCRIPTION
Register **glu_jvp** and **glu_jvp_backward** for XPU. Only **glu_jvp** needs xpu kernel. **glu_jvp_backward** will use pytorch's common implementation just like cuda at [code](https://github.com/pytorch/pytorch/blob/v2.5.1/aten/src/ATen/native/GatedLinearUnit.cpp#L111).