### PR TITLE
Update passed models and fixed issues

### DIFF
--- a/.github/ci_expected_accuracy/inductor_timm_models_inference.csv
+++ b/.github/ci_expected_accuracy/inductor_timm_models_inference.csv
@@ -27,8 +27,7 @@ hrnet_w18,pass,pass,pass,pass,pass
 inception_v3,pass,pass,pass,pass,pass
 jx_nest_base,pass,pass,pass,pass,pass
 lcnet_050,pass,pass,pass,pass,pass
-# https://github.com/pytorch/pytorch/pull/145112
-levit_128,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
+levit_128,pass,pass,pass,pass,pass
 mixer_b16_224,pass,pass,pass,pass,pass
 mixnet_l,pass,pass,pass,pass,pass
 mnasnet_100,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/inductor_timm_models_training.csv
+++ b/.github/ci_expected_accuracy/inductor_timm_models_training.csv
@@ -30,8 +30,7 @@ hrnet_w18,pass,pass,pass,pass,pass
 inception_v3,pass,pass,pass,pass,pass
 jx_nest_base,pass,pass,pass,pass,pass
 lcnet_050,pass,pass,pass,pass,pass
-# https://github.com/pytorch/pytorch/pull/145112
-levit_128,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
+levit_128,pass,pass,pass,pass,pass
 mixer_b16_224,pass,pass,pass,pass,pass
 mixnet_l,pass,pass,pass,pass,pass
 mnasnet_100,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/inductor_torchbench_inference.csv
+++ b/.github/ci_expected_accuracy/inductor_torchbench_inference.csv
@@ -4,8 +4,7 @@ torchrec_dlrm,pass,eager_fail_to_run,eager_fail_to_run,fail_to_run,fail_to_run
 BERT_pytorch,pass,pass,pass,pass,pass
 Background_Matting,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
 DALLE2_pytorch,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
-# https://github.com/intel/torch-xpu-ops/issues/1263
-LearningToPaint,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
+LearningToPaint,pass,pass,pass,pass,pass
 Super_SloMo,pass,pass,pass,pass,pass
 alexnet,pass,pass,pass,pass,pass
 basic_gnn_edgecnn,pass,pass,pass,pass,pass
@@ -69,8 +68,7 @@ mobilenet_v3_large,pass,pass,pass,pass,pass
 moco,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 moondream,pass,pass,pass,pass,pass
 nanogpt,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1260
-nvidia_deeprecommender,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
+nvidia_deeprecommender,pass,pass,pass,pass,pass
 opacus_cifar10,pass,pass,pass,pass,pass
 phlippe_densenet,pass,pass,pass,pass,pass
 phlippe_resnet,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/inductor_torchbench_inference.csv
+++ b/.github/ci_expected_accuracy/inductor_torchbench_inference.csv
@@ -88,8 +88,7 @@ sam_fast,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 shufflenet_v2_x1_0,pass,pass,pass,pass,pass
 simple_gpt,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load
 simple_gpt_tp_manual,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load
-# https://github.com/intel/torch-xpu-ops/issues/1273
-soft_actor_critic,pass,fail_accuracy,pass,pass,pass
+soft_actor_critic,pass,pass,pass,pass,pass
 speech_transformer,pass,pass,pass,pass,pass
 squeezenet1_1,pass,fail_accuracy,pass,pass,pass
 stable_diffusion_text_encoder,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/inductor_torchbench_inference.csv
+++ b/.github/ci_expected_accuracy/inductor_torchbench_inference.csv
@@ -45,8 +45,7 @@ hf_DistilBert,pass,pass,pass,pass,pass
 hf_GPT2,pass,pass,pass,pass,pass
 hf_GPT2_large,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
 hf_Longformer,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1262
-hf_Reformer,eager_two_runs_differ,eager_two_runs_differ,eager_two_runs_differ,eager_two_runs_differ,eager_two_runs_differ
+hf_Reformer,pass,pass,pass,pass,pass
 hf_T5,pass,pass,pass,pass,pass
 # https://github.com/intel/torch-xpu-ops/issues/1276
 hf_T5_base,pass,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run

