### PR TITLE
reduce.max/min: Fixing performance issue due to too large vec size of…

### DIFF
--- a/src/ATen/native/xpu/sycl/ReduceMaxValuesKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ReduceMaxValuesKernels.cpp
@@ -37,7 +37,7 @@ void max_values_kernel(TensorIterator& iter) {
 void max_kernel(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES_AND3(
       kBFloat16, kHalf, kBool, iter.input_dtype(), "max_xpu", [&]() {
-        gpu_reduce_kernel<scalar_t, scalar_t>(
+        gpu_reduce_kernel<scalar_t, scalar_t, 4, 2>(
             iter,
             MaxOps<scalar_t>{},
             at::xpu::pair<scalar_t, int64_t>(

--- a/src/ATen/native/xpu/sycl/ReduceMinValuesKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ReduceMinValuesKernels.cpp
@@ -36,7 +36,7 @@ void min_values_kernel(TensorIterator& iter) {
 void min_kernel(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES_AND3(
       kBFloat16, kHalf, kBool, iter.input_dtype(), "min_xpu", [&]() {
-        gpu_reduce_kernel<scalar_t, scalar_t>(
+        gpu_reduce_kernel<scalar_t, scalar_t, 4, 2>(
             iter,
             MinOps<scalar_t>{},
             at::xpu::pair<scalar_t, int64_t>(


### PR DESCRIPTION
… output

Vec size of output was 4, which might cause 1. register spill 2. concurrency issue. Change vec size of output to 2.