### PR TITLE
Pack int4gemm weight to uint4x8 with little-endian

### DIFF
--- a/src/ATen/native/xpu/sycl/WeightInt4PackKernel.cpp
+++ b/src/ATen/native/xpu/sycl/WeightInt4PackKernel.cpp
@@ -16,15 +16,15 @@ struct WeightToInt4PackKernelFunctor {
     int in_y = out_y;
     int in_x = out_x * 4;
 
-    using vec_t = memory::aligned_vector<uint8_t, 4>;
-    vec_t input = *reinterpret_cast<vec_t*>(&weight_[in_y * K_div_2 + in_x]);
-    vec_t output;
-#pragma unroll
+    weight_packed_[out_y * K_div_8 + out_x] = 0x00000000;
     for (int i = 0; i < 4; i++) {
-      output[i] = input[i];
+      uint32_t low = weight_[in_y * K_div_2 + in_x + i] & 0x0000000F;
+      uint32_t high = weight_[in_y * K_div_2 + in_x + i] >> 4;
+      uint32_t ele_i = (low) | (high << 4);
+      weight_packed_[out_y * K_div_8 + out_x] |= ele_i << (i * 8);
     }
-    *reinterpret_cast<vec_t*>(&weight_packed_[out_y * K_div_8 + out_x]) = output;
   }
+
   WeightToInt4PackKernelFunctor(
       uint32_t* weight_packed,
       uint8_t* weight,

--- a/test/regressions/test_int4pack.py
+++ b/test/regressions/test_int4pack.py
@@ -4,16 +4,23 @@ from torch.testing._internal.common_utils import TestCase
 
 
 def rand_weight_uint8(n, k_div_2, device="xpu"):
-    rand = torch.randint(-128, 128, [n, k_div_2], device=device).to(torch.uint8)
+    rand = torch.randint(0, 255, [n, k_div_2], device=device).to(torch.uint8)
     return rand
 
 
 def weight_unpack(weight_packed, n, k_div_2):
     k_div_8 = k_div_2 // 4
-    weight_packed = weight_packed.view(n, k_div_8).contiguous()
-    weight_packed = weight_packed.view(torch.uint8).view(n, k_div_8, 4)
-    weight_unpacked = weight_packed.view(n, -1).contiguous()
-    return weight_unpacked.view(torch.uint8).view(n, -1)
+    byte_d = (weight_packed & 0xFF000000) >> 24
+    byte_c = (weight_packed & 0x00FF0000) >> 16
+    byte_b = (weight_packed & 0x0000FF00) >> 8
+    byte_a = weight_packed & 0x000000FF
+    weight_unpacked = torch.empty([n, k_div_2], dtype=torch.uint8, device="xpu")
+    weight_unpacked = weight_unpacked.view(n, k_div_8, 4)
+    weight_unpacked[:, :, 0] = byte_a
+    weight_unpacked[:, :, 1] = byte_b
+    weight_unpacked[:, :, 2] = byte_c
+    weight_unpacked[:, :, 3] = byte_d
+    return weight_unpacked.view(n, -1)
 
 
 class TestNNMethod(TestCase):


### PR DESCRIPTION
# Motivation
Use little endian layout for int4 gemm weight packing. Full process could be 
Weight: [a, b, c, d, e, f, g, h]  (uint4 value, stored in int32)
AO packing: [ba, dc, fe, hg], (uint4x2 packing, stored as torch.uint8)
_convert_weight_to_int4pack: [hgfedcba] (uint4x8 packing, stored as torch.int32)