### PR TITLE
change dtypesIfXPU to dtypesIf['xpu'] to align with stock pytorch cha…

### DIFF
--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -975,6 +975,11 @@ skip_dict = {
         "test_to_nn_TransformerEncoder_eval_mode_swap_True_set_grad_True_xpu_float32",
         "test_to_nn_TransformerEncoder_train_mode_swap_True_set_grad_True_xpu_float32",
         "test_to_nn_Transformer_swap_True_set_grad_True_xpu_float32",
+        # Unexpected succuss
+        "test_memory_format_nn_Conv2d_xpu_float64",
+        "test_memory_format_nn_ConvTranspose2d_xpu_float64",
+        "test_memory_format_nn_LazyConv2d_xpu_float64",
+        "test_memory_format_nn_LazyConvTranspose2d_xpu_float64",
     ),
     "test_nn_xpu.py": (
         # AttributeError: module 'torch.xpu' has no attribute 'FloatTensor'

--- a/test/xpu/xpu_test_utils.py
+++ b/test/xpu/xpu_test_utils.py
@@ -899,10 +899,10 @@ class XPUPatchForImport:
                     else True
                 )
             ) or opinfo.name in _ops_without_cuda_support:
-                opinfo.dtypesIf['xpu'] = opinfo.dtypes
+                opinfo.dtypesIf["xpu"] = opinfo.dtypes
             else:
                 backward_dtypes = set(opinfo.backward_dtypesIfCUDA)
-                if bfloat16 in opinfo.dtypesIf['xpu']:
+                if bfloat16 in opinfo.dtypesIf["xpu"]:
                     backward_dtypes.add(bfloat16)
                 opinfo.backward_dtypes = tuple(backward_dtypes)
 
@@ -912,8 +912,10 @@ class XPUPatchForImport:
                     torch.complex128,
                     torch.double,
                 ]
-                opinfo.dtypesIf['xpu'] = set(
-                    filter(lambda x: (x not in fp64_dtypes), list(opinfo.dtypesIf['xpu']))
+                opinfo.dtypesIf["xpu"] = set(
+                    filter(
+                        lambda x: (x not in fp64_dtypes), list(opinfo.dtypesIf["xpu"])
+                    )
                 )
                 opinfo.backward_dtypes = tuple(
                     filter(

--- a/test/xpu/xpu_test_utils.py
+++ b/test/xpu/xpu_test_utils.py
@@ -899,10 +899,10 @@ class XPUPatchForImport:
                     else True
                 )
             ) or opinfo.name in _ops_without_cuda_support:
-                opinfo.dtypesIfXPU = opinfo.dtypes
+                opinfo.dtypesIf['xpu'] = opinfo.dtypes
             else:
                 backward_dtypes = set(opinfo.backward_dtypesIfCUDA)
-                if bfloat16 in opinfo.dtypesIfXPU:
+                if bfloat16 in opinfo.dtypesIf['xpu']:
                     backward_dtypes.add(bfloat16)
                 opinfo.backward_dtypes = tuple(backward_dtypes)
 
@@ -912,8 +912,8 @@ class XPUPatchForImport:
                     torch.complex128,
                     torch.double,
                 ]
-                opinfo.dtypesIfXPU = set(
-                    filter(lambda x: (x not in fp64_dtypes), list(opinfo.dtypesIfXPU))
+                opinfo.dtypesIf['xpu'] = set(
+                    filter(lambda x: (x not in fp64_dtypes), list(opinfo.dtypesIf['xpu']))
                 )
                 opinfo.backward_dtypes = tuple(
                     filter(


### PR DESCRIPTION
Stock pytorch changed opinfo/core.py dtypesIfXPU to dtypeIf['xpu'] with commit https://github.com/pytorch/pytorch/commit/66fb10fc53b678f15485a6042875345adeaaf2ae, this PR is to update the xpu_test_utils.py to align with this change. 

![image](https://github.com/user-attachments/assets/812427a2-a90f-4882-afe1-e887dee54476)
