### PR TITLE
Reuse the max op implemented by the reduction kernel to optimize the global max pooling

### DIFF
--- a/src/ATen/native/xpu/sycl/DilatedMaxPool2d.h
+++ b/src/ATen/native/xpu/sycl/DilatedMaxPool2d.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <comm/xpu_aten.h>
+#include <ATen/core/Tensor.h>
 
 namespace at::native::xpu {
 


### PR DESCRIPTION
Fix: https://github.com/intel/torch-xpu-ops/issues/938