### PR TITLE
fix import errors and type errors in UT

### DIFF
--- a/test/xpu/nn/test_init_xpu.py
+++ b/test/xpu/nn/test_init_xpu.py
@@ -8,7 +8,7 @@ except Exception as e:
     from ..xpu_test_utils import XPUPatchForImport
 
 with XPUPatchForImport(False):
-    pass  # noqa: F401`
+    from test_init import TestNNInit  # noqa: F401`
 
 
 if __name__ == "__main__":

--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -1024,6 +1024,8 @@ skip_dict = {
         # AssertionError: False is not true
         "test_ctc_loss_cudnn_xpu",  # want "xpu" in function name
         "test_ctc_loss_cudnn_tensor",  # want "xpu" in function name
+        # RuntimeError: reflection_pad2d_backward_xpu does not have a deterministic implementation, but you set 'torch.use_deterministic_algorithms(True)'.
+        "test_ReflectionPad2d_large_deterministic_xpu",
     ),
     "test_indexing_xpu.py": (
         # XPU implementation doesn't claimn FP8 now

--- a/test/xpu/test_comparison_utils_xpu.py
+++ b/test/xpu/test_comparison_utils_xpu.py
@@ -2,5 +2,14 @@
 
 from torch.testing._internal.common_utils import run_tests
 
+try:
+    from xpu_test_utils import XPUPatchForImport
+except Exception as e:
+    from .xpu_test_utils import XPUPatchForImport
+
+with XPUPatchForImport(False):
+    from test_comparison_utils import TestComparisonUtils  # noqa: F401`
+
+
 if __name__ == "__main__":
     run_tests()

--- a/test/xpu/test_native_functions_xpu.py
+++ b/test/xpu/test_native_functions_xpu.py
@@ -2,5 +2,13 @@
 
 from torch.testing._internal.common_utils import run_tests
 
+try:
+    from xpu_test_utils import XPUPatchForImport
+except Exception as e:
+    from .xpu_test_utils import XPUPatchForImport
+
+with XPUPatchForImport(False):
+    from test_native_functions import TestNativeFunctions  # noqa: F401`
+
 if __name__ == "__main__":
     run_tests()

--- a/test/xpu/test_torch_xpu.py
+++ b/test/xpu/test_torch_xpu.py
@@ -38,7 +38,6 @@ from torch.testing._internal.common_cuda import (
     _create_scaling_models_optimizers,
     TEST_CUDNN,
     TEST_MULTIGPU,
-    tf32_is_not_fp32,
     tf32_on_and_off,
 )
 from torch.testing._internal.common_device_type import (
@@ -212,7 +211,7 @@ assert torch.get_default_dtype() is torch.float32
 # sharding on sandcastle. This line silences flake warnings
 load_tests = load_tests
 
-AMPERE_OR_ROCM = TEST_WITH_ROCM or tf32_is_not_fp32()
+AMPERE_OR_ROCM = TEST_WITH_ROCM or torch.cuda.is_tf32_supported()
 
 
 @contextlib.contextmanager

--- a/test/xpu/xpu_test_utils.py
+++ b/test/xpu/xpu_test_utils.py
@@ -802,6 +802,10 @@ def sample_inputs_like_fns_nofp64(self, device, dtype, requires_grad, **kwargs):
         yield SampleInput(t, **kwargs)
 
 
+def is_tf32_supported() -> bool:
+    return False
+
+
 class XPUPatchForImport:
     def __init__(self, patch_test_case=True) -> None:
         test_dir = os.path.join(
@@ -837,8 +841,9 @@ class XPUPatchForImport:
         self.largeTensorTest = common_device_type.largeTensorTest
         self.TEST_CUDA = common_cuda.TEST_CUDA
         self.TEST_CUDNN = common_cuda.TEST_CUDNN
-        self.cuda_is_available = cuda.is_available
         self.cuda_is_bf16_supported = cuda.is_bf16_supported
+        self.cuda_is_tf32_supported = cuda.is_tf32_supported
+        self.cuda_get_device_capability = torch.cuda.get_device_capability
 
     def align_db_decorators(self, db):
         def gen_xpu_wrappers(op_name, wrappers):
@@ -1064,8 +1069,9 @@ class XPUPatchForImport:
         common_cuda.TEST_CUDA = True
         common_cuda.TEST_CUDNN = True
         common_cuda.TEST_CUDNN_VERSION = 0
-        cuda.is_available = lambda: True
         cuda.is_bf16_supported = lambda: True
+        torch.cuda.is_tf32_supported = is_tf32_supported
+        torch.cuda.get_device_capability = torch.xpu.get_device_capability
 
         sys.path.extend(self.test_package)
 
@@ -1088,8 +1094,9 @@ class XPUPatchForImport:
         common_device_type.largeTensorTest = self.largeTensorTest
         common_cuda.TEST_CUDA = self.TEST_CUDA
         common_cuda.TEST_CUDNN = self.TEST_CUDNN
-        cuda.is_available = self.cuda_is_available
         cuda.is_bf16_supported = self.cuda_is_bf16_supported
+        torch.cuda.is_tf32_supported = self.cuda_is_tf32_supported
+        torch.cuda.get_device_capability = self.cuda_get_device_capability
 
 
 # Copy the test cases from generic_base_class to generic_test_class.


### PR DESCRIPTION
To fix https://github.com/intel/torch-xpu-ops/issues/1343. 

1. The definition of AMPERE_OR_ROCM is changed in pytorch tests and become cuda specific. - Add hook for it.
2. We should not hook torch.cuda.is_available in XPUPatchForImport because some API would depend on the return value of this interface, for example _get_device_index
3. Recovered some test classes removed by lintrunner -a