### PR TITLE
Turn off USE_ONEMKL by default

### DIFF
--- a/.github/workflows/_linux_build.yml
+++ b/.github/workflows/_linux_build.yml
@@ -88,6 +88,7 @@ jobs:
         run: |
           source activate xpu_build
           source .github/scripts/env.sh ${{ inputs.pytorch }}
+          export USE_ONEMKL=1
           export USE_XCCL=1
           pip install mkl-static==2025.0.1 mkl-include==2025.0.1
           if [[ ${{ inputs.abi }} == '0' ]]; then

--- a/.github/workflows/_windows_ut.yml
+++ b/.github/workflows/_windows_ut.yml
@@ -102,6 +102,7 @@ jobs:
           pip install -r requirements.txt
           pip install cmake setuptools==72.1.0 clang-format
           set USE_KINETO=0
+          set USE_ONEMKL=1
           set CMAKE_SHARED_LINKER_FLAGS=/FORCE:MULTIPLE
           set CMAKE_MODULE_LINKER_FLAGS=/FORCE:MULTIPLE
           set CMAKE_EXE_LINKER_FLAGS=/FORCE:MULTIPLE

--- a/cmake/ONEMKL.cmake
+++ b/cmake/ONEMKL.cmake
@@ -1,4 +1,4 @@
-option(USE_ONEMKL "Build with ONEMKL XPU support" ON)
+option(USE_ONEMKL "Build with ONEMKL XPU support" OFF)
 
 if(DEFINED ENV{USE_ONEMKL})
   set(USE_ONEMKL $ENV{USE_ONEMKL})

--- a/src/ATen/native/xpu/SpectralOps.cpp
+++ b/src/ATen/native/xpu/SpectralOps.cpp
@@ -1,6 +1,7 @@
 #if defined(USE_ONEMKL)
 #include <ATen/native/xpu/mkl/SpectralOps.h>
 #else
+#include <ATen/native/Resize.h>
 #include <ATen/ops/_fft_c2c_native.h>
 #endif // USE_ONEMKL
 
@@ -33,9 +34,9 @@ Tensor& _fft_c2c_xpu_out(
 #if defined(USE_ONEMKL)
   return native::xpu::_fft_c2c_mkl_out(self, dim, normalization, forward, out);
 #else
-  Tensor out_cpu = out.to(Device(at::kCPU));
-  native::_fft_c2c_mkl_out(
-      self.to(Device(at::kCPU)), dim, normalization, forward, out_cpu);
+  Tensor out_cpu = native::_fft_c2c_mkl(
+      self.to(Device(at::kCPU)), dim, normalization, forward);
+  at::native::resize_output(out, out_cpu.sizes());
   out.copy_(out_cpu);
   return out;
 #endif // USE_ONEMKL


### PR DESCRIPTION
- Turn off USE_ONEMKL by default before this feature matures.
- Fix `_fft_c2c_xpu_out` fallback.
- Set `USE_ONEMKL=1` in torch-xpu-ops CI.