### PR TITLE
Optimize `layernom_vectorized_impl` by using adaptive wg selection

### DIFF
--- a/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
@@ -172,6 +172,7 @@ class LayerNormBackward : public NormBackward<scalar_t, mean_t, weight_t> {
 
 constexpr int vec_size =
     4; // we could make it dependent on dtype, but that would lead to different
+       // results between float and low-p types
 
 // Checks alignment of buffers for using vectorized loads / stores
 template <typename T>

--- a/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
@@ -546,7 +546,7 @@ void launch_vectorized_layer_norm_kernel(
     T_ACC* mean_data,
     T_ACC* rstd_data) {
   using KernelClass = VectorizedLayerNormKernelFunctor<T, T_ACC>;
-  int64_t wg_size = syclMaxWorkGroupSize<KernelClass>();
+  int64_t wg_size = syclMaxWorkItemsPerSubSlice();
   KernelClass kfn(
       N,
       eps,


### PR DESCRIPTION
The optimization mainly targets small norm dimensions. We try to reduces more idle computation resources
Test on 1550 & A100:
| shape | stride | latency(old) | latency(new) | improvement | A100 |
| --- | --- | --- | --- | --- | --- |
| bf16[25088, 16, 24] | (384, 1, 16) | 14.685ms | 0.384ms | +3824% | 1.5ms |
| bf16(1, 1024) | contig | 7.392us | 7.576us | ~= | 3.841us |
| f16(1, 1024) | contig | 6.896us | 7.216us | ~= | 3.851us |
| f32(1, 1024) | contig | 6.208us | 6.424us | ~= | 5.921us |
| bf16(2, 4096, 320) | contig | 589.648us | 589.768us | ~= | 2.691ms |
| f16(2, 4096, 320) | contig | 429.704us | 429.320us | ~= | 2.208ms |
| f32(2, 4096, 320) | contig | 402.792us | 402.816us | ~= | 2.802ms |
| bf16(512, 3136, 128) | contig | 1.251ms | 1.249ms | ~= | 1.405ms |
| f16(512, 3136, 128) | contig | 1.074ms | 1.062ms | ~= | 1.405ms |
| f32(512, 3136, 128) | contig | 2.448ms | 2.448ms | ~= | 2.013ms |
| bf16(128, 49, 196, 1024) | contig | 7.871ms | 7.796ms | ~= | 27.047ms |
| f16(128, 49, 196, 1024) | contig | 8.306ms | 8.334ms | ~= | 27.026ms |
| f32(128, 49, 196, 1024) | contig | 16.788ms | 16.864ms | ~= | 28.659ms |
