### PR TITLE
Deprecate c10::optional, use std instead

### DIFF
--- a/src/ATen/native/xpu/Bucketization.cpp
+++ b/src/ATen/native/xpu/Bucketization.cpp
@@ -94,7 +94,7 @@ Tensor& bucketize_out_xpu(
       boundaries.dim(),
       ")");
   searchsorted_out_xpu(
-      boundaries, self, out_int32, right, nullopt, nullopt, result);
+      boundaries, self, out_int32, right, std::nullopt, std::nullopt, result);
   return result;
 }
 

--- a/src/ATen/native/xpu/ForeachReduceOp.cpp
+++ b/src/ATen/native/xpu/ForeachReduceOp.cpp
@@ -8,7 +8,7 @@ namespace at {
 namespace native {
 
 static inline void check_foreach_norm_dtype(
-    optional<ScalarType> opt_dtype,
+    std::optional<ScalarType> opt_dtype,
     ScalarType self_dtype,
     const char* const name) {
   if (opt_dtype.has_value()) {

--- a/src/ATen/native/xpu/XPUFallback.template
+++ b/src/ATen/native/xpu/XPUFallback.template
@@ -95,7 +95,7 @@ static bool lazy_registration_and_redispatch(
           torch::Library::IMPL,
           register_func,
           "torchvision",
-          c10::make_optional(c10::DispatchKey::XPU),
+          std::make_optional(c10::DispatchKey::XPU),
           __FILE__,
           __LINE__);
 


### PR DESCRIPTION
# Motivation
This PR aims to land https://github.com/pytorch/pytorch/pull/153935