### PR TITLE
Fix group norm vectorize path accuracy issue by enforcing shape alignment

### DIFF
--- a/src/ATen/native/xpu/sycl/GroupNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/GroupNormKernels.cpp
@@ -110,22 +110,12 @@ struct GNRowwiseMomentsVectorizedFunctor
         for (int64_t j = item.get_local_id(0) * VEC_SIZE; j < N_;
              j += item.get_local_range(0) * VEC_SIZE) {
           const int64_t vec_index = i * N_ + j;
-          auto remaining = N_ - j;
-          if (remaining < VEC_SIZE) {
-            for (int iv = 0; iv < remaining; ++iv) {
-              val[v] = welford_op.reduce(
-                  val[v],
-                  static_cast<T_ACC>(X_[vec_index + iv]),
-                  vec_index + iv);
-            }
-          } else {
-            vec_t vec_in =
-                *reinterpret_cast<vec_t*>(const_cast<T*>(X_) + vec_index);
+          vec_t vec_in =
+              *reinterpret_cast<vec_t*>(const_cast<T*>(X_) + vec_index);
 #pragma unroll
-            for (int iv = 0; iv < VEC_SIZE; ++iv) {
-              val[v] = welford_op.reduce(
-                  val[v], static_cast<T_ACC>(vec_in[iv]), vec_index + iv);
-            }
+          for (int iv = 0; iv < VEC_SIZE; ++iv) {
+            val[v] = welford_op.reduce(
+                val[v], static_cast<T_ACC>(vec_in[iv]), vec_index + iv);
           }
         }
       }
@@ -138,30 +128,18 @@ struct GNRowwiseMomentsVectorizedFunctor
     }
 
     if (item.get_local_id(0) == 0) {
-      auto remaining = G_ - g_start;
-      if (remaining < VEC_SIZE) {
-        for (int v = 0; v < remaining; ++v) {
-          T_ACC m1;
-          T_ACC m2;
-          std::tie(m2, m1) = welford_op.project(val[v]);
-          mean_[g_start + v] = m1;
-          rstd_[g_start + v] =
-              c10::xpu::compat::rsqrt(m2 + static_cast<T_ACC>(eps_));
-        }
-      } else {
-        vec_t mean_vec;
-        vec_t rstd_vec;
+      vec_t mean_vec;
+      vec_t rstd_vec;
 #pragma unroll
-        for (int v = 0; v < VEC_SIZE; ++v) {
-          T_ACC m1;
-          T_ACC m2;
-          std::tie(m2, m1) = welford_op.project(val[v]);
-          mean_vec[v] = m1;
-          rstd_vec[v] = c10::xpu::compat::rsqrt(m2 + static_cast<T_ACC>(eps_));
-        }
-        *(reinterpret_cast<vec_t*>(mean_ + g_start)) = mean_vec;
-        *(reinterpret_cast<vec_t*>(rstd_ + g_start)) = rstd_vec;
+      for (int v = 0; v < VEC_SIZE; ++v) {
+        T_ACC m1;
+        T_ACC m2;
+        std::tie(m2, m1) = welford_op.project(val[v]);
+        mean_vec[v] = m1;
+        rstd_vec[v] = c10::xpu::compat::rsqrt(m2 + static_cast<T_ACC>(eps_));
       }
+      *(reinterpret_cast<vec_t*>(mean_ + g_start)) = mean_vec;
+      *(reinterpret_cast<vec_t*>(rstd_ + g_start)) = rstd_vec;
     }
   }
 
@@ -443,7 +421,8 @@ void group_norm_kernel_impl(
 
   auto& queue = getCurrentSYCLQueue();
   int64_t simd = syclMaxSubGroupSize();
-  int64_t wg_size = D * HxW < get_group_reduce_group_size(simd)
+  int64_t prob_size = D * HxW;
+  int64_t wg_size = prob_size < get_group_reduce_group_size(simd)
       ? simd
       : get_group_reduce_group_size(simd);
   int64_t nwg = N * G;
@@ -461,7 +440,8 @@ void group_norm_kernel_impl(
       if (sizeof(T) < sizeof(float) &&
           can_use_vectorization(X_data, VEC_SIZE) &&
           can_use_vectorization(mean_data, VEC_SIZE) &&
-          can_use_vectorization(rstd_data, VEC_SIZE)) {
+          can_use_vectorization(rstd_data, VEC_SIZE) &&
+          prob_size % VEC_SIZE == 0) {
         using FUNC_T_SIMD16 =
             GNRowwiseMomentsVectorizedFunctor<T, SIMD16, VEC_SIZE>;
         using FUNC_T_SIMD32 =
@@ -483,7 +463,7 @@ void group_norm_kernel_impl(
             global_range_,
             local_range_,
             queue,
-            D * HxW,
+            prob_size,
             N * G,
             eps,
             X_data,
@@ -497,7 +477,7 @@ void group_norm_kernel_impl(
             global_range,
             local_range,
             queue,
-            D * HxW,
+            prob_size,
             eps,
             X_data,
             mean_data,
@@ -539,8 +519,8 @@ void group_norm_kernel_impl(
   } else if (!gamma.defined() && !beta.defined()) {
     auto iter = TensorIteratorConfig()
                     .resize_outputs(false)
-                    .add_owned_output(Y.view({N * G, D * HxW}))
-                    .add_owned_const_input(X.view({N * G, D * HxW}))
+                    .add_owned_output(Y.view({N * G, prob_size}))
+                    .add_owned_const_input(X.view({N * G, prob_size}))
                     .add_owned_input(mean.view({N * G, 1}))
                     .add_owned_input(rstd.view({N * G, 1}))
                     .build();


### PR DESCRIPTION
When to implement a kernel for all shapes with vectorized LD/ST, we have to handle non-aligned head (base address) and short tail (tail < vector size). Before the commit, there was lack of head handling which leaded to non-vector-size-aligned vectorized ST.
The fixing enforces shapes for vectorize path. The vectorized kernel could be called only in the case in which feature dim could be divided by vector size. There will always be aligned head and exact tail.