### PR TITLE
Don't use c10:string_view

### DIFF
--- a/src/ATen/native/xpu/Activation.cpp
+++ b/src/ATen/native/xpu/Activation.cpp
@@ -61,14 +61,14 @@ REGISTER_XPU_DISPATCH(hardshrink_stub, &xpu::hardshrink_kernel);
 TORCH_IMPL_FUNC(gelu_backward_out_xpu)
 (const Tensor& /*grad*/,
  const Tensor& /*self*/,
- c10::string_view approximate,
+ std::string_view approximate,
  const Tensor& /*grad_input*/
 ) {
   xpu::gelu_backward_kernel(*this, approximate);
 }
 
 TORCH_IMPL_FUNC(gelu_out_xpu)
-(const Tensor& /*self*/, c10::string_view approximate, const Tensor& /*result*/
+(const Tensor& /*self*/, std::string_view approximate, const Tensor& /*result*/
 ) {
   xpu::gelu_kernel(*this, approximate);
 }

--- a/src/ATen/native/xpu/Bucketization.cpp
+++ b/src/ATen/native/xpu/Bucketization.cpp
@@ -10,7 +10,7 @@ Tensor& searchsorted_out_xpu(
     const Tensor& self,
     bool out_int32,
     bool right,
-    const std::optional<c10::string_view> side_opt,
+    const std::optional<std::string_view> side_opt,
     const std::optional<Tensor>& sorter_opt,
     Tensor& result) {
   // See [Note: hacky wrapper removal for optional tensor]
@@ -38,7 +38,7 @@ Tensor& searchsorted_out_xpu(
     const Scalar& self,
     bool out_int32,
     bool right,
-    const std::optional<c10::string_view> side_opt,
+    const std::optional<std::string_view> side_opt,
     const std::optional<Tensor>& sorter_opt,
     Tensor& result) {
   const Tensor& scalar_tensor =
@@ -58,7 +58,7 @@ Tensor searchsorted_xpu(
     const Tensor& self,
     bool out_int32,
     bool right,
-    const std::optional<c10::string_view> side_opt,
+    const std::optional<std::string_view> side_opt,
     const std::optional<Tensor>& sorter) {
   ScalarType scalar_type = out_int32 ? ScalarType::Int : ScalarType::Long;
   c10::TensorOptions options =
@@ -74,7 +74,7 @@ Tensor searchsorted_xpu(
     const Scalar& self,
     bool out_int32,
     bool right,
-    const std::optional<c10::string_view> side_opt,
+    const std::optional<std::string_view> side_opt,
     const std::optional<Tensor>& sorter) {
   const Tensor& scalar_tensor =
       searchsorted_scalar_tensor(self, sorted_sequence.device());

--- a/src/ATen/native/xpu/TensorAdvancedIndexing.cpp
+++ b/src/ATen/native/xpu/TensorAdvancedIndexing.cpp
@@ -139,7 +139,7 @@ TORCH_IMPL_FUNC(index_reduce_xpu_out)
  int64_t dim,
  const Tensor& index,
  const Tensor& source,
- const c10::string_view reduce,
+ const std::string_view reduce,
  bool include_self,
  const Tensor& result) {
   TORCH_WARN_ONCE(

--- a/src/ATen/native/xpu/TensorCompare.cpp
+++ b/src/ATen/native/xpu/TensorCompare.cpp
@@ -73,7 +73,7 @@ REGISTER_XPU_DISPATCH(isin_default_stub, &xpu::isin_kernel);
 
 void _assert_async_msg_xpu(
     const Tensor& self_tensor,
-    c10::string_view assert_msg) {
+    std::string_view assert_msg) {
   xpu::_assert_async_msg_kernel(self_tensor, assert_msg);
 }
 

--- a/src/ATen/native/xpu/sycl/ActivationGeluKernel.cpp
+++ b/src/ATen/native/xpu/sycl/ActivationGeluKernel.cpp
@@ -76,7 +76,7 @@ struct GeluErfBackwardFunctor {
   }
 };
 
-void gelu_kernel(TensorIteratorBase& iter, c10::string_view approximate) {
+void gelu_kernel(TensorIteratorBase& iter, std::string_view approximate) {
   auto approximate_ = at::native::get_gelutype_enum(approximate);
   if (approximate_ == at::native::GeluType::Tanh) {
     AT_DISPATCH_FLOATING_TYPES_AND2(
@@ -97,7 +97,7 @@ void gelu_kernel(TensorIteratorBase& iter, c10::string_view approximate) {
 
 void gelu_backward_kernel(
     TensorIteratorBase& iter,
-    c10::string_view approximate) {
+    std::string_view approximate) {
   auto approximate_ = at::native::get_gelutype_enum(approximate);
   if (approximate_ == at::native::GeluType::Tanh) {
     AT_DISPATCH_FLOATING_TYPES_AND2(

--- a/src/ATen/native/xpu/sycl/ActivationGeluKernel.h
+++ b/src/ATen/native/xpu/sycl/ActivationGeluKernel.h
@@ -8,11 +8,11 @@ namespace xpu {
 
 TORCH_XPU_API void gelu_kernel(
     TensorIteratorBase& iter,
-    c10::string_view approximate);
+    std::string_view approximate);
 
 TORCH_XPU_API void gelu_backward_kernel(
     TensorIteratorBase& iter,
-    c10::string_view approximate);
+    std::string_view approximate);
 
 } // namespace xpu
 } // namespace native

--- a/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
@@ -92,7 +92,7 @@ template <
     template <typename U> class PtrTraits = DefaultPtrTraits,
     typename index_t = int64_t>
 static GenericPackedTensorAccessor<scalar_t, dim, PtrTraits, index_t>
-get_packed_accessor(const Tensor& t, c10::string_view var_name) {
+get_packed_accessor(const Tensor& t, std::string_view var_name) {
   constexpr auto expect_type = c10::CppTypeToScalarType<
       typename std::remove_const<scalar_t>::type>::value;
   const auto actual_type = t.scalar_type();
@@ -113,7 +113,7 @@ template <
     template <typename U> class PtrTraits = DefaultPtrTraits,
     typename index_t = int64_t>
 static GenericPackedTensorAccessor<scalar_t, dim, PtrTraits, index_t>
-packed_accessor_or_dummy(const Tensor& t, c10::string_view var_name) {
+packed_accessor_or_dummy(const Tensor& t, std::string_view var_name) {
   if (!t.defined()) {
     const std::array<index_t, dim> zeros{{0}};
     return GenericPackedTensorAccessor<scalar_t, dim, PtrTraits, index_t>(

--- a/src/ATen/native/xpu/sycl/TensorCompareKernels.cpp
+++ b/src/ATen/native/xpu/sycl/TensorCompareKernels.cpp
@@ -214,7 +214,7 @@ void launch_assert_async_kernel(const c10::complex<double>* input, Msg msg) {
 
 void _assert_async_msg_kernel(
     const Tensor& self_tensor,
-    c10::string_view assert_msg) {
+    std::string_view assert_msg) {
   const TensorBase& self = get_tensor_base(self_tensor);
   auto n = self.numel();
   TORCH_CHECK(n != 0, "Boolean value of Tensor with no values is ambiguous");

--- a/src/ATen/native/xpu/sycl/TensorCompareKernels.h
+++ b/src/ATen/native/xpu/sycl/TensorCompareKernels.h
@@ -33,6 +33,6 @@ TORCH_XPU_API void isin_kernel(
 
 TORCH_XPU_API void _assert_async_msg_kernel(
     const Tensor& self_tensor,
-    c10::string_view assert_msg);
+    std::string_view assert_msg);
 
 } // namespace at::native::xpu


### PR DESCRIPTION
`c10::string_view` is an alias of `std::string_view` and we are planning to deprecate it.