### PR TITLE
Update Exception Handling in test_unflatten Method for Dimensionless Tensor Case

### DIFF
--- a/test/xpu/test_torch_xpu.py
+++ b/test/xpu/test_torch_xpu.py
@@ -8354,7 +8354,7 @@ class TestTorch(TestCase):
         ):
             torch.tensor([1]).unflatten(0, [2, 2])
         with self.assertRaisesRegex(
-            RuntimeError, r"Dimension specified as 0 but tensor has no dimensions"
+            RuntimeError, r".*Dimension specified as 0 but tensor has no dimensions.*"
         ):
             torch.tensor(1).unflatten(0, [0])
         with self.assertRaisesRegex(

--- a/test/xpu/test_torch_xpu.py
+++ b/test/xpu/test_torch_xpu.py
@@ -8354,7 +8354,7 @@ class TestTorch(TestCase):
         ):
             torch.tensor([1]).unflatten(0, [2, 2])
         with self.assertRaisesRegex(
-            IndexError, r"Dimension specified as 0 but tensor has no dimensions"
+            RuntimeError, r"Dimension specified as 0 but tensor has no dimensions"
         ):
             torch.tensor(1).unflatten(0, [0])
         with self.assertRaisesRegex(


### PR DESCRIPTION
Updates the exception type raised in a specific test case in the `test/xpu/test_torch_xpu.py` file. 

### Test case update:
* [`test/xpu/test_torch_xpu.py`]: Updated the exception type in the `test_unflatten` method from `IndexError` to `RuntimeError` for the case where a tensor with no dimensions is unflattened.

Ref:https://github.com/pytorch/pytorch/pull/148872/files#diff-8aa1a200ec63d23db422aa31b6dca1e6cb372887c43b064ef435210b1b0dec0a