### PR TITLE
Adding `at::_fft_r2c` and `at::_fft_c2r` methods with OneMKL

### DIFF
--- a/src/ATen/native/xpu/SpectralOps.cpp
+++ b/src/ATen/native/xpu/SpectralOps.cpp
@@ -3,6 +3,8 @@
 #else
 #include <ATen/native/Resize.h>
 #include <ATen/ops/_fft_c2c_native.h>
+#include <ATen/ops/_fft_c2r_native.h>
+#include <ATen/ops/_fft_r2c_native.h>
 #endif // USE_ONEMKL
 
 namespace at::native {
@@ -39,6 +41,76 @@ Tensor& _fft_c2c_xpu_out(
   at::native::resize_output(out, out_cpu.sizes());
   out.copy_(out_cpu);
   return out;
+#endif // USE_ONEMKL
+}
+
+Tensor _fft_c2r_xpu(
+  const Tensor& self,
+  IntArrayRef dim,
+  int64_t normalization,
+  int64_t last_dim_size) {
+TORCH_CHECK(self.is_complex());
+
+#if defined(USE_ONEMKL)
+return native::xpu::_fft_c2r_mkl(self, dim, normalization, last_dim_size);
+#else
+Tensor out_cpu = native::_fft_c2r_mkl(
+    self.to(Device(at::kCPU)), dim, normalization, last_dim_size);
+return out_cpu.to(Device(at::kXPU));
+#endif // USE_ONEMKL
+}
+
+Tensor& _fft_c2r_xpu_out(
+  const Tensor& self,
+  IntArrayRef dim,
+  int64_t normalization,
+  int64_t last_dim_size,
+  Tensor& out) {
+TORCH_CHECK(self.is_complex());
+
+#if defined(USE_ONEMKL)
+return native::xpu::_fft_c2r_mkl_out(self, dim, normalization, last_dim_size, out);
+#else
+Tensor out_cpu = native::_fft_c2r_mkl(
+    self.to(Device(at::kCPU)), dim, normalization, last_dim_size);
+at::native::resize_output(out, out_cpu.sizes());
+out.copy_(out_cpu);
+return out;
+#endif // USE_ONEMKL
+}
+
+Tensor _fft_r2c_xpu(
+  const Tensor& self,
+  IntArrayRef dim,
+  int64_t normalization,
+  bool onesided) {
+TORCH_CHECK(!self.is_complex());
+
+#if defined(USE_ONEMKL)
+return native::xpu::_fft_r2c_mkl(self, dim, normalization, onesided);
+#else
+Tensor out_cpu = native::_fft_r2c_mkl(
+    self.to(Device(at::kCPU)), dim, normalization, onesided);
+return out_cpu.to(Device(at::kXPU));
+#endif // USE_ONEMKL
+}
+
+Tensor& _fft_r2c_xpu_out(
+  const Tensor& self,
+  IntArrayRef dim,
+  int64_t normalization,
+  bool onesided,
+  Tensor& out) {
+TORCH_CHECK(!self.is_complex());
+
+#if defined(USE_ONEMKL)
+return native::xpu::_fft_r2c_mkl_out(self, dim, normalization, onesided, out);
+#else
+Tensor out_cpu = native::_fft_r2c_mkl(
+    self.to(Device(at::kCPU)), dim, normalization, onesided);
+at::native::resize_output(out, out_cpu.sizes());
+out.copy_(out_cpu);
+return out;
 #endif // USE_ONEMKL
 }
 

--- a/src/ATen/native/xpu/XPUFallback.template
+++ b/src/ATen/native/xpu/XPUFallback.template
@@ -190,8 +190,6 @@ TORCH_LIBRARY_IMPL(aten, XPU, m) {
     "_cholesky_solve_helper",
     "dot",
     "_efficient_attention_forward",
-    "_fft_c2r",
-    "_fft_r2c",
     "_flash_attention_forward",
     "geqrf",
     "linalg_cholesky_ex.L",

--- a/src/ATen/native/xpu/mkl/SpectralOps.cpp
+++ b/src/ATen/native/xpu/mkl/SpectralOps.cpp
@@ -275,8 +275,7 @@ Tensor& _exec_fft(
 
 double _dft_scale(
     IntArrayRef dim,
-    IntArrayRef input_sizes,
-    IntArrayRef out_sizes,
+    IntArrayRef norm_sizes,
     int64_t normalization) {
   const auto norm = static_cast<fft_norm_mode>(normalization);
   double double_scale = 1.0;
@@ -285,21 +284,10 @@ double _dft_scale(
     return double_scale;
   }
 
-  const int64_t signal_ndim = dim.size();
   int64_t signal_numel = 1;
-
-  for (int64_t i = 0; i < signal_ndim; ++i) {
-    auto in_size = input_sizes[dim[i]];
-    auto out_size = out_sizes[dim[i]];
-    auto signal_size = std::max(in_size, out_size);
-
-    signal_numel *= signal_size;
-    TORCH_INTERNAL_ASSERT(
-        in_size == signal_size || in_size == (signal_size / 2) + 1);
-    TORCH_INTERNAL_ASSERT(
-        out_size == signal_size || out_size == (signal_size / 2) + 1);
+  for (const int64_t& d : dim) {
+    signal_numel *= norm_sizes[d];
   }
-
   if (norm == fft_norm_mode::by_root_n) {
     double_scale = 1.0 / std::sqrt(signal_numel);
   } else {
@@ -312,9 +300,9 @@ double _dft_scale(
 const Tensor& _fft_apply_normalization(
     const Tensor& self,
     int64_t normalization,
-    IntArrayRef sizes,
+    IntArrayRef norm_sizes,
     IntArrayRef dims) {
-  auto scale = _dft_scale(dims, sizes, self.sizes(), normalization);
+  auto scale = _dft_scale(dims, norm_sizes, normalization);
   return (scale == 1.0) ? self : self.mul_(scale);
 }
 
@@ -403,6 +391,7 @@ if (dim.size() > 1) {
 
 auto input_sizes = working_tensor.sizes();
 DimVector out_sizes(input_sizes.begin(), input_sizes.end());
+TORCH_INTERNAL_ASSERT(input_sizes.back() == (last_dim_size / 2) + 1);
 out_sizes[dim.back()] = last_dim_size;
 auto out = at::empty(out_sizes, self.options().dtype(c10::toRealValueType(self.scalar_type())));
 
@@ -414,7 +403,7 @@ impl::_exec_fft(
   /*onesided=*/true,
   /*forward=*/false);
 
-return impl::_fft_apply_normalization(out, normalization, input_sizes, dim);
+return impl::_fft_apply_normalization(out, normalization, out_sizes, dim);
 }
 
 Tensor& _fft_c2r_mkl_out(

--- a/src/ATen/native/xpu/mkl/SpectralOps.h
+++ b/src/ATen/native/xpu/mkl/SpectralOps.h
@@ -17,4 +17,30 @@ TORCH_XPU_API Tensor& _fft_c2c_mkl_out(
     bool forward,
     Tensor& out);
 
+TORCH_XPU_API Tensor _fft_c2r_mkl(
+    const Tensor& self,
+    IntArrayRef dim,
+    int64_t normalization,
+    int64_t last_dim_size);
+
+TORCH_XPU_API Tensor& _fft_c2r_mkl_out(
+    const Tensor& self,
+    IntArrayRef dim,
+    int64_t normalization,
+    int64_t last_dim_size,
+    Tensor& out);
+
+TORCH_XPU_API Tensor _fft_r2c_mkl(
+    const Tensor& self,
+    IntArrayRef dim,
+    int64_t normalization,
+    bool onesided);
+
+TORCH_XPU_API Tensor& _fft_r2c_mkl_out(
+    const Tensor& self,
+    IntArrayRef dim,
+    int64_t normalization,
+    bool onesided,
+    Tensor& out);
+
 } // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/FFTKernelFunctor.cpp
+++ b/src/ATen/native/xpu/sycl/FFTKernelFunctor.cpp
@@ -1,0 +1,237 @@
+#include <ATen/WrapDimUtils.h>
+#include <ATen/native/SpectralOpsUtils.h>
+#include <ATen/native/xpu/sycl/FFTKernelFunctor.h>
+#include <ATen/native/xpu/sycl/OffsetCalculator.h>
+#include <comm/SYCLContext.h>
+#include <comm/TensorInfo.h>
+
+namespace at::native::xpu {
+
+template <typename index_t>
+struct HermitianSymmetryOffsetCalculator {
+  using offset_type = at::detail::Array<index_t, 1>;
+  using dim_type = std::remove_cv_t<decltype(XPU_MAX_TENSORINFO_DIMS)>;
+
+  dim_type dims;
+  at::detail::IntDivider<index_t> sizes_[XPU_MAX_TENSORINFO_DIMS];
+  index_t strides_[XPU_MAX_TENSORINFO_DIMS];
+  uint32_t mirror_dim_; // bit mask
+  static_assert(XPU_MAX_TENSORINFO_DIMS < 32, "Need a bigger mask type");
+
+  HermitianSymmetryOffsetCalculator(
+      IntArrayRef sizes,
+      IntArrayRef strides,
+      IntArrayRef dim,
+      const int64_t element_size) {
+    TORCH_INTERNAL_ASSERT(sizes.size() == strides.size());
+    TORCH_INTERNAL_ASSERT(sizes.size() <= XPU_MAX_TENSORINFO_DIMS);
+    dims = sizes.size();
+
+    {
+      dim_type i;
+      for (i = 0; i < dims; ++i) {
+        sizes_[i] = at::detail::IntDivider<index_t>(sizes[i]);
+        strides_[i] = strides[i] / element_size;
+      }
+      for (; i < XPU_MAX_TENSORINFO_DIMS; ++i) {
+        sizes_[i] = at::detail::IntDivider<index_t>(1);
+        strides_[i] = 0;
+      }
+    }
+
+    mirror_dim_ = 0;
+    for (int64_t i = 0; i < dim.size(); ++i) {
+      mirror_dim_ |= (uint32_t{1} << dim[i]);
+    }
+  }
+
+  offset_type get(index_t linear_idx) const {
+    index_t offset = 0;
+
+    for (dim_type dim = 0; dim < dims; ++dim) {
+      auto divmod = sizes_[dim].divmod(linear_idx);
+      linear_idx = divmod.div;
+
+      if ((mirror_dim_ & (uint32_t{1} << dim)) == 0) {
+        offset += divmod.mod * strides_[dim];
+      } else if (divmod.mod != 0) {
+        offset += (sizes_[dim].divisor - divmod.mod) * strides_[dim];
+      }
+    }
+    offset_type offsets;
+    offsets[0] = offset;
+
+    return offsets;
+  }
+};
+
+template <typename scalar_t, typename inp_calc_t, typename out_calc_t>
+struct FFTConjugateCopyKernelFunctor {
+  void operator()(sycl::item<1> item_id) const {
+    auto in_offset = ic.get(item_id)[0];
+    auto out_offset = oc.get(item_id)[0];
+    out_data[out_offset] = std::conj(in_data[in_offset]);
+  }
+
+  FFTConjugateCopyKernelFunctor(
+      int64_t numel_,
+      scalar_t* out_data_,
+      const scalar_t* in_data_,
+      inp_calc_t ic_,
+      out_calc_t oc_)
+      : numel(numel_),
+        out_data(out_data_),
+        in_data(in_data_),
+        ic(ic_),
+        oc(oc_) {}
+
+ private:
+  int64_t numel;
+  scalar_t* out_data;
+  const scalar_t* in_data;
+  inp_calc_t ic;
+  out_calc_t oc;
+};
+
+template <typename scalar_t, typename inp_calc_t, typename out_calc_t>
+void _fft_conjugate_copy_kernel(
+    int64_t numel,
+    scalar_t* out_data,
+    const scalar_t* in_data,
+    inp_calc_t ic,
+    out_calc_t oc) {
+  auto& queue = at::xpu::getCurrentSYCLQueue();
+  int thread_num = numel;
+
+  auto ker = FFTConjugateCopyKernelFunctor<scalar_t, inp_calc_t, out_calc_t>(
+      numel, out_data, in_data, ic, oc);
+  sycl_kernel_submit(sycl::range<1>(thread_num), queue, ker);
+}
+
+void _fft_fill_with_conjugate_symmetry_xpu(
+    ScalarType dtype,
+    IntArrayRef mirror_dims,
+    IntArrayRef signal_half_sizes,
+    IntArrayRef in_strides,
+    const void* in_data,
+    IntArrayRef out_strides,
+    void* out_data) {
+  // Do the actual conjugate mirroring.
+  auto* in_strides_ptr = in_strides.data();
+  const int ndim = in_strides.size();
+  const int64_t element_size = scalarTypeToTypeMeta(dtype).itemsize();
+
+  OffsetCalculator<1, int64_t> input_offset_calculator(
+      ndim, signal_half_sizes.data(), &in_strides_ptr, &element_size);
+  HermitianSymmetryOffsetCalculator<int64_t> output_offset_calculator(
+      signal_half_sizes, out_strides, mirror_dims, element_size);
+
+  const auto numel = c10::multiply_integers(signal_half_sizes);
+  AT_DISPATCH_COMPLEX_TYPES(dtype, "_fft_fill_with_conjugate_symmetry_", [&] {
+    _fft_conjugate_copy_kernel(
+        numel,
+        static_cast<scalar_t*>(out_data),
+        static_cast<const scalar_t*>(in_data),
+        input_offset_calculator,
+        output_offset_calculator);
+  });
+}
+
+void _fft_fill_with_conjugate_symmetry_(const Tensor& input, IntArrayRef dim_) {
+  const auto input_sizes = input.sizes();
+  const auto input_strides = input.strides();
+  TORCH_CHECK(dim_.size() > 0);
+  DimVector dim(dim_.begin(), dim_.end());
+  at::maybe_wrap_dims(dim, input_strides.size(), /*wrap_scalars=*/false);
+
+  if (input.numel() == 0 || input_sizes[dim.back()] <= 2) {
+    return; // No elements need writing
+  }
+
+  // Small dimensions may be treated as batch dims since they don't get mirrored
+  dim.erase(
+      std::remove_if(
+          dim.begin(),
+          dim.end(),
+          [&](int64_t dim) { return (input_sizes[dim] <= 2); }),
+      dim.end());
+
+  // Use TensorIterator to coalesce batch dimensions
+  // NOTE: Can't use TensorIterator loops because we need negative strides
+  auto iter = TensorIteratorConfig()
+                  .add_output(input)
+                  .add_input(input)
+                  .resize_outputs(false)
+                  .declare_static_shape(input_sizes, dim)
+                  .build();
+
+  const auto iter_strides = iter.strides(0);
+  const auto iter_sizes = iter.shape();
+  const auto ndim = static_cast<int64_t>(iter_strides.size() + dim.size());
+  DimVector in_strides(ndim), signal_half_sizes(ndim);
+  // Take coalesced batch dimensions from TensorIterator
+  std::copy(iter_strides.begin(), iter_strides.end(), in_strides.begin());
+  std::copy(iter_sizes.begin(), iter_sizes.end(), signal_half_sizes.begin());
+
+  // Take transformed dimensions directly from the input
+  const auto element_size = iter.element_size(0);
+  for (const auto i : c10::irange(dim.size())) {
+    // Convert to byte strides to match TensorIterator
+    in_strides[iter_strides.size() + i] = input_strides[dim[i]] * element_size;
+    signal_half_sizes[iter_strides.size() + i] = input_sizes[dim[i]];
+  }
+
+  // For the last dimension, use negative strides to perform the mirroring
+  signal_half_sizes.back() = (input_sizes[dim.back()] - 1) / 2;
+  auto out_strides = in_strides;
+  out_strides.back() *= -1;
+
+  auto* data_ptr = static_cast<char*>(input.data_ptr());
+  const auto* in_data = data_ptr + input_strides[dim.back()] * element_size;
+  auto* out_data = data_ptr +
+      (input_strides[dim.back()] * (input_sizes[dim.back()] - 1) *
+       element_size);
+
+  // Reorder dimensions by stride to maximize data locality
+  DimVector dim_permute(ndim);
+  std::iota(dim_permute.begin(), dim_permute.end(), 0);
+  std::sort(dim_permute.begin(), dim_permute.end(), [&](auto dim1, auto dim2) {
+    return in_strides[dim1] < in_strides[dim2];
+  });
+  DimVector temp(ndim);
+  auto apply_permutation = [&](DimVector& vec) {
+    // Do permuted index copy into a temporary, then copy back
+    for (const auto i : c10::irange(ndim)) {
+      temp[i] = vec[dim_permute[i]];
+    }
+    vec = temp;
+  };
+  apply_permutation(in_strides);
+  apply_permutation(out_strides);
+  apply_permutation(signal_half_sizes);
+
+  // Find dims.slice(dims.size() - 1) in the new permuted order.
+  // These are the dimensions that need explicit Hermitian mirroring
+  DimVector mirror_dims;
+  mirror_dims.reserve(dim.size() - 1);
+  for (const auto i : c10::irange(ndim)) {
+    if (dim_permute[i] >= static_cast<int64_t>(
+                              iter_strides.size()) && // Not a batch dimension
+        dim_permute[i] != ndim - 1) { // Not the last dim, which is mirrored
+                                      // separately with negative strides
+      mirror_dims.push_back(i);
+    }
+  }
+  TORCH_INTERNAL_ASSERT(mirror_dims.size() == dim.size() - 1);
+
+  _fft_fill_with_conjugate_symmetry_xpu(
+      input.scalar_type(),
+      mirror_dims,
+      signal_half_sizes,
+      in_strides,
+      in_data,
+      out_strides,
+      out_data);
+}
+
+} // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/FFTKernelFunctor.h
+++ b/src/ATen/native/xpu/sycl/FFTKernelFunctor.h
@@ -1,0 +1,24 @@
+#pragma once
+
+namespace at::native::xpu {
+
+void _fft_fill_with_conjugate_symmetry_xpu(
+    ScalarType dtype,
+    IntArrayRef mirror_dims,
+    IntArrayRef signal_half_sizes,
+    IntArrayRef in_strides,
+    const void* in_data,
+    IntArrayRef out_strides,
+    void* out_data);
+
+template <typename scalar_t, typename inp_calc_t, typename out_calc_t>
+void _fft_conjugate_copy_kernel(
+    int64_t numel,
+    scalar_t* out_data,
+    const scalar_t* in_data,
+    inp_calc_t ic,
+    out_calc_t oc);
+
+void _fft_fill_with_conjugate_symmetry_(const Tensor& input, IntArrayRef dim_);
+
+} // namespace at::native::xpu

--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -634,25 +634,6 @@ skip_dict = {
         "test_python_ref_torch_fallback__refs_div_trunc_rounding_xpu_float64",
         # TODO: passed from source code building version, investigate
         "test_python_ref__refs_log2_xpu_complex128",
-        # The following dtypes did not work in backward but are listed by the OpInfo: {torch.bfloat16}.
-        "test_dtypes_fft_fft2_xpu",
-        "test_dtypes_fft_fft_xpu",
-        "test_dtypes_fft_fftn_xpu",
-        "test_dtypes_fft_hfft2_xpu",
-        "test_dtypes_fft_hfft_xpu",
-        "test_dtypes_fft_hfftn_xpu",
-        "test_dtypes_fft_ifft2_xpu",
-        "test_dtypes_fft_ifft_xpu",
-        "test_dtypes_fft_ifftn_xpu",
-        "test_dtypes_fft_ihfft2_xpu",
-        "test_dtypes_fft_ihfft_xpu",
-        "test_dtypes_fft_ihfftn_xpu",
-        "test_dtypes_fft_irfft2_xpu",
-        "test_dtypes_fft_irfft_xpu",
-        "test_dtypes_fft_irfftn_xpu",
-        "test_dtypes_fft_rfft2_xpu",
-        "test_dtypes_fft_rfft_xpu",
-        "test_dtypes_fft_rfftn_xpu",
     ),
     "test_binary_ufuncs_xpu.py": (
         "test_fmod_remainder_by_zero_integral_xpu_int64",  # zero division is an undefined behavior: different handles on different backends

--- a/yaml/native/native_functions.yaml
+++ b/yaml/native/native_functions.yaml
@@ -9322,3 +9322,25 @@
   variants: function
   dispatch:
     XPU: _fft_c2c_xpu_out
+
+# Standard complex to real backward FFT
+- func: _fft_c2r(Tensor self, int[] dim, int normalization, int last_dim_size) -> Tensor
+  variants: function
+  dispatch:
+    XPU: _fft_c2r_xpu
+
+- func: _fft_c2r.out(Tensor self, int[] dim, int normalization, int last_dim_size, *, Tensor(a!) out) -> Tensor(a!)
+  variants: function
+  dispatch:
+    XPU: _fft_c2r_xpu_out
+
+# Standard real to complex forward FFT
+- func: _fft_r2c(Tensor self, int[] dim, int normalization, bool onesided) -> Tensor
+  variants: function
+  dispatch:
+    XPU: _fft_r2c_xpu
+
+- func: _fft_r2c.out(Tensor self, int[] dim, int normalization, bool onesided, *, Tensor(a!) out) -> Tensor(a!)
+  variants: function
+  dispatch:
+    XPU: _fft_r2c_xpu_out

--- a/yaml/xpu_functions.yaml
+++ b/yaml/xpu_functions.yaml
@@ -747,3 +747,9 @@ supported:
   - take.out
   - segment_reduce
   - _segment_reduce_backward
+  - _fft_c2c
+  - _fft_c2c.out
+  - _fft_c2r
+  - _fft_c2r.out
+  - _fft_r2c
+  - _fft_r2c.out


### PR DESCRIPTION
Some of the code originates from the branch [yifeng/fft_c2r](5bd9c00558444e40886ff196b71f761032e22cf3) and [yifeng/fft_r2c_with_abi](adceb4b820c1005e71e3d3294e1d6a7ed7cd0a33), and also [intel/intel-extension-for-pytorch](https://github.com/intel/intel-extension-for-pytorch/tree/xpu-main).

However, the problem of redundant normalisations in the `_fft_c2c_mkl_out` function has been fixed. Some loops have also been simplified.