### PR TITLE
fix windows build failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ include(${TORCH_XPU_OPS_ROOT}/cmake/ONEMKL.cmake)
 include(${TORCH_XPU_OPS_ROOT}/cmake/BuildFlags.cmake)
 
 option(USE_XCCL "Build with XCCL support" OFF)
-cmake_dependent_option(USE_C10D_XCCL "USE C10D XCCL" ON "USE_DISTRIBUTED;USE_XCCL" OFF)
+option(USE_C10D_XCCL "Build with XCCL support for C10D" ON)
 
 # -- [ Re-generate the macros file for https://github.com/pytorch/pytorch/pull/147161
 macro(update_caffe2_macros_file)

--- a/tools/codegen/install_xpu_headers.py
+++ b/tools/codegen/install_xpu_headers.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import re
 import shutil
+from pathlib import Path
 
 
 parser = argparse.ArgumentParser(description="Utils for append ops headers")
@@ -65,7 +66,7 @@ def generate_xpu_ops_headers_cmake(src_dir, dst_dir, xpu_ops_headers):
     with open(os.path.join(src_dir, "xpu_ops_generated_headers.cmake"), "w") as fw:
         fw.write("set(xpu_ops_generated_headers\n")
         for header in xpu_ops_headers:
-            fw.write(f'    "{os.path.join(dst_dir, header)}"\n')
+            fw.write(f'    "{Path(os.path.join(dst_dir, header)).as_posix()}"\n')
         fw.write(")\n")
 
 


### PR DESCRIPTION
# Motivation
 1. fix codegen path on Windows - avoid `//` on Windows, use posix style `\` instead.
 2. `USE_C10D_XCCL` is an undefined option that can't be updated by caffe2_update_option on Windows.
 
 # Additional Context
build pass on local Windows machine 