### PR TITLE
Optimize roi_align on BMG

### DIFF
--- a/src/ATen/native/xpu/sycl/UpSampleBilinear2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleBilinear2dKernels.cpp
@@ -425,9 +425,9 @@ struct UpsampleBilinear2dBackwardNotAlignKernelFunctor {
           // scale is 1 if on boundary
           distance_w =
               distance_w + is_boundary_w * (output_width_ * 2 - distance_w);
-          bool is_boundary_h =
-              !((point_h >= output_height_) &&
-                (point_h <= output_height_ * input_height_ * 2 - output_height_));
+          bool is_boundary_h = !(
+              (point_h >= output_height_) &&
+              (point_h <= output_height_ * input_height_ * 2 - output_height_));
           distance_h =
               distance_h + is_boundary_h * (output_height_ * 2 - distance_h);
           accscalar_t scale =
@@ -606,8 +606,10 @@ void launch_upsample_bilinear2d_backward_kernel(
   // TODO: when input 3x3, scale is 1.5, output is 4x4,
   // pytorch prefer use 1/1.5, but my implementation treat it as 3/4...
   // I also have to skip double because of rounding issues, it will not pass ut
-  can_optimize = can_optimize && (align_corners || (input_width == (rwidth * output_width) &&
-      input_height == (rheight * output_height))) &&
+  can_optimize = can_optimize &&
+      (align_corners ||
+       (input_width == (rwidth * output_width) &&
+        input_height == (rheight * output_height))) &&
       !std::is_same<scalar_t, double>::value;
   if (can_optimize) {
     if (align_corners) {
@@ -790,8 +792,10 @@ void launch_upsample_bilinear2d_backward_nhwc_kernel(
   // TODO: when input 3x3, scale is 1.5, output is 4x4,
   // pytorch prefer use 1/1.5, but my implementation treat it as 3/4...
   // I also have to skip double because of rounding issues, it will not pass ut
-  can_optimize = can_optimize && (align_corners || (input_width == (rwidth * output_width) &&
-      input_height == (rheight * output_height))) &&
+  can_optimize = can_optimize &&
+      (align_corners ||
+       (input_width == (rwidth * output_width) &&
+        input_height == (rheight * output_height))) &&
       !std::is_same<scalar_t, double>::value;
   if (can_optimize) {
     if (align_corners) {


### PR DESCRIPTION
For input [1, 2048, 50, 75], rois [1000,5], roi align takes 4.7 ms on PVC but 75 ms on BMG. Each roi will have 2048x50x75 work items reading the same value from LLC, and it's very slow on BMG. After opt, PVC takes 2.42ms, BMG reaches  5.7ms