### PR TITLE
Apply adaptive kernel config for vectorized `group_norm` forward kernels

### DIFF
--- a/src/ATen/native/xpu/sycl/GroupNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/GroupNormKernels.cpp
@@ -17,8 +17,11 @@ namespace at::native::xpu {
 #define PREFERRED_VEC_SIZE \
   2 // To reduce register spill, we should not allocate too many
 
-int64_t get_adaptive_workgroup_size(int64_t prob_size, int simd) {
-  auto max_size = get_group_reduce_group_size(simd);
+int64_t get_adaptive_workgroup_size(
+    int64_t prob_size,
+    int simd,
+    int max_wg_size) {
+  auto max_size = std::min(max_wg_size, simd * simd);
   int64_t sizes[5] = {simd, 64, 128, 256, max_size};
   for (int i = 0; i < 5; ++i) {
     if (prob_size <= sizes[i]) {
@@ -120,17 +123,15 @@ struct GNRowwiseMomentsVectorizedFunctor
 #pragma unroll
     for (int v = 0; v < VEC_SIZE; ++v) {
       const int64_t i = g_start + v;
-      if (i < G_) {
-        for (int64_t j = item.get_local_id(0) * VEC_SIZE; j < N_;
-             j += item.get_local_range(0) * VEC_SIZE) {
-          const int64_t vec_index = i * N_ + j;
-          vec_t vec_in =
-              *reinterpret_cast<vec_t*>(const_cast<T*>(X_) + vec_index);
+      for (int64_t j = item.get_local_id(0) * VEC_SIZE; j < N_;
+           j += item.get_local_range(0) * VEC_SIZE) {
+        const int64_t vec_index = i * N_ + j;
+        vec_t vec_in =
+            *reinterpret_cast<vec_t*>(const_cast<T*>(X_) + vec_index);
 #pragma unroll
-          for (int iv = 0; iv < VEC_SIZE; ++iv) {
-            val[v] = welford_op.reduce(
-                val[v], static_cast<T_ACC>(vec_in[iv]), vec_index + iv);
-          }
+        for (int iv = 0; iv < VEC_SIZE; ++iv) {
+          val[v] = welford_op.reduce(
+              val[v], static_cast<T_ACC>(vec_in[iv]), vec_index + iv);
         }
       }
     }
@@ -163,93 +164,14 @@ struct GNRowwiseMomentsVectorizedFunctor
 
   GNRowwiseMomentsVectorizedFunctor(
       int64_t N,
-      int64_t G,
       T eps,
       const T* X,
       T* mean,
       T* rstd)
-      : N_(N), G_(G), eps_(eps), X_(X), mean_(mean), rstd_(rstd) {}
+      : N_(N), eps_(eps), X_(X), mean_(mean), rstd_(rstd) {}
 
  private:
   int64_t N_;
-  int64_t G_;
-  T eps_;
-  const T* X_;
-  T* mean_;
-  T* rstd_;
-  sycl_local_acc_t<WelfordType> shared_;
-};
-
-template <typename T, int SIMD>
-struct GNRowwiseMomentsNHWCFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
-  using T_ACC = acc_type_device<T, kXPU>;
-  using WelfordType = WelfordData<T_ACC, int64_t>;
-  using WelfordOp =
-      WelfordOpsXPU<T_ACC, T_ACC, int64_t, std::pair<T_ACC, T_ACC>>;
-
-  [[intel::reqd_sub_group_size(SIMD)]] void operator()(
-      sycl::nd_item<1> item) const {
-    auto group_x = item.get_group(0);
-    auto gorup_dim_x = item.get_local_range(0);
-    auto thread_x = item.get_local_id(0);
-    const int64_t channels_per_group = C_ / G_;
-    const int64_t batch_index = group_x / G_;
-    const int64_t ng = group_x % G_;
-    const int64_t batch_offset = batch_index * H_ * W_ * C_;
-    const int64_t group_offset = ng * channels_per_group;
-    const int64_t start = batch_offset + group_offset;
-
-    WelfordOp welford_op = {/*correction=*/0, /*take_sqrt=*/false, item};
-    WelfordType val(0, 0, 0, 0);
-    for (int64_t j = thread_x; j < H_ * W_; j += gorup_dim_x) {
-      for (int64_t c = 0; c < channels_per_group; ++c) {
-        const int64_t index = start + j * C_ + c;
-        val = welford_op.reduce(val, static_cast<T_ACC>(X_[index]), index);
-      }
-    }
-
-    val = GroupReduceWithoutBroadcast<WelfordType, WelfordOp, SIMD>(
-        item, val, welford_op, shared_);
-
-    if (thread_x == 0) {
-      T_ACC m1;
-      T_ACC m2;
-      std::tie(m2, m1) = welford_op.project(val);
-      mean_[group_x] = m1;
-      rstd_[group_x] = c10::xpu::compat::rsqrt(m2 + static_cast<T_ACC>(eps_));
-    }
-  }
-
-  void sycl_ker_config_convention(sycl::handler& cgh) {
-    shared_ = sycl_local_acc_t<WelfordType>(SIMD, cgh);
-  }
-
-  GNRowwiseMomentsNHWCFunctor(
-      int64_t N,
-      int64_t H,
-      int64_t W,
-      int64_t C,
-      int64_t G,
-      T eps,
-      const T* X,
-      T* mean,
-      T* rstd)
-      : N_(N),
-        H_(H),
-        W_(W),
-        C_(C),
-        G_(G),
-        eps_(eps),
-        X_(X),
-        mean_(mean),
-        rstd_(rstd) {}
-
- private:
-  int64_t N_;
-  int64_t H_;
-  int64_t W_;
-  int64_t C_;
-  int64_t G_;
   T eps_;
   const T* X_;
   T* mean_;
@@ -430,9 +352,6 @@ void group_norm_kernel_impl(
   T* mean_data = mean.mutable_data_ptr<T>();
   T* rstd_data = rstd.mutable_data_ptr<T>();
 
-  at::MemoryFormat x_format = X.suggest_memory_format();
-  Y.is_contiguous(x_format);
-
   auto& queue = getCurrentSYCLQueue();
   int64_t simd = syclMaxSubGroupSize();
   int64_t prob_size = D * HxW;
@@ -440,77 +359,46 @@ void group_norm_kernel_impl(
 
   constexpr int VEC_SIZE = PREFERRED_VEC_SIZE;
 
-  switch (x_format) {
-    case MemoryFormat::Contiguous: {
-      if (can_use_vectorization(X_data, VEC_SIZE) &&
-          can_use_vectorization(mean_data, VEC_SIZE) &&
-          can_use_vectorization(rstd_data, VEC_SIZE) &&
-          prob_size % VEC_SIZE == 0 && stride % VEC_SIZE == 0) {
-        auto wg_size = get_adaptive_workgroup_size(prob_size / VEC_SIZE, simd);
-        auto global_range = sycl::range<1>((stride / VEC_SIZE) * wg_size);
-        auto local_range = sycl::range<1>(wg_size);
-        group_norm_kernel_simd_choice_and_launch<
-            GNRowwiseMomentsVectorizedFunctor<T, SIMD16, VEC_SIZE>,
-            GNRowwiseMomentsVectorizedFunctor<T, SIMD32, VEC_SIZE>>(
-            simd,
-            global_range,
-            local_range,
-            queue,
-            prob_size,
-            stride,
-            eps,
-            X_data,
-            mean_data,
-            rstd_data);
-      } else {
-        auto wg_size = get_adaptive_workgroup_size(prob_size, simd);
-        auto global_range = sycl::range<1>(stride * wg_size);
-        auto local_range = sycl::range<1>(wg_size);
-        group_norm_kernel_simd_choice_and_launch<
-            GNRowwiseMomentsFunctor<T, SIMD16>,
-            GNRowwiseMomentsFunctor<T, SIMD32>>(
-            simd,
-            global_range,
-            local_range,
-            queue,
-            prob_size,
-            eps,
-            X_data,
-            mean_data,
-            rstd_data);
-      }
-      break;
-    }
-    case MemoryFormat::ChannelsLast: {
-      auto wg_size = get_adaptive_workgroup_size(prob_size, simd);
-      auto global_range = sycl::range<1>(stride * wg_size);
-      auto local_range = sycl::range<1>(wg_size);
-      int height = X.size(2);
-      int width = X.size(3);
-      group_norm_kernel_simd_choice_and_launch<
-          GNRowwiseMomentsNHWCFunctor<T, SIMD16>,
-          GNRowwiseMomentsNHWCFunctor<T, SIMD32>>(
-          simd,
-          global_range,
-          local_range,
-          queue,
-          N,
-          height,
-          width,
-          C,
-          G,
-          eps,
-          X_data,
-          mean_data,
-          rstd_data);
-      break;
-    }
-    default: {
-      TORCH_CHECK(
-          false,
-          "Unsupported memory format for group normalization: ",
-          x_format);
-    }
+  if (can_use_vectorization(X_data, VEC_SIZE) &&
+      can_use_vectorization(mean_data, VEC_SIZE) &&
+      can_use_vectorization(rstd_data, VEC_SIZE) && prob_size % VEC_SIZE == 0 &&
+      stride % VEC_SIZE == 0) {
+    using KernelS16T = GNRowwiseMomentsVectorizedFunctor<T, SIMD16, VEC_SIZE>;
+    using KernelS32T = GNRowwiseMomentsVectorizedFunctor<T, SIMD32, VEC_SIZE>;
+    auto max_size = std::min(
+        syclMaxWorkGroupSize<KernelS16T>(), syclMaxWorkGroupSize<KernelS32T>());
+    auto wg_size =
+        get_adaptive_workgroup_size(prob_size / VEC_SIZE, simd, max_size);
+    auto global_range = sycl::range<1>((stride / VEC_SIZE) * wg_size);
+    auto local_range = sycl::range<1>(wg_size);
+    group_norm_kernel_simd_choice_and_launch<KernelS16T, KernelS32T>(
+        simd,
+        global_range,
+        local_range,
+        queue,
+        prob_size,
+        eps,
+        X_data,
+        mean_data,
+        rstd_data);
+  } else {
+    using KernelS16T = GNRowwiseMomentsFunctor<T, SIMD16>;
+    using KernelS32T = GNRowwiseMomentsFunctor<T, SIMD32>;
+    auto max_size = std::min(
+        syclMaxWorkGroupSize<KernelS16T>(), syclMaxWorkGroupSize<KernelS32T>());
+    auto wg_size = get_adaptive_workgroup_size(prob_size, simd, max_size);
+    auto global_range = sycl::range<1>(stride * wg_size);
+    auto local_range = sycl::range<1>(wg_size);
+    group_norm_kernel_simd_choice_and_launch<KernelS16T, KernelS32T>(
+        simd,
+        global_range,
+        local_range,
+        queue,
+        prob_size,
+        eps,
+        X_data,
+        mean_data,
+        rstd_data);
   }
 
   if (HxW == 1) {
@@ -540,36 +428,15 @@ void group_norm_kernel_impl(
         C, G, mean_data, rstd_data, gamma_data, beta_data, a_data, b_data);
     sycl_kernel_submit(sycl::range<1>(N * C), queue, caller);
 
-    switch (x_format) {
-      case MemoryFormat::Contiguous: {
-        TensorIterator iter =
-            TensorIteratorConfig()
-                .check_all_same_dtype(std::is_same_v<T, T_ACC>)
-                .resize_outputs(false)
-                .add_owned_output(Y.view({N * C, HxW}))
-                .add_owned_const_input(X.view({N * C, HxW}))
-                .add_owned_input(a.view({N * C, 1}))
-                .add_owned_input(b.view({N * C, 1}))
-                .build();
-        gpu_kernel(iter, GroupNormFunctor<T, T_ACC>());
-        break;
-      }
-      case MemoryFormat::ChannelsLast: {
-        TensorIterator iter =
-            TensorIteratorConfig()
-                .check_all_same_dtype(std::is_same_v<T, T_ACC>)
-                .resize_outputs(false)
-                .add_owned_output(Y)
-                .add_owned_const_input(X)
-                .add_owned_input(a.view({N, C, 1, 1}))
-                .add_owned_input(b.view({N, C, 1, 1}))
-                .build();
-        gpu_kernel(iter, GroupNormFunctor<T, T_ACC>());
-        break;
-      }
-      default:
-        break; // shouldn't hit this
-    }
+    TensorIterator iter = TensorIteratorConfig()
+                              .check_all_same_dtype(std::is_same_v<T, T_ACC>)
+                              .resize_outputs(false)
+                              .add_owned_output(Y.view({N * C, HxW}))
+                              .add_owned_const_input(X.view({N * C, HxW}))
+                              .add_owned_input(a.view({N * C, 1}))
+                              .add_owned_input(b.view({N * C, 1}))
+                              .build();
+    gpu_kernel(iter, GroupNormFunctor<T, T_ACC>());
   }
 }
 


### PR DESCRIPTION
- Apply adaptive kernel config for `group_norm_forward`.
- Fix pointer misalignment relevant bugs