### PR TITLE
Use std::optional instead

### DIFF
--- a/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
@@ -1759,7 +1759,7 @@ void batch_norm_elemt_channels_last_template(
     const at::Tensor& shift, // bias of BN
     const at::Tensor& mean,
     const at::Tensor& inv_std,
-    const at::optional<at::Tensor>& z = std::nullopt, // bias after BN
+    const std::optional<at::Tensor>& z = std::nullopt, // bias after BN
     const bool fuse_relu = false) {
   const auto stride = input.sizes()[1];
   const auto reduction_size = input.numel() / stride;


### PR DESCRIPTION
# Motivation
`c10::optional` is deprecated, use `std::optional` instead.