### PR TITLE
Update USE_XCCL back to PyTorch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,9 +40,35 @@ include(${TORCH_XPU_OPS_ROOT}/cmake/ONEMKL.cmake)
 include(${TORCH_XPU_OPS_ROOT}/cmake/BuildFlags.cmake)
 
 option(USE_XCCL "Build with XCCL support" OFF)
+option(USE_C10D_XCCL "Build with XCCL support for C10D" OFF)
 
-if(NOT WIN32 AND USE_XCCL)
+# -- [ Re-generate the macros file for https://github.com/pytorch/pytorch/pull/147161
+macro(update_caffe2_macros_file)
+  configure_file(
+    ${TORCH_ROOT}/caffe2/core/macros.h.in
+    ${CMAKE_BINARY_DIR}/caffe2/core/macros.h)
+endmacro()
+
+if(NOT DEFINED USE_XCCL)
+  # Propagate the option to PyTorch
+  caffe2_update_option(USE_XCCL OFF)
+  update_caffe2_macros_file()
+endif()
+
+if(USE_XCCL)
   include(${TORCH_XPU_OPS_ROOT}/cmake/XCCL.cmake)
+  if(NOT PYTORCH_FOUND_XCCL)
+    # Propagate the option to PyTorch
+    caffe2_update_option(USE_XCCL OFF)
+    update_caffe2_macros_file()
+  endif()
+endif()
+
+# Propagate the option to PyTorch
+if(USE_DISTRIBUTED AND USE_XCCL AND USE_C10D_XCCL)
+  caffe2_update_option(USE_C10D_XCCL ON)
+else()
+  caffe2_update_option(USE_C10D_XCCL OFF)
 endif()
 
 if(BUILD_TEST)

--- a/cmake/Modules/FindXCCL.cmake
+++ b/cmake/Modules/FindXCCL.cmake
@@ -6,6 +6,12 @@
 
 include(${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake)
 
+if(NOT CMAKE_SYSTEM_NAME MATCHES "Linux")
+  set(XCCL_FOUND False)
+  set(XCCL_NOT_FOUND_MESSAGE "OneCCL library is only supported on Linux!")
+  return()
+endif()
+
 # we need source OneCCL environment before building.
 set(XCCL_ROOT $ENV{CCL_ROOT})
 

--- a/cmake/XCCL.cmake
+++ b/cmake/XCCL.cmake
@@ -4,18 +4,17 @@ if(NOT __XCCL_INCLUDED)
   # XCCL_ROOT, XCCL_LIBRARY_DIR, XCCL_INCLUDE_DIR are handled by FindXCCL.cmake.
   find_package(XCCL REQUIRED)
   if(NOT XCCL_FOUND)
-    message("${XCCL_NOT_FOUND_MESSAGE}")
+    set(PYTORCH_FOUND_XCCL FALSE)
+    message(WARNING "${XCCL_NOT_FOUND_MESSAGE}")
     return()
   endif()
-  if(XCCL_FOUND)
-    add_library(torch::xccl INTERFACE IMPORTED)
-    set_property(
-      TARGET torch::xccl PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-      ${XCCL_INCLUDE_DIR})
-    set_property(
-      TARGET torch::xccl PROPERTY INTERFACE_LINK_LIBRARIES
-      ${XCCL_LIBRARY})
-    set(USE_C10D_XCCL ON)
-    set(USE_C10D_XCCL ${USE_C10D_XCCL} PARENT_SCOPE)
-  endif()
+
+  set(PYTORCH_FOUND_XCCL TRUE)
+  add_library(torch::xccl INTERFACE IMPORTED)
+  set_property(
+    TARGET torch::xccl PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+    ${XCCL_INCLUDE_DIR})
+  set_property(
+    TARGET torch::xccl PROPERTY INTERFACE_LINK_LIBRARIES
+    ${XCCL_LIBRARY})
 endif()


### PR DESCRIPTION
# Motivation
We need to update `USE_XCCL` back to PyTorch to facilitate https://github.com/pytorch/pytorch/pull/147161