### PR TITLE
ci: update Transformers to v4.51.3

### DIFF
--- a/.github/actions/print-environment/action.yml
+++ b/.github/actions/print-environment/action.yml
@@ -16,6 +16,11 @@ inputs:
     type: string
     default: ''
     description: "Space separated list of PyPi packages to evaluate"
+  to:
+    required: false
+    type: string
+    default: ''
+    description: "File to print environment to"
 
 runs:
   using: composite
@@ -25,6 +30,11 @@ runs:
       run: |
         if [ -n "${{ inputs.conda }}" ]; then
           source activate ${{ inputs.conda }}
+        fi
+        to=$GITHUB_STEP_SUMMARY
+        if [ -n "${{ inputs.to }}" ]; then
+          to="${{ inputs.to }}"
+          mkdir -p $(dirname $to)
         fi
         {
           echo "### Environment"
@@ -71,4 +81,4 @@ runs:
           echo "| jobs.$GITHUB_JOB.env.NEOReadDebugKeys | $NEOReadDebugKeys |"
           echo "| jobs.$GITHUB_JOB.env.PYTORCH_ENABLE_XPU_FALLBACK | $PYTORCH_ENABLE_XPU_FALLBACK |"
           echo "| jobs.$GITHUB_JOB.env.PYTORCH_DEBUG_XPU_FALLBACK | $PYTORCH_DEBUG_XPU_FALLBACK |"
-        } >> $GITHUB_STEP_SUMMARY
+        } >> $to

--- a/.github/scripts/check-transformers.py
+++ b/.github/scripts/check-transformers.py
@@ -7,19 +7,6 @@ parser = argparse.ArgumentParser()
 parser.add_argument('junitxml', nargs='+')
 args = parser.parse_args()
 
-layernorm_accuracy_failures = {
-    'link': 'https://github.com/pytorch/pytorch/issues/141642',
-    'cuda': 'passed',
-}
-
-# Tests were enabled for non-cuda backends by v4.49.0 (previously were
-# skipped for xpu):
-# https://github.com/huggingface/transformers/commit/2fa876d2d824123b80ced9d689f75a153731769b
-test_cpu_offload_failures = {
-    'link': 'https://github.com/huggingface/accelerate/issues/3402',
-    'cuda': 'passed',
-}
-
 # That's a list of known test failures. Each listed test can have
 # associated metadata in the following format:
 #   failing_cases = {
