### PR TITLE
[CI] Update windows CI label set

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -39,7 +39,7 @@ jobs:
   
   preci-windows:
     # Don't run on forked repos and draft PRs
-    if: ${{ (github.repository_owner == 'intel') && (github.event.pull_request.draft == false) }} && contains(github.event.pull_request.labels.*.name, 'windows_ci')
+    if: ${{ (github.repository_owner == 'intel') && (github.event.pull_request.draft == false) && contains(github.event.pull_request.labels.*.name, 'windows_ci') }} 
     uses: ./.github/workflows/_windows_ut.yml
     with: 
       ut: op_extended


### PR DESCRIPTION
Update windows CI label set so that only the PR that sets a specific label 'windows_ci' will trigger windows CI.