### PR TITLE
Eliminate `Werror` flag to prevent building failures on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ set(PROJECT_NAME "torch-xpu-ops")
 set(PROJECT_VERSION "2.3.0")
 # Avoid SYCL compiler error
 if(NOT WIN32)
-  string(APPEND CMAKE_CXX_FLAGS " -Wno-error=comment")
+  string(APPEND CMAKE_CXX_FLAGS " -Wno-error")
 endif()
 
 cmake_policy(SET CMP0048 NEW)


### PR DESCRIPTION
Warnings are generated within the SYCL library when using the OneAPI compiler, so `-Wno-error` is used to prevent failures when the `WERROR` flag is enabled.