### PR TITLE
Ues the new added unified API for host allocator

### DIFF
--- a/src/ATen/native/xpu/sycl/ForeachReduceKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ForeachReduceKernels.cpp
@@ -243,7 +243,7 @@ std::vector<Tensor> foreach_norm_kernel(
   void** tensor_list_addresses = nullptr;
 
   auto tensor_list_addresses_dptr =
-      at::xpu::HostAlloc(sizeof(void*) * ntensors);
+      at::getHostAllocator(at::kXPU)->allocate(sizeof(void*) * ntensors);
   tensor_list_addresses = (void**)tensor_list_addresses_dptr.get();
 
   auto tensor_lists = std::vector<std::vector<Tensor>>{tensors.vec()};
@@ -300,7 +300,7 @@ std::vector<Tensor> foreach_norm_kernel(
                     (void*)tensor_list_addresses,
                     sizeof(void*) * ntensors);
 
-                at::xpu::CachingHostAllocator_recordEvent(
+                at::getHostAllocator(at::kXPU)->record_event(
                     (void*)tensor_list_addresses,
                     tensor_list_addresses_dptr.get_context(),
                     at::xpu::getCurrentXPUStream());
@@ -369,7 +369,7 @@ std::vector<Tensor> foreach_norm_kernel(
                     (void*)tensor_list_addresses,
                     sizeof(void*) * ntensors);
 
-                at::xpu::CachingHostAllocator_recordEvent(
+                at::getHostAllocator(at::kXPU)->record_event(
                     (void*)tensor_list_addresses,
                     tensor_list_addresses_dptr.get_context(),
                     at::xpu::getCurrentXPUStream());
@@ -438,7 +438,7 @@ std::vector<Tensor> foreach_norm_kernel(
                     (void*)tensor_list_addresses,
                     sizeof(void*) * ntensors);
 
-                at::xpu::CachingHostAllocator_recordEvent(
+                at::getHostAllocator(at::kXPU)->record_event(
                     (void*)tensor_list_addresses,
                     tensor_list_addresses_dptr.get_context(),
                     at::xpu::getCurrentXPUStream());
@@ -629,7 +629,7 @@ std::vector<Tensor> foreach_max_kernel(TensorList tensors) {
   auto metaAddress = static_cast<void**>(addressStorage.mutable_data_ptr());
   void** tensor_list_addresses = nullptr;
   auto tensor_list_addresses_dptr =
-      at::xpu::HostAlloc(sizeof(void*) * ntensors);
+      at::getHostAllocator(at::kXPU)->allocate(sizeof(void*) * ntensors);
   tensor_list_addresses = (void**)tensor_list_addresses_dptr.get();
 
   // Store thunks count for each tensor
@@ -637,7 +637,8 @@ std::vector<Tensor> foreach_max_kernel(TensorList tensors) {
       at::empty({(int)(sizeof(int) * ntensors)}, options.dtype(at::kByte));
   auto metaCounts = static_cast<int*>(countsStorage.mutable_data_ptr());
   int* thunk_counts = nullptr;
-  auto thunk_counts_dptr = at::xpu::HostAlloc(sizeof(int) * ntensors);
+  auto thunk_counts_dptr =
+      at::getHostAllocator(at::kXPU)->allocate(sizeof(int) * ntensors);
   thunk_counts = (int*)thunk_counts_dptr.get();
 
   int max_chunks_per_tensor = -1;
@@ -700,13 +701,13 @@ std::vector<Tensor> foreach_max_kernel(TensorList tensors) {
             (void*)metaAddress,
             (void*)tensor_list_addresses,
             sizeof(void*) * ntensors);
-        at::xpu::CachingHostAllocator_recordEvent(
+        at::getHostAllocator(at::kXPU)->record_event(
             (void*)tensor_list_addresses,
             tensor_list_addresses_dptr.get_context(),
             at::xpu::getCurrentXPUStream());
         q.memcpy(
             (void*)metaCounts, (void*)thunk_counts, sizeof(int) * ntensors);
-        at::xpu::CachingHostAllocator_recordEvent(
+        at::getHostAllocator(at::kXPU)->record_event(
             (void*)thunk_counts,
             thunk_counts_dptr.get_context(),
             at::xpu::getCurrentXPUStream());

--- a/src/ATen/native/xpu/sycl/MultiTensorApply.h
+++ b/src/ATen/native/xpu/sycl/MultiTensorApply.h
@@ -167,7 +167,7 @@ void multi_tensor_apply(
           addressStorage.mutable_data_ptr());
   TLMetaForAddressScalar<scalar_vals_t, depth>* tlAddress = nullptr;
 
-  auto tlAddress_dptr = at::xpu::HostAlloc(
+  auto tlAddress_dptr = at::getHostAllocator(at::kXPU)->allocate(
       sizeof(TLMetaForAddressScalar<scalar_vals_t, depth>) * n_tensors);
   tlAddress =
       (TLMetaForAddressScalar<scalar_vals_t, depth>*)tlAddress_dptr.get();
@@ -188,7 +188,7 @@ void multi_tensor_apply(
       (void*)metaAddressInput,
       (void*)tlAddress,
       sizeof(TLMetaForAddressScalar<scalar_vals_t, depth>) * n_tensors);
-  at::xpu::CachingHostAllocator_recordEvent(
+  at::getHostAllocator(at::kXPU)->record_event(
       (void*)tlAddress,
       tlAddress_dptr.get_context(),
       at::xpu::getCurrentXPUStream());
@@ -200,7 +200,8 @@ void multi_tensor_apply(
       static_cast<TLMetaForWG*>(wgMetaStorage.mutable_data_ptr());
   TLMetaForWG* tlWGMeta = nullptr;
 
-  auto tlWGMeta_dptr = at::xpu::HostAlloc(sizeof(TLMetaForWG) * totalWG);
+  auto tlWGMeta_dptr =
+      at::getHostAllocator(at::kXPU)->allocate(sizeof(TLMetaForWG) * totalWG);
   tlWGMeta = (TLMetaForWG*)tlWGMeta_dptr.get();
   uint64_t posWG = 0;
   // this loop record the correspond tensor and chunk info for each work group.
@@ -217,7 +218,7 @@ void multi_tensor_apply(
       "Work group index dose not equal to the allocated memory size, segment fault might occur");
 
   q.memcpy((void*)metaWGInput, (void*)tlWGMeta, sizeof(TLMetaForWG) * totalWG);
-  at::xpu::CachingHostAllocator_recordEvent(
+  at::getHostAllocator(at::kXPU)->record_event(
       (void*)tlWGMeta,
       tlWGMeta_dptr.get_context(),
       at::xpu::getCurrentXPUStream());
@@ -247,8 +248,8 @@ void multi_tensor_apply(
       static_cast<TLMetaForAddress<depth>*>(addressStorage.mutable_data_ptr());
   TLMetaForAddress<depth>* tlAddress = nullptr;
 
-  auto tlAddress_dptr =
-      at::xpu::HostAlloc(sizeof(TLMetaForAddress<depth>) * n_tensors);
+  auto tlAddress_dptr = at::getHostAllocator(at::kXPU)->allocate(
+      sizeof(TLMetaForAddress<depth>) * n_tensors);
   tlAddress = (TLMetaForAddress<depth>*)tlAddress_dptr.get();
   uint64_t totalWG = 0;
 
@@ -266,7 +267,7 @@ void multi_tensor_apply(
       (void*)metaAddressInput,
       (void*)tlAddress,
       sizeof(TLMetaForAddress<depth>) * n_tensors);
-  at::xpu::CachingHostAllocator_recordEvent(
+  at::getHostAllocator(at::kXPU)->record_event(
       (void*)tlAddress,
       tlAddress_dptr.get_context(),
       at::xpu::getCurrentXPUStream());
@@ -278,7 +279,8 @@ void multi_tensor_apply(
       static_cast<TLMetaForWG*>(wgMetaStorage.mutable_data_ptr());
   TLMetaForWG* tlWGMeta = nullptr;
 
-  auto tlWGMeta_dptr = at::xpu::HostAlloc(sizeof(TLMetaForWG) * totalWG);
+  auto tlWGMeta_dptr =
+      at::getHostAllocator(at::kXPU)->allocate(sizeof(TLMetaForWG) * totalWG);
   tlWGMeta = (TLMetaForWG*)tlWGMeta_dptr.get();
   uint64_t posWG = 0;
   // this loop record the correspond tensor and chunk info for each work group.
@@ -295,7 +297,7 @@ void multi_tensor_apply(
       "Work group index dose not equal to the allocated memory size, segment fault might occur");
 
   q.memcpy((void*)metaWGInput, (void*)tlWGMeta, sizeof(TLMetaForWG) * totalWG);
-  at::xpu::CachingHostAllocator_recordEvent(
+  at::getHostAllocator(at::kXPU)->record_event(
       (void*)tlWGMeta,
       tlWGMeta_dptr.get_context(),
       at::xpu::getCurrentXPUStream());
@@ -325,8 +327,8 @@ void multi_tensor_apply_for_fused_optimizer(
       addressStorage.mutable_data_ptr());
   TLFusedMetaForAddress<depth>* tlAddress = nullptr;
 
-  auto tlAddress_dptr =
-      at::xpu::HostAlloc(sizeof(TLFusedMetaForAddress<depth>) * n_tensors);
+  auto tlAddress_dptr = at::getHostAllocator(at::kXPU)->allocate(
+      sizeof(TLFusedMetaForAddress<depth>) * n_tensors);
   tlAddress = (TLFusedMetaForAddress<depth>*)tlAddress_dptr.get();
   uint64_t totalWG = 0;
 
@@ -345,7 +347,7 @@ void multi_tensor_apply_for_fused_optimizer(
       (void*)metaFusedAddressInput,
       (void*)tlAddress,
       sizeof(TLFusedMetaForAddress<depth>) * n_tensors);
-  at::xpu::CachingHostAllocator_recordEvent(
+  at::getHostAllocator(at::kXPU)->record_event(
       (void*)tlAddress,
       tlAddress_dptr.get_context(),
       at::xpu::getCurrentXPUStream());
@@ -357,7 +359,8 @@ void multi_tensor_apply_for_fused_optimizer(
       static_cast<TLMetaForWG*>(wgMetaStorage.mutable_data_ptr());
   TLMetaForWG* tlWGMeta = nullptr;
 
-  auto tlWGMeta_dptr = at::xpu::HostAlloc(sizeof(TLMetaForWG) * totalWG);
+  auto tlWGMeta_dptr =
+      at::getHostAllocator(at::kXPU)->allocate(sizeof(TLMetaForWG) * totalWG);
   tlWGMeta = (TLMetaForWG*)tlWGMeta_dptr.get();
   uint64_t posWG = 0;
   // this loop record the correspond tensor and chunk info for each work group.
@@ -374,7 +377,7 @@ void multi_tensor_apply_for_fused_optimizer(
       "Work group index dose not equal to the allocated memory size, segment fault might occur");
 
   q.memcpy((void*)metaWGInput, (void*)tlWGMeta, sizeof(TLMetaForWG) * totalWG);
-  at::xpu::CachingHostAllocator_recordEvent(
+  at::getHostAllocator(at::kXPU)->record_event(
       (void*)tlWGMeta,
       tlWGMeta_dptr.get_context(),
       at::xpu::getCurrentXPUStream());

--- a/src/ATen/native/xpu/sycl/Shape.cpp
+++ b/src/ATen/native/xpu/sycl/Shape.cpp
@@ -218,7 +218,8 @@ void parallel_cat(
     {
       CatArrInputTensor<scalar_in_t, unsigned int>* stackInputs;
 
-      auto stackInputs_dptr = at::xpu::HostAlloc(tensorMetadataSize);
+      auto stackInputs_dptr =
+          at::getHostAllocator(at::kXPU)->allocate(tensorMetadataSize);
       stackInputs =
           (CatArrInputTensor<scalar_in_t, unsigned int>*)stackInputs_dptr.get();
 
@@ -240,7 +241,7 @@ void parallel_cat(
       }
 
       q.memcpy((void*)d_inputs, (void*)stackInputs, tensorMetadataSize);
-      at::xpu::CachingHostAllocator_recordEvent(
+      at::getHostAllocator(at::kXPU)->record_event(
           (void*)stackInputs,
           stackInputs_dptr.get_context(),
           at::xpu::getCurrentXPUStream());


### PR DESCRIPTION
# Motivation
The host allocator legacy APsI will be deprecated in https://github.com/pytorch/pytorch/pull/151437. Instead, we will transition to the new unified allocator APIs introduced in [pytorch/pytorch#151431](https://github.com/pytorch/pytorch/pull/151431).

# Additional Context
```cpp
at::getHostAllocator(device_type)->allocate(...);
at::getHostAllocator(device_type)->empty_cache();
at::getHostAllocator(device_type)->record_event(...);
at::getHostAllocator(device_type)->get_stats();
at::getHostAllocator(device_type)->reset_accumulated_stats();
at::getHostAllocator(device_type)->reset_peak_stats();
```