### PR TITLE
Fix when USE_C10D_XCCL define in pytorch will not correct update cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,8 @@ endif()
 if(USE_DISTRIBUTED AND USE_XCCL AND USE_C10D_XCCL)
   caffe2_update_option(USE_C10D_XCCL ON)
 else()
+  # WA for USE_C10D_XCCL duplicated definition, will remove it after USE_C10D_XCCL and USE_XCCL define in PyTorch
+  set(USE_C10D_XCCL OFF CACHE BOOL "Build with XCCL support for C10D" FORCE)
   caffe2_update_option(USE_C10D_XCCL OFF)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ include(${TORCH_XPU_OPS_ROOT}/cmake/ONEMKL.cmake)
 include(${TORCH_XPU_OPS_ROOT}/cmake/BuildFlags.cmake)
 
 option(USE_XCCL "Build with XCCL support" OFF)
-option(USE_C10D_XCCL "Build with XCCL support for C10D" ON)
+cmake_dependent_option(USE_C10D_XCCL "USE C10D XCCL" ON "USE_DISTRIBUTED;USE_XCCL" OFF)
 
 # -- [ Re-generate the macros file for https://github.com/pytorch/pytorch/pull/147161
 macro(update_caffe2_macros_file)
@@ -68,8 +68,6 @@ endif()
 if(USE_DISTRIBUTED AND USE_XCCL AND USE_C10D_XCCL)
   caffe2_update_option(USE_C10D_XCCL ON)
 else()
-  # WA for USE_C10D_XCCL duplicated definition, will remove it after USE_C10D_XCCL and USE_XCCL define in PyTorch
-  set(USE_C10D_XCCL OFF CACHE BOOL "Build with XCCL support for C10D" FORCE)
   caffe2_update_option(USE_C10D_XCCL OFF)
 endif()
 


### PR DESCRIPTION
This pr for fix use_xccl and use_c10_xccl define in pytorch raise build error
https://github.com/pytorch/pytorch/pull/147593
After pytorch pr land, we will remove torch-xpu-ops defination.