### PR TITLE
Nll_loss backward optimization

### DIFF
--- a/src/ATen/native/xpu/sycl/LossNLLKernel.cpp
+++ b/src/ATen/native/xpu/sycl/LossNLLKernel.cpp
@@ -471,11 +471,11 @@ struct NllLossBackwardReduce2DKernelFunctor {
               ? static_cast<scalar_t>(gradOutput_ptr[0]) /
                   static_cast<scalar_t>(*total_weight_ptr)
               : static_cast<scalar_t>(gradOutput_ptr[0]));
-    for (i = local_item_id; i < nframe; i += local_size) {
-      t = (int)target_ptr[i];
+    i = local_item_id;
+    if (i < ndim * nframe) {
+      t = (int)target_ptr[i % ndim];
       if (t != (int)ignore_index) {
-        gradInput_ptr[i * ndim + t] =
-            has_weights ? weights_ptr[t] * grad : grad;
+        gradInput_ptr[i] = has_weights ? weights_ptr[t] * grad : grad;
       }
     }
   }


### PR DESCRIPTION
The organization of sub groups is optimized, unnecessary for loops are eliminated.
And the time required for kernel execution was reduced by ~6% (from 2.9ms to  2.7ms).
