### PR TITLE
Improve torch-xpu-ops codegen

### DIFF
--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -106,6 +106,8 @@ function(GEN_XPU file_yaml)
     ${CODEGEN_XPU_YAML_DIR}/native/${file_yaml}
     ${XPUFallback_TEMPLATE}
     ${TORCH_XPU_OPS_ROOT}/tools/codegen/install_xpu_headers.py
+    ${ops_generated_headers}
+    ${ops_generated_sources}
   )
 
   # Post codegen delete the copied templates folder only on Windows.

--- a/tools/codegen/install_xpu_headers.py
+++ b/tools/codegen/install_xpu_headers.py
@@ -97,18 +97,22 @@ def append_xpu_ops_headers(src_dir, dst_dir, common_headers, xpu_ops_headers):
                 re.findall(r"struct TORCH_XPU_API.*xpu.*?{.*?};\n", src_text, re.DOTALL)
             )
 
-        with open(dst) as fr:
-            dst_lines = fr.readlines()
+        if not xpu_declarations:
+            continue
+
+        with open(dst, "r+") as f:
+            dst_lines = f.readlines()
             dst_text = "".join(dst_lines)
-            for line in dst_lines:
+            for index, line in enumerate(dst_lines):
                 if re.match(r"^(TORCH_API.*;|struct TORCH_API.*)", line):
                     for xpu_declaration in xpu_declarations:
                         if not re.search(re.escape(xpu_declaration), dst_text):
-                            dst_lines.insert(dst_lines.index(line), xpu_declaration)
+                            dst_lines.insert(index, xpu_declaration)
                     break
 
-        with open(dst, "w") as fw:
-            fw.writelines(dst_lines)
+            f.seek(0)
+            f.writelines(dst_lines)
+            f.truncate()
 
 
 def main():


### PR DESCRIPTION
# Motivation
Improve code to avoid `PermissionError` on Windows:
Previously, the script n `install_xpu_headers.py` opened the file twice - once for reading and once for writing:
```python
for file in files:
    with open(file) as fr:
        # modify fr
    with open(file, "w") as fw:
        # write fw
```
However, on Windows, this can lead to `PermissionError` due to file access conflicts. It looks like a bug related to the Windows system or Python. I am not sure. 
To avoid this issue, we now open the file only once using `"r+"` mode, allowing both reading and writing within the same context:
```python
for file in files:
    with open(file, "r+") as f:
        # modify f
        # rewrite f
```
Additionally, add dependencies for torch-xpu-ops codegen to ensure proper execution.

# Solution
Trying to prevent writing back an unchanged file. And open the file only once to allow both reading and writing.

# Additional Context
Windows CI build pass refer to https://github.com/pytorch/pytorch/actions/runs/14236812185/job/39897594304?pr=139971