### PR TITLE
Add sycl convention invocation in MultiTensorApplyKernelFunctor

### DIFF
--- a/test/xpu/test_binary_ufuncs_xpu.py
+++ b/test/xpu/test_binary_ufuncs_xpu.py
@@ -65,7 +65,7 @@ with XPUPatchForImport(False):
                 else:
                     self.assertRaisesRegex(
                         RuntimeError,
-                        "Found dtype \\w+ but expected \\w+",
+                        r"result type \w+ can't be cast to the desired output type \w+",
                         lambda: actual.pow_(exponent),
                     )
 


### PR DESCRIPTION
Fix the bug where shared memory initialization is missing in the foreach backbone