### PR TITLE
Enable CLANGTIDY AND CLANGFORMAT lint check

### DIFF
--- a/.github/scripts/lintrunner.sh
+++ b/.github/scripts/lintrunner.sh
@@ -26,10 +26,13 @@ fi
 # This has already been cached in the docker image
 lintrunner init 2> /dev/null
 
-## Do build steps necessary for linters
-#if [[ "${CLANG}" == "1" ]]; then
-#    python3 -m tools.linter.clang_tidy.generate_build_files
-#fi
+# Do build steps necessary for linters
+if [[ "${CLANG}" == "1" ]]; then
+    pushd ../../
+    cp -rf ./torchgen/packaged/ATen/templates third_party/torch-xpu-ops/yaml/templates
+    python3 third_party/torch-xpu-ops/tools/linter/clang_tidy/generate_build_files.py
+    popd
+fi
 #python3 -m tools.generate_torch_version --is_debug=false
 #python3 -m tools.pyi.gen_pyi \
 #    --native-functions-path aten/src/ATen/native/native_functions.yaml \

--- a/.github/scripts/lintrunner.sh
+++ b/.github/scripts/lintrunner.sh
@@ -31,7 +31,6 @@ if [[ "${CLANG}" == "1" ]]; then
     pushd ../../
     cp -rf ./torchgen/packaged/ATen/templates third_party/torch-xpu-ops/yaml/templates
     python3 third_party/torch-xpu-ops/tools/linter/clang_tidy/generate_build_files.py
-    popd
 fi
 #python3 -m tools.generate_torch_version --is_debug=false
 #python3 -m tools.pyi.gen_pyi \
@@ -48,6 +47,10 @@ if ! lintrunner --force-color --tee-json=lint.json ${ADDITIONAL_LINTRUNNER_ARGS}
     echo -e "\e[1m\e[36mSee https://github.com/pytorch/pytorch/wiki/lintrunner for setup instructions. To apply suggested patches automatically, use the -a flag. Before pushing another commit,\e[0m"
     echo -e "\e[1m\e[36mplease verify locally and ensure everything passes.\e[0m"
     RC=1
+fi
+
+if [[ "${CLANG}" == "1" ]]; then
+    popd
 fi
 
 # Use jq to massage the JSON lint output into GitHub Actions workflow commands.

--- a/tools/linter/clang_tidy/generate_build_files.py
+++ b/tools/linter/clang_tidy/generate_build_files.py
@@ -61,6 +61,29 @@ def run_autogen() -> None:
     )
 
 
+    run_cmd(
+        [
+            sys.executable,
+            "-m",
+            "torchgen.gen",
+            "--source-path",
+            "third_party/torch-xpu-ops/yaml",
+            "--install-dir",
+            "build/xpu",
+            "--per-operator-headers",
+            "--static-dispatch-backend",
+            "--backend-whitelist",
+            "XPU SparseXPU NestedTensorXPU",
+            "--xpu",
+            "--update-aoti-c-shim",
+            "--extend-aoti-c-shim",
+            "--aoti-install-dir",
+            "torch/csrc/inductor/aoti_torch/generated/extend",
+        ]
+
+
+    )
+
 def generate_build_files() -> None:
     update_submodules()
     gen_compile_commands()


### PR DESCRIPTION
With the following command, lintrunner.sh will do a cmake-only build and call torchgen to create xpu files under pytorch/build/xpu, then will call lintrunner to check CLANGTIDY and CLANGFORMAT for xpu related cpp and .h code.
```
export ADDITIONAL_LINTRUNNER_ARGS="--take CLANGTIDY,CLANGFORMAT build/xpu/**/*.* build/xpu/*.* third_party/torch-xpu-ops/src/*.* third_party/torch-xpu-ops/src/**/*.* third_party/torch-xpu-ops/src/**/**/*.* third_party/torch-xpu-ops/src/**/**/**/*.*"
export CLANG=1
bash third_party/torch-xpu-ops/.github/scripts/lintrunner.sh
```


