### PR TITLE
layernorm: supplement for adaptive wg size adjustment

### DIFF
--- a/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
@@ -553,8 +553,8 @@ void launch_vectorized_layer_norm_kernel(
     T_ACC* mean_data,
     T_ACC* rstd_data) {
   using KernelClass = VectorizedLayerNormKernelFunctor<T, T_ACC>;
-  auto wg_size =
-      layer_norm_wg_size_select(syclMaxWorkGroupSize<KernelClass>(), N);
+  auto wg_size = layer_norm_wg_size_select(
+      syclMaxWorkGroupSize<KernelClass>(), N / vec_size);
   KernelClass kfn(
       N,
       eps,


### PR DESCRIPTION
This PR is a supplement for PR https://github.com/intel/torch-xpu-ops/pull/1635.
From the work scheduling, consider the benchmark model hf_Bert_large as an example, which utilizes a layernorm with a shape of [16, 128, 1024]. Since the vec_size is set to 4, 256 items per work group can help solve the norm operation on 1024 elements.
From the coding perspective,  the kernel implementation uses "const int n_vec_to_read = N / vec_size; " to set active items. So the item num of each work group should be  N / vec_size instead of N.

# Perf data.
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/wdeng/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/wdeng/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl63
	{mso-number-format:0%;}
-->
</style>
</head>

<body link="#467886" vlink="#96607D">


  | main | PR | imporvement
-- | -- | -- | --
128, 197, 384 | 181.304us | 52.624us | 345%
16, 128, 1024 | 76.152us | 19.232us | 396%
2,   4096, 320 | 61.800us | 19.816us | 312%
512,   3136, 128 | 5.144ms | 1.076ms | 478%
1, 1024 | 6.128us | 5.320us | 115%



</body>

</html>

