### PR TITLE
Don't use `c10::optional`

### DIFF
--- a/src/ATen/native/xpu/BatchNorm.cpp
+++ b/src/ATen/native/xpu/BatchNorm.cpp
@@ -231,8 +231,8 @@ _batch_norm_legit_no_stats_xpu_out(
 
 std::tuple<Tensor, Tensor, Tensor, Tensor> _batch_norm_with_update_xpu(
     const Tensor& input,
-    const c10::optional<Tensor>& weight_opt,
-    const c10::optional<Tensor>& bias_opt,
+    const std::optional<Tensor>& weight_opt,
+    const std::optional<Tensor>& bias_opt,
     Tensor& running_mean,
     Tensor& running_var,
     double momentum,
@@ -271,8 +271,8 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> _batch_norm_with_update_xpu(
 
 std::tuple<Tensor&, Tensor&, Tensor&, Tensor&> _batch_norm_with_update_xpu_out(
     const Tensor& input,
-    const c10::optional<Tensor>& weight_opt,
-    const c10::optional<Tensor>& bias_opt,
+    const std::optional<Tensor>& weight_opt,
+    const std::optional<Tensor>& bias_opt,
     Tensor& running_mean,
     Tensor& running_var,
     double momentum,

--- a/src/ATen/native/xpu/Distributions.cpp
+++ b/src/ATen/native/xpu/Distributions.cpp
@@ -57,7 +57,7 @@ Tensor _s_binomial_xpu(
   return ret;
 }
 
-Tensor _s_gamma_xpu(const Tensor& alpha, c10::optional<Generator> gen_) {
+Tensor _s_gamma_xpu(const Tensor& alpha, std::optional<Generator> gen_) {
   auto gen = get_generator_or_default<at::XPUGeneratorImpl>(
       gen_, at::xpu::detail::getDefaultXPUGenerator());
   Tensor ret = at::empty(alpha.sizes(), alpha.options());

--- a/src/ATen/native/xpu/EmbeddingBag.cpp
+++ b/src/ATen/native/xpu/EmbeddingBag.cpp
@@ -55,7 +55,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> _embedding_bag_forward_only_xpu(
     bool scale_grad_by_freq,
     int64_t mode,
     bool sparse,
-    const c10::optional<Tensor>& per_sample_weights_opt,
+    const std::optional<Tensor>& per_sample_weights_opt,
     bool include_last_offset,
     int64_t padding_idx) {
   return _embedding_bag_xpu(
@@ -79,7 +79,7 @@ Tensor _embedding_bag_dense_backward_xpu(
     int64_t num_weights,
     bool scale_grad_by_freq,
     int64_t mode,
-    const c10::optional<at::Tensor>& per_sample_weights_opt,
+    const std::optional<at::Tensor>& per_sample_weights_opt,
     int64_t padding_idx) {
   c10::MaybeOwned<Tensor> per_sample_weights_maybe_owned =
       at::borrow_from_optional_tensor(per_sample_weights_opt);

--- a/src/ATen/native/xpu/ForeachReduceOp.cpp
+++ b/src/ATen/native/xpu/ForeachReduceOp.cpp
@@ -44,7 +44,7 @@ static inline void check_foreach_norm_dtype(
 std::vector<Tensor> foreach_tensor_norm_xpu(
     TensorList tensors,
     const Scalar& ord,
-    c10::optional<ScalarType> dtype) {
+    std::optional<ScalarType> dtype) {
   const auto p = [&]() -> double {
     if (ord.isIntegral(false)) {
       return ord.to<int64_t>();

--- a/src/ATen/native/xpu/FusedAdam.cpp
+++ b/src/ATen/native/xpu/FusedAdam.cpp
@@ -86,8 +86,8 @@ void _fused_adam_kernel_xpu_(
     const double eps,
     const bool amsgrad,
     const bool maximize,
-    const c10::optional<at::Tensor>& grad_scale,
-    const c10::optional<at::Tensor>& found_inf) {
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf) {
   if (lr.is_cpu()) {
     _fused_adam_kernel_xpu_(
         params,

--- a/src/ATen/native/xpu/FusedAdamW.cpp
+++ b/src/ATen/native/xpu/FusedAdamW.cpp
@@ -27,8 +27,8 @@ void _fused_adamw_kernel_xpu_(
     const double eps,
     const bool amsgrad,
     const bool maximize,
-    const c10::optional<at::Tensor>& grad_scale,
-    const c10::optional<at::Tensor>& found_inf) {
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf) {
   if (amsgrad) {
     TORCH_CHECK(
         at::native::check_fast_path_restrictions(
@@ -86,8 +86,8 @@ void _fused_adamw_kernel_xpu_(
     const double eps,
     const bool amsgrad,
     const bool maximize,
-    const c10::optional<at::Tensor>& grad_scale,
-    const c10::optional<at::Tensor>& found_inf) {
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf) {
   if (lr.is_cpu()) {
     _fused_adamw_kernel_xpu_(
         params,

--- a/src/ATen/native/xpu/LayerNorm.cpp
+++ b/src/ATen/native/xpu/LayerNorm.cpp
@@ -124,43 +124,43 @@ namespace native {
   if (grad_input_mask[0]) {
     grad_input = at::native::empty_like(
         *X,
-        c10::nullopt /* dtype */,
-        c10::nullopt /* layout */,
-        c10::nullopt /* device */,
-        c10::nullopt /* pin_memory */,
+        std::nullopt /* dtype */,
+        std::nullopt /* layout */,
+        std::nullopt /* device */,
+        std::nullopt /* pin_memory */,
         LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   }
 
   if (grad_input_mask[1]) {
     grad_weight = M > 0 ? at::native::empty_like(
                               *gamma,
-                              c10::nullopt /* dtype */,
-                              c10::nullopt /* layout */,
-                              c10::nullopt /* device */,
-                              c10::nullopt /* pin_memory */,
+                              std::nullopt /* dtype */,
+                              std::nullopt /* layout */,
+                              std::nullopt /* device */,
+                              std::nullopt /* pin_memory */,
                               LEGACY_CONTIGUOUS_MEMORY_FORMAT)
                         : at::native::zeros_like(
                               *gamma,
-                              c10::nullopt /* dtype */,
-                              c10::nullopt /* layout */,
-                              c10::nullopt /* device */,
-                              c10::nullopt /* pin_memory */,
+                              std::nullopt /* dtype */,
+                              std::nullopt /* layout */,
+                              std::nullopt /* device */,
+                              std::nullopt /* pin_memory */,
                               LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   }
   if (grad_input_mask[2]) {
     grad_bias = M > 0 ? at::native::empty_like(
                             *beta,
-                            c10::nullopt /* dtype */,
-                            c10::nullopt /* layout */,
-                            c10::nullopt /* device */,
-                            c10::nullopt /* pin_memory */,
+                            std::nullopt /* dtype */,
+                            std::nullopt /* layout */,
+                            std::nullopt /* device */,
+                            std::nullopt /* pin_memory */,
                             LEGACY_CONTIGUOUS_MEMORY_FORMAT)
                       : at::native::zeros_like(
                             *beta,
-                            c10::nullopt /* dtype */,
-                            c10::nullopt /* layout */,
-                            c10::nullopt /* device */,
-                            c10::nullopt /* pin_memory */,
+                            std::nullopt /* dtype */,
+                            std::nullopt /* layout */,
+                            std::nullopt /* device */,
+                            std::nullopt /* pin_memory */,
                             LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   }
 

--- a/src/ATen/native/xpu/PinnedMemoryAllocator.cpp
+++ b/src/ATen/native/xpu/PinnedMemoryAllocator.cpp
@@ -8,7 +8,7 @@
 namespace at {
 namespace native {
 // Note: The user must call is_pinned(device='xpu') to explicitly call here.
-bool is_pinned_xpu(const Tensor& self, c10::optional<Device> device) {
+bool is_pinned_xpu(const Tensor& self, std::optional<Device> device) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
       !device.has_value() || device->type() == c10::DeviceType::XPU);
 
@@ -17,7 +17,7 @@ bool is_pinned_xpu(const Tensor& self, c10::optional<Device> device) {
 
 // Note: The user must call tensor.pin_memory(device='xpu') to explicitly call
 // here.
-Tensor _pin_memory_xpu(const Tensor& self, c10::optional<Device> device) {
+Tensor _pin_memory_xpu(const Tensor& self, std::optional<Device> device) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
       !device.has_value() || device->type() == c10::DeviceType::XPU);
 

--- a/src/ATen/native/xpu/Repeat.cpp
+++ b/src/ATen/native/xpu/Repeat.cpp
@@ -5,7 +5,7 @@ namespace at {
 namespace native {
 Tensor repeat_interleave_xpu(
     const Tensor& repeats,
-    c10::optional<int64_t> output_size) {
+    std::optional<int64_t> output_size) {
   return at::native::xpu::repeat_interleave_kernel(repeats, output_size);
 }
 

--- a/src/ATen/native/xpu/Resize.cpp
+++ b/src/ATen/native/xpu/Resize.cpp
@@ -25,14 +25,14 @@ namespace native::xpu {
 const Tensor& resize_xpu_(
     const Tensor& self,
     IntArrayRef size,
-    c10::optional<MemoryFormat> optional_memory_format) {
+    std::optional<MemoryFormat> optional_memory_format) {
   if (self.has_names()) {
     return resize_named_tensor_(self, size, optional_memory_format);
   }
   auto* self_ = self.unsafeGetTensorImpl();
   int64_t old_storage_nbytes =
       self_->unsafe_storage() ? self_->unsafe_storage().nbytes() : 0;
-  resize_impl_xpu_(self_, size, /*strides=*/c10::nullopt);
+  resize_impl_xpu_(self_, size, /*strides=*/std::nullopt);
   if (optional_memory_format.has_value()) {
     auto memory_format = optional_memory_format.value();
     TORCH_CHECK(
@@ -53,14 +53,14 @@ const Tensor& resize_xpu_(
 const Tensor& resize_as_(
     const Tensor& self,
     const Tensor& the_template,
-    c10::optional<MemoryFormat> optional_memory_format = c10::nullopt) {
+    std::optional<MemoryFormat> optional_memory_format = std::nullopt) {
   return resize_xpu_(self, the_template.sizes(), optional_memory_format);
 }
 
 Tensor _copy_from_and_resize(const at::Tensor& self, const at::Tensor& dst) {
   // Dispatch explicitly to bypass redispatching in ATen CPU fallback routine.
   if (dst.is_xpu()) {
-    resize_xpu_(dst, self.sizes(), c10::nullopt);
+    resize_xpu_(dst, self.sizes(), std::nullopt);
   } else {
     at::native::resize_(dst, self.sizes());
   }
@@ -89,7 +89,7 @@ namespace native {
 const at::Tensor& resize_xpu_(
     const at::Tensor& self,
     at::IntArrayRef size,
-    c10::optional<at::MemoryFormat> memory_format) {
+    std::optional<at::MemoryFormat> memory_format) {
   return native::xpu::resize_xpu_(self, size, memory_format);
 }
 
@@ -102,9 +102,9 @@ Tensor& set_storage_xpu_(
   at::native::checkSetStorage(self, source, storage_offset, size, stride);
 
   self.unsafeGetTensorImpl()->set_storage_offset(storage_offset);
-  c10::optional<IntArrayRef> stride_opt = stride.data() != nullptr
-      ? c10::optional<IntArrayRef>(stride)
-      : c10::nullopt;
+  std::optional<IntArrayRef> stride_opt = stride.data() != nullptr
+      ? std::optional<IntArrayRef>(stride)
+      : std::nullopt;
   native::xpu::resize_impl_xpu_(self.unsafeGetTensorImpl(), size, stride_opt);
   return self;
 }

--- a/src/ATen/native/xpu/SummaryOps.cpp
+++ b/src/ATen/native/xpu/SummaryOps.cpp
@@ -9,7 +9,7 @@ namespace native {
 
 Tensor _bincount_xpu(
     const Tensor& self,
-    const c10::optional<Tensor>& weights_opt,
+    const std::optional<Tensor>& weights_opt,
     int64_t minlength) {
   c10::MaybeOwned<Tensor> weights_maybe_owned =
       at::borrow_from_optional_tensor(weights_opt);

--- a/src/ATen/native/xpu/TensorFactories.cpp
+++ b/src/ATen/native/xpu/TensorFactories.cpp
@@ -41,11 +41,11 @@ Tensor& eye_out_xpu(int64_t n, Tensor& result) {
 
 Tensor empty_xpu(
     IntArrayRef size,
-    c10::optional<ScalarType> dtype_opt,
-    c10::optional<Layout> layout_opt,
-    c10::optional<Device> device_opt,
-    c10::optional<bool> pin_memory_opt,
-    c10::optional<c10::MemoryFormat> memory_format_opt) {
+    std::optional<ScalarType> dtype_opt,
+    std::optional<Layout> layout_opt,
+    std::optional<Device> device_opt,
+    std::optional<bool> pin_memory_opt,
+    std::optional<c10::MemoryFormat> memory_format_opt) {
   Tensor result = at::detail::empty_xpu(
       size,
       dtype_opt,
@@ -65,10 +65,10 @@ Tensor empty_xpu(
 Tensor empty_strided_xpu(
     IntArrayRef size,
     IntArrayRef stride,
-    c10::optional<ScalarType> dtype_opt,
-    c10::optional<Layout> layout_opt,
-    c10::optional<Device> device_opt,
-    c10::optional<bool> pin_memory_opt) {
+    std::optional<ScalarType> dtype_opt,
+    std::optional<Layout> layout_opt,
+    std::optional<Device> device_opt,
+    std::optional<bool> pin_memory_opt) {
   Tensor result = at::detail::empty_strided_xpu(
       size, stride, dtype_opt, layout_opt, device_opt, pin_memory_opt);
   // See Note [Enabling Deterministic Operations]
@@ -95,13 +95,13 @@ Tensor _efficientzerotensor_xpu(
   auto zero_ks = at::DispatchKeySet(c10::DispatchKey::XPU) |
       at::DispatchKeySet(c10::DispatchKey::ZeroTensor);
   auto out = at::detail::empty_generic(
-      size, &allocator, zero_ks, dtype_, c10::nullopt);
+      size, &allocator, zero_ks, dtype_, std::nullopt);
   return out;
 }
 
 Tensor& randperm_out_xpu(
     int64_t n,
-    c10::optional<Generator> generator,
+    std::optional<Generator> generator,
     Tensor& result) {
   TORCH_CHECK(n >= 0, "n must be non-negative, got", n);
   at::native::check_supported_max_int_with_precision(n, result);
@@ -120,10 +120,10 @@ Tensor tril_indices_xpu(
     int64_t row,
     int64_t col,
     int64_t offset,
-    c10::optional<at::ScalarType> dtype,
-    c10::optional<at::Layout> layout,
-    c10::optional<at::Device> device,
-    c10::optional<bool> pin_memory) {
+    std::optional<at::ScalarType> dtype,
+    std::optional<at::Layout> layout,
+    std::optional<at::Device> device,
+    std::optional<bool> pin_memory) {
   TensorOptions options =
       TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(
           pin_memory);
@@ -134,10 +134,10 @@ Tensor triu_indices_xpu(
     int64_t row,
     int64_t col,
     int64_t offset,
-    c10::optional<at::ScalarType> dtype,
-    c10::optional<at::Layout> layout,
-    c10::optional<at::Device> device,
-    c10::optional<bool> pin_memory) {
+    std::optional<at::ScalarType> dtype,
+    std::optional<at::Layout> layout,
+    std::optional<at::Device> device,
+    std::optional<bool> pin_memory) {
   TensorOptions options =
       TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(
           pin_memory);

--- a/src/ATen/native/xpu/TensorShape.cpp
+++ b/src/ATen/native/xpu/TensorShape.cpp
@@ -27,7 +27,7 @@ Tensor as_strided_xpu(
     const Tensor& self,
     IntArrayRef size,
     IntArrayRef stride,
-    c10::optional<int64_t> storage_offset = c10::nullopt) {
+    std::optional<int64_t> storage_offset = std::nullopt) {
   if (self.is_quantized()) {
     return at::native::as_strided_qtensorimpl(
         self, size, stride, storage_offset);

--- a/src/ATen/native/xpu/UpSample.h
+++ b/src/ATen/native/xpu/UpSample.h
@@ -115,7 +115,7 @@ inline scalar_t max(scalar_t a, scalar_t b) {
 
 template <typename accscalar_t>
 static inline accscalar_t compute_scales_value(
-    const c10::optional<double> scale,
+    const std::optional<double> scale,
     int64_t src_size,
     int64_t dst_size) {
   return (scale.has_value() && scale.value() > 0.)
@@ -125,7 +125,7 @@ static inline accscalar_t compute_scales_value(
 
 template <typename accscalar_t>
 static inline accscalar_t compute_scales_value_backwards(
-    const c10::optional<double> scale,
+    const std::optional<double> scale,
     int64_t src_size,
     int64_t dst_size) {
   return (scale.has_value() && scale.value() > 0.)
@@ -138,7 +138,7 @@ static inline accscalar_t area_pixel_compute_scale(
     int input_size,
     int output_size,
     bool align_corners,
-    const c10::optional<double> scale) {
+    const std::optional<double> scale) {
   if (align_corners) {
     if (output_size > 1) {
       return (accscalar_t)(input_size - 1) / (output_size - 1);

--- a/src/ATen/native/xpu/XPUScalar.cpp
+++ b/src/ATen/native/xpu/XPUScalar.cpp
@@ -16,10 +16,10 @@ Scalar _local_scalar_dense_xpu(const Tensor& self) {
         auto value = at::detail::empty_cpu(
             {1}, /* size */
             c10::CppTypeToScalarType<scalar_t>(), /* dtype */
-            c10::nullopt, /* layout */
-            c10::nullopt, /* device */
+            std::nullopt, /* layout */
+            std::nullopt, /* device */
             false, /* pin_memory */
-            c10::nullopt /* memory format */
+            std::nullopt /* memory format */
         );
 
         auto queue = at::xpu::getCurrentSYCLQueue();

--- a/src/ATen/native/xpu/mkl/SpectralOps.cpp
+++ b/src/ATen/native/xpu/mkl/SpectralOps.cpp
@@ -107,7 +107,7 @@ void _mkl_dft(
   Tensor workspaceBuf = at::empty(
       {(long)(workspaceSizeBytes / sizeof(double))},
       input.options().dtype(at::kDouble),
-      c10::nullopt);
+      std::nullopt);
   desc.set_workspace((double*)workspaceBuf.mutable_data_ptr());
 
   auto in_data = (scalar_t*)input.const_data_ptr();

--- a/src/ATen/native/xpu/sycl/AveragePool2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/AveragePool2dKernels.cpp
@@ -642,7 +642,7 @@ void avg_pool2d_kernel(
     int64_t padW_,
     bool ceil_mode,
     bool count_include_pad,
-    c10::optional<int64_t> divisor_override,
+    std::optional<int64_t> divisor_override,
     const Tensor& output) {
   const int64_t nInputPlane = input_.size(-3);
   const int64_t inputHeight = input_.size(-2);
@@ -728,7 +728,7 @@ void avg_pool2d_backward_kernel(
     IntArrayRef padding,
     bool ceil_mode,
     bool count_include_pad,
-    c10::optional<int64_t> divisor_override,
+    std::optional<int64_t> divisor_override,
     const Tensor& gradInput) {
   const int kH = safe_downcast<int, int64_t>(kernel_size[0]);
   const int kW = kernel_size.size() == 1

--- a/src/ATen/native/xpu/sycl/AveragePool2dKernels.h
+++ b/src/ATen/native/xpu/sycl/AveragePool2dKernels.h
@@ -12,7 +12,7 @@ TORCH_XPU_API void avg_pool2d_kernel(
     int64_t padW_,
     bool ceil_mode,
     bool count_include_pad,
-    c10::optional<int64_t> divisor_override,
+    std::optional<int64_t> divisor_override,
     const Tensor& output);
 
 TORCH_XPU_API void avg_pool2d_backward_kernel(
@@ -23,7 +23,7 @@ TORCH_XPU_API void avg_pool2d_backward_kernel(
     IntArrayRef padding,
     bool ceil_mode,
     bool count_include_pad,
-    c10::optional<int64_t> divisor_override,
+    std::optional<int64_t> divisor_override,
     const Tensor& gradInput);
 
 } // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/AveragePool3dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/AveragePool3dKernels.cpp
@@ -193,7 +193,7 @@ void avg_pool3d_kernel(
     IntArrayRef padding,
     bool ceil_mode,
     bool count_include_pad,
-    c10::optional<int64_t> divisor_override,
+    std::optional<int64_t> divisor_override,
     const Tensor& output) {
   TensorArg output_arg{output, "output", 1};
   TensorArg input_arg{input, "input", 2};
@@ -718,7 +718,7 @@ void avg_pool3d_backward_kernel(
     IntArrayRef padding,
     bool ceil_mode,
     bool count_include_pad,
-    c10::optional<int64_t> divisor_override,
+    std::optional<int64_t> divisor_override,
     const Tensor& gradInput) {
   // See Note [Writing Nondeterministic Operations]
   // Nondeterministic because of atomicAdd usage

--- a/src/ATen/native/xpu/sycl/AveragePool3dKernels.h
+++ b/src/ATen/native/xpu/sycl/AveragePool3dKernels.h
@@ -11,7 +11,7 @@ TORCH_XPU_API void avg_pool3d_kernel(
     IntArrayRef padding,
     bool ceil_mode,
     bool count_include_pad,
-    c10::optional<int64_t> divisor_override,
+    std::optional<int64_t> divisor_override,
     const Tensor& output);
 
 TORCH_XPU_API void avg_pool3d_backward_kernel(
@@ -22,7 +22,7 @@ TORCH_XPU_API void avg_pool3d_backward_kernel(
     IntArrayRef padding,
     bool ceil_mode,
     bool count_include_pad,
-    c10::optional<int64_t> divisor_override,
+    std::optional<int64_t> divisor_override,
     const Tensor& gradInput);
 
 } // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
@@ -1759,7 +1759,7 @@ void batch_norm_elemt_channels_last_template(
     const at::Tensor& shift, // bias of BN
     const at::Tensor& mean,
     const at::Tensor& inv_std,
-    const at::optional<at::Tensor>& z = c10::nullopt, // bias after BN
+    const at::optional<at::Tensor>& z = std::nullopt, // bias after BN
     const bool fuse_relu = false) {
   const auto stride = input.sizes()[1];
   const auto reduction_size = input.numel() / stride;
@@ -1947,8 +1947,8 @@ struct BatchNormElementwiseLoopsFunctor {
 void batch_norm_elemt_kernel(
     Tensor& out,
     const Tensor& self,
-    const c10::optional<Tensor>& weight_opt,
-    const c10::optional<Tensor>& bias_opt,
+    const std::optional<Tensor>& weight_opt,
+    const std::optional<Tensor>& bias_opt,
     const Tensor& mean_,
     const Tensor& invstd_) {
   switch (batch_norm_choose_impl(self)) {
@@ -2661,7 +2661,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> batch_norm_backward_reduce_kernel(
     const Tensor& input,
     const Tensor& mean,
     const Tensor& invstd,
-    const c10::optional<Tensor>& weight_opt,
+    const std::optional<Tensor>& weight_opt,
     bool input_g,
     bool weight_g,
     bool bias_g) {
@@ -3867,7 +3867,7 @@ Tensor batch_norm_backward_elemt_kernel(
     const Tensor& input,
     const Tensor& mean,
     const Tensor& invstd,
-    const c10::optional<Tensor>& weight_opt,
+    const std::optional<Tensor>& weight_opt,
     const Tensor& sum_dy,
     const Tensor& sum_dy_xmu,
     const Tensor& count) {
@@ -4042,8 +4042,8 @@ void batch_norm_mean_var(
 
 std::tuple<Tensor, Tensor> batch_norm_update_stats_kernel(
     const Tensor& self,
-    const c10::optional<Tensor>& running_mean_opt,
-    const c10::optional<Tensor>& running_var_opt,
+    const std::optional<Tensor>& running_mean_opt,
+    const std::optional<Tensor>& running_var_opt,
     double momentum) {
   c10::MaybeOwned<Tensor> running_mean =
       at::borrow_from_optional_tensor(running_mean_opt);
@@ -4191,8 +4191,8 @@ struct BatchNormElementwiseFunctor {
 void batch_norm_elementwise(
     const Tensor& out,
     const Tensor& self,
-    const c10::optional<Tensor>& weight_opt,
-    const c10::optional<Tensor>& bias_opt,
+    const std::optional<Tensor>& weight_opt,
+    const std::optional<Tensor>& bias_opt,
     const Tensor& mean_,
     const Tensor& invstd_) {
   switch (batch_norm_choose_impl(self)) {
@@ -4287,10 +4287,10 @@ void batch_norm_elementwise(
 
 std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_kernel(
     const Tensor& self,
-    const c10::optional<Tensor>& weight_opt,
-    const c10::optional<Tensor>& bias_opt,
-    const c10::optional<Tensor>& running_mean_opt,
-    const c10::optional<Tensor>& running_var_opt,
+    const std::optional<Tensor>& weight_opt,
+    const std::optional<Tensor>& bias_opt,
+    const std::optional<Tensor>& running_mean_opt,
+    const std::optional<Tensor>& running_var_opt,
     bool train,
     double momentum,
     double epsilon,
@@ -5127,11 +5127,11 @@ Tensor batch_norm_elementwise_backward_eval(
 std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_kernel(
     const Tensor& grad_out,
     const Tensor& input,
-    const c10::optional<Tensor>& weight_opt,
-    const c10::optional<Tensor>& running_mean_opt,
-    const c10::optional<Tensor>& running_var_opt,
-    const c10::optional<Tensor>& save_mean_opt,
-    const c10::optional<Tensor>& save_invstd_opt,
+    const std::optional<Tensor>& weight_opt,
+    const std::optional<Tensor>& running_mean_opt,
+    const std::optional<Tensor>& running_var_opt,
+    const std::optional<Tensor>& save_mean_opt,
+    const std::optional<Tensor>& save_invstd_opt,
     bool train,
     double epsilon,
     std::array<bool, 3> grad_input_mask) {

--- a/src/ATen/native/xpu/sycl/BatchNormKernels.h
+++ b/src/ATen/native/xpu/sycl/BatchNormKernels.h
@@ -13,8 +13,8 @@ TORCH_XPU_API std::tuple<Tensor, Tensor> batch_norm_stats_kernel(
 TORCH_XPU_API void batch_norm_elemt_kernel(
     Tensor& out,
     const Tensor& self,
-    const c10::optional<Tensor>& weight_opt,
-    const c10::optional<Tensor>& bias_opt,
+    const std::optional<Tensor>& weight_opt,
+    const std::optional<Tensor>& bias_opt,
     const Tensor& mean_,
     const Tensor& invstd_);
 
@@ -24,7 +24,7 @@ batch_norm_backward_reduce_kernel(
     const Tensor& input,
     const Tensor& mean,
     const Tensor& invstd,
-    const c10::optional<Tensor>& weight_opt,
+    const std::optional<Tensor>& weight_opt,
     bool input_g,
     bool weight_g,
     bool bias_g);
@@ -34,23 +34,23 @@ TORCH_XPU_API Tensor batch_norm_backward_elemt_kernel(
     const Tensor& input,
     const Tensor& mean,
     const Tensor& invstd,
-    const c10::optional<Tensor>& weight_opt,
+    const std::optional<Tensor>& weight_opt,
     const Tensor& sum_dy,
     const Tensor& sum_dy_xmu,
     const Tensor& count);
 
 TORCH_XPU_API std::tuple<Tensor, Tensor> batch_norm_update_stats_kernel(
     const Tensor& self,
-    const c10::optional<Tensor>& running_mean_opt,
-    const c10::optional<Tensor>& running_var_opt,
+    const std::optional<Tensor>& running_mean_opt,
+    const std::optional<Tensor>& running_var_opt,
     double momentum);
 
 TORCH_XPU_API std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_kernel(
     const Tensor& self,
-    const c10::optional<Tensor>& weight_opt,
-    const c10::optional<Tensor>& bias_opt,
-    const c10::optional<Tensor>& running_mean_opt,
-    const c10::optional<Tensor>& running_var_opt,
+    const std::optional<Tensor>& weight_opt,
+    const std::optional<Tensor>& bias_opt,
+    const std::optional<Tensor>& running_mean_opt,
+    const std::optional<Tensor>& running_var_opt,
     bool train,
     double momentum,
     double epsilon,
@@ -61,11 +61,11 @@ TORCH_XPU_API std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_kernel(
 TORCH_XPU_API std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_kernel(
     const Tensor& grad_out,
     const Tensor& input,
-    const c10::optional<Tensor>& weight_opt,
-    const c10::optional<Tensor>& running_mean_opt,
-    const c10::optional<Tensor>& running_var_opt,
-    const c10::optional<Tensor>& save_mean_opt,
-    const c10::optional<Tensor>& save_invstd_opt,
+    const std::optional<Tensor>& weight_opt,
+    const std::optional<Tensor>& running_mean_opt,
+    const std::optional<Tensor>& running_var_opt,
+    const std::optional<Tensor>& save_mean_opt,
+    const std::optional<Tensor>& save_invstd_opt,
     bool train,
     double epsilon,
     std::array<bool, 3> grad_input_mask);

--- a/src/ATen/native/xpu/sycl/DistributionBernoulli.cpp
+++ b/src/ATen/native/xpu/sycl/DistributionBernoulli.cpp
@@ -16,7 +16,7 @@ namespace xpu {
 void bernoulli_tensor_kernel(
     const TensorBase& self,
     const TensorBase& p_,
-    c10::optional<Generator> gen_) {
+    std::optional<Generator> gen_) {
   auto generator = get_generator_or_default<at::XPUGeneratorImpl>(
       gen_, at::xpu::detail::getDefaultXPUGenerator());
   at::native::templates::xpu::bernoulli_kernel(self, p_, generator);
@@ -25,7 +25,7 @@ void bernoulli_tensor_kernel(
 void bernoulli_scalar_kernel(
     const TensorBase& self,
     double p,
-    c10::optional<Generator> gen) {
+    std::optional<Generator> gen) {
   auto iter = TensorIterator::borrowing_nullary_op(self);
   auto generator = get_generator_or_default<at::XPUGeneratorImpl>(
       gen, at::xpu::detail::getDefaultXPUGenerator());

--- a/src/ATen/native/xpu/sycl/DistributionCauchyKernel.cpp
+++ b/src/ATen/native/xpu/sycl/DistributionCauchyKernel.cpp
@@ -9,7 +9,7 @@ void cauchy_kernel(
     TensorIteratorBase& iter,
     double median,
     double sigma,
-    c10::optional<Generator> gen) {
+    std::optional<Generator> gen) {
   auto generator = get_generator_or_default<at::XPUGeneratorImpl>(
       gen, at::xpu::detail::getDefaultXPUGenerator());
   at::native::templates::xpu::cauchy_kernel(iter, median, sigma, generator);

--- a/src/ATen/native/xpu/sycl/DistributionExponentialKernel.cpp
+++ b/src/ATen/native/xpu/sycl/DistributionExponentialKernel.cpp
@@ -14,7 +14,7 @@ namespace at::native::xpu {
 void exponential_kernel(
     TensorIteratorBase& iter,
     double lambda,
-    c10::optional<Generator> gen) {
+    std::optional<Generator> gen) {
   auto generator = get_generator_or_default<at::XPUGeneratorImpl>(
       gen, at::xpu::detail::getDefaultXPUGenerator());
   at::native::templates::xpu::exponential_kernel(iter, lambda, generator);

--- a/src/ATen/native/xpu/sycl/DistributionGeometricKernel.cpp
+++ b/src/ATen/native/xpu/sycl/DistributionGeometricKernel.cpp
@@ -8,7 +8,7 @@ namespace at::native::xpu {
 void geometric_kernel(
     TensorIteratorBase& iter,
     double p_,
-    c10::optional<Generator> gen) {
+    std::optional<Generator> gen) {
   auto generator = get_generator_or_default<at::XPUGeneratorImpl>(
       gen, at::xpu::detail::getDefaultXPUGenerator());
   at::native::templates::xpu::geometric_kernel(iter, p_, generator);

--- a/src/ATen/native/xpu/sycl/DistributionKernels.h
+++ b/src/ATen/native/xpu/sycl/DistributionKernels.h
@@ -9,42 +9,42 @@ TORCH_XPU_API void random_from_to_kernel(
     TensorIteratorBase& iter,
     uint64_t range,
     int64_t base,
-    c10::optional<Generator> gen_);
+    std::optional<Generator> gen_);
 
 TORCH_XPU_API void random_full_64_bits_range_kernel(
     TensorIteratorBase& iter,
-    c10::optional<Generator> gen_);
+    std::optional<Generator> gen_);
 
 TORCH_XPU_API void random_kernel(
     TensorIteratorBase& iter,
-    c10::optional<Generator> gen_);
+    std::optional<Generator> gen_);
 
 TORCH_XPU_API void uniform_kernel(
     TensorIteratorBase& iter,
     double from,
     double to,
-    c10::optional<Generator> gen);
+    std::optional<Generator> gen);
 
 TORCH_XPU_API void normal_kernel(
     const TensorBase& self,
     double mean,
     double std,
-    c10::optional<Generator> gen);
+    std::optional<Generator> gen);
 
 TORCH_XPU_API void bernoulli_tensor_kernel(
     const TensorBase& self,
     const TensorBase& p_,
-    c10::optional<Generator> gen_);
+    std::optional<Generator> gen_);
 
 TORCH_XPU_API void bernoulli_scalar_kernel(
     const TensorBase& self,
     double p,
-    c10::optional<Generator> gen);
+    std::optional<Generator> gen);
 
 TORCH_XPU_API void exponential_kernel(
     TensorIteratorBase& iter,
     double lambda,
-    c10::optional<Generator> gen);
+    std::optional<Generator> gen);
 
 TORCH_XPU_API void log_normal_kernel(
     TensorIteratorBase& iter,
@@ -56,11 +56,11 @@ TORCH_XPU_API void cauchy_kernel(
     TensorIteratorBase& iter,
     double median,
     double sigma,
-    c10::optional<Generator> gen);
+    std::optional<Generator> gen);
 
 TORCH_XPU_API void geometric_kernel(
     TensorIteratorBase& iter,
     double p_,
-    c10::optional<Generator> gen);
+    std::optional<Generator> gen);
 
 } // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/DistributionNormal.cpp
+++ b/src/ATen/native/xpu/sycl/DistributionNormal.cpp
@@ -19,7 +19,7 @@ void normal_kernel(
     const TensorBase& self,
     double mean,
     double std,
-    c10::optional<Generator> gen) {
+    std::optional<Generator> gen) {
   auto generator = get_generator_or_default<at::XPUGeneratorImpl>(
       gen, at::xpu::detail::getDefaultXPUGenerator());
   at::native::templates::xpu::normal_kernel(self, mean, std, generator);

--- a/src/ATen/native/xpu/sycl/DistributionRandomKernel.cpp
+++ b/src/ATen/native/xpu/sycl/DistributionRandomKernel.cpp
@@ -19,7 +19,7 @@ void random_from_to_kernel(
     TensorIteratorBase& iter,
     uint64_t range,
     int64_t base,
-    c10::optional<Generator> gen_) {
+    std::optional<Generator> gen_) {
   auto gen = get_generator_or_default<at::XPUGeneratorImpl>(
       gen_, at::xpu::detail::getDefaultXPUGenerator());
   at::native::templates::xpu::random_from_to_kernel(iter, range, base, gen);
@@ -27,13 +27,13 @@ void random_from_to_kernel(
 
 void random_full_64_bits_range_kernel(
     TensorIteratorBase& iter,
-    c10::optional<Generator> gen_) {
+    std::optional<Generator> gen_) {
   auto gen = get_generator_or_default<at::XPUGeneratorImpl>(
       gen_, at::xpu::detail::getDefaultXPUGenerator());
   at::native::templates::xpu::random_full_64_bits_range_kernel(iter, gen);
 }
 
-void random_kernel(TensorIteratorBase& iter, c10::optional<Generator> gen_) {
+void random_kernel(TensorIteratorBase& iter, std::optional<Generator> gen_) {
   auto gen = get_generator_or_default<at::XPUGeneratorImpl>(
       gen_, at::xpu::detail::getDefaultXPUGenerator());
   at::native::templates::xpu::random_kernel(iter, gen);

--- a/src/ATen/native/xpu/sycl/DistributionUniform.cpp
+++ b/src/ATen/native/xpu/sycl/DistributionUniform.cpp
@@ -19,7 +19,7 @@ void uniform_kernel(
     TensorIteratorBase& iter,
     double from,
     double to,
-    c10::optional<Generator> gen) {
+    std::optional<Generator> gen) {
   auto generator = get_generator_or_default<at::XPUGeneratorImpl>(
       gen, at::xpu::detail::getDefaultXPUGenerator());
   at::native::templates::xpu::uniform_kernel(iter, from, to, generator);

--- a/src/ATen/native/xpu/sycl/Dropout.cpp
+++ b/src/ATen/native/xpu/sycl/Dropout.cpp
@@ -412,7 +412,7 @@ std::tuple<Tensor, Tensor> dropout(
 std::tuple<Tensor, Tensor> dropout_kernel(
     const Tensor& self,
     double p,
-    c10::optional<bool> train) {
+    std::optional<bool> train) {
   // short-cut for train == false
   if (train.has_value() && !train.value()) {
     return std::make_tuple(
@@ -428,7 +428,7 @@ std::tuple<Tensor, Tensor> dropout_kernel(
     return std::tuple<Tensor, Tensor>(ret, mask);
   }
   auto gen = get_generator_or_default<at::XPUGeneratorImpl>(
-      c10::nullopt, at::xpu::detail::getDefaultXPUGenerator());
+      std::nullopt, at::xpu::detail::getDefaultXPUGenerator());
   double p1m = 1. - p;
   return dropout<bool>(gen, self, p1m);
 }
@@ -436,7 +436,7 @@ std::tuple<Tensor, Tensor> dropout_kernel(
 std::tuple<Tensor, Tensor> fused_dropout_kernel(
     const Tensor& self,
     double p,
-    c10::optional<Generator> gen_) {
+    std::optional<Generator> gen_) {
   auto gen = get_generator_or_default<at::XPUGeneratorImpl>(
       gen_, at::xpu::detail::getDefaultXPUGenerator());
   return dropout<uint8_t>(gen, self, p);

--- a/src/ATen/native/xpu/sycl/DropoutKernels.h
+++ b/src/ATen/native/xpu/sycl/DropoutKernels.h
@@ -9,7 +9,7 @@ namespace xpu {
 TORCH_XPU_API std::tuple<Tensor, Tensor> dropout_kernel(
     const Tensor& self,
     double p,
-    c10::optional<bool> train);
+    std::optional<bool> train);
 
 TORCH_XPU_API Tensor
 dropout_backward_kernel(const Tensor& grad, const Tensor& mask, double scale);
@@ -17,7 +17,7 @@ dropout_backward_kernel(const Tensor& grad, const Tensor& mask, double scale);
 TORCH_XPU_API std::tuple<Tensor, Tensor> fused_dropout_kernel(
     const Tensor& self,
     double p,
-    c10::optional<Generator> gen_);
+    std::optional<Generator> gen_);
 
 TORCH_XPU_API Tensor
 masked_scale_kernel(const Tensor& self, const Tensor& mask, double scale);

--- a/src/ATen/native/xpu/sycl/ForeachReduceKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ForeachReduceKernels.cpp
@@ -224,7 +224,7 @@ std::vector<Tensor> foreach_norm_kernel(
     TensorList tensors,
     const Scalar& ord,
     double p,
-    c10::optional<ScalarType> dtype) {
+    std::optional<ScalarType> dtype) {
   const int ntensors = tensors.size();
   const ScalarType output_dtype = // tensors[0].scalar_type();
       dtype.has_value() ? dtype.value() : tensors[0].scalar_type();

--- a/src/ATen/native/xpu/sycl/ForeachReduceKernels.h
+++ b/src/ATen/native/xpu/sycl/ForeachReduceKernels.h
@@ -7,7 +7,7 @@ TORCH_XPU_API std::vector<Tensor> foreach_norm_kernel(
     TensorList tensors,
     const Scalar& ord,
     double p,
-    c10::optional<ScalarType> dtype);
+    std::optional<ScalarType> dtype);
 
 TORCH_XPU_API std::vector<Tensor> foreach_max_kernel(TensorList tensors);
 

--- a/src/ATen/native/xpu/sycl/FusedAdamAmsgradKernels.cpp
+++ b/src/ATen/native/xpu/sycl/FusedAdamAmsgradKernels.cpp
@@ -21,8 +21,8 @@ void fused_adam_amsgrad_kernel(
     const double weight_decay,
     const double eps,
     const bool maximize,
-    const c10::optional<at::Tensor>& grad_scale,
-    const c10::optional<at::Tensor>& found_inf) {
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf) {
   std::vector<std::vector<at::Tensor>> tensor_lists{
       params.vec(),
       grads.vec(),
@@ -71,8 +71,8 @@ void fused_adam_amsgrad_kernel(
     const double weight_decay,
     const double eps,
     const bool maximize,
-    const c10::optional<at::Tensor>& grad_scale,
-    const c10::optional<at::Tensor>& found_inf) {
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf) {
   std::vector<std::vector<at::Tensor>> tensor_lists{
       params.vec(),
       grads.vec(),

--- a/src/ATen/native/xpu/sycl/FusedAdamKernels.cpp
+++ b/src/ATen/native/xpu/sycl/FusedAdamKernels.cpp
@@ -20,8 +20,8 @@ void fused_adam_kernel(
     const double weight_decay,
     const double eps,
     const bool maximize,
-    const c10::optional<at::Tensor>& grad_scale,
-    const c10::optional<at::Tensor>& found_inf) {
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf) {
   std::vector<std::vector<at::Tensor>> tensor_lists{
       params.vec(), grads.vec(), exp_avgs.vec(), exp_avg_sqs.vec()};
 
@@ -65,8 +65,8 @@ void fused_adam_kernel(
     const double weight_decay,
     const double eps,
     const bool maximize,
-    const c10::optional<at::Tensor>& grad_scale,
-    const c10::optional<at::Tensor>& found_inf) {
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf) {
   std::vector<std::vector<at::Tensor>> tensor_lists{
       params.vec(), grads.vec(), exp_avgs.vec(), exp_avg_sqs.vec()};
 

--- a/src/ATen/native/xpu/sycl/FusedAdamKernels.h
+++ b/src/ATen/native/xpu/sycl/FusedAdamKernels.h
@@ -16,8 +16,8 @@ TORCH_XPU_API void fused_adam_amsgrad_kernel(
     const double weight_decay,
     const double eps,
     const bool maximize,
-    const c10::optional<at::Tensor>& grad_scale,
-    const c10::optional<at::Tensor>& found_inf);
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf);
 
 TORCH_XPU_API void fused_adam_amsgrad_kernel(
     at::TensorList params,
@@ -32,8 +32,8 @@ TORCH_XPU_API void fused_adam_amsgrad_kernel(
     const double weight_decay,
     const double eps,
     const bool maximize,
-    const c10::optional<at::Tensor>& grad_scale,
-    const c10::optional<at::Tensor>& found_inf);
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf);
 
 TORCH_XPU_API void fused_adam_kernel(
     at::TensorList params,
@@ -47,8 +47,8 @@ TORCH_XPU_API void fused_adam_kernel(
     const double weight_decay,
     const double eps,
     const bool maximize,
-    const c10::optional<at::Tensor>& grad_scale,
-    const c10::optional<at::Tensor>& found_inf);
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf);
 
 TORCH_XPU_API void fused_adam_kernel(
     at::TensorList params,
@@ -62,7 +62,7 @@ TORCH_XPU_API void fused_adam_kernel(
     const double weight_decay,
     const double eps,
     const bool maximize,
-    const c10::optional<at::Tensor>& grad_scale,
-    const c10::optional<at::Tensor>& found_inf);
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf);
 
 } // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/FusedAdamWAmsgradKernels.cpp
+++ b/src/ATen/native/xpu/sycl/FusedAdamWAmsgradKernels.cpp
@@ -21,8 +21,8 @@ void fused_adamw_amsgrad_kernel(
     const double weight_decay,
     const double eps,
     const bool maximize,
-    const c10::optional<at::Tensor>& grad_scale,
-    const c10::optional<at::Tensor>& found_inf) {
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf) {
   std::vector<std::vector<at::Tensor>> tensor_lists{
       params.vec(),
       grads.vec(),
@@ -71,8 +71,8 @@ void fused_adamw_amsgrad_kernel(
     const double weight_decay,
     const double eps,
     const bool maximize,
-    const c10::optional<at::Tensor>& grad_scale,
-    const c10::optional<at::Tensor>& found_inf) {
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf) {
   std::vector<std::vector<at::Tensor>> tensor_lists{
       params.vec(),
       grads.vec(),

--- a/src/ATen/native/xpu/sycl/FusedAdamWKernels.cpp
+++ b/src/ATen/native/xpu/sycl/FusedAdamWKernels.cpp
@@ -20,8 +20,8 @@ void fused_adamw_kernel(
     const double weight_decay,
     const double eps,
     const bool maximize,
-    const c10::optional<at::Tensor>& grad_scale,
-    const c10::optional<at::Tensor>& found_inf) {
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf) {
   std::vector<std::vector<at::Tensor>> tensor_lists{
       params.vec(), grads.vec(), exp_avgs.vec(), exp_avg_sqs.vec()};
 
@@ -65,8 +65,8 @@ void fused_adamw_kernel(
     const double weight_decay,
     const double eps,
     const bool maximize,
-    const c10::optional<at::Tensor>& grad_scale,
-    const c10::optional<at::Tensor>& found_inf) {
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf) {
   std::vector<std::vector<at::Tensor>> tensor_lists{
       params.vec(), grads.vec(), exp_avgs.vec(), exp_avg_sqs.vec()};
 

--- a/src/ATen/native/xpu/sycl/FusedAdamWKernels.h
+++ b/src/ATen/native/xpu/sycl/FusedAdamWKernels.h
@@ -16,8 +16,8 @@ TORCH_XPU_API void fused_adamw_amsgrad_kernel(
     const double weight_decay,
     const double eps,
     const bool maximize,
-    const c10::optional<at::Tensor>& grad_scale,
-    const c10::optional<at::Tensor>& found_inf);
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf);
 
 TORCH_XPU_API void fused_adamw_amsgrad_kernel(
     at::TensorList params,
@@ -32,8 +32,8 @@ TORCH_XPU_API void fused_adamw_amsgrad_kernel(
     const double weight_decay,
     const double eps,
     const bool maximize,
-    const c10::optional<at::Tensor>& grad_scale,
-    const c10::optional<at::Tensor>& found_inf);
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf);
 
 TORCH_XPU_API void fused_adamw_kernel(
     at::TensorList params,
@@ -47,8 +47,8 @@ TORCH_XPU_API void fused_adamw_kernel(
     const double weight_decay,
     const double eps,
     const bool maximize,
-    const c10::optional<at::Tensor>& grad_scale,
-    const c10::optional<at::Tensor>& found_inf);
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf);
 
 TORCH_XPU_API void fused_adamw_kernel(
     at::TensorList params,
@@ -62,7 +62,7 @@ TORCH_XPU_API void fused_adamw_kernel(
     const double weight_decay,
     const double eps,
     const bool maximize,
-    const c10::optional<at::Tensor>& grad_scale,
-    const c10::optional<at::Tensor>& found_inf);
+    const std::optional<at::Tensor>& grad_scale,
+    const std::optional<at::Tensor>& found_inf);
 
 } // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/Indexing.cpp
+++ b/src/ATen/native/xpu/sycl/Indexing.cpp
@@ -386,7 +386,7 @@ void index_add_kernel(
       ") dims");
 
   if (globalContext().deterministicAlgorithms()) {
-    torch::List<c10::optional<Tensor>> indices;
+    torch::List<std::optional<Tensor>> indices;
     indices.reserve(dim + 1);
     for (int i = 0; i < dim; i++) {
       indices.emplace_back();
@@ -593,7 +593,7 @@ void index_put_kernel(
 
 void index_put_deterministic_kernel(
     Tensor& self,
-    const c10::List<c10::optional<Tensor>>& indices,
+    const c10::List<std::optional<Tensor>>& indices,
     const Tensor& value,
     bool accumulate,
     bool unsafe) {

--- a/src/ATen/native/xpu/sycl/IndexingKernels.h
+++ b/src/ATen/native/xpu/sycl/IndexingKernels.h
@@ -42,7 +42,7 @@ TORCH_XPU_API void index_put_kernel(
 
 TORCH_XPU_API void index_put_deterministic_kernel(
     Tensor& self,
-    const c10::List<c10::optional<Tensor>>& indices,
+    const c10::List<std::optional<Tensor>>& indices,
     const Tensor& value,
     bool accumulate,
     bool unsafe);

--- a/src/ATen/native/xpu/sycl/MultinomialKernel.cpp
+++ b/src/ATen/native/xpu/sycl/MultinomialKernel.cpp
@@ -422,7 +422,7 @@ void multinomial_kernel(
     Tensor& result,
     const Tensor& self,
     const int64_t n_sample,
-    c10::optional<Generator> generator) {
+    std::optional<Generator> generator) {
   auto& sycl_queue = at::xpu::getCurrentSYCLQueue();
   auto gen = get_generator_or_default<at::XPUGeneratorImpl>(
       generator, at::xpu::detail::getDefaultXPUGenerator());
@@ -476,27 +476,27 @@ void multinomial_kernel(
         } else {
           Tensor origDist = native::empty_like(
               self_v,
-              c10::nullopt /* dtype */,
-              c10::nullopt /* layout */,
-              c10::nullopt /* device */,
-              c10::nullopt /* pin_memory */,
+              std::nullopt /* dtype */,
+              std::nullopt /* layout */,
+              std::nullopt /* device */,
+              std::nullopt /* pin_memory */,
               LEGACY_CONTIGUOUS_MEMORY_FORMAT);
           origDist.copy_(self_v);
 
           Tensor normDist = native::empty_like(
               self_v,
-              c10::nullopt /* dtype */,
-              c10::nullopt /* layout */,
-              c10::nullopt /* device */,
-              c10::nullopt /* pin_memory */,
+              std::nullopt /* dtype */,
+              std::nullopt /* layout */,
+              std::nullopt /* device */,
+              std::nullopt /* pin_memory */,
               LEGACY_CONTIGUOUS_MEMORY_FORMAT);
 
           Tensor prefixSum = native::empty_like(
               self_v,
-              c10::nullopt /* dtype */,
-              c10::nullopt /* layout */,
-              c10::nullopt /* device */,
-              c10::nullopt /* pin_memory */,
+              std::nullopt /* dtype */,
+              std::nullopt /* layout */,
+              std::nullopt /* device */,
+              std::nullopt /* pin_memory */,
               LEGACY_CONTIGUOUS_MEMORY_FORMAT);
 
           // Renorm along rows

--- a/src/ATen/native/xpu/sycl/MultinomialKernel.h
+++ b/src/ATen/native/xpu/sycl/MultinomialKernel.h
@@ -7,6 +7,6 @@ TORCH_XPU_API void multinomial_kernel(
     Tensor& result,
     const Tensor& self,
     const int64_t n_sample,
-    c10::optional<Generator> generator);
+    std::optional<Generator> generator);
 
 } // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/RandpermKernel.cpp
+++ b/src/ATen/native/xpu/sycl/RandpermKernel.cpp
@@ -104,7 +104,7 @@ void randperm_handle_duplicate_keys(
 Tensor randperm_kernel(
     Tensor& result,
     int64_t n,
-    c10::optional<Generator> generator) {
+    std::optional<Generator> generator) {
   auto range = at::arange(n, result.options());
 
   Tensor shuffled;

--- a/src/ATen/native/xpu/sycl/RandpermKernel.h
+++ b/src/ATen/native/xpu/sycl/RandpermKernel.h
@@ -4,6 +4,6 @@
 namespace at::native::xpu {
 
 TORCH_XPU_API Tensor
-randperm_kernel(Tensor& result, int64_t n, c10::optional<Generator> generator);
+randperm_kernel(Tensor& result, int64_t n, std::optional<Generator> generator);
 
 } // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/Reduce.h
+++ b/src/ATen/native/xpu/sycl/Reduce.h
@@ -503,7 +503,7 @@ struct ReduceOp {
       OutputCalculator output_calc,
       const void* src,
       char* dst0,
-      c10::optional<char*> dst1,
+      std::optional<char*> dst1,
       void* acc_buf,
       void* group_buf,
       int* semaphores,
@@ -1193,7 +1193,7 @@ inline void gpu_reduce_kernel(
   char* in_data = (char*)iter.data_ptr(iter.ntensors() - 1);
   char* out_data = (char*)iter.data_ptr(0);
   const auto noutputs = iter.noutputs();
-  c10::optional<char*> out_data_extra;
+  std::optional<char*> out_data_extra;
   if (noutputs > 1) {
     out_data_extra = (char*)iter.data_ptr(1);
   } else {

--- a/src/ATen/native/xpu/sycl/Reduce.h
+++ b/src/ATen/native/xpu/sycl/Reduce.h
@@ -1197,7 +1197,7 @@ inline void gpu_reduce_kernel(
   if (noutputs > 1) {
     out_data_extra = (char*)iter.data_ptr(1);
   } else {
-    out_data_extra = c10::nullopt;
+    out_data_extra = std::nullopt;
   }
   char* acc_data = acc_buf_ptr->get_acc_slice(out_data);
 

--- a/src/ATen/native/xpu/sycl/RepeatKernel.cpp
+++ b/src/ATen/native/xpu/sycl/RepeatKernel.cpp
@@ -66,7 +66,7 @@ static void compute_xpu(
 
 Tensor repeat_interleave_kernel(
     const Tensor& repeat,
-    c10::optional<int64_t> output_size) {
+    std::optional<int64_t> output_size) {
   Tensor output;
 
   AT_DISPATCH_INDEX_TYPES(repeat.scalar_type(), "repeat_interleave_xpu", [&] {

--- a/src/ATen/native/xpu/sycl/RepeatKernel.h
+++ b/src/ATen/native/xpu/sycl/RepeatKernel.h
@@ -4,6 +4,6 @@ namespace at::native::xpu {
 
 TORCH_XPU_API Tensor repeat_interleave_kernel(
     const Tensor& repeats,
-    c10::optional<int64_t> output_size);
+    std::optional<int64_t> output_size);
 
 } // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
+++ b/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
@@ -2279,8 +2279,8 @@ Tensor _safe_softmax_kernel(
 Tensor masked_softmax_kernel(
     const Tensor& input_,
     const Tensor& mask_,
-    const c10::optional<int64_t> dim_,
-    const c10::optional<int64_t> mask_type_) {
+    const std::optional<int64_t> dim_,
+    const std::optional<int64_t> mask_type_) {
   Tensor output = at::empty_like(input_, input_.options());
   TORCH_CHECK(
       mask_.scalar_type() == ScalarType::Bool,
@@ -2340,7 +2340,7 @@ Tensor masked_softmax_backward_kernel(
     const Tensor& grad_,
     const Tensor& output_,
     const Tensor& mask_,
-    const c10::optional<int64_t> dim_) {
+    const std::optional<int64_t> dim_) {
   Tensor grad_input = at::empty_like(grad_, grad_.options());
   if (grad_.numel() == 0) {
     return grad_input;

--- a/src/ATen/native/xpu/sycl/SoftMaxKernels.h
+++ b/src/ATen/native/xpu/sycl/SoftMaxKernels.h
@@ -38,14 +38,14 @@ _safe_softmax_kernel(const Tensor& self, int64_t dim, const bool half_to_float);
 TORCH_XPU_API Tensor masked_softmax_kernel(
     const Tensor& input_,
     const Tensor& mask_,
-    const c10::optional<int64_t> dim_,
-    const c10::optional<int64_t> mask_type_);
+    const std::optional<int64_t> dim_,
+    const std::optional<int64_t> mask_type_);
 
 TORCH_XPU_API Tensor masked_softmax_backward_kernel(
     const Tensor& grad_,
     const Tensor& output_,
     const Tensor& mask_,
-    const c10::optional<int64_t> dim_);
+    const std::optional<int64_t> dim_);
 
 } // namespace xpu
 } // namespace native

--- a/src/ATen/native/xpu/sycl/SummaryOpsKernels.cpp
+++ b/src/ATen/native/xpu/sycl/SummaryOpsKernels.cpp
@@ -290,9 +290,9 @@ Tensor bincount_template(
     output = at::zeros(
         {nbins},
         kLong,
-        c10::nullopt /* layout */,
+        std::nullopt /* layout */,
         DeviceType::XPU,
-        c10::nullopt /* pin_memory */);
+        std::nullopt /* pin_memory */);
     tensor_histogram<
         typename c10::impl::ScalarTypeToCPPType<kLong>::type,
         input_t,

--- a/src/ATen/native/xpu/sycl/UniqueKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UniqueKernels.cpp
@@ -188,7 +188,7 @@ std::tuple<Tensor, Tensor, Tensor> unique_consecutive_kernel(
     const Tensor& self,
     const bool return_inverse,
     const bool return_counts,
-    c10::optional<int64_t> dim) {
+    std::optional<int64_t> dim) {
   return AT_DISPATCH_V2(
       self.scalar_type(),
       "unique_consecutive",

--- a/src/ATen/native/xpu/sycl/UniqueKernels.h
+++ b/src/ATen/native/xpu/sycl/UniqueKernels.h
@@ -8,7 +8,7 @@ TORCH_XPU_API std::tuple<Tensor, Tensor, Tensor> unique_consecutive_kernel(
     const Tensor& self,
     const bool return_inverse,
     const bool return_counts,
-    c10::optional<int64_t> dim);
+    std::optional<int64_t> dim);
 
 TORCH_XPU_API std::tuple<Tensor, Tensor, Tensor> unique_dim_consecutive_kernel(
     const Tensor& self,

--- a/src/ATen/native/xpu/sycl/UpSampleBilinear2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleBilinear2dKernels.cpp
@@ -872,8 +872,8 @@ void upsample_bilinear2d_out_kernel(
     const Tensor& input,
     IntArrayRef output_size,
     bool align_corners,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w) {
+    std::optional<double> scales_h,
+    std::optional<double> scales_w) {
   TensorArg input_arg{input, "input", 1}, output_arg{output, "output", 2};
   checkAllSameGPU(__func__, {input_arg, output_arg});
 
@@ -972,8 +972,8 @@ void upsample_bilinear2d_backward_out_kernel(
     IntArrayRef output_size,
     IntArrayRef input_size,
     bool align_corners,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w) {
+    std::optional<double> scales_h,
+    std::optional<double> scales_w) {
   TensorArg grad_input_arg{grad_input, "grad_input", 1},
       grad_output_arg{grad_output_, "grad_output_", 2};
   checkAllSameGPU(__func__, {grad_output_arg, grad_input_arg});
@@ -1509,8 +1509,8 @@ void upsample_gen2d_aa_out_kernel(
     const Tensor& input_,
     IntArrayRef output_size,
     bool align_corners,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w) {
+    std::optional<double> scales_h,
+    std::optional<double> scales_w) {
   TensorArg input_arg{input_, "input_", 1}, output_arg{output, "output", 2};
   checkAllSameGPU(__func__, {input_arg, output_arg});
 
@@ -1577,8 +1577,8 @@ void upsample_gen2d_aa_backward_out_kernel(
     IntArrayRef output_size,
     IntArrayRef input_size,
     bool align_corners,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w) {
+    std::optional<double> scales_h,
+    std::optional<double> scales_w) {
   TensorArg grad_input_arg{grad_input, "grad_input", 1},
       grad_output_arg{grad_output_, "grad_output_", 2};
   checkAllSameGPU(
@@ -1643,8 +1643,8 @@ void _upsample_bilinear2d_aa_out_kernel(
     const Tensor& input,
     IntArrayRef output_size,
     bool align_corners,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w) {
+    std::optional<double> scales_h,
+    std::optional<double> scales_w) {
   return upsample_gen2d_aa_out_kernel<
       upsample_antialias::BilinearFilterFunctor>(
       output, input, output_size, align_corners, scales_h, scales_w);
@@ -1656,8 +1656,8 @@ void _upsample_bilinear2d_aa_backward_out_kernel(
     IntArrayRef output_size,
     IntArrayRef input_size,
     bool align_corners,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w) {
+    std::optional<double> scales_h,
+    std::optional<double> scales_w) {
   return upsample_gen2d_aa_backward_out_kernel<
       upsample_antialias::BilinearFilterFunctor>(
       grad_input,
@@ -1674,8 +1674,8 @@ void _upsample_bicubic2d_aa_out_kernel(
     const Tensor& input,
     IntArrayRef output_size,
     bool align_corners,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w) {
+    std::optional<double> scales_h,
+    std::optional<double> scales_w) {
   return upsample_gen2d_aa_out_kernel<upsample_antialias::BicubicFilterFunctor>(
       output, input, output_size, align_corners, scales_h, scales_w);
 }
@@ -1686,8 +1686,8 @@ void _upsample_bicubic2d_aa_backward_out_kernel(
     IntArrayRef output_size,
     IntArrayRef input_size,
     bool align_corners,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w) {
+    std::optional<double> scales_h,
+    std::optional<double> scales_w) {
   return upsample_gen2d_aa_backward_out_kernel<
       upsample_antialias::BicubicFilterFunctor>(
       grad_input,

--- a/src/ATen/native/xpu/sycl/UpSampleBilinear2dKernels.h
+++ b/src/ATen/native/xpu/sycl/UpSampleBilinear2dKernels.h
@@ -18,16 +18,16 @@ TORCH_XPU_API void upsample_bilinear2d_backward_out_kernel(
     IntArrayRef output_size,
     IntArrayRef input_size,
     bool align_corners,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w);
+    std::optional<double> scales_h,
+    std::optional<double> scales_w);
 
 TORCH_XPU_API void _upsample_bilinear2d_aa_out_kernel(
     const Tensor& output,
     const Tensor& input,
     IntArrayRef output_size,
     bool align_corners,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w);
+    std::optional<double> scales_h,
+    std::optional<double> scales_w);
 
 TORCH_XPU_API void _upsample_bilinear2d_aa_backward_out_kernel(
     const Tensor& grad_input,
@@ -35,16 +35,16 @@ TORCH_XPU_API void _upsample_bilinear2d_aa_backward_out_kernel(
     IntArrayRef output_size,
     IntArrayRef input_size,
     bool align_corners,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w);
+    std::optional<double> scales_h,
+    std::optional<double> scales_w);
 
 TORCH_XPU_API void _upsample_bicubic2d_aa_out_kernel(
     const Tensor& output,
     const Tensor& input,
     IntArrayRef output_size,
     bool align_corners,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w);
+    std::optional<double> scales_h,
+    std::optional<double> scales_w);
 
 TORCH_XPU_API void _upsample_bicubic2d_aa_backward_out_kernel(
     const Tensor& grad_input,
@@ -52,7 +52,7 @@ TORCH_XPU_API void _upsample_bicubic2d_aa_backward_out_kernel(
     IntArrayRef output_size,
     IntArrayRef input_size,
     bool align_corners,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w);
+    std::optional<double> scales_h,
+    std::optional<double> scales_w);
 
 } // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/UpSampleNearest1dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleNearest1dKernels.cpp
@@ -247,7 +247,7 @@ void upsample_nearest1d_kernel(
     const Tensor& output,
     const Tensor& input_,
     IntArrayRef output_size,
-    c10::optional<double> scales,
+    std::optional<double> scales,
     bool is_exact) {
   TensorArg input_arg{input_, "input_", 1};
   TensorArg output_arg{output, "output", 2};

--- a/src/ATen/native/xpu/sycl/UpSampleNearest1dKernels.h
+++ b/src/ATen/native/xpu/sycl/UpSampleNearest1dKernels.h
@@ -9,7 +9,7 @@ TORCH_XPU_API void upsample_nearest1d_kernel(
     const Tensor& output,
     const Tensor& input_,
     IntArrayRef output_size,
-    c10::optional<double> scales,
+    std::optional<double> scales,
     bool is_exact);
 
 TORCH_XPU_API void upsample_nearest1d_backward_kernel(

--- a/src/ATen/native/xpu/sycl/UpSampleNearest2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleNearest2dKernels.cpp
@@ -228,8 +228,8 @@ void upsample_nearest2d_backward_kernel(
     const Tensor& grad_output_,
     IntArrayRef output_size,
     IntArrayRef input_size,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w,
+    std::optional<double> scales_h,
+    std::optional<double> scales_w,
     bool is_exact) {
   TensorArg grad_input_arg{grad_input, "grad_input", 1};
   TensorArg grad_output_arg{grad_output_, "grad_output_", 2};
@@ -577,8 +577,8 @@ void upsample_nearest2d_kernel(
     const Tensor& output,
     const Tensor& input_,
     IntArrayRef output_size,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w,
+    std::optional<double> scales_h,
+    std::optional<double> scales_w,
     bool is_exact) {
   TensorArg input_arg{input_, "input_", 1};
   TensorArg output_arg{output, "output", 2};

--- a/src/ATen/native/xpu/sycl/UpSampleNearest2dKernels.h
+++ b/src/ATen/native/xpu/sycl/UpSampleNearest2dKernels.h
@@ -9,8 +9,8 @@ TORCH_XPU_API void upsample_nearest2d_kernel(
     const Tensor& output,
     const Tensor& input_,
     IntArrayRef output_size,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w,
+    std::optional<double> scales_h,
+    std::optional<double> scales_w,
     bool is_exact);
 
 TORCH_XPU_API void upsample_nearest2d_backward_kernel(
@@ -18,8 +18,8 @@ TORCH_XPU_API void upsample_nearest2d_backward_kernel(
     const Tensor& grad_output_,
     IntArrayRef output_size,
     IntArrayRef input_size,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w,
+    std::optional<double> scales_h,
+    std::optional<double> scales_w,
     bool is_exact);
 
 } // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/UpSampleNearest3dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleNearest3dKernels.cpp
@@ -136,9 +136,9 @@ void upsample_nearest3d_kernel(
     const Tensor& output,
     const Tensor& input_,
     IntArrayRef output_size,
-    c10::optional<double> scales_d,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w,
+    std::optional<double> scales_d,
+    std::optional<double> scales_h,
+    std::optional<double> scales_w,
     bool is_exact) {
   TensorArg input_arg{input_, "input_", 1};
   TensorArg output_arg{output, "output", 2};
@@ -351,9 +351,9 @@ void upsample_nearest3d_backward_kernel(
     const Tensor& grad_output_,
     IntArrayRef output_size,
     IntArrayRef input_size,
-    c10::optional<double> scales_d,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w,
+    std::optional<double> scales_d,
+    std::optional<double> scales_h,
+    std::optional<double> scales_w,
     bool is_exact) {
   TensorArg grad_input_arg{grad_input, "grad_input", 1};
   TensorArg grad_output_arg{grad_output_, "grad_output_", 2};

--- a/src/ATen/native/xpu/sycl/UpSampleNearest3dKernels.h
+++ b/src/ATen/native/xpu/sycl/UpSampleNearest3dKernels.h
@@ -8,9 +8,9 @@ TORCH_XPU_API void upsample_nearest3d_kernel(
     const Tensor& output,
     const Tensor& input_,
     IntArrayRef output_size,
-    c10::optional<double> scales_d,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w,
+    std::optional<double> scales_d,
+    std::optional<double> scales_h,
+    std::optional<double> scales_w,
     bool is_exact);
 
 TORCH_XPU_API void upsample_nearest3d_backward_kernel(
@@ -18,9 +18,9 @@ TORCH_XPU_API void upsample_nearest3d_backward_kernel(
     const Tensor& grad_output_,
     IntArrayRef output_size,
     IntArrayRef input_size,
-    c10::optional<double> scales_d,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w,
+    std::optional<double> scales_d,
+    std::optional<double> scales_h,
+    std::optional<double> scales_w,
     bool is_exact);
 
 } // namespace at::native::xpu

--- a/src/ATen/xpu/EmptyTensor.cpp
+++ b/src/ATen/xpu/EmptyTensor.cpp
@@ -10,8 +10,8 @@ namespace at::detail {
 TensorBase empty_xpu(
     IntArrayRef size,
     ScalarType dtype,
-    c10::optional<Device> device_opt,
-    c10::optional<c10::MemoryFormat> memory_format_opt) {
+    std::optional<Device> device_opt,
+    std::optional<c10::MemoryFormat> memory_format_opt) {
   at::globalContext().lazyInitDevice(c10::DeviceType::XPU);
   const auto device = device_or_default(device_opt);
   TORCH_INTERNAL_ASSERT(device.is_xpu());
@@ -24,11 +24,11 @@ TensorBase empty_xpu(
 
 TensorBase empty_xpu(
     IntArrayRef size,
-    c10::optional<ScalarType> dtype_opt,
-    c10::optional<Layout> layout_opt,
-    c10::optional<Device> device_opt,
-    c10::optional<bool> pin_memory_opt,
-    c10::optional<c10::MemoryFormat> memory_format_opt) {
+    std::optional<ScalarType> dtype_opt,
+    std::optional<Layout> layout_opt,
+    std::optional<Device> device_opt,
+    std::optional<bool> pin_memory_opt,
+    std::optional<c10::MemoryFormat> memory_format_opt) {
   TORCH_CHECK(
       !pin_memory_opt.has_value() || !*pin_memory_opt,
       "Only dense CPU tensors can be pinned");
@@ -53,7 +53,7 @@ TensorBase empty_strided_xpu(
     IntArrayRef size,
     IntArrayRef stride,
     ScalarType dtype,
-    c10::optional<Device> device_opt) {
+    std::optional<Device> device_opt) {
   at::globalContext().lazyInitDevice(c10::DeviceType::XPU);
   const auto device = device_or_default(device_opt);
   TORCH_INTERNAL_ASSERT(device.is_xpu());
@@ -67,10 +67,10 @@ TensorBase empty_strided_xpu(
 TensorBase empty_strided_xpu(
     IntArrayRef size,
     IntArrayRef stride,
-    c10::optional<ScalarType> dtype_opt,
-    c10::optional<Layout> layout_opt,
-    c10::optional<Device> device_opt,
-    c10::optional<bool> pin_memory_opt) {
+    std::optional<ScalarType> dtype_opt,
+    std::optional<Layout> layout_opt,
+    std::optional<Device> device_opt,
+    std::optional<bool> pin_memory_opt) {
   TORCH_CHECK(
       !pin_memory_opt.has_value() || !*pin_memory_opt,
       "Only dense CPU tensors can be pinned");

--- a/src/ATen/xpu/EmptyTensor.h
+++ b/src/ATen/xpu/EmptyTensor.h
@@ -6,16 +6,16 @@ namespace at::detail {
 TORCH_XPU_API TensorBase empty_xpu(
     IntArrayRef size,
     ScalarType dtype,
-    c10::optional<Device> device_opt,
-    c10::optional<c10::MemoryFormat> memory_format_opt);
+    std::optional<Device> device_opt,
+    std::optional<c10::MemoryFormat> memory_format_opt);
 
 TORCH_XPU_API TensorBase empty_xpu(
     IntArrayRef size,
-    c10::optional<ScalarType> dtype_opt,
-    c10::optional<Layout> layout_opt,
-    c10::optional<Device> device_opt,
-    c10::optional<bool> pin_memory_opt,
-    c10::optional<c10::MemoryFormat> memory_format_opt);
+    std::optional<ScalarType> dtype_opt,
+    std::optional<Layout> layout_opt,
+    std::optional<Device> device_opt,
+    std::optional<bool> pin_memory_opt,
+    std::optional<c10::MemoryFormat> memory_format_opt);
 
 TORCH_XPU_API TensorBase
 empty_xpu(IntArrayRef size, const TensorOptions& options);
@@ -24,15 +24,15 @@ TORCH_XPU_API TensorBase empty_strided_xpu(
     IntArrayRef size,
     IntArrayRef stride,
     ScalarType dtype,
-    c10::optional<Device> device_opt);
+    std::optional<Device> device_opt);
 
 TORCH_XPU_API TensorBase empty_strided_xpu(
     IntArrayRef size,
     IntArrayRef stride,
-    c10::optional<ScalarType> dtype_opt,
-    c10::optional<Layout> layout_opt,
-    c10::optional<Device> device_opt,
-    c10::optional<bool> pin_memory_opt);
+    std::optional<ScalarType> dtype_opt,
+    std::optional<Layout> layout_opt,
+    std::optional<Device> device_opt,
+    std::optional<bool> pin_memory_opt);
 
 TORCH_XPU_API TensorBase empty_strided_xpu(
     IntArrayRef size,


### PR DESCRIPTION
It's just an alias to `std::optional` and it would be nice to eventually remove it from the repository