### PR TITLE
ci: update Accelerate to v1.6.0 and impove ci workflow

### DIFF
--- a/.github/workflows/_linux_accelerate.yml
+++ b/.github/workflows/_linux_accelerate.yml
@@ -31,15 +31,18 @@ on:
       accelerate:
         required: false
         type: string
-        default: 'v1.4.0'
+        default: 'v1.6.0'
         description: Accelerate version
       transformers:
         required: false
         type: string
-        default: 'v4.49.0'
+        default: 'v4.51.3'
         description: Transformers version
 
 permissions: read-all
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   Torch-XPU-Accelerate-Tests:
@@ -48,8 +51,8 @@ jobs:
       WORK_DIR: 'accelerate'
       NEOReadDebugKeys: 0
       DisableScratchPages: 0
-      accelerate: ${{ inputs.accelerate != '' && inputs.accelerate || 'v1.4.0' }}
-      transformers: ${{ inputs.transformers != '' && inputs.transformers || 'v4.49.0' }}
+      accelerate: ${{ inputs.accelerate != '' && inputs.accelerate || 'v1.6.0' }}
+      transformers: ${{ inputs.transformers != '' && inputs.transformers || 'v4.51.3' }}
       python: ${{ inputs.python != '' && inputs.python || '3.10' }}
       PYTORCH_DEBUG_XPU_FALLBACK: 1
       ZE_AFFINITY_MASK: 0
@@ -67,11 +70,11 @@ jobs:
           path: accelerate
       - name: Create unique Conda ENV name
         run: |
-          echo "CONDA_ENV_NAME=hf_accelerate_test_${ZE_AFFINITY_MASK}" >> $GITHUB_ENV
+          random=$(head /dev/urandom | tr -dc A-Za-z0-9_ | head -c ${1:-5} | xargs)
+          echo "CONDA_ENV_NAME=hf_accelerate_test_${ZE_AFFINITY_MASK}_${random}" >> $GITHUB_ENV
       - name: Prepare Conda ENV
         run: |
           echo "Using Conda ENV name: $CONDA_ENV_NAME"
-          which conda && conda clean -ay
           conda remove --all -y -n $CONDA_ENV_NAME || rm -rf $(dirname ${CONDA_EXE})/../envs/$CONDA_ENV_NAME
           conda create -y -n $CONDA_ENV_NAME python=${{ env.python }}
           source activate $CONDA_ENV_NAME
@@ -119,8 +122,11 @@ jobs:
           #   Kineto profiler initialization for XPU device: PTI_ERROR_INTERNAL
           # * tests/test_cli.py::ModelEstimatorTester::test_gated for failures due
           #   to not root caused environment configuration issue
-          pattern="not test_profiler and not test_gated"
-          cmd=(python3 -m pytest --timeout 600 -rsf --junitxml=reports/accelerate.xml -k "$pattern" tests/)
+          # * tests/test_big_modeling.py::test_dispatch_model_tied_weights_memory_with_nested_offload_cpu fails
+          #   with OOM. That's a new test added by https://github.com/huggingface/accelerate/pull/3445
+          pattern="not test_profiler and not test_gated and not test_dispatch_model_tied_weights_memory_with_nested_offload_cpu"
+          cmd=(python3 -m pytest --timeout 600 -rsf --junitxml=reports/accelerate.xml -k "$pattern" \
+            tests/)
           {
             echo "### Running"
             echo "\`\`\`"
@@ -147,6 +153,12 @@ jobs:
         with:
           conda: $CONDA_ENV_NAME
           pip_packages: 'accelerate transformers'
+      - name: Clean up
+        if: ${{ always() }}
+        run: |
+          if [ -n "$CONDA_ENV_NAME" ]; then
+            conda remove --all -y -n $CONDA_ENV_NAME || rm -rf $(dirname ${CONDA_EXE})/../envs/$CONDA_ENV_NAME
+          fi
       - name: Upload Test log
         if: ${{ ! cancelled() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
* Update Accelerate to v1.6.0
* Update Transformers (in the Accelerate test) to v4.51.3
* Add concurency check to automatically abort ci jobs on new pushes to PRs
* Stop cleaning conda to avoid collisions with parallel tests running on the same system and use conda
* Create really unique conda environment to avoid collisions with parallel tests for the same workflow

Commits which added new tests (or enabled previously skipped tests) which fail:
* https://github.com/huggingface/accelerate/commit/8576112bc8d232fb7ce54ffba752851c383cfa1f
  * `tests/test_big_modeling.py::BigModelingTester::test_dispatch_model_tied_weights_memory_with_nested_offload_cpu`