### PR TITLE
Enable FP8 for aten::index_select

### DIFF
--- a/src/ATen/native/xpu/sycl/Indexing.cpp
+++ b/src/ATen/native/xpu/sycl/Indexing.cpp
@@ -207,6 +207,7 @@ void index_select_kernel(
         }),
         AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX),
         AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES),
+	AT_EXPAND(AT_FLOAT8_TYPES),
         kComplexHalf,
         kHalf,
         kBool,


### PR DESCRIPTION
For issue https://github.com/intel/torch-xpu-ops/issues/1053, verified with the test:

![image](https://github.com/user-attachments/assets/6583b12e-d22d-4810-b5f5-1bbea6b20d33)



