### PR TITLE
optimize embedding bag

### DIFF
--- a/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
+++ b/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
@@ -73,7 +73,7 @@ void embedding_bag(
 
   int vectorized_feature_dim = feature_dim / vec_size;
   int64_t work_group_size = syclMaxWorkGroupSize<KernelClass>();
-  // TODO: we can set num_work_group = 1024 and add for loop in kernel
+  // TODO: we can set a smaller num_work_group and add for loop in kernel
   int64_t num_work_group = ceil_div(
       static_cast<int64_t>(bag_num * vectorized_feature_dim),
       static_cast<int64_t>(work_group_size));

--- a/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
+++ b/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
@@ -73,8 +73,9 @@ void embedding_bag(
 
   vec_len = vec_len / vec_size;
   int tile = 1;
-  if (32 % vec_len == 0) {
-    tile = 32 / vec_len;
+  int sub_group_size = syclMaxSubGroupSize();
+  if (sub_group_size % vec_len == 0) {
+    tile = sub_group_size / vec_len;
   }
   int batch = (bag_num + tile - 1) / tile;
   BatchKernelConfig cfg = BatchKernelConfig::make_config<KernelClass>(

--- a/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
+++ b/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
@@ -418,6 +418,14 @@ void embedding_bag_mean_template(
               int vec_size = memory::can_vectorize_up_to<scalar_t>(
                   (char*)weights.const_data_ptr());
               vec_size = feature_dim % vec_size == 0 ? vec_size : 1;
+              for (int v : {8, 4, 2, 1}) {
+                // We only load one weight[i] in one subgroup, otherwise memory
+                // load cannot be coalesce
+                if (feature_dim % v == 0 && (feature_dim / v) % 32 == 0) {
+                  vec_size = v;
+                  break;
+                }
+              }
               switch (vec_size) {
                 case 8:
                   EXTEND_EMBBAG_MEAN_KERNEL_VEC(8);
@@ -485,6 +493,14 @@ void embedding_bag_max_template(
               int vec_size = memory::can_vectorize_up_to<scalar_t>(
                   (char*)weights.const_data_ptr());
               vec_size = feature_dim % vec_size == 0 ? vec_size : 1;
+              for (int v : {8, 4, 2, 1}) {
+                // We only load one weight[i] in one subgroup, otherwise memory
+                // load cannot be coalesce
+                if (feature_dim % v == 0 && (feature_dim / v) % 32 == 0) {
+                  vec_size = v;
+                  break;
+                }
+              }
               switch (vec_size) {
                 case 8:
                   EXTEND_EMBBAG_MAX_KERNEL_VEC(8);

--- a/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
+++ b/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
@@ -342,17 +342,16 @@ void embedding_bag_sum_template(
               int vec_size = memory::can_vectorize_up_to<scalar_t>(
                   (char*)weights.const_data_ptr());
               vec_size = feature_dim % vec_size == 0 ? vec_size : 1;
-              auto num_wg = bag_num * feature_dim / vec_size /
-                  syclDeviceMaxWorkGroupSize();
-              auto num_xe = syclGpuEuCount() / syclGpuEUCountPerSubslice();
-              if (num_wg < num_xe) {
-                for (int v = vec_size; v != 1; v = v / 2) {
-                  // We only load one weight[i] in one subgroup, otherwise
-                  // memory load cannot be coalesce
-                  if (feature_dim % v == 0 && (feature_dim / v) % 32 == 0) {
-                    vec_size = v;
-                    break;
-                  }
+              int num_sub_wg =
+                  bag_num * feature_dim / vec_size / syclMaxSubGroupSize();
+              int thread_slots = syclGpuEuCount() * syclGpuHWThreadsPerEU();
+              for (int v = vec_size; v != 1;
+                   v = v / 2, num_sub_wg = num_sub_wg * 2) {
+                if (2 * num_sub_wg > thread_slots) {
+                  // peak occurancy = num_sub_wg / thread_slots
+                  // it should > 50%
+                  vec_size = v;
+                  break;
                 }
               }
               switch (vec_size) {
@@ -423,17 +422,16 @@ void embedding_bag_mean_template(
               int vec_size = memory::can_vectorize_up_to<scalar_t>(
                   (char*)weights.const_data_ptr());
               vec_size = feature_dim % vec_size == 0 ? vec_size : 1;
-              auto num_wg = bag_num * feature_dim / vec_size /
-                  syclDeviceMaxWorkGroupSize();
-              auto num_xe = syclGpuEuCount() / syclGpuEUCountPerSubslice();
-              if (num_wg < num_xe) {
-                for (int v = vec_size; v != 1; v = v / 2) {
-                  // We only load one weight[i] in one subgroup, otherwise
-                  // memory load cannot be coalesce
-                  if (feature_dim % v == 0 && (feature_dim / v) % 32 == 0) {
-                    vec_size = v;
-                    break;
-                  }
+              int num_sub_wg =
+                  bag_num * feature_dim / vec_size / syclMaxSubGroupSize();
+              int thread_slots = syclGpuEuCount() * syclGpuHWThreadsPerEU();
+              for (int v = vec_size; v != 1;
+                   v = v / 2, num_sub_wg = num_sub_wg * 2) {
+                if (2 * num_sub_wg > thread_slots) {
+                  // peak occurancy = num_sub_wg / thread_slots
+                  // it should > 50%
+                  vec_size = v;
+                  break;
                 }
               }
               switch (vec_size) {
@@ -503,17 +501,16 @@ void embedding_bag_max_template(
               int vec_size = memory::can_vectorize_up_to<scalar_t>(
                   (char*)weights.const_data_ptr());
               vec_size = feature_dim % vec_size == 0 ? vec_size : 1;
-              auto num_wg = bag_num * feature_dim / vec_size /
-                  syclDeviceMaxWorkGroupSize();
-              auto num_xe = syclGpuEuCount() / syclGpuEUCountPerSubslice();
-              if (num_wg < num_xe) {
-                for (int v = vec_size; v != 1; v = v / 2) {
-                  // We only load one weight[i] in one subgroup, otherwise
-                  // memory load cannot be coalesce
-                  if (feature_dim % v == 0 && (feature_dim / v) % 32 == 0) {
-                    vec_size = v;
-                    break;
-                  }
+              int num_sub_wg =
+                  bag_num * feature_dim / vec_size / syclMaxSubGroupSize();
+              int thread_slots = syclGpuEuCount() * syclGpuHWThreadsPerEU();
+              for (int v = vec_size; v != 1;
+                   v = v / 2, num_sub_wg = num_sub_wg * 2) {
+                if (2 * num_sub_wg > thread_slots) {
+                  // peak occurancy = num_sub_wg / thread_slots
+                  // it should > 50%
+                  vec_size = v;
+                  break;
                 }
               }
               switch (vec_size) {

--- a/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
+++ b/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
@@ -52,9 +52,9 @@ void embedding_bag(
     index_t padding_idx,
     bool ignore_offsets,
     int64_t num_row) {
-  using vec_t = at::detail::Array<scalar_t, vec_size>;
-  using vec_acc_t = at::detail::Array<accscalar_t, vec_size>;
-  using vec_idx_t = at::detail::Array<index_t, vec_size>;
+  using vec_t = memory::aligned_vector<scalar_t, vec_size>;
+  using vec_acc_t = memory::aligned_vector<accscalar_t, vec_size>;
+  using vec_idx_t = memory::aligned_vector<index_t, vec_size>;
   using KernelClass = EmbeddingBagKernelFunctor<
       scalar_t,
       accscalar_t,

--- a/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
+++ b/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
@@ -348,7 +348,7 @@ void embedding_bag_sum_template(
               for (int v = vec_size; v != 1;
                    v = v / 2, num_sub_wg = num_sub_wg * 2) {
                 if (2 * num_sub_wg > thread_slots) {
-                  // peak occurancy = num_sub_wg / thread_slots
+                  // peak occupancy = num_sub_wg / thread_slots
                   // it should > 50%
                   vec_size = v;
                   break;
@@ -428,7 +428,7 @@ void embedding_bag_mean_template(
               for (int v = vec_size; v != 1;
                    v = v / 2, num_sub_wg = num_sub_wg * 2) {
                 if (2 * num_sub_wg > thread_slots) {
-                  // peak occurancy = num_sub_wg / thread_slots
+                  // peak occupancy = num_sub_wg / thread_slots
                   // it should > 50%
                   vec_size = v;
                   break;
@@ -507,7 +507,7 @@ void embedding_bag_max_template(
               for (int v = vec_size; v != 1;
                    v = v / 2, num_sub_wg = num_sub_wg * 2) {
                 if (2 * num_sub_wg > thread_slots) {
-                  // peak occurancy = num_sub_wg / thread_slots
+                  // peak occupancy = num_sub_wg / thread_slots
                   // it should > 50%
                   vec_size = v;
                   break;

--- a/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
+++ b/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
@@ -72,8 +72,13 @@ void embedding_bag(
   vec_idx_t* max_idx_vec = reinterpret_cast<vec_idx_t*>(max_index);
 
   vec_len = vec_len / vec_size;
+  int tile = 1;
+  if (32 % vec_len == 0) {
+    tile = 32 / vec_len;
+  }
+  int batch = (bag_num + tile - 1) / tile;
   BatchKernelConfig cfg = BatchKernelConfig::make_config<KernelClass>(
-      bag_num, vec_len, 1, bag_num, true, BatchKernelConfig::Policy::pAdaptive);
+      batch, vec_len * tile, 1, batch, true, BatchKernelConfig::Policy::pAdaptive);
 
   index_t fixing_bag_size = ignore_offsets ? index_size / bag_num : 0;
   auto kfn = KernelClass(
@@ -86,6 +91,7 @@ void embedding_bag(
       index_size,
       bag_num,
       vec_len,
+      tile,
       padding_idx,
       ignore_offsets,
       o_vec,

--- a/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
+++ b/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
@@ -342,14 +342,14 @@ void embedding_bag_sum_template(
               int vec_size = memory::can_vectorize_up_to<scalar_t>(
                   (char*)weights.const_data_ptr());
               vec_size = feature_dim % vec_size == 0 ? vec_size : 1;
-              for (int v : {8, 4, 2, 1}) {
-                // We only load one weight[i] in one subgroup, otherwise memory
-                // load cannot be coalesce
-                if (feature_dim % v == 0 && (feature_dim / v) % 32 == 0) {
-                  vec_size = v;
-                  break;
-                }
-              }
+              // for (int v : {8, 4, 2, 1}) {
+              //   // We only load one weight[i] in one subgroup, otherwise memory
+              //   // load cannot be coalesce
+              //   if (feature_dim % v == 0 && (feature_dim / v) % 32 == 0) {
+              //     vec_size = v;
+              //     break;
+              //   }
+              // }
               switch (vec_size) {
                 case 8:
                   EXTEND_EMBBAG_SUM_KERNEL_VEC(8);
@@ -418,14 +418,6 @@ void embedding_bag_mean_template(
               int vec_size = memory::can_vectorize_up_to<scalar_t>(
                   (char*)weights.const_data_ptr());
               vec_size = feature_dim % vec_size == 0 ? vec_size : 1;
-              for (int v : {8, 4, 2, 1}) {
-                // We only load one weight[i] in one subgroup, otherwise memory
-                // load cannot be coalesce
-                if (feature_dim % v == 0 && (feature_dim / v) % 32 == 0) {
-                  vec_size = v;
-                  break;
-                }
-              }
               switch (vec_size) {
                 case 8:
                   EXTEND_EMBBAG_MEAN_KERNEL_VEC(8);
@@ -493,14 +485,6 @@ void embedding_bag_max_template(
               int vec_size = memory::can_vectorize_up_to<scalar_t>(
                   (char*)weights.const_data_ptr());
               vec_size = feature_dim % vec_size == 0 ? vec_size : 1;
-              for (int v : {8, 4, 2, 1}) {
-                // We only load one weight[i] in one subgroup, otherwise memory
-                // load cannot be coalesce
-                if (feature_dim % v == 0 && (feature_dim / v) % 32 == 0) {
-                  vec_size = v;
-                  break;
-                }
-              }
               switch (vec_size) {
                 case 8:
                   EXTEND_EMBBAG_MAX_KERNEL_VEC(8);

--- a/src/ATen/native/xpu/sycl/EmbeddingBag.h
+++ b/src/ATen/native/xpu/sycl/EmbeddingBag.h
@@ -90,7 +90,7 @@ struct EmbeddingBagKernelFunctor {
         for (index_t off = start; off < end; off++) {
           index_off = off;
           vec_idx = index_[index_off];
-          // SYCL_KERNEL_ASSERT(vec_idx < num_row_);
+          SYCL_KERNEL_ASSERT(vec_idx < num_row_);
 
           if (walk_on_bag && desc.glb_problem == 0) {
             offset2bag_[index_off] = off_off;

--- a/src/ATen/native/xpu/sycl/EmbeddingBag.h
+++ b/src/ATen/native/xpu/sycl/EmbeddingBag.h
@@ -32,7 +32,6 @@ struct EmbeddingBagKernelFunctor {
       auto current_bag = thread_id / vectorized_feature_dim_len_;
       index_t start, end;
       bool last_bag = current_bag == bag_num_ - 1;
-      // TODO: add template
       if (!ignore_offsets_) {
         start = offset_[current_bag];
         end = last_bag ? index_size_ : offset_[current_bag + 1];


### PR DESCRIPTION
I have remove the batch kernel config so that igc will choose grf mode 128 with the sycl assert inside kernel with vec size = 8. We can now get equivalent optimization compare to previous result.

~~1. remove SYCL_KERNEL_ASSERT, this will change grf mode from 256 to 128, but there is an existing issue https://github.com/intel/torch-xpu-ops/issues/1052, I did not remove it in this pr. We should add NDEBUG flag later or use vec_size = 4~~
2. I see instruction fetch stalls because of the if branches, so move them to template params.
3. I also fixed the vectorization. Previously we actually do not enable it.
4. Previously we only use 256 threads per workgroup, but workgroup size is 1024

performance on input [409581], weight [1000000,64], offset [4096] (4096 bags), dtype = half, mode = sum

|    | PVC | BMG |
| ------------- | ------------- |----|
| main branch | 0.18ms | 0.43ms |
| current change | 0.08ms | 0.23ms |
| current change + if we remove assert | 0.07 ms | 0.22 ms|

| ~~remove sycl assert~~ | ~~0.10ms~~ | ~~0.30 ms~~ |
| ~~remove branching~~ | ~~0.08ms~~ | ~~0.28 ms~~ |
| ~~tiling~~ | ~~0.087ms~~ | ~~0.22 ms~~ |

~~Note: We are stalled [here](https://github.com/intel/torch-xpu-ops/blob/5b4d7444484576f721d2295761cf8fafa924ef36/src/ATen/native/xpu/sycl/EmbeddingBag.h#L68)  `vec_t other = w_vec_[i_off];` when vector size is 8, the assembly is `load.ugm.d32.a64; load.ugm.d32.a64.flat[A+0x4]; load.ugm.d32.a64.flat[A+0x8]; load.ugm.d32.a64.flat[A+0xC];` After fix, it changes to `load.ugm.d32x4`. There is no performance change on peak frequency, but when profiling on lower frequency, I see 9% faster.~~

~~PVC does not benefit from tiling, in this case, there will be 32 workgroups but 64 Xe core. However, even we set vec_size =4, tiling 2 batch is still a regression. The best config is vec_size=4, and set workgroup size =512, it can reach 0.71ms. There's no benefit on BMG to set a smaller work group size.~~


























































