### PR TITLE
Skip random failure cases caused by tolerance

### DIFF
--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -2293,6 +2293,7 @@ skip_dict = {
     "test_foreach_xpu.py": (
         # RuntimeError: Tried to instantiate dummy base class CUDAGraph
         "use_cuda_graph_True",
+        "test_parity__foreach_div_fastpath_inplace_xpu_complex128",
     ),
     "nn/test_convolution_xpu.py": (
         # Summary: all of them are oneDNN related issues


### PR DESCRIPTION
`test_parity__foreach_div_fastpath_inplace_xpu_complex128`  often randomly fails because the tolerance happens to be near the threshold. We plan to skip it to improve the stability of our CI.