### PR TITLE
Support half precision compute for histc kernel

### DIFF
--- a/.github/scripts/apply_torch_pr.py
+++ b/.github/scripts/apply_torch_pr.py
@@ -15,6 +15,8 @@ parser.add_argument('--pr-list', '-n', nargs='+',
         "https://github.com/pytorch/pytorch/pull/143739",
         # Allow XPU device for validating the arguments to sparse compressed tensor factory functions
         "https://github.com/pytorch/pytorch/pull/147306",
+        "Enhance testing infrastructure to add half-precision support for histc on XPU"
+        "https://github.com/pytorch/pytorch/pull/154339",
     ]
 )
 parser.add_argument('--extra-pr-list', '-e', nargs='+',default=[])

--- a/src/ATen/native/xpu/sycl/SummaryOpsKernels.cpp
+++ b/src/ATen/native/xpu/sycl/SummaryOpsKernels.cpp
@@ -238,14 +238,12 @@ Tensor _histc_kernel(
     int64_t nbins,
     const Scalar& min,
     const Scalar& max) {
-  if (self.scalar_type() == ScalarType::Half) {
-    AT_ERROR("HalfTensor is not supported");
-  }
-  return AT_DISPATCH_ALL_TYPES(self.scalar_type(), "_histc_xpu", [&] {
-    using bounds_t = at::acc_type_device<scalar_t, kXPU>;
-    return _histc_template<scalar_t>(
-        self, nbins, min.to<bounds_t>(), max.to<bounds_t>());
-  });
+  return AT_DISPATCH_ALL_TYPES_AND2(
+      kHalf, kBFloat16, self.scalar_type(), "_histc_xpu", [&] {
+        using bounds_t = at::acc_type_device<scalar_t, kXPU>;
+        return _histc_template<scalar_t>(
+            self, nbins, min.to<bounds_t>(), max.to<bounds_t>());
+      });
 }
 
 template <typename input_t, typename weights_t>

--- a/test/xpu/extended/skip_list_common.py
+++ b/test/xpu/extended/skip_list_common.py
@@ -58,6 +58,8 @@ skip_dict = {
         "test_compare_cpu_log_softmax_xpu_bfloat16",
         "test_compare_cpu__softmax_backward_data_xpu_bfloat16",
         "test_compare_cpu__softmax_backward_data_xpu_float16",
+        "test_compare_cpu_histc_xpu_bfloat16",
+        "test_compare_cpu_histc_xpu_float16",
         # TestCompositeCompliance::test_cow_input
         # XPU Tensor fails in copy-on-write cases
         # AssertionError: False is not true : Keyword argument 'output grad 0' during backward call unexpectedly materializes.


### PR DESCRIPTION
We decided to keep the data type consistent with the CPU for the `histc` op.