### PR TITLE
Align latest dist.barrier test change

### DIFF
--- a/test/xpu/distributed/test_c10d_xccl.py
+++ b/test/xpu/distributed/test_c10d_xccl.py
@@ -277,18 +277,16 @@ class ProcessGroupXCCLTest(MultiProcessTestCase):
         time.sleep(2)
         dist.destroy_process_group()
 
-    # todo: https://github.com/pytorch/pytorch/blob/c06b5048ba866e2dd39e5da5399fe8261322c7ca/
-    #       torch/distributed/distributed_c10d.py#L1862 device agnostic
-    # @requires_xccl()
-    # @skip_but_pass_in_sandcastle_if(not TEST_MULTIXPU, "XCCL test requires 2+ GPUs")
-    # def test_set_process_group_desc(self):
-    #     device = torch.device(f"xpu:{self.rank}")
-    #     pg_default = self._create_process_group_xccl(device_id=device)
-    #     self.assertEqual(pg_default.group_desc, "default_pg")
-    #     pg_1 = c10d.new_group([0, 1], group_desc="test_purpose")
-    #     self.assertEqual(pg_1.group_desc, "test_purpose")
-    #     pg_2 = c10d.new_group([0, 1])
-    #     self.assertEqual(pg_2.group_desc, "undefined")
+    @requires_xccl()
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIXPU, "XCCL test requires 2+ GPUs")
+    def test_set_process_group_desc(self):
+        device = torch.device(f"xpu:{self.rank}")
+        pg_default = self._create_process_group_xccl(device_id=device)
+        self.assertEqual(pg_default.group_desc, "default_pg")
+        pg_1 = c10d.new_group([0, 1], group_desc="test_purpose")
+        self.assertEqual(pg_1.group_desc, "test_purpose")
+        pg_2 = c10d.new_group([0, 1])
+        self.assertEqual(pg_2.group_desc, "undefined")
 
 
 class CommTest(MultiProcessTestCase):
@@ -447,17 +445,6 @@ class CommTest(MultiProcessTestCase):
         )
 
         c10d.barrier(device_ids=[self.rank])
-
-    @requires_xccl()
-    @skip_if_lt_x_gpu(2)
-    def test_xccl_barrier_device_ids_function_argument(self):
-        store = c10d.FileStore(self.file_name, self.world_size)
-        c10d.init_process_group(
-            backend="xccl", rank=self.rank, world_size=self.world_size, store=store
-        )
-
-        with self.assertRaisesRegex(TypeError, "Invalid function argument"):
-            c10d.barrier(device_ids=self.rank)
 
     @requires_xccl()
     @skip_if_lt_x_gpu(2)


### PR DESCRIPTION
Refer https://github.com/pytorch/pytorch/pull/149144, Currently, `dist.barrier` accepts `device_ids` as a parameter that doesn't have to be a list. When `device_ids` is not provided or another value is passed, `barrier` will use the device associated with the process group at initialization to perform the synchronization.