@@ -33,24 +20,29 @@ test_cpu_offload_failures = {
 #   }
 # Use None if no metadata is needed.
 failing_cases = {
-    'tests.generation.test_logits_process.LogitsProcessorTest': {
-        'test_watermarking_processor': { 'cuda': 'passed', },
-    },
     'tests.generation.test_utils.GenerationIntegrationTests': {
         'test_assisted_decoding_encoder_decoder_shared_encoder': { 'cuda': 'failed', },
         'test_assisted_decoding_num_assistant_tokens_heuristic_schedule': { 'cuda': 'failed', },
         'test_assisted_generation_early_exit': { 'cuda': 'failed', },
         'test_custom_logits_processor': { 'cuda': 'failed', },
+        # v4.50.0+ (regression)
+        # https://github.com/huggingface/transformers/commit/fc8764c9a618add64c33e83720f974750bcd0978
+        'test_custom_stopping_criteria_overload_error': {},
         'test_default_max_length_warning': { 'cuda': 'failed', },
         # v4.49.0+ (regression)
         # https://github.com/huggingface/transformers/commit/365fecb4d0b6c87f20b93561e11c3d4c77938012
-        'test_encoder_decoder_generate_attention_mask': { 'cuda': 'failed', },
         'test_eos_token_id_int_and_list_beam_search': { 'cuda': 'failed', },
         'test_eos_token_id_int_and_list_top_k_top_sampling': { 'cuda': 'failed', },
         'test_generate_compile_fullgraph_tiny': { 'cuda': 'failed', },
+        # v4.50.0+ (regression)
+        # https://github.com/huggingface/transformers/commit/55493f13906acaa6fc1b90601098c50c3d0cb6a5
+        'test_generate_encoder_outputs_attention_mask': {},
         # v4.49.0+ (regression)
         # https://github.com/huggingface/transformers/commit/da334bcfa8ff7feb85138ce90ca7340e4fc6e704
         'test_generate_input_features_as_encoder_kwarg': { 'cuda': 'failed' },
+        # v4.50.0+ (regression)
+        # https://github.com/huggingface/transformers/commit/55493f13906acaa6fc1b90601098c50c3d0cb6a5
+        'test_generate_input_ids_as_encoder_kwarg': {},
         'test_max_new_tokens_encoder_decoder': { 'cuda': 'failed', },
         'test_min_length_if_input_embeds': { 'cuda': 'passed' },
         'test_model_kwarg_assisted_decoding_decoder_only': { 'cuda': 'failed' },
@@ -59,20 +51,10 @@ failing_cases = {
         'test_prepare_inputs_for_generation_decoder_llm': { 'cuda': 'failed' },
         'test_stop_sequence_stopping_criteria': { 'cuda': 'failed' },
     },
-    'tests.models.blip.test_modeling_blip.BlipTextImageModelTest': {
-        'test_cpu_offload': test_cpu_offload_failures,
-        'test_disk_offload_bin': test_cpu_offload_failures,
-        'test_disk_offload_safetensors': test_cpu_offload_failures,
-    },
-    'tests.models.blip.test_modeling_blip.BlipVQAModelTest': {
-        'test_cpu_offload': test_cpu_offload_failures,
-        'test_disk_offload_bin': test_cpu_offload_failures,
-        'test_disk_offload_safetensors': test_cpu_offload_failures,
-    },
-    'tests.models.dab_detr.test_modeling_dab_detr.DabDetrModelTest': {
-        'test_cpu_offload': test_cpu_offload_failures,
-        'test_disk_offload_bin': test_cpu_offload_failures,
-        'test_disk_offload_safetensors': test_cpu_offload_failures,
+    'tests.generation.test_utils.UtilsFunctionsTest': {
+        # v4.51.0 (new test)
+        # https://github.com/huggingface/transformers/commit/6f5dc9c82efd347bcc1941da64739d269e741771
+        'test_cache_dependant_input_preparation_exporting': {},
     },
     'tests.models.detr.test_image_processing_detr.DetrImageProcessingTest': {
         'test_fast_is_faster_than_slow': { 'flaky': True },
@@ -86,61 +68,59 @@ failing_cases = {
     'tests.models.git.test_modeling_git.GitModelTest': {
         'test_generate_continue_from_past_key_values': { 'flaky': True, 'cuda': 'passed' },
     },
-    'tests.models.hiera.test_modeling_hiera.HieraModelTest': {
-        'test_torch_fx': layernorm_accuracy_failures,
-        'test_torch_fx_output_loss': layernorm_accuracy_failures,
+    'tests.models.informer.test_modeling_informer.InformerModelTest': {
+        # v4.51.0 (regression)
+        # https://github.com/huggingface/transformers/commit/f304318f5ffa530a4948aed552d3405708163b52
+        'test_encoder_decoder_model_standalone': {},
     },
-    'tests.models.llava.test_modeling_llava.LlavaForConditionalGenerationModelTest': {
-        # v4.49.0+ (regression)
-        # https://github.com/huggingface/transformers/commit/bcfc9d795e1330faaa8b39ffa18732f8b40fe7c0
-        'test_config': { 'cuda': 'failed' },
+    # v4.51.0 (new tests)
+    # https://github.com/huggingface/transformers/commit/25b7f272347a93d6fb73cad126f6f6dc88e8ce89
+    'tests.models.llama4.test_image_processing_llama4.Llama4ImageProcessingTest': {
+        'test_image_processor_save_load_with_autoimageprocessor': {},
     },
-    'tests.models.mamba.test_modeling_mamba.MambaIntegrationTests': {
-        'test_simple_generate_1_cpu': { 'cuda': 'passed' },
+    # v4.51.0 (new tests)
+    # https://github.com/huggingface/transformers/commit/25b7f272347a93d6fb73cad126f6f6dc88e8ce89
+    'tests.models.llama4.test_processor_llama4.Llama4ProcessorTest': {
+        'test_image_chat_template_accepts_processing_kwargs': {},
+        'test_image_processor_defaults_preserved_by_image_kwargs': {},
+        'test_kwargs_overrides_default_image_processor_kwargs': {},
+        'test_kwargs_overrides_default_tokenizer_kwargs': {},
+        'test_structured_kwargs_nested': {},
+        'test_structured_kwargs_nested_from_dict': {},
+        'test_tokenizer_defaults_preserved_by_kwargs': {},
+        'test_unstructured_kwargs': {},
+        'test_unstructured_kwargs_batched': {},
     },
-    # v4.49.0 (new test)
-    # https://github.com/huggingface/transformers/commit/be2ac0916a7902e1683d708805270142257a254a
-    'tests.models.paligemma.test_modeling_paligemma.PaliGemmaForConditionalGenerationModelTest': {
-        'test_generate_compilation_all_outputs': { 'cuda': 'failed' },
-    },
-    # v4.49.0 (new test)
-    # https://github.com/huggingface/transformers/commit/be2ac0916a7902e1683d708805270142257a254a
-    'tests.models.paligemma2.test_modeling_paligemma2.PaliGemma2ForConditionalGenerationModelTest': {
-        'test_generate_compilation_all_outputs': { 'cuda': 'failed' },
+    # v4.51.0 (new test)
+    # https://github.com/huggingface/transformers/commit/90e2df5d5544e3624ce711a28717204b7779c2d7
+    'tests.models.mllama.test_modeling_mllama.MllamaForConditionalGenerationModelTest': {
+        'test_resize_embeddings_results_in_successful_loss': {},
     },
     'tests.models.pix2struct.test_modeling_pix2struct.Pix2StructModelTest': {
         'test_new_cache_format_0': { 'cuda': 'passed' },
         'test_new_cache_format_1': { 'cuda': 'passed' },
         'test_new_cache_format_2': { 'cuda': 'passed' },
     },
-    'tests.models.qwen2_5_vl.test_processor_qwen2_5_vl.Qwen2_5_VLProcessorTest': {
-        # v4.49.0+ (new test)
-        # https://github.com/huggingface/transformers/commit/15ec971b8ec999c6a511debe04ba32c115fb7413
-        'test_chat_template_video_custom_sampling': { 'cuda': 'failed' },
-        # v4.49.0+ (new test)
-        # https://github.com/huggingface/transformers/commit/15ec971b8ec999c6a511debe04ba32c115fb7413
-        'test_chat_template_video_special_processing': { 'cuda': 'failed' },
-    },
-    'tests.models.qwen2_vl.test_processor_qwen2_vl.Qwen2VLProcessorTest': {
-        'test_chat_template_video_custom_sampling': { 'cuda': 'failed' },
-        'test_chat_template_video_special_processing': { 'cuda': 'failed' },
-    },
-    # different failure signature than described in 'test_cpu_offload_failures'
     'tests.models.roberta.test_modeling_roberta.RobertaModelTest': {
         'test_cpu_offload': { 'cuda': 'failed' },
         'test_disk_offload_bin': { 'cuda': 'failed' },
         'test_disk_offload_safetensors': { 'cuda': 'failed' },
+    },
+    'tests.models.roformer.test_modeling_roformer.RoFormerSinusoidalPositionalEmbeddingTest': {
+        # v4.51.0+ (regression)
+        # https://github.com/huggingface/transformers/commit/f304318f5ffa530a4948aed552d3405708163b52
+        'test_basic': {},
+    },
+    'tests.models.roformer.test_modeling_roformer.RoFormerSelfAttentionRotaryPositionEmbeddingTest': {
+        # v4.51.0+ (regression)
+        # https://github.com/huggingface/transformers/commit/f304318f5ffa530a4948aed552d3405708163b52
+        'test_apply_rotary_position_embeddings': {},
     },
     'tests.models.rt_detr.test_image_processing_rt_detr.RtDetrImageProcessingTest': {
         'test_fast_is_faster_than_slow': { 'flaky': True },
     },
     'tests.models.speecht5.test_modeling_speecht5.SpeechT5ForTextToSpeechIntegrationTests': {
         'test_batch_generation': { 'cuda': 'passed' },
-    },
-    'tests.models.vilt.test_modeling_vilt.ViltModelTest': {
-        'test_cpu_offload': test_cpu_offload_failures,
-        'test_disk_offload_bin': test_cpu_offload_failures,
-        'test_disk_offload_safetensors': test_cpu_offload_failures,
     },
     'tests.pipelines.test_pipelines_audio_classification.AudioClassificationPipelineTests': {
         # v4.49.0+ (new test)
@@ -181,12 +161,10 @@ failing_cases = {
         'test_small_model_pt': { 'cuda': "failed" },
         'test_small_model_pt_fp16': { 'cuda': "failed" },
     },
-    'tests.test_pipeline_mixin.AudioClassificationPipelineTests': {
-        # v4.49.0+ (new test)
-        # https://github.com/huggingface/transformers/commit/f19135afc77053834f1b0cdf46d9a6bf7faf7cc3
-        'test_small_model_pt_fp16': { 'cuda': "failed", 'link': 'https://github.com/huggingface/transformers/issues/36340' },
-    },
     'tests.test_pipeline_mixin.AutomaticSpeechRecognitionPipelineTests': {
+        'test_small_model_pt': { 'flaky': True },
+        'test_small_model_pt_bf16': { 'flaky': True },
+        'test_small_model_pt_fp16': { 'flaky': True },
         'test_small_model_pt_seq2seq': { 'cuda': "failed" },
     },
     'tests.test_pipeline_mixin.DepthEstimationPipelineTests': {
@@ -216,11 +194,6 @@ failing_cases = {
     'tests.test_pipeline_mixin.ZeroShotImageClassificationPipelineTests': {
         'test_small_model_pt': { 'cuda': "failed" },
         'test_small_model_pt_fp16': { 'cuda': "failed" },
-    },
-    'tests.trainer.test_trainer.TrainerIntegrationPrerunTest': {
-        # v4.49.0+ (promoted from slow tests)
-        # https://github.com/huggingface/transformers/commit/1fae54c7216e144b426e753400abdc1299d4fc74
-        'test_gradient_accumulation_loss_alignment_with_model_loss': { 'cuda': "failed" },
     },
 }
 

--- a/.github/workflows/_linux_accelerate.yml
+++ b/.github/workflows/_linux_accelerate.yml
@@ -57,6 +57,8 @@ jobs:
       PYTORCH_DEBUG_XPU_FALLBACK: 1
       ZE_AFFINITY_MASK: 0
       PARSE_JUNIT: ${{ github.workspace }}/torch-xpu-ops/.github/scripts/parse-junitxml.py
+      HF_HUB_ETAG_TIMEOUT: 120
+      HF_HUB_DOWNLOAD_TIMEOUT: 120
     steps:
       - name: Checkout torch-xpu-ops
         uses: actions/checkout@v4

--- a/.github/workflows/_linux_transformers.yml
+++ b/.github/workflows/_linux_transformers.yml
@@ -41,7 +41,7 @@ on:
       transformers:
         required: false
         type: string
-        default: 'v4.47.0'
+        default: 'v4.49.0'
         description: Transformers version
 
 permissions: read-all
@@ -56,7 +56,8 @@ jobs:
       DisableScratchPages: ${{ inputs.driver == 'rolling' && '1' || '0' }}
       python: ${{ inputs.python != '' && inputs.python || '3.10' }}
       pytorch: ${{ inputs.pytorch != '' && inputs.pytorch || 'nightly' }}
-      transformers: ${{ inputs.transformers != '' && inputs.transformers || 'v4.47.0' }}
+      transformers: ${{ inputs.transformers != '' && inputs.transformers || 'v4.49.0' }}
+      PYTEST_TIMEOUT: 600
       PYTORCH_DEBUG_XPU_FALLBACK: '1'
       TRANSFORMERS_TEST_DEVICE_SPEC: 'spec.py'
     steps:
@@ -144,7 +145,11 @@ jobs:
         run: |
           source activate $CONDA_ENV_NAME
           cd transformers
-          python3 -m pytest --timeout 600 -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml -k backbone tests || \
+          # Excluding tests due to:
+          # * https://github.com/huggingface/transformers/issues/36267 (marian tests)
+          python3 -m pytest -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml \
+            --ignore=tests/models/marian/test_modeling_marian.py \
+            -k backbone tests || \
             (echo "FAILED_CASES=$FAILED_CASES,$TEST_CASE" >> $GITHUB_ENV)
       - name: Run tests/*.py
         env:
@@ -152,14 +157,7 @@ jobs:
         run: |
           source activate $CONDA_ENV_NAME
           cd transformers
-          python3 -m pytest --timeout 600 -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml tests/*.py || true
-      - name: Run tests/benchmark
-        env:
-          TEST_CASE: 'tests_benchmark'
-        run: |
-          source activate $CONDA_ENV_NAME
-          cd transformers
-          python3 -m pytest --timeout 600 -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml tests/benchmark || true
+          python3 -m pytest -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml tests/*.py || true
       - name: Run tests/generation
         env:
           TEST_CASE: 'tests_generation'
@@ -169,7 +167,7 @@ jobs:
           # Excluding tests due to:
           # * torch.distributed.* not yet supported by XPU
           pattern="not TestFSDPGeneration"
-          python3 -m pytest --timeout 600 -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml tests/generation -k "$pattern" || true
+          python3 -m pytest -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml tests/generation -k "$pattern" || true
       - name: Run tests/models
         env:
           TEST_CASE: 'tests_models'
@@ -177,14 +175,14 @@ jobs:
           source activate $CONDA_ENV_NAME
           cd transformers
           # Excluding tests due to:
-          # * https://github.com/huggingface/transformers/issues/35252 (CUDA specific tests)
           # * https://github.com/pytorch/pytorch/issues/140965 (aten::_linalg_eigvals)
+          # * https://github.com/huggingface/transformers/issues/36267 (marian tests)
           pattern=" \
-            not test_model_parallelization and \
-            not test_model_parallel_equal_results and \
             not test_resize_embeddings_untied and \
             not test_resize_tokens_embeddings"
-          python3 -m pytest --timeout 600 -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml tests/models -k "$pattern" || true
+          python3 -m pytest -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml \
+            -k "$pattern" --ignore=tests/models/marian/test_modeling_marian.py \
+            tests/models || true
       - name: Run tests/pipelines
         env:
           TEST_CASE: 'tests_pipelines'
@@ -193,7 +191,7 @@ jobs:
           cd transformers
           # Some tests are known to fail w/o clear pattern
           # TODO: drop ||true after triage and fixes
-          python3 -m pytest --timeout 600 -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml tests/pipelines || true
+          python3 -m pytest -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml tests/pipelines || true
       - name: Run tests/trainer
         env:
           TEST_CASE: 'tests_trainer'
@@ -208,7 +206,7 @@ jobs:
             not TestTrainerDistributed and \
             not TestTrainerDistributedXPU and \
             not TestFSDPTrainer"
-          python3 -m pytest --timeout 600 -rsf --make-reports=$TEST_CASE tests/trainer --junit-xml=reports/$TEST_CASE.xml -k "$pattern" || \
+          python3 -m pytest -rsf --make-reports=$TEST_CASE tests/trainer --junit-xml=reports/$TEST_CASE.xml -k "$pattern" || \
             (echo "FAILED_CASES=$FAILED_CASES,$TEST_CASE" >> $GITHUB_ENV)
       - name: Run tests/utils
         env:
@@ -219,8 +217,11 @@ jobs:
           # Excluding tests due to:
           # * Network proxy connection issue, reason unknown
           pattern="not test_load_img_url_timeout"
-          python3 -m pytest --timeout 600 -rsf --make-reports=$TEST_CASE tests/utils --junit-xml=reports/$TEST_CASE.xml -k "$pattern" || \
-            (echo "FAILED_CASES=$FAILED_CASES,$TEST_CASE" >> $GITHUB_ENV)
+          # 'tests/utils/test_import_utils.py' invalidates state of the test engine causing
+          # next tests to fail. See: https://github.com/huggingface/transformers/issues/36267
+          python3 -m pytest -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml \
+            -k "$pattern" --ignore=tests/utils/test_import_utils.py \
+            tests/utils || (echo "FAILED_CASES=$FAILED_CASES,$TEST_CASE" >> $GITHUB_ENV)
       - name: Check for errors in tests
         run: |
           FAILED_CASES=$(echo $FAILED_CASES | sed 's/^,//')

--- a/.github/workflows/_linux_transformers.yml
+++ b/.github/workflows/_linux_transformers.yml
@@ -36,12 +36,12 @@ on:
       accelerate:
         required: false
         type: string
-        default: 'v1.4.0'
+        default: 'v1.7.0'
         description: Accelerate version
       transformers:
         required: false
         type: string
-        default: 'v4.49.0'
+        default: 'v4.51.3'
         description: Transformers version
 
 permissions: read-all
@@ -55,8 +55,8 @@ env:
   NEOReadDebugKeys: ${{ inputs.driver == 'rolling' && '1' || '0' }}
   DisableScratchPages: ${{ inputs.driver == 'rolling' && '1' || '0' }}
   python: ${{ inputs.python != '' && inputs.python || '3.10' }}
-  accelerate: ${{ inputs.accelerate != '' && inputs.accelerate || 'v1.4.0'}}
-  transformers: ${{ inputs.transformers != '' && inputs.transformers || 'v4.49.0' }}
+  accelerate: ${{ inputs.accelerate != '' && inputs.accelerate || 'v1.7.0'}}
+  transformers: ${{ inputs.transformers != '' && inputs.transformers || 'v4.51.3' }}
   PACKAGES: |
     espeak-ng
     git-lfs
@@ -68,6 +68,7 @@ env:
     libavutil-dev
     libswresample-dev
     libswscale-dev
+    pciutils
   PYTEST_TIMEOUT: 600
   TORCH_INDEX: '--pre --index-url https://download.pytorch.org/whl/nightly/xpu'
 
@@ -78,22 +79,32 @@ jobs:
       torch: ${{ steps.getver.outputs.torch }}
       torchvision: ${{ steps.getver.outputs.torchvision }}
       torchaudio: ${{ steps.getver.outputs.torchaudio }}
+      triton: ${{ steps.getver.outputs.triton }}
     steps:
       - id: getver
         run: |
-          torch="2.8.0.dev20250412+xpu"  #$(pip index versions torch $TORCH_INDEX | grep torch | sed -E 's/.*\((.*)\)/\1/')
-          torchvision="0.22.0.dev20250412+xpu"  #$(pip index versions torchvision $TORCH_INDEX | grep torch | sed -E 's/.*\((.*)\)/\1/')
-          torchaudio="2.6.0.dev20250412+xpu"  #$(pip index versions torchaudio $TORCH_INDEX | grep torch | sed -E 's/.*\((.*)\)/\1/')
+          # We can't just `pip index version...` and get the last available
+          # version as pytorch packages may have tricky dependencies. Instead
+          # we dry run install packages and get versions which would be installed.
+          # See: https://github.com/pytorch/pytorch/issues/154687
+          pip install --dry-run --ignore-installed $TORCH_INDEX \
+            torch torchvision torchaudio pytorch-triton-xpu >_log.txt
+
+          torch=$(cat _log.txt | grep "Would install" | sed -E "s/.*torch-([^ ]*).*/\1/")
+          torchvision=$(cat _log.txt | grep "Would install" | sed -E "s/.*torchvision-([^ ]*).*/\1/")
+          torchaudio=$(cat _log.txt | grep "Would install" | sed -E "s/.*torchaudio-([^ ]*).*/\1/")
+          triton=$(cat _log.txt | grep "Would install" | sed -E "s/.*pytorch-triton-xpu-([^ ]*).*/\1/")
           echo "torch=$torch" | tee -a "$GITHUB_OUTPUT"
           echo "torchvision=$torchvision" | tee -a "$GITHUB_OUTPUT"
           echo "torchaudio=$torchaudio" | tee -a "$GITHUB_OUTPUT"
+          echo "triton=$triton" | tee -a "$GITHUB_OUTPUT"
 
   tests:
     needs: prepare
     runs-on: ${{ inputs.runner != '' && inputs.runner || 'linux.idc.xpu' }}
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 1
       matrix:
         test:
           # Excluding tests due to:
@@ -195,10 +206,6 @@ jobs:
           if [ -d "$HF_HOME" ]; then
             ls -al ${{ env.HF_HOME }}
             du -sh ${{ env.HF_HOME }}
-          else
-            echo "HF cache directory does not exist"
-            echo "WARNING: Some tests might fail fetching content from the hub!"
-            echo "WARNING: Populate cache with test content!"
           fi
       - name: Prepare OS environment
         run: |
@@ -227,14 +234,15 @@ jobs:
           conda remove --all -y -n $CONDA_ENV_NAME || rm -rf $(dirname ${CONDA_EXE})/../envs/$CONDA_ENV_NAME
           conda create -y -n $CONDA_ENV_NAME python=${{ env.python }}
           source activate $CONDA_ENV_NAME
-          pip install junitparser pytest-rerunfailures pytest-shard pytest-timeout
+          pip install junitparser pytest-shard pytest-timeout
       - name: Prepare Stock XPU Pytorch
         run: |
           source activate $CONDA_ENV_NAME
           pip install $TORCH_INDEX \
             torch==${{ needs.prepare.outputs.torch }} \
             torchvision==${{ needs.prepare.outputs.torchvision }} \
-            torchaudio==${{ needs.prepare.outputs.torchaudio }}
+            torchaudio==${{ needs.prepare.outputs.torchaudio }} \
+            pytorch-triton-xpu==${{needs.prepare.outputs.triton }}
       - name: Prepare Transformers
         run: |
           pwd
@@ -444,4 +452,3 @@ jobs:
           if [ -n "$CONDA_ENV_NAME" ]; then
             conda remove --all -y -n $CONDA_ENV_NAME || rm -rf $(dirname ${CONDA_EXE})/../envs/$CONDA_ENV_NAME
           fi
-

--- a/.github/workflows/_linux_transformers.yml
+++ b/.github/workflows/_linux_transformers.yml
@@ -13,11 +13,6 @@ on:
       - '.github/workflows/_linux_transformers.yml'
   workflow_dispatch:
     inputs:
-      pytorch:
-        required: false
-        type: string
-        default: 'nightly'
-        description: Pytorch branch/commit
       python:
         required: false
         type: string
@@ -38,6 +33,11 @@ on:
         type: string
         default: ''
         description: Pytorch nightly wheel version
+      accelerate:
+        required: false
+        type: string
+        default: 'v1.4.0'
+        description: Accelerate version
       transformers:
         required: false
         type: string
@@ -45,19 +45,134 @@ on:
         description: Transformers version
 
 permissions: read-all
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+env:
+  HF_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+  HF_HUB_ETAG_TIMEOUT: 120
+  HF_HUB_DOWNLOAD_TIMEOUT: 120
+  NEOReadDebugKeys: ${{ inputs.driver == 'rolling' && '1' || '0' }}
+  DisableScratchPages: ${{ inputs.driver == 'rolling' && '1' || '0' }}
+  python: ${{ inputs.python != '' && inputs.python || '3.10' }}
+  accelerate: ${{ inputs.accelerate != '' && inputs.accelerate || 'v1.4.0'}}
+  transformers: ${{ inputs.transformers != '' && inputs.transformers || 'v4.49.0' }}
+  PACKAGES: |
+    espeak-ng
+    git-lfs
+    pkg-config
+    libavcodec-dev
+    libavdevice-dev
+    libavfilter-dev
+    libavformat-dev
+    libavutil-dev
+    libswresample-dev
+    libswscale-dev
+  PYTEST_TIMEOUT: 600
+  TORCH_INDEX: '--pre --index-url https://download.pytorch.org/whl/nightly/xpu'
 
 jobs:
-  Torch-XPU-Transformers-Tests:
+  prepare:
     runs-on: ${{ inputs.runner != '' && inputs.runner || 'linux.idc.xpu' }}
+    outputs:
+      torch: ${{ steps.getver.outputs.torch }}
+      torchvision: ${{ steps.getver.outputs.torchvision }}
+      torchaudio: ${{ steps.getver.outputs.torchaudio }}
+    steps:
+      - id: getver
+        run: |
+          torch="2.8.0.dev20250412+xpu"  #$(pip index versions torch $TORCH_INDEX | grep torch | sed -E 's/.*\((.*)\)/\1/')
+          torchvision="0.22.0.dev20250412+xpu"  #$(pip index versions torchvision $TORCH_INDEX | grep torch | sed -E 's/.*\((.*)\)/\1/')
+          torchaudio="2.6.0.dev20250412+xpu"  #$(pip index versions torchaudio $TORCH_INDEX | grep torch | sed -E 's/.*\((.*)\)/\1/')
+          echo "torch=$torch" | tee -a "$GITHUB_OUTPUT"
+          echo "torchvision=$torchvision" | tee -a "$GITHUB_OUTPUT"
+          echo "torchaudio=$torchaudio" | tee -a "$GITHUB_OUTPUT"
+
+  tests:
+    needs: prepare
+    runs-on: ${{ inputs.runner != '' && inputs.runner || 'linux.idc.xpu' }}
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:
+        test:
+          # Excluding tests due to:
+          # * https://github.com/huggingface/transformers/issues/36267 (marian tests)
+          - test_case: 'tests_backbone'
+            cmd: '--ignore=tests/models/marian/test_modeling_marian.py -k backbone tests'
+          - test_case: "tests_py"
+            cmd: "tests/*.py"
+          # Excluding tests due to:
+          # * torch.distributed.* not yet supported by XPU
+          - test_case: 'tests_generation'
+            cmd: 'tests/generation'
+            filter: 'not TestFSDPGeneration'
+          # breaking for each shard to take ~15-30 minutes to complete
+          # Excluding tests due to:
+          # * https://github.com/pytorch/pytorch/issues/140965 (aten::_linalg_eigvals)
+          # * https://github.com/huggingface/transformers/issues/36267 (marian tests)
+          - test_case: 'tests_models_0'
+            cmd: 'tests/models --num-shards 16 --shard-id 0 --ignore=tests/models/marian/test_modeling_marian.py'
+            filter: 'not test_resize_embeddings_untied and not test_resize_tokens_embeddings'
+          - test_case: 'tests_models_1'
+            cmd: 'tests/models --num-shards 16 --shard-id 1 --ignore=tests/models/marian/test_modeling_marian.py'
+            filter: 'not test_resize_embeddings_untied and not test_resize_tokens_embeddings'
+          - test_case: 'tests_models_2'
+            cmd: 'tests/models --num-shards 16 --shard-id 2 --ignore=tests/models/marian/test_modeling_marian.py'
+            filter: 'not test_resize_embeddings_untied and not test_resize_tokens_embeddings'
+          - test_case: 'tests_models_3'
+            cmd: 'tests/models --num-shards 16 --shard-id 3 --ignore=tests/models/marian/test_modeling_marian.py'
+            filter: 'not test_resize_embeddings_untied and not test_resize_tokens_embeddings'
+          - test_case: 'tests_models_4'
+            cmd: 'tests/models --num-shards 16 --shard-id 4 --ignore=tests/models/marian/test_modeling_marian.py'
+            filter: 'not test_resize_embeddings_untied and not test_resize_tokens_embeddings'
+          - test_case: 'tests_models_5'
+            cmd: 'tests/models --num-shards 16 --shard-id 5 --ignore=tests/models/marian/test_modeling_marian.py'
+            filter: 'not test_resize_embeddings_untied and not test_resize_tokens_embeddings'
+          - test_case: 'tests_models_6'
+            cmd: 'tests/models --num-shards 16 --shard-id 6 --ignore=tests/models/marian/test_modeling_marian.py'
+            filter: 'not test_resize_embeddings_untied and not test_resize_tokens_embeddings'
+          - test_case: 'tests_models_7'
+            cmd: 'tests/models --num-shards 16 --shard-id 7 --ignore=tests/models/marian/test_modeling_marian.py'
+            filter: 'not test_resize_embeddings_untied and not test_resize_tokens_embeddings'
+          - test_case: 'tests_models_8'
+            cmd: 'tests/models --num-shards 16 --shard-id 8 --ignore=tests/models/marian/test_modeling_marian.py'
+            filter: 'not test_resize_embeddings_untied and not test_resize_tokens_embeddings'
+          - test_case: 'tests_models_9'
+            cmd: 'tests/models --num-shards 16 --shard-id 9 --ignore=tests/models/marian/test_modeling_marian.py'
+            filter: 'not test_resize_embeddings_untied and not test_resize_tokens_embeddings'
+          - test_case: 'tests_models_10'
+            cmd: 'tests/models --num-shards 16 --shard-id 10 --ignore=tests/models/marian/test_modeling_marian.py'
+            filter: 'not test_resize_embeddings_untied and not test_resize_tokens_embeddings'
+          - test_case: 'tests_models_11'
+            cmd: 'tests/models --num-shards 16 --shard-id 11 --ignore=tests/models/marian/test_modeling_marian.py'
+            filter: 'not test_resize_embeddings_untied and not test_resize_tokens_embeddings'
+          - test_case: 'tests_models_12'
+            cmd: 'tests/models --num-shards 16 --shard-id 12 --ignore=tests/models/marian/test_modeling_marian.py'
+            filter: 'not test_resize_embeddings_untied and not test_resize_tokens_embeddings'
+          - test_case: 'tests_models_13'
+            cmd: 'tests/models --num-shards 16 --shard-id 13 --ignore=tests/models/marian/test_modeling_marian.py'
+            filter: 'not test_resize_embeddings_untied and not test_resize_tokens_embeddings'
+          - test_case: 'tests_models_14'
+            cmd: 'tests/models --num-shards 16 --shard-id 14 --ignore=tests/models/marian/test_modeling_marian.py'
+            filter: 'not test_resize_embeddings_untied and not test_resize_tokens_embeddings'
+          - test_case: 'tests_models_15'
+            cmd: 'tests/models --num-shards 16 --shard-id 15 --ignore=tests/models/marian/test_modeling_marian.py'
+            filter: 'not test_resize_embeddings_untied and not test_resize_tokens_embeddings'
+          # Excluding tests due to:
+          # * Some ray tests hang, reason unknown
+          # * torch.distributed.* not yet supported by XPU
+          - test_case: 'tests_trainer'
+            cmd: 'tests/trainer'
+            filter: 'not ray and not TestTrainerDistributed and not TestTrainerDistributedXPU and not TestFSDPTrainer'
+          # Excluding tests due to:
+          # * Network proxy connection issue, reason unknown
+          # *'tests/utils/test_import_utils.py' invalidates state of the test engine causing
+          #   next tests to fail. See: https://github.com/huggingface/transformers/issues/36267
+          - test_case: 'tests_utils'
+            cmd: '--ignore=tests/utils/test_import_utils.py tests/utils'
+            filter: 'not test_load_img_url_timeout'
     env:
-      HF_HOME: ${{ github.workspace }}/.hf_home
-      HF_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
-      NEOReadDebugKeys: ${{ inputs.driver == 'rolling' && '1' || '0' }}
-      DisableScratchPages: ${{ inputs.driver == 'rolling' && '1' || '0' }}
-      python: ${{ inputs.python != '' && inputs.python || '3.10' }}
-      pytorch: ${{ inputs.pytorch != '' && inputs.pytorch || 'nightly' }}
-      transformers: ${{ inputs.transformers != '' && inputs.transformers || 'v4.49.0' }}
-      PYTEST_TIMEOUT: 600
       PYTORCH_DEBUG_XPU_FALLBACK: '1'
       TRANSFORMERS_TEST_DEVICE_SPEC: 'spec.py'
     steps:
@@ -71,60 +186,76 @@ jobs:
           repository: huggingface/transformers
           ref: ${{ env.transformers }}
           path: transformers
+      - name: Prepare test vars
+        run: |
+          echo "HF_HOME=$HOME/.hf_home_of_transformers_test" >> $GITHUB_ENV
+          echo "TEST_CASE=${{matrix.test.test_case}}" >> $GITHUB_ENV
+      - name: Report HF cache directory
+        run: |
+          if [ -d "$HF_HOME" ]; then
+            ls -al ${{ env.HF_HOME }}
+            du -sh ${{ env.HF_HOME }}
+          else
+            echo "HF cache directory does not exist"
+            echo "WARNING: Some tests might fail fetching content from the hub!"
+            echo "WARNING: Populate cache with test content!"
+          fi
       - name: Prepare OS environment
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            espeak-ng \
-            git-lfs \
-            pkg-config \
-            libavcodec-dev \
-            libavdevice-dev \
-            libavfilter-dev \
-            libavformat-dev \
-            libavutil-dev \
-            libswresample-dev \
-            libswscale-dev
-          git lfs install
+          # as jobs might run in parallel on the same system, apt-get might
+          # step into the lock hold by other job
+          start_time=$SECONDS
+          while ! sudo apt-get update; do
+            sleep 1;
+            if (( $SECONDS - start_time > 60 )); then false; fi
+          done
+          while ! sudo apt-get install -y $PACKAGES; do
+            sleep 1;
+            if (( $SECONDS - start_time > 60 )); then false; fi
+          done
+          while ! git lfs install; do
+            sleep 1;
+            if (( $SECONDS - start_time > 60 )); then false; fi
+          done
       - name: Create unique Conda ENV name
         run: |
-          echo "CONDA_ENV_NAME=hf_transformers_test_${ZE_AFFINITY_MASK}" >> $GITHUB_ENV
+          random=$(head /dev/urandom | tr -dc A-Za-z0-9_ | head -c ${1:-5} | xargs)
+          echo "CONDA_ENV_NAME=hf_transformers_test_${ZE_AFFINITY_MASK}_${random}" >> $GITHUB_ENV
       - name: Prepare Conda ENV
         run: |
           echo "Using Conda ENV name: $CONDA_ENV_NAME"
-          which conda && conda clean -ay
           conda remove --all -y -n $CONDA_ENV_NAME || rm -rf $(dirname ${CONDA_EXE})/../envs/$CONDA_ENV_NAME
           conda create -y -n $CONDA_ENV_NAME python=${{ env.python }}
           source activate $CONDA_ENV_NAME
-          pip install junitparser pytest-timeout
+          pip install junitparser pytest-rerunfailures pytest-shard pytest-timeout
       - name: Prepare Stock XPU Pytorch
         run: |
-          pwd
           source activate $CONDA_ENV_NAME
-          if [ -z "${{ inputs.nightly_whl }}" ]; then
-            pip install torch torchvision torchaudio --pre --index-url https://download.pytorch.org/whl/nightly/xpu
-          else
-            pip install torch==$(echo ${{ inputs.nightly_whl }}) torchvision torchaudio --pre --index-url https://download.pytorch.org/whl/nightly/xpu
-          fi
+          pip install $TORCH_INDEX \
+            torch==${{ needs.prepare.outputs.torch }} \
+            torchvision==${{ needs.prepare.outputs.torchvision }} \
+            torchaudio==${{ needs.prepare.outputs.torchaudio }}
       - name: Prepare Transformers
         run: |
           pwd
           source activate $CONDA_ENV_NAME
           cd transformers
+          pip install accelerate==${{ env.accelerate }}
           pip install -e .
           pip install -e ".[dev-torch,testing,video]"
-          rm -rf tests_log && mkdir -p tests_log
+          rm -rf logs && mkdir -p logs
           rm -rf reports
           cp ${{ github.workspace }}/torch-xpu-ops/.github/scripts/spec.py ./
       - name: Report installed versions
         run: |
           source activate $CONDA_ENV_NAME
+          LOGS_DIR="${{ github.workspace }}/transformers/logs"
           echo "pip installed packages:"
-          pip list | tee ${{ github.workspace }}/transformers/tests_log/pip_list.txt
+          pip list | tee "$LOGS_DIR/pip_list-$TEST_CASE.txt"
           echo "lspci gpu devices:"
-          lspci -d ::0380 | tee ${{ github.workspace }}/transformers/tests_log/lspci_0380.txt
+          lspci -d ::0380 | tee "$LOGS_DIR/lspci_0380-$TEST_CASE.txt"
           echo "GPU render nodes:"
-          cat /sys/class/drm/render*/device/device | tee ${{ github.workspace }}/transformers/tests_log/device_IDs.txt
+          cat /sys/class/drm/render*/device/device | tee "$LOGS_DIR/device_IDs-$TEST_CASE.txt"
           echo "xpu-smi output:"
           xpu-smi discovery -y --json --dump -1
       - name: Sanity check installed packages
@@ -136,100 +267,77 @@ jobs:
           pip show torchaudio | grep Version | grep xpu
           pip show torchvision | grep Version | grep xpu
           python -c 'import torch; exit(not torch.xpu.is_available())'
-      - name: Clean HF home directory and cache
-        run: |
-          rm -rf ${{ env.HF_HOME }}
-      - name: Run -k backbone tests
-        env:
-          TEST_CASE: 'tests_backbone'
+      - name: Run tests
         run: |
           source activate $CONDA_ENV_NAME
           cd transformers
-          # Excluding tests due to:
-          # * https://github.com/huggingface/transformers/issues/36267 (marian tests)
           python3 -m pytest -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml \
-            --ignore=tests/models/marian/test_modeling_marian.py \
-            -k backbone tests || true
-      - name: Run tests/*.py
-        env:
-          TEST_CASE: 'tests_py'
-        run: |
-          source activate $CONDA_ENV_NAME
-          cd transformers
-          python3 -m pytest -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml tests/*.py || true
-      - name: Run tests/generation
-        env:
-          TEST_CASE: 'tests_generation'
-        run: |
-          source activate $CONDA_ENV_NAME
-          cd transformers
-          # Excluding tests due to:
-          # * torch.distributed.* not yet supported by XPU
-          pattern="not TestFSDPGeneration"
-          python3 -m pytest -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml tests/generation -k "$pattern" || true
-      - name: Run tests/models
-        env:
-          TEST_CASE: 'tests_models'
-        run: |
-          source activate $CONDA_ENV_NAME
-          cd transformers
-          # Excluding tests due to:
-          # * https://github.com/pytorch/pytorch/issues/140965 (aten::_linalg_eigvals)
-          # * https://github.com/huggingface/transformers/issues/36267 (marian tests)
-          pattern=" \
-            not test_resize_embeddings_untied and \
-            not test_resize_tokens_embeddings"
-          python3 -m pytest -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml \
-            -k "$pattern" --ignore=tests/models/marian/test_modeling_marian.py \
-            tests/models || true
-      - name: Run tests/pipelines
-        env:
-          TEST_CASE: 'tests_pipelines'
-        run: |
-          source activate $CONDA_ENV_NAME
-          cd transformers
-          # Some tests are known to fail w/o clear pattern
-          # TODO: drop ||true after triage and fixes
-          python3 -m pytest -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml tests/pipelines || true
-      - name: Run tests/trainer
-        env:
-          TEST_CASE: 'tests_trainer'
-        run: |
-          source activate $CONDA_ENV_NAME
-          cd transformers
-          # Excluding tests due to:
-          # * Some ray tests hang, reason unknown
-          # * torch.distributed.* not yet supported by XPU
-          pattern=" \
-            not ray and \
-            not TestTrainerDistributed and \
-            not TestTrainerDistributedXPU and \
-            not TestFSDPTrainer"
-          python3 -m pytest -rsf --make-reports=$TEST_CASE tests/trainer --junit-xml=reports/$TEST_CASE.xml -k "$pattern" || \
-            true
-      - name: Run tests/utils
-        env:
-          TEST_CASE: 'tests_utils'
-        run: |
-          source activate $CONDA_ENV_NAME
-          cd transformers
-          # Excluding tests due to:
-          # * Network proxy connection issue, reason unknown
-          pattern="not test_load_img_url_timeout"
-          # 'tests/utils/test_import_utils.py' invalidates state of the test engine causing
-          # next tests to fail. See: https://github.com/huggingface/transformers/issues/36267
-          python3 -m pytest -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml \
-            -k "$pattern" --ignore=tests/utils/test_import_utils.py \
-            tests/utils || true
+            -k "${{ matrix.test.filter}}" ${{ matrix.test.cmd }} || true
       - name: Check for errors in tests
         run: |
           source activate $CONDA_ENV_NAME
           python3 torch-xpu-ops/.github/scripts/check-transformers.py transformers/reports/*.xml
-      - name: Clean HF home directory and cache
+      - name: Print environment
+        if: ${{ ! cancelled() }}
+        uses: ./torch-xpu-ops/.github/actions/print-environment
+        with:
+          conda: $CONDA_ENV_NAME
+          pip_packages: 'accelerate transformers'
+          to: 'transformers/logs/environment-$TEST_CASE.md'
+      - name: Clean up
         if: ${{ always() }}
         run: |
           du -sh ${{ env.HF_HOME }} || true
-          rm -rf ${{ env.HF_HOME }}
+          if [ -n "$CONDA_ENV_NAME" ]; then
+            conda remove --all -y -n $CONDA_ENV_NAME || rm -rf $(dirname ${CONDA_EXE})/../envs/$CONDA_ENV_NAME
+          fi
+      - name: Upload reports
+        if: ${{ ! cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports-${{ matrix.test.test_case }}-${{ github.event.pull_request.number || github.sha }}
+          path: ${{ github.workspace }}/transformers/reports
+      - name: Upload logs
+        if: ${{ ! cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-${{ matrix.test.test_case }}-${{ github.event.pull_request.number || github.sha }}
+          path: ${{ github.workspace }}/transformers/logs
+
+  report:
+    needs: tests
+    if: "always()"
+    runs-on: ${{ inputs.runner != '' && inputs.runner || 'linux.idc.xpu' }}
+    steps:
+      - name: Download reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: 'reports-*'
+          path: 'transformers/reports/'
+          merge-multiple: true
+      - name: Download logs
+        if: ${{ ! cancelled() }}
+        uses: actions/download-artifact@v4
+        with:
+          pattern: 'logs-*'
+          path: 'transformers/logs/'
+          merge-multiple: true
+      - name: Checkout torch-xpu-ops
+        if: ${{ ! cancelled() }}
+        uses: actions/checkout@v4
+        with:
+          path: torch-xpu-ops
+      - name: Create unique Conda ENV name
+        run: |
+          random=$(head /dev/urandom | tr -dc A-Za-z0-9_ | head -c ${1:-5} | xargs)
+          echo "CONDA_ENV_NAME=hf_transformers_test_${ZE_AFFINITY_MASK}_${random}" >> $GITHUB_ENV
+      - name: Prepare Conda ENV
+        run: |
+          echo "Using Conda ENV name: $CONDA_ENV_NAME"
+          conda remove --all -y -n $CONDA_ENV_NAME || rm -rf $(dirname ${CONDA_EXE})/../envs/$CONDA_ENV_NAME
+          conda create -y -n $CONDA_ENV_NAME python=${{ env.python }}
+          source activate $CONDA_ENV_NAME
+          pip install junitparser
       - name: Print results table
         if: ${{ ! cancelled() }}
         run: |
@@ -322,15 +430,18 @@ jobs:
           } >> $GITHUB_STEP_SUMMARY
       - name: Print environment
         if: ${{ ! cancelled() }}
-        uses: ./torch-xpu-ops/.github/actions/print-environment
-        with:
-          conda: $CONDA_ENV_NAME
-          pip_packages: 'accelerate transformers'
-      - name: Upload Test log
-        if: ${{ ! cancelled() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: Torch-XPU-Transformers-Log-${{ github.event.pull_request.number || github.sha }}
-          path: | 
-            ${{ github.workspace }}/transformers/reports
-            ${{ github.workspace }}/transformers/tests_log
+        run: |
+          first_md=$(find transformers/logs -name "environment-*.md" | head -1)
+          cat $first_md >> $GITHUB_STEP_SUMMARY
+          # we expect environments to be identical except for the ZE_AFFINITY_MASK line
+          find transformers/logs -name "environment-*.md" | xargs sed -i '/ZE_AFFINITY_MASK/d'
+          for f in $(find transformers/logs -name "environment-*.md"); do
+             diff $f $first_md
+          done
+      - name: Clean up
+        if: ${{ always() }}
+        run: |
+          if [ -n "$CONDA_ENV_NAME" ]; then
+            conda remove --all -y -n $CONDA_ENV_NAME || rm -rf $(dirname ${CONDA_EXE})/../envs/$CONDA_ENV_NAME
+          fi
+

--- a/.github/workflows/_linux_transformers.yml
+++ b/.github/workflows/_linux_transformers.yml
@@ -149,8 +149,7 @@ jobs:
           # * https://github.com/huggingface/transformers/issues/36267 (marian tests)
           python3 -m pytest -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml \
             --ignore=tests/models/marian/test_modeling_marian.py \
-            -k backbone tests || \
-            (echo "FAILED_CASES=$FAILED_CASES,$TEST_CASE" >> $GITHUB_ENV)
+            -k backbone tests || true
       - name: Run tests/*.py
         env:
           TEST_CASE: 'tests_py'
@@ -207,7 +206,7 @@ jobs:
             not TestTrainerDistributedXPU and \
             not TestFSDPTrainer"
           python3 -m pytest -rsf --make-reports=$TEST_CASE tests/trainer --junit-xml=reports/$TEST_CASE.xml -k "$pattern" || \
-            (echo "FAILED_CASES=$FAILED_CASES,$TEST_CASE" >> $GITHUB_ENV)
+            true
       - name: Run tests/utils
         env:
           TEST_CASE: 'tests_utils'
@@ -221,12 +220,9 @@ jobs:
           # next tests to fail. See: https://github.com/huggingface/transformers/issues/36267
           python3 -m pytest -rsf --make-reports=$TEST_CASE --junit-xml=reports/$TEST_CASE.xml \
             -k "$pattern" --ignore=tests/utils/test_import_utils.py \
-            tests/utils || (echo "FAILED_CASES=$FAILED_CASES,$TEST_CASE" >> $GITHUB_ENV)
+            tests/utils || true
       - name: Check for errors in tests
         run: |
-          FAILED_CASES=$(echo $FAILED_CASES | sed 's/^,//')
-          echo "Failed cases: [$(echo $FAILED_CASES | sed 's/,/, /g')]"
-          test -z "$FAILED_CASES"
           source activate $CONDA_ENV_NAME
           python3 torch-xpu-ops/.github/scripts/check-transformers.py transformers/reports/*.xml
       - name: Clean HF home directory and cache


### PR DESCRIPTION
Changes:
* Benchmarking scripts are pruned from Transformers by v4.49.0 due to deprecation. So we don't need to test them anymore.
* Some cuda specific tests were generalized to cover non-cuda devices which uncovered some issues.
* Some new tests were added which fail for both cuda and xpu.
* Few regressions due to changes on Transformers side
* Time required to run the test on a single system increased from around 2h to 4h
* Test split by matrix to be able to test in smaller rerunnable chunks
* Test chunks are run sequentially due to issue with parallel HF downloads

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>
