### PR TITLE
run distributed test on xelink, and enable WA with FI_PROVIDER=tcp

### DIFF
--- a/test/xpu/run_distributed.py
+++ b/test/xpu/run_distributed.py
@@ -9,6 +9,43 @@ res = 0
 res2 = 0
 fail_test = []
 
+# libfabric WA to avoid hang issue
+os.environ["FI_PROVIDER"] = "tcp"
+
+ret = os.system("xpu-smi topology -m 2>&1|tee topology.log")
+if ret == 0:
+    gpu_dict = {}
+    with open("topology.log") as file:
+        lines = file.readlines()
+        for line in lines:
+            if "CPU Affinity" in line:
+                continue
+            line = line.strip()
+            if line.startswith("GPU "):
+                items = line.split(" ")
+                items = [x for x in items if x]
+                gpu_id = items[1]
+                i = gpu_id.split("/")[0]
+                affinity = ""
+                for j, item in enumerate(items):
+                    if "SYS" not in item and ("XL" in item or "S" in item):
+                        if len(affinity) == 0:
+                            affinity = str(j - 2)
+                        else:
+                            affinity = affinity + "," + str(j - 2)
+                gpu_dict[i] = affinity
+
+    max_affinity = ""
+    for key, value in gpu_dict.items():
+        if len(value) > len(max_affinity):
+            max_affinity = value
+
+    os.environ["ZE_AFFINITY_MASK"] = str(max_affinity)
+    print(str("ZE_AFFINITY_MASK=" + os.environ.get("ZE_AFFINITY_MASK")))
+
+else:
+    print("xpu-smi topology failed")
+    sys.exit(255)
 
 # run python test
 def run(test_command):


### PR DESCRIPTION
Automatically detect XELINK nodes and set ZE_AFFINITY_MASK to ensure the test runs on XELINK.
Enabled FI_PROVIDER=tcp as workaround for hang issue. 