### PR TITLE
Support lazy initialization for empty_xpu

### DIFF
--- a/src/ATen/xpu/EmptyTensor.cpp
+++ b/src/ATen/xpu/EmptyTensor.cpp
@@ -12,6 +12,7 @@ TensorBase empty_xpu(
     ScalarType dtype,
     c10::optional<Device> device_opt,
     c10::optional<c10::MemoryFormat> memory_format_opt) {
+  at::globalContext().lazyInitDevice(c10::DeviceType::XPU);
   const auto device = device_or_default(device_opt);
   TORCH_INTERNAL_ASSERT(device.is_xpu());
   const c10::DeviceGuard device_guard(device);


### PR DESCRIPTION
# Motivation
Fix https://github.com/pytorch/pytorch/issues/140877
Some PyTorch C++ users could call empty op directly. In this situation, lazy initialization would not have been triggered. So we have to add `lazyInitDevice` here, which also aligns with CUDA [convention](https://github.com/pytorch/pytorch/blob/150ffb6e07f3802f8d0d3e843486e77a872803cf/aten/src/ATen/cuda/EmptyTensor.cpp#L13).