### PR TITLE
Use `sycl::signbit` to avoid compile error when compiling with GCC 12

### DIFF
--- a/src/ATen/native/xpu/sycl/UnarySignKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UnarySignKernels.cpp
@@ -67,7 +67,7 @@ template <typename scalar_t>
 struct SignbitFunctor {
   bool operator()(scalar_t a) const {
     using opmath_t = at::opmath_type<scalar_t>;
-    return std::signbit(opmath_t{a});
+    return sycl::signbit(opmath_t{a});
   }
 };
 


### PR DESCRIPTION
Use `sycl::signbit` instead of  `std::signbit`  to avoid compile error when compiling with GCC 12