### PR TITLE
[Hotfix] Manually adjust the vector width for vectorized kernel

### DIFF
--- a/src/comm/DeviceProperties.h
+++ b/src/comm/DeviceProperties.h
@@ -142,26 +142,30 @@ template <typename T>
 uint32_t syclPrefVectorWidth(
     at::DeviceIndex dev_id = at::xpu::getDeviceIndexOfCurrentQueue()) {
   auto* dev_prop = at::xpu::getDeviceProperties(dev_id);
+
+  // Hot fix. This is the preferred vector width for GPUs up to LNL/BMG.
+  uint32_t vec_width = 16;
+
   if (std::is_same<T, char>::value) {
-    return dev_prop->preferred_vector_width_char;
+    return vec_width/sizeof(char);
   }
   if (std::is_same<T, short>::value) {
-    return dev_prop->preferred_vector_width_short;
+    return vec_width/sizeof(short);
   }
   if (std::is_same<T, int>::value) {
-    return dev_prop->preferred_vector_width_int;
+    return vec_width/sizeof(int);
   }
   if (std::is_same<T, int64_t>::value) {
-    return dev_prop->preferred_vector_width_long;
+    return vec_width/sizeof(int64_t);
   }
   if (std::is_same<T, float>::value) {
-    return dev_prop->preferred_vector_width_float;
+    return vec_width/sizeof(float);
   }
   if (std::is_same<T, double>::value) {
-    return dev_prop->preferred_vector_width_double;
+    return vec_width/sizeof(double);
   }
   if (std::is_same<T, ::sycl::half>::value) {
-    return dev_prop->preferred_vector_width_half;
+    return vec_width/sizeof(::sycl::half);
   }
   throw std::invalid_argument(
       "Invalid data type to fetch preferred vector width!");

--- a/src/comm/DeviceProperties.h
+++ b/src/comm/DeviceProperties.h
@@ -141,7 +141,7 @@ static inline int64_t syclLocalMemSize(
 template <typename T>
 uint32_t syclPrefVectorWidth(
     at::DeviceIndex dev_id = at::xpu::getDeviceIndexOfCurrentQueue()) {
-  auto* dev_prop = at::xpu::getDeviceProperties(dev_id);
+  (void)dev_id; // Suppress unused variable warning
 
   // Hot fix. This is the preferred vector width for GPUs up to LNL/BMG.
   uint32_t vec_width = 16;


### PR DESCRIPTION
Tested with copy_() operator and ran a ResNet-50 on PVC to verify the functionality.
