### PR TITLE
Fix `index_with_sort` kernel accuracy error with nonstandard bool dtype

### DIFF
--- a/src/ATen/native/xpu/sycl/Indexing.h
+++ b/src/ATen/native/xpu/sycl/Indexing.h
@@ -802,16 +802,16 @@ struct IndexPutDeterministicKernelFunctor {
 
     accscalar_t acc;
     if (accumulate_)
-      acc = self_[s_gid];
+      acc = c10::load(&self_[s_gid]);
     for (int64_t inner_idx = id.glb_batch;
          inner_idx < cfg_.problem_batch_ && sorted_indices_[inner_idx] == idx;
          inner_idx++) {
       int64_t idx_orig = indices_[inner_idx];
       int64_t v_gid = idx_orig * stride_ + v_stride;
       if (accumulate_) {
-        acc += (accscalar_t)value_[v_gid];
+        acc += (accscalar_t)c10::load(&value_[v_gid]);
       } else {
-        self_[s_gid] = value_[v_gid];
+        self_[s_gid] = c10::load(&value_[v_gid]);
         break;
       }
     }


### PR DESCRIPTION
Resolve issue: https://github.com/intel/torch-xpu-ops/issues/1048