### PR TITLE
Refine XCCL build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ include(${TORCH_XPU_OPS_ROOT}/cmake/ONEMKL.cmake)
 include(${TORCH_XPU_OPS_ROOT}/cmake/BuildFlags.cmake)
 
 option(USE_XCCL "Build with XCCL support" OFF)
-option(USE_C10D_XCCL "Build with XCCL support for C10D" OFF)
+option(USE_C10D_XCCL "Build with XCCL support for C10D" ON)
 
 # -- [ Re-generate the macros file for https://github.com/pytorch/pytorch/pull/147161
 macro(update_caffe2_macros_file)


### PR DESCRIPTION
# Motivation
Prior to this PR, building PyTorch XPU with CCL distribution support required setting `USE_XCCL=ON USE_C10D_XCCL=ON python setup.py install`.
With this PR, it only requires `USE_XCCL=ON python setup.py install`, simplifying the process.