--- a/.github/ci_expected_accuracy/inductor_torchbench_training.csv
+++ b/.github/ci_expected_accuracy/inductor_torchbench_training.csv
@@ -3,8 +3,7 @@ torchrec_dlrm,pass,eager_fail_to_run,eager_fail_to_run,pass,pass
 BERT_pytorch,pass,pass,pass,pass,pass
 Background_Matting,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
 DALLE2_pytorch,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
-# https://github.com/intel/torch-xpu-ops/issues/1263
-LearningToPaint,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
+LearningToPaint,pass,pass,pass,pass,pass
 # https://github.com/intel/torch-xpu-ops/issues/1256
 Super_SloMo,eager_two_runs_differ,pass,pass,eager_two_runs_differ,pass
 alexnet,pass,pass,pass,pass,pass
@@ -68,8 +67,7 @@ mobilenet_v3_large,pass,pass,pass,pass,pass
 moco,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 moondream,pass,pass,pass,pass,pass
 nanogpt,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1260
-nvidia_deeprecommender,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
+nvidia_deeprecommender,pass,pass,pass,pass,pass
 opacus_cifar10,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 phlippe_densenet,pass,pass,pass,pass,pass
 # https://github.com/intel/torch-xpu-ops/issues/509

--- a/.github/ci_expected_accuracy/inductor_torchbench_training.csv
+++ b/.github/ci_expected_accuracy/inductor_torchbench_training.csv
@@ -5,7 +5,7 @@ Background_Matting,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_t
 DALLE2_pytorch,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 LearningToPaint,pass,pass,pass,pass,pass
 # https://github.com/intel/torch-xpu-ops/issues/1256
-Super_SloMo,eager_two_runs_differ,pass,pass,eager_two_runs_differ,pass
+Super_SloMo,eager_two_runs_differ,pass,pass,pass,pass
 alexnet,pass,pass,pass,pass,pass
 basic_gnn_edgecnn,pass,pass,pass,pass,pass
 basic_gnn_gcn,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/inductor_torchbench_training.csv
+++ b/.github/ci_expected_accuracy/inductor_torchbench_training.csv
@@ -109,5 +109,5 @@ tts_angular,pass,pass,pass,pass,pass
 vgg16,pass,pass,pass,pass,pass
 # https://github.com/intel/torch-xpu-ops/issues/1264
 vision_maskrcnn,eager_fail_to_run,pass,pass,eager_fail_to_run,eager_fail_to_run
-yolov3,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
+yolov3,pass,pass,pass,pass,pass
 hf_Roberta_base,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/inductor_torchbench_training.csv
+++ b/.github/ci_expected_accuracy/inductor_torchbench_training.csv
@@ -46,8 +46,7 @@ hf_DistilBert,pass,pass,pass,pass,pass
 hf_GPT2,pass,pass,pass,pass,pass
 hf_GPT2_large,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
 hf_Longformer,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1262
-hf_Reformer,eager_two_runs_differ,eager_two_runs_differ,eager_two_runs_differ,eager_two_runs_differ,eager_two_runs_differ
+hf_Reformer,pass,pass,pass,pass,pass
 hf_T5,pass,pass,pass,pass,pass
 hf_T5_base,pass,pass,pass,pass,pass
 hf_T5_generate,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run


### PR DESCRIPTION
According to latest weekly https://github.com/intel/torch-xpu-ops/actions/runs/13332933285
1. levit_128 https://github.com/pytorch/pytorch/pull/145112
2. hf_Reformer https://github.com/intel/torch-xpu-ops/issues/1262
3. nvidia_deeprecommender https://github.com/intel/torch-xpu-ops/issues/1260
4. yolov3 pytorch pinned torchbench upgraded to 373ffb19dc470f4423a3176a4133f8f4b3cdb5bd
5. soft_actor_critic https://github.com/intel/torch-xpu-ops/issues/1273
6. Super_SloMo amp_bf16 passed