### PR TITLE
[CI] Update accuracy reference according to pytorch 2.8 rc3 test results

### DIFF
--- a/.github/ci_expected_accuracy/lts/inductor_huggingface_training.csv
+++ b/.github/ci_expected_accuracy/lts/inductor_huggingface_training.csv
@@ -1,10 +1,10 @@
 name,float32,bfloat16,float16,amp_bf16,amp_fp16
-# https://github.com/intel/torch-xpu-ops/issues/1768
-# https://github.com/intel/torch-xpu-ops/issues/1767
-AlbertForMaskedLM,pass,pass,fail_accuracy,pass,fail_accuracy
-# https://github.com/intel/torch-xpu-ops/issues/1768
-# https://github.com/intel/torch-xpu-ops/issues/1767
-AlbertForQuestionAnswering,pass,fail_accuracy,fail_accuracy,fail_accuracy,fail_accuracy
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1767,,,,,
+AlbertForMaskedLM,pass,pass,pass,pass,pass
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1767,,,,,
+AlbertForQuestionAnswering,pass,pass,pass,pass,pass
 AllenaiLongformerBase,pass,pass,pass,pass,pass
 BartForCausalLM,pass,pass,pass,pass,pass
 BartForConditionalGeneration,pass,pass,pass,pass,pass
@@ -17,7 +17,7 @@ CamemBert,pass,pass,pass,pass,pass
 DebertaForMaskedLM,pass,pass,pass,pass,pass
 DebertaForQuestionAnswering,pass,pass,pass,pass,pass
 DebertaV2ForMaskedLM,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
-# Skip DebertaV2ForQuestionAnswering issue: https://github.com/intel/torch-xpu-ops/issues/1216
+# Skip DebertaV2ForQuestionAnswering issue: https://github.com/intel/torch-xpu-ops/issues/1216,,,,,
 DebertaV2ForQuestionAnswering,fail_accuracy,fail_accuracy,fail_accuracy,pass,pass
 DistilBertForMaskedLM,pass,pass,pass,pass,pass
 DistilBertForQuestionAnswering,pass,pass,pass,pass,pass
@@ -31,8 +31,8 @@ LayoutLMForSequenceClassification,pass,pass,pass,pass,pass
 M2M100ForConditionalGeneration,pass,pass,pass,pass,pass
 MBartForCausalLM,pass,pass,pass,pass,pass
 MBartForConditionalGeneration,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768
-MT5ForConditionalGeneration,pass,fail_accuracy,pass,pass,pass
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+MT5ForConditionalGeneration,pass,pass,pass,pass,pass
 MegatronBertForCausalLM,pass,pass,pass,pass,pass
 MegatronBertForQuestionAnswering,pass,pass,pass,pass,pass
 MobileBertForMaskedLM,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/lts/inductor_huggingface_training.csv
+++ b/.github/ci_expected_accuracy/lts/inductor_huggingface_training.csv
@@ -1,9 +1,5 @@
 name,float32,bfloat16,float16,amp_bf16,amp_fp16
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
-# https://github.com/intel/torch-xpu-ops/issues/1767,,,,,
 AlbertForMaskedLM,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
-# https://github.com/intel/torch-xpu-ops/issues/1767,,,,,
 AlbertForQuestionAnswering,pass,pass,pass,pass,pass
 AllenaiLongformerBase,pass,pass,pass,pass,pass
 BartForCausalLM,pass,pass,pass,pass,pass
@@ -17,7 +13,7 @@ CamemBert,pass,pass,pass,pass,pass
 DebertaForMaskedLM,pass,pass,pass,pass,pass
 DebertaForQuestionAnswering,pass,pass,pass,pass,pass
 DebertaV2ForMaskedLM,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
-# Skip DebertaV2ForQuestionAnswering issue: https://github.com/intel/torch-xpu-ops/issues/1216,,,,,
+# Skip DebertaV2ForQuestionAnswering issue: https://github.com/intel/torch-xpu-ops/issues/1216
 DebertaV2ForQuestionAnswering,fail_accuracy,fail_accuracy,fail_accuracy,pass,pass
 DistilBertForMaskedLM,pass,pass,pass,pass,pass
 DistilBertForQuestionAnswering,pass,pass,pass,pass,pass
@@ -31,7 +27,6 @@ LayoutLMForSequenceClassification,pass,pass,pass,pass,pass
 M2M100ForConditionalGeneration,pass,pass,pass,pass,pass
 MBartForCausalLM,pass,pass,pass,pass,pass
 MBartForConditionalGeneration,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
 MT5ForConditionalGeneration,pass,pass,pass,pass,pass
 MegatronBertForCausalLM,pass,pass,pass,pass,pass
 MegatronBertForQuestionAnswering,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/lts/inductor_timm_models_training.csv
+++ b/.github/ci_expected_accuracy/lts/inductor_timm_models_training.csv
@@ -19,7 +19,8 @@ eca_halonext26ts,pass,pass,pass,pass,pass
 ese_vovnet19b_dw,pass,pass,pass,pass,pass
 fbnetc_100,pass,pass,pass,pass,pass
 # https://github.com/intel/torch-xpu-ops/issues/1275
-fbnetv3_b,pass,pass,pass,fail_accuracy,pass
+# https://github.com/intel/torch-xpu-ops/issues/1765
+fbnetv3_b,pass,fail_accuracy,pass,fail_accuracy,pass
 gernet_l,pass,pass,pass,pass,pass
 ghostnet_100,pass,pass,pass,pass,pass
 gluon_inception_v3,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/lts/inductor_timm_models_training.csv
+++ b/.github/ci_expected_accuracy/lts/inductor_timm_models_training.csv
@@ -2,12 +2,11 @@ name,float32,bfloat16,float16,amp_bf16,amp_fp16
 adv_inception_v3,pass,pass,pass,pass,pass
 beit_base_patch16_224,pass,pass,pass,pass,pass
 botnet26t_256,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
 cait_m36_384,pass,pass,pass,pass,pass
 coat_lite_mini,pass,pass,pass,pass,pass
 convit_base,pass,pass,pass,pass,pass
 convmixer_768_32,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1274,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1274
 convnext_base,pass,fail_accuracy,fail_accuracy,pass,pass
 crossvit_9_240,pass,pass,pass,pass,pass
 cspdarknet53,pass,pass,pass,pass,pass
@@ -19,8 +18,7 @@ eca_botnext26ts_256,pass,pass,pass,pass,pass
 eca_halonext26ts,pass,pass,pass,pass,pass
 ese_vovnet19b_dw,pass,pass,pass,pass,pass
 fbnetc_100,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1275,,,,,
-# https://github.com/intel/torch-xpu-ops/issues/1765,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1275
 fbnetv3_b,pass,pass,pass,fail_accuracy,pass
 gernet_l,pass,pass,pass,pass,pass
 ghostnet_100,pass,pass,pass,pass,pass
@@ -35,7 +33,6 @@ levit_128,pass,pass,pass,pass,pass
 mixer_b16_224,pass,pass,pass,pass,pass
 mixnet_l,pass,pass,pass,pass,pass
 mnasnet_100,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
 mobilenetv2_100,pass,pass,pass,pass,pass
 mobilenetv3_large_100,pass,pass,pass,pass,pass
 mobilevit_s,pass,pass,pass,pass,pass
@@ -54,10 +51,9 @@ rexnet_100,pass,pass,pass,pass,pass
 sebotnet33ts_256,pass,pass,pass,pass,pass
 selecsls42b,pass,pass,pass,pass,pass
 spnasnet_100,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1768
 swin_base_patch4_window7_224,pass,fail_accuracy,fail_accuracy,pass,pass
 swsl_resnext101_32x16d,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1767,,,,,
 tf_efficientnet_b0,pass,pass,pass,pass,pass
 tf_mixnet_l,pass,pass,pass,pass,pass
 tinynet_a,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/lts/inductor_timm_models_training.csv
+++ b/.github/ci_expected_accuracy/lts/inductor_timm_models_training.csv
@@ -2,12 +2,12 @@ name,float32,bfloat16,float16,amp_bf16,amp_fp16
 adv_inception_v3,pass,pass,pass,pass,pass
 beit_base_patch16_224,pass,pass,pass,pass,pass
 botnet26t_256,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768
-cait_m36_384,pass,pass,fail_accuracy,pass,pass
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+cait_m36_384,pass,pass,pass,pass,pass
 coat_lite_mini,pass,pass,pass,pass,pass
 convit_base,pass,pass,pass,pass,pass
 convmixer_768_32,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1274
+# https://github.com/intel/torch-xpu-ops/issues/1274,,,,,
 convnext_base,pass,fail_accuracy,fail_accuracy,pass,pass
 crossvit_9_240,pass,pass,pass,pass,pass
 cspdarknet53,pass,pass,pass,pass,pass
@@ -19,12 +19,12 @@ eca_botnext26ts_256,pass,pass,pass,pass,pass
 eca_halonext26ts,pass,pass,pass,pass,pass
 ese_vovnet19b_dw,pass,pass,pass,pass,pass
 fbnetc_100,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1275
-# https://github.com/intel/torch-xpu-ops/issues/1765
-fbnetv3_b,pass,fail_accuracy,pass,fail_accuracy,pass
+# https://github.com/intel/torch-xpu-ops/issues/1275,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1765,,,,,
+fbnetv3_b,pass,pass,pass,fail_accuracy,pass
 gernet_l,pass,pass,pass,pass,pass
 ghostnet_100,pass,pass,pass,pass,pass
-gluon_inception_v3,pass,fail_accuracy,pass,pass,pass
+gluon_inception_v3,pass,pass,pass,pass,pass
 gmixer_24_224,pass,pass,pass,pass,pass
 gmlp_s16_224,pass,pass,pass,pass,pass
 hrnet_w18,pass,pass,pass,pass,pass
@@ -35,8 +35,8 @@ levit_128,pass,pass,pass,pass,pass
 mixer_b16_224,pass,pass,pass,pass,pass
 mixnet_l,pass,pass,pass,pass,pass
 mnasnet_100,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768
-mobilenetv2_100,pass,pass,fail_accuracy,pass,pass
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+mobilenetv2_100,pass,pass,pass,pass,pass
 mobilenetv3_large_100,pass,pass,pass,pass,pass
 mobilevit_s,pass,pass,pass,pass,pass
 nfnet_l0,pass,pass,pass,pass,pass
@@ -54,11 +54,11 @@ rexnet_100,pass,pass,pass,pass,pass
 sebotnet33ts_256,pass,pass,pass,pass,pass
 selecsls42b,pass,pass,pass,pass,pass
 spnasnet_100,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
 swin_base_patch4_window7_224,pass,fail_accuracy,fail_accuracy,pass,pass
 swsl_resnext101_32x16d,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1767
-tf_efficientnet_b0,pass,pass,fail_accuracy,pass,pass
+# https://github.com/intel/torch-xpu-ops/issues/1767,,,,,
+tf_efficientnet_b0,pass,pass,pass,pass,pass
 tf_mixnet_l,pass,pass,pass,pass,pass
 tinynet_a,pass,pass,pass,pass,pass
 tnt_s_patch16_224,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/lts/inductor_torchbench_inference.csv
+++ b/.github/ci_expected_accuracy/lts/inductor_torchbench_inference.csv
@@ -1,7 +1,7 @@
 name,float32,bfloat16,float16,amp_bf16,amp_fp16
-# https://github.com/intel/torch-xpu-ops/issues/1221
-torchrec_dlrm,pass,eager_fail_to_run,eager_fail_to_run,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768
+# https://github.com/intel/torch-xpu-ops/issues/1221,,,,,
+torchrec_dlrm,pass,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,pass
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
 BERT_pytorch,pass,pass,pass,fail_accuracy,pass
 Background_Matting,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
 DALLE2_pytorch,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
@@ -16,23 +16,23 @@ cm3leon_generate,pass,pass,pass,pass,pass
 dcgan,pass,pass,pass,pass,pass
 demucs,pass,pass,pass,pass,pass
 densenet121,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1278
-detectron2_fasterrcnn_r_101_c4,pass,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
-detectron2_fasterrcnn_r_101_dc5,pass,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
-detectron2_fasterrcnn_r_101_fpn,pass,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
-detectron2_fasterrcnn_r_50_c4,pass,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
-detectron2_fasterrcnn_r_50_dc5,pass,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
-detectron2_fasterrcnn_r_50_fpn,pass,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
+# https://github.com/intel/torch-xpu-ops/issues/1278,,,,,
+detectron2_fasterrcnn_r_101_c4,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
+detectron2_fasterrcnn_r_101_dc5,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
+detectron2_fasterrcnn_r_101_fpn,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
+detectron2_fasterrcnn_r_50_c4,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
+detectron2_fasterrcnn_r_50_dc5,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
+detectron2_fasterrcnn_r_50_fpn,pass,eager_fail_to_run,pass,fail_accuracy,fail_accuracy
 detectron2_fcos_r_50_fpn,pass,pass,pass,pass,pass
 detectron2_maskrcnn,fail_to_run,eager_fail_to_run,fail_to_run,eager_fail_to_run,fail_to_run
-detectron2_maskrcnn_r_101_c4,fail_accuracy,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
-detectron2_maskrcnn_r_101_fpn,fail_accuracy,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
-detectron2_maskrcnn_r_50_c4,pass,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
-detectron2_maskrcnn_r_50_fpn,pass,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
+detectron2_maskrcnn_r_101_c4,fail_accuracy,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
+detectron2_maskrcnn_r_101_fpn,fail_accuracy,eager_fail_to_run,eager_1st_run_OOM,eager_1st_run_OOM,fail_accuracy
+detectron2_maskrcnn_r_50_c4,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
+detectron2_maskrcnn_r_50_fpn,pass,eager_fail_to_run,eager_1st_run_OOM,eager_1st_run_OOM,fail_accuracy
 dlrm,pass,pass,pass,pass,pass
 doctr_det_predictor,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768
-doctr_reco_predictor,pass,pass,pass,fail_accuracy,pass
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+doctr_reco_predictor,pass,pass,pass,pass,pass
 drq,pass,pass,pass,pass,pass
 fastNLP_Bert,pass,pass,pass,pass,pass
 functorch_dp_cifar10,pass,pass,pass,pass,pass
@@ -43,13 +43,13 @@ hf_Bert,pass,pass,pass,pass,pass
 hf_Bert_large,pass,pass,pass,pass,pass
 hf_BigBird,pass,pass,pass,pass,pass
 hf_DistilBert,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1767
+# https://github.com/intel/torch-xpu-ops/issues/1767,,,,,
 hf_GPT2,pass,eager_two_runs_differ,eager_two_runs_differ,eager_two_runs_differ,eager_two_runs_differ
 hf_GPT2_large,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
 hf_Longformer,pass,pass,pass,pass,pass
 hf_Reformer,pass,pass,pass,pass,pass
 hf_T5,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1276
+# https://github.com/intel/torch-xpu-ops/issues/1276,,,,,
 hf_T5_base,pass,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 hf_T5_generate,pass,pass,pass,pass,pass
 hf_T5_large,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
@@ -59,7 +59,7 @@ hf_distil_whisper,pass,pass,pass,pass,pass
 lennard_jones,pass,pass,pass,pass,pass
 llama,pass,pass,pass,pass,pass
 llama_v2_7b_16h,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
-# https://github.com/intel/torch-xpu-ops/issues/1277
+# https://github.com/intel/torch-xpu-ops/issues/1277,,,,,
 llava,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 maml,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
 maml_omniglot,pass,pass,pass,pass,pass
@@ -68,9 +68,9 @@ mnasnet1_0,pass,pass,pass,pass,pass
 mobilenet_v2,pass,pass,pass,pass,pass
 mobilenet_v2_quantized_qat,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load
 mobilenet_v3_large,pass,pass,pass,pass,pass
-moco,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,model_fail_to_load,model_fail_to_load
+moco,eager_fail_to_run,eager_fail_to_run,model_fail_to_load,model_fail_to_load,model_fail_to_load
 moondream,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1767
+# https://github.com/intel/torch-xpu-ops/issues/1767,,,,,
 nanogpt,pass,eager_two_runs_differ,eager_two_runs_differ,eager_two_runs_differ,eager_two_runs_differ
 nvidia_deeprecommender,pass,pass,pass,pass,pass
 opacus_cifar10,pass,pass,pass,pass,pass
@@ -96,7 +96,7 @@ soft_actor_critic,pass,pass,pass,pass,pass
 speech_transformer,pass,pass,pass,pass,pass
 squeezenet1_1,pass,fail_accuracy,pass,pass,pass
 stable_diffusion_text_encoder,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1261
+# https://github.com/intel/torch-xpu-ops/issues/1261,,,,,
 stable_diffusion_unet,eager_fail_to_run,pass_due_to_skip,pass_due_to_skip,eager_fail_to_run,eager_fail_to_run
 tacotron2,pass,pass,pass,fail_to_run,fail_to_run
 timm_efficientdet,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load
@@ -107,7 +107,7 @@ timm_resnest,pass,pass,pass,pass,pass
 timm_vision_transformer,pass,pass,pass,pass,pass
 timm_vision_transformer_large,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
 timm_vovnet,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1767
+# https://github.com/intel/torch-xpu-ops/issues/1767,,,,,
 torch_multimodal_clip,pass,eager_two_runs_differ,eager_two_runs_differ,eager_two_runs_differ,eager_two_runs_differ
 tts_angular,pass,pass,pass,pass,pass
 vgg16,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/lts/inductor_torchbench_inference.csv
+++ b/.github/ci_expected_accuracy/lts/inductor_torchbench_inference.csv
@@ -1,7 +1,7 @@
 name,float32,bfloat16,float16,amp_bf16,amp_fp16
-# https://github.com/intel/torch-xpu-ops/issues/1221,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1221
 torchrec_dlrm,pass,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1768
 BERT_pytorch,pass,pass,pass,fail_accuracy,pass
 Background_Matting,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
 DALLE2_pytorch,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
@@ -16,7 +16,7 @@ cm3leon_generate,pass,pass,pass,pass,pass
 dcgan,pass,pass,pass,pass,pass
 demucs,pass,pass,pass,pass,pass
 densenet121,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1278,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1278
 detectron2_fasterrcnn_r_101_c4,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
 detectron2_fasterrcnn_r_101_dc5,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
 detectron2_fasterrcnn_r_101_fpn,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
@@ -31,7 +31,6 @@ detectron2_maskrcnn_r_50_c4,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,f
 detectron2_maskrcnn_r_50_fpn,pass,eager_fail_to_run,eager_1st_run_OOM,eager_1st_run_OOM,fail_accuracy
 dlrm,pass,pass,pass,pass,pass
 doctr_det_predictor,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
 doctr_reco_predictor,pass,pass,pass,pass,pass
 drq,pass,pass,pass,pass,pass
 fastNLP_Bert,pass,pass,pass,pass,pass
@@ -43,13 +42,13 @@ hf_Bert,pass,pass,pass,pass,pass
 hf_Bert_large,pass,pass,pass,pass,pass
 hf_BigBird,pass,pass,pass,pass,pass
 hf_DistilBert,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1767,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1767
 hf_GPT2,pass,eager_two_runs_differ,eager_two_runs_differ,eager_two_runs_differ,eager_two_runs_differ
 hf_GPT2_large,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
 hf_Longformer,pass,pass,pass,pass,pass
 hf_Reformer,pass,pass,pass,pass,pass
 hf_T5,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1276,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1276
 hf_T5_base,pass,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 hf_T5_generate,pass,pass,pass,pass,pass
 hf_T5_large,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
@@ -59,7 +58,7 @@ hf_distil_whisper,pass,pass,pass,pass,pass
 lennard_jones,pass,pass,pass,pass,pass
 llama,pass,pass,pass,pass,pass
 llama_v2_7b_16h,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
-# https://github.com/intel/torch-xpu-ops/issues/1277,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1277
 llava,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 maml,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
 maml_omniglot,pass,pass,pass,pass,pass
@@ -70,7 +69,7 @@ mobilenet_v2_quantized_qat,model_fail_to_load,model_fail_to_load,model_fail_to_l
 mobilenet_v3_large,pass,pass,pass,pass,pass
 moco,eager_fail_to_run,eager_fail_to_run,model_fail_to_load,model_fail_to_load,model_fail_to_load
 moondream,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1767,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1767
 nanogpt,pass,eager_two_runs_differ,eager_two_runs_differ,eager_two_runs_differ,eager_two_runs_differ
 nvidia_deeprecommender,pass,pass,pass,pass,pass
 opacus_cifar10,pass,pass,pass,pass,pass
@@ -96,7 +95,7 @@ soft_actor_critic,pass,pass,pass,pass,pass
 speech_transformer,pass,pass,pass,pass,pass
 squeezenet1_1,pass,fail_accuracy,pass,pass,pass
 stable_diffusion_text_encoder,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1261,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1261
 stable_diffusion_unet,eager_fail_to_run,pass_due_to_skip,pass_due_to_skip,eager_fail_to_run,eager_fail_to_run
 tacotron2,pass,pass,pass,fail_to_run,fail_to_run
 timm_efficientdet,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load
@@ -107,7 +106,7 @@ timm_resnest,pass,pass,pass,pass,pass
 timm_vision_transformer,pass,pass,pass,pass,pass
 timm_vision_transformer_large,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
 timm_vovnet,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1767,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1767
 torch_multimodal_clip,pass,eager_two_runs_differ,eager_two_runs_differ,eager_two_runs_differ,eager_two_runs_differ
 tts_angular,pass,pass,pass,pass,pass
 vgg16,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/lts/inductor_torchbench_training.csv
+++ b/.github/ci_expected_accuracy/lts/inductor_torchbench_training.csv
@@ -31,10 +31,10 @@ doctr_det_predictor,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_
 doctr_reco_predictor,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 drq,pass,pass,pass,pass,pass
 fastNLP_Bert,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/508
+# https://github.com/intel/torch-xpu-ops/issues/508,,,,,
 functorch_dp_cifar10,fail_accuracy,fail_accuracy,fail_accuracy,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768
-functorch_maml_omniglot,pass,fail_accuracy,pass,pass,pass
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+functorch_maml_omniglot,pass,pass,pass,pass,pass
 hf_Albert,pass,pass,pass,pass,pass
 hf_Bart,pass,pass,pass,pass,pass
 hf_Bert,pass,pass,pass,pass,pass
@@ -63,13 +63,13 @@ mnasnet1_0,pass,pass,pass,pass,pass
 mobilenet_v2,pass,pass,pass,pass,pass
 mobilenet_v2_quantized_qat,pass,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 mobilenet_v3_large,pass,pass,pass,pass,pass
-moco,model_fail_to_load,eager_fail_to_run,eager_fail_to_run,model_fail_to_load,model_fail_to_load
+moco,model_fail_to_load,model_fail_to_load,eager_fail_to_run,model_fail_to_load,model_fail_to_load
 moondream,pass,pass,pass,pass,pass
 nanogpt,pass,pass,pass,pass,pass
 nvidia_deeprecommender,pass,pass,pass,pass,pass
 opacus_cifar10,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 phlippe_densenet,pass,pass,pass,pass,pass
-phlippe_resnet,pass,pass,pass,pass,pass
+phlippe_resnet,pass,fail_accuracy,pass,pass,pass
 pyhpc_equation_of_state,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 pyhpc_isoneutral_mixing,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 pyhpc_turbulent_kinetic_energy,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load
@@ -90,19 +90,19 @@ soft_actor_critic,pass,pass,pass,pass,pass
 speech_transformer,pass,pass,pass,pass,pass
 squeezenet1_1,pass,pass,pass,pass,pass
 stable_diffusion_text_encoder,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1261
+# https://github.com/intel/torch-xpu-ops/issues/1261,,,,,
 stable_diffusion_unet,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 tacotron2,fail_to_run,fail_to_run,fail_to_run,fail_to_run,fail_to_run
 timm_efficientdet,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load
 timm_efficientnet,pass,pass,pass,pass,pass
 timm_nfnet,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1334
+# https://github.com/intel/torch-xpu-ops/issues/1334,,,,,
 timm_regnet,pass,fail_accuracy,pass,pass,pass
 timm_resnest,pass,pass,pass,pass,pass
 timm_vision_transformer,pass,pass,pass,pass,pass
 timm_vision_transformer_large,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
-# https://github.com/intel/torch-xpu-ops/issues/1768
-timm_vovnet,pass,fail_accuracy,pass,pass,pass
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+timm_vovnet,pass,pass,pass,pass,pass
 torch_multimodal_clip,pass,pass,pass,pass,pass
 tts_angular,pass,pass,pass,pass,pass
 vgg16,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/lts/inductor_torchbench_training.csv
+++ b/.github/ci_expected_accuracy/lts/inductor_torchbench_training.csv
@@ -31,9 +31,8 @@ doctr_det_predictor,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_
 doctr_reco_predictor,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 drq,pass,pass,pass,pass,pass
 fastNLP_Bert,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/508,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/508
 functorch_dp_cifar10,fail_accuracy,fail_accuracy,fail_accuracy,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
 functorch_maml_omniglot,pass,pass,pass,pass,pass
 hf_Albert,pass,pass,pass,pass,pass
 hf_Bart,pass,pass,pass,pass,pass
@@ -90,18 +89,17 @@ soft_actor_critic,pass,pass,pass,pass,pass
 speech_transformer,pass,pass,pass,pass,pass
 squeezenet1_1,pass,pass,pass,pass,pass
 stable_diffusion_text_encoder,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1261,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1261
 stable_diffusion_unet,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 tacotron2,fail_to_run,fail_to_run,fail_to_run,fail_to_run,fail_to_run
 timm_efficientdet,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load
 timm_efficientnet,pass,pass,pass,pass,pass
 timm_nfnet,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1334,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1334
 timm_regnet,pass,fail_accuracy,pass,pass,pass
 timm_resnest,pass,pass,pass,pass,pass
 timm_vision_transformer,pass,pass,pass,pass,pass
 timm_vision_transformer_large,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
 timm_vovnet,pass,pass,pass,pass,pass
 torch_multimodal_clip,pass,pass,pass,pass,pass
 tts_angular,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/rolling/inductor_huggingface_training.csv
+++ b/.github/ci_expected_accuracy/rolling/inductor_huggingface_training.csv
@@ -1,7 +1,5 @@
 name,float32,bfloat16,float16,amp_bf16,amp_fp16
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
 AlbertForMaskedLM,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
 AlbertForQuestionAnswering,pass,pass,pass,pass,pass
 AllenaiLongformerBase,pass,pass,pass,pass,pass
 BartForCausalLM,pass,pass,pass,pass,pass
@@ -15,7 +13,7 @@ CamemBert,pass,pass,pass,pass,pass
 DebertaForMaskedLM,pass,pass,pass,pass,pass
 DebertaForQuestionAnswering,pass,pass,pass,pass,pass
 DebertaV2ForMaskedLM,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
-# Skip DebertaV2ForQuestionAnswering issue: https://github.com/intel/torch-xpu-ops/issues/1216,,,,,
+# Skip DebertaV2ForQuestionAnswering issue: https://github.com/intel/torch-xpu-ops/issues/1216
 DebertaV2ForQuestionAnswering,fail_accuracy,fail_accuracy,fail_accuracy,pass,pass
 DistilBertForMaskedLM,pass,pass,pass,pass,pass
 DistilBertForQuestionAnswering,pass,pass,pass,pass,pass
@@ -29,7 +27,6 @@ LayoutLMForSequenceClassification,pass,pass,pass,pass,pass
 M2M100ForConditionalGeneration,pass,pass,pass,pass,pass
 MBartForCausalLM,pass,pass,pass,pass,pass
 MBartForConditionalGeneration,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
 MT5ForConditionalGeneration,pass,pass,pass,pass,pass
 MegatronBertForCausalLM,pass,pass,pass,pass,pass
 MegatronBertForQuestionAnswering,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/rolling/inductor_huggingface_training.csv
+++ b/.github/ci_expected_accuracy/rolling/inductor_huggingface_training.csv
@@ -1,8 +1,8 @@
 name,float32,bfloat16,float16,amp_bf16,amp_fp16
-# https://github.com/intel/torch-xpu-ops/issues/1768
-AlbertForMaskedLM,pass,pass,fail_accuracy,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768
-AlbertForQuestionAnswering,pass,fail_accuracy,fail_accuracy,pass,pass
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+AlbertForMaskedLM,pass,pass,pass,pass,pass
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+AlbertForQuestionAnswering,pass,pass,pass,pass,pass
 AllenaiLongformerBase,pass,pass,pass,pass,pass
 BartForCausalLM,pass,pass,pass,pass,pass
 BartForConditionalGeneration,pass,pass,pass,pass,pass
@@ -15,7 +15,7 @@ CamemBert,pass,pass,pass,pass,pass
 DebertaForMaskedLM,pass,pass,pass,pass,pass
 DebertaForQuestionAnswering,pass,pass,pass,pass,pass
 DebertaV2ForMaskedLM,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
-# Skip DebertaV2ForQuestionAnswering issue: https://github.com/intel/torch-xpu-ops/issues/1216
+# Skip DebertaV2ForQuestionAnswering issue: https://github.com/intel/torch-xpu-ops/issues/1216,,,,,
 DebertaV2ForQuestionAnswering,fail_accuracy,fail_accuracy,fail_accuracy,pass,pass
 DistilBertForMaskedLM,pass,pass,pass,pass,pass
 DistilBertForQuestionAnswering,pass,pass,pass,pass,pass
@@ -29,8 +29,8 @@ LayoutLMForSequenceClassification,pass,pass,pass,pass,pass
 M2M100ForConditionalGeneration,pass,pass,pass,pass,pass
 MBartForCausalLM,pass,pass,pass,pass,pass
 MBartForConditionalGeneration,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768
-MT5ForConditionalGeneration,pass,fail_accuracy,pass,pass,pass
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+MT5ForConditionalGeneration,pass,pass,pass,pass,pass
 MegatronBertForCausalLM,pass,pass,pass,pass,pass
 MegatronBertForQuestionAnswering,pass,pass,pass,pass,pass
 MobileBertForMaskedLM,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/rolling/inductor_timm_models_training.csv
+++ b/.github/ci_expected_accuracy/rolling/inductor_timm_models_training.csv
@@ -2,12 +2,12 @@ name,float32,bfloat16,float16,amp_bf16,amp_fp16
 adv_inception_v3,pass,pass,pass,pass,pass
 beit_base_patch16_224,pass,pass,pass,pass,pass
 botnet26t_256,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768
-cait_m36_384,pass,pass,fail_accuracy,pass,pass
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+cait_m36_384,pass,pass,pass,pass,pass
 coat_lite_mini,pass,pass,pass,pass,pass
 convit_base,pass,pass,pass,pass,pass
 convmixer_768_32,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1274
+# https://github.com/intel/torch-xpu-ops/issues/1274,,,,,
 convnext_base,pass,fail_accuracy,fail_accuracy,pass,pass
 crossvit_9_240,pass,pass,pass,pass,pass
 cspdarknet53,pass,pass,pass,pass,pass
@@ -19,7 +19,7 @@ eca_botnext26ts_256,pass,pass,pass,pass,pass
 eca_halonext26ts,pass,pass,pass,pass,pass
 ese_vovnet19b_dw,pass,pass,pass,pass,pass
 fbnetc_100,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1275
+# https://github.com/intel/torch-xpu-ops/issues/1275,,,,,
 fbnetv3_b,pass,pass,pass,fail_accuracy,pass
 gernet_l,pass,pass,pass,pass,pass
 ghostnet_100,pass,pass,pass,pass,pass
@@ -34,8 +34,8 @@ levit_128,pass,pass,pass,pass,pass
 mixer_b16_224,pass,pass,pass,pass,pass
 mixnet_l,pass,pass,pass,pass,pass
 mnasnet_100,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768
-mobilenetv2_100,pass,pass,fail_accuracy,pass,pass
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+mobilenetv2_100,pass,pass,pass,pass,pass
 mobilenetv3_large_100,pass,pass,pass,pass,pass
 mobilevit_s,pass,pass,pass,pass,pass
 nfnet_l0,pass,pass,pass,pass,pass
@@ -53,7 +53,7 @@ rexnet_100,pass,pass,pass,pass,pass
 sebotnet33ts_256,pass,pass,pass,pass,pass
 selecsls42b,pass,pass,pass,pass,pass
 spnasnet_100,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
 swin_base_patch4_window7_224,pass,fail_accuracy,fail_accuracy,pass,pass
 swsl_resnext101_32x16d,pass,pass,pass,pass,pass
 tf_efficientnet_b0,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/rolling/inductor_timm_models_training.csv
+++ b/.github/ci_expected_accuracy/rolling/inductor_timm_models_training.csv
@@ -2,12 +2,11 @@ name,float32,bfloat16,float16,amp_bf16,amp_fp16
 adv_inception_v3,pass,pass,pass,pass,pass
 beit_base_patch16_224,pass,pass,pass,pass,pass
 botnet26t_256,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
 cait_m36_384,pass,pass,pass,pass,pass
 coat_lite_mini,pass,pass,pass,pass,pass
 convit_base,pass,pass,pass,pass,pass
 convmixer_768_32,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1274,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1274
 convnext_base,pass,fail_accuracy,fail_accuracy,pass,pass
 crossvit_9_240,pass,pass,pass,pass,pass
 cspdarknet53,pass,pass,pass,pass,pass
@@ -19,7 +18,7 @@ eca_botnext26ts_256,pass,pass,pass,pass,pass
 eca_halonext26ts,pass,pass,pass,pass,pass
 ese_vovnet19b_dw,pass,pass,pass,pass,pass
 fbnetc_100,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1275,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1275
 fbnetv3_b,pass,pass,pass,fail_accuracy,pass
 gernet_l,pass,pass,pass,pass,pass
 ghostnet_100,pass,pass,pass,pass,pass
@@ -34,7 +33,6 @@ levit_128,pass,pass,pass,pass,pass
 mixer_b16_224,pass,pass,pass,pass,pass
 mixnet_l,pass,pass,pass,pass,pass
 mnasnet_100,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
 mobilenetv2_100,pass,pass,pass,pass,pass
 mobilenetv3_large_100,pass,pass,pass,pass,pass
 mobilevit_s,pass,pass,pass,pass,pass
@@ -53,7 +51,7 @@ rexnet_100,pass,pass,pass,pass,pass
 sebotnet33ts_256,pass,pass,pass,pass,pass
 selecsls42b,pass,pass,pass,pass,pass
 spnasnet_100,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1768
 swin_base_patch4_window7_224,pass,fail_accuracy,fail_accuracy,pass,pass
 swsl_resnext101_32x16d,pass,pass,pass,pass,pass
 tf_efficientnet_b0,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/rolling/inductor_torchbench_inference.csv
+++ b/.github/ci_expected_accuracy/rolling/inductor_torchbench_inference.csv
@@ -1,7 +1,7 @@
 name,float32,bfloat16,float16,amp_bf16,amp_fp16
-# https://github.com/intel/torch-xpu-ops/issues/1221,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1221
 torchrec_dlrm,pass,eager_fail_to_run,eager_fail_to_run,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1768
 BERT_pytorch,pass,pass,pass,fail_accuracy,pass
 Background_Matting,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
 DALLE2_pytorch,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
@@ -16,7 +16,7 @@ cm3leon_generate,pass,pass,pass,pass,pass
 dcgan,pass,pass,pass,pass,pass
 demucs,pass,pass,pass,pass,pass
 densenet121,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1278,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1278
 detectron2_fasterrcnn_r_101_c4,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
 detectron2_fasterrcnn_r_101_dc5,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
 detectron2_fasterrcnn_r_101_fpn,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
@@ -31,7 +31,6 @@ detectron2_maskrcnn_r_50_c4,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,f
 detectron2_maskrcnn_r_50_fpn,pass,eager_fail_to_run,eager_1st_run_OOM,eager_1st_run_OOM,fail_accuracy
 dlrm,pass,pass,pass,pass,pass
 doctr_det_predictor,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
 doctr_reco_predictor,pass,pass,pass,pass,pass
 drq,pass,pass,pass,pass,pass
 fastNLP_Bert,pass,pass,pass,pass,pass
@@ -48,7 +47,7 @@ hf_GPT2_large,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_ski
 hf_Longformer,pass,pass,pass,pass,pass
 hf_Reformer,pass,pass,pass,pass,pass
 hf_T5,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1276,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1276
 hf_T5_base,pass,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 hf_T5_generate,pass,pass,pass,pass,pass
 hf_T5_large,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
@@ -58,7 +57,7 @@ hf_distil_whisper,pass,pass,pass,pass,pass
 lennard_jones,pass,pass,pass,pass,pass
 llama,pass,pass,pass,pass,pass
 llama_v2_7b_16h,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
-# https://github.com/intel/torch-xpu-ops/issues/1277,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1277
 llava,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 maml,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
 maml_omniglot,pass,pass,pass,pass,pass
@@ -94,7 +93,7 @@ soft_actor_critic,pass,pass,pass,pass,pass
 speech_transformer,pass,pass,pass,pass,pass
 squeezenet1_1,pass,fail_accuracy,pass,pass,pass
 stable_diffusion_text_encoder,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1261,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1261
 stable_diffusion_unet,eager_fail_to_run,pass_due_to_skip,pass_due_to_skip,eager_fail_to_run,eager_fail_to_run
 tacotron2,pass,pass,pass,fail_to_run,fail_to_run
 timm_efficientdet,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load

--- a/.github/ci_expected_accuracy/rolling/inductor_torchbench_inference.csv
+++ b/.github/ci_expected_accuracy/rolling/inductor_torchbench_inference.csv
@@ -1,7 +1,7 @@
 name,float32,bfloat16,float16,amp_bf16,amp_fp16
-# https://github.com/intel/torch-xpu-ops/issues/1221
+# https://github.com/intel/torch-xpu-ops/issues/1221,,,,,
 torchrec_dlrm,pass,eager_fail_to_run,eager_fail_to_run,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
 BERT_pytorch,pass,pass,pass,fail_accuracy,pass
 Background_Matting,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
 DALLE2_pytorch,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
@@ -16,23 +16,23 @@ cm3leon_generate,pass,pass,pass,pass,pass
 dcgan,pass,pass,pass,pass,pass
 demucs,pass,pass,pass,pass,pass
 densenet121,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1278
-detectron2_fasterrcnn_r_101_c4,pass,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
-detectron2_fasterrcnn_r_101_dc5,pass,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
-detectron2_fasterrcnn_r_101_fpn,pass,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
-detectron2_fasterrcnn_r_50_c4,pass,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
-detectron2_fasterrcnn_r_50_dc5,pass,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
-detectron2_fasterrcnn_r_50_fpn,pass,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
+# https://github.com/intel/torch-xpu-ops/issues/1278,,,,,
+detectron2_fasterrcnn_r_101_c4,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
+detectron2_fasterrcnn_r_101_dc5,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
+detectron2_fasterrcnn_r_101_fpn,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
+detectron2_fasterrcnn_r_50_c4,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
+detectron2_fasterrcnn_r_50_dc5,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
+detectron2_fasterrcnn_r_50_fpn,pass,eager_fail_to_run,pass,fail_accuracy,fail_accuracy
 detectron2_fcos_r_50_fpn,pass,pass,pass,pass,pass
 detectron2_maskrcnn,fail_to_run,eager_fail_to_run,fail_to_run,eager_fail_to_run,fail_to_run
-detectron2_maskrcnn_r_101_c4,fail_accuracy,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
-detectron2_maskrcnn_r_101_fpn,fail_accuracy,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
-detectron2_maskrcnn_r_50_c4,pass,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
-detectron2_maskrcnn_r_50_fpn,pass,eager_fail_to_run,fail_accuracy,eager_fail_to_run,fail_accuracy
+detectron2_maskrcnn_r_101_c4,fail_accuracy,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
+detectron2_maskrcnn_r_101_fpn,fail_accuracy,eager_fail_to_run,eager_1st_run_OOM,eager_1st_run_OOM,fail_accuracy
+detectron2_maskrcnn_r_50_c4,pass,eager_fail_to_run,fail_accuracy,fail_accuracy,fail_accuracy
+detectron2_maskrcnn_r_50_fpn,pass,eager_fail_to_run,eager_1st_run_OOM,eager_1st_run_OOM,fail_accuracy
 dlrm,pass,pass,pass,pass,pass
 doctr_det_predictor,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768
-doctr_reco_predictor,pass,pass,pass,fail_accuracy,pass
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+doctr_reco_predictor,pass,pass,pass,pass,pass
 drq,pass,pass,pass,pass,pass
 fastNLP_Bert,pass,pass,pass,pass,pass
 functorch_dp_cifar10,pass,pass,pass,pass,pass
@@ -48,7 +48,7 @@ hf_GPT2_large,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_ski
 hf_Longformer,pass,pass,pass,pass,pass
 hf_Reformer,pass,pass,pass,pass,pass
 hf_T5,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1276
+# https://github.com/intel/torch-xpu-ops/issues/1276,,,,,
 hf_T5_base,pass,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 hf_T5_generate,pass,pass,pass,pass,pass
 hf_T5_large,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
@@ -58,7 +58,7 @@ hf_distil_whisper,pass,pass,pass,pass,pass
 lennard_jones,pass,pass,pass,pass,pass
 llama,pass,pass,pass,pass,pass
 llama_v2_7b_16h,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
-# https://github.com/intel/torch-xpu-ops/issues/1277
+# https://github.com/intel/torch-xpu-ops/issues/1277,,,,,
 llava,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 maml,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
 maml_omniglot,pass,pass,pass,pass,pass
@@ -67,7 +67,7 @@ mnasnet1_0,pass,pass,pass,pass,pass
 mobilenet_v2,pass,pass,pass,pass,pass
 mobilenet_v2_quantized_qat,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load
 mobilenet_v3_large,pass,pass,pass,pass,pass
-moco,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,model_fail_to_load,model_fail_to_load
+moco,eager_fail_to_run,eager_fail_to_run,model_fail_to_load,model_fail_to_load,model_fail_to_load
 moondream,pass,pass,pass,pass,pass
 nanogpt,pass,pass,pass,pass,pass
 nvidia_deeprecommender,pass,pass,pass,pass,pass
@@ -94,7 +94,7 @@ soft_actor_critic,pass,pass,pass,pass,pass
 speech_transformer,pass,pass,pass,pass,pass
 squeezenet1_1,pass,fail_accuracy,pass,pass,pass
 stable_diffusion_text_encoder,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1261
+# https://github.com/intel/torch-xpu-ops/issues/1261,,,,,
 stable_diffusion_unet,eager_fail_to_run,pass_due_to_skip,pass_due_to_skip,eager_fail_to_run,eager_fail_to_run
 tacotron2,pass,pass,pass,fail_to_run,fail_to_run
 timm_efficientdet,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load

--- a/.github/ci_expected_accuracy/rolling/inductor_torchbench_training.csv
+++ b/.github/ci_expected_accuracy/rolling/inductor_torchbench_training.csv
@@ -31,10 +31,10 @@ doctr_det_predictor,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_
 doctr_reco_predictor,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 drq,pass,pass,pass,pass,pass
 fastNLP_Bert,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/508
+# https://github.com/intel/torch-xpu-ops/issues/508,,,,,
 functorch_dp_cifar10,fail_accuracy,fail_accuracy,fail_accuracy,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768
-functorch_maml_omniglot,pass,fail_accuracy,pass,pass,pass
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+functorch_maml_omniglot,pass,pass,pass,pass,pass
 hf_Albert,pass,pass,pass,pass,pass
 hf_Bart,pass,pass,pass,pass,pass
 hf_Bert,pass,pass,pass,pass,pass
@@ -63,7 +63,7 @@ mnasnet1_0,pass,pass,pass,pass,pass
 mobilenet_v2,pass,pass,pass,pass,pass
 mobilenet_v2_quantized_qat,pass,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 mobilenet_v3_large,pass,pass,pass,pass,pass
-moco,model_fail_to_load,eager_fail_to_run,eager_fail_to_run,model_fail_to_load,model_fail_to_load
+moco,model_fail_to_load,model_fail_to_load,eager_fail_to_run,model_fail_to_load,model_fail_to_load
 moondream,pass,pass,pass,pass,pass
 nanogpt,pass,pass,pass,pass,pass
 nvidia_deeprecommender,pass,pass,pass,pass,pass
@@ -90,19 +90,19 @@ soft_actor_critic,pass,pass,pass,pass,pass
 speech_transformer,pass,pass,pass,pass,pass
 squeezenet1_1,pass,pass,pass,pass,pass
 stable_diffusion_text_encoder,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1261
+# https://github.com/intel/torch-xpu-ops/issues/1261,,,,,
 stable_diffusion_unet,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 tacotron2,fail_to_run,fail_to_run,fail_to_run,fail_to_run,fail_to_run
 timm_efficientdet,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load
 timm_efficientnet,pass,pass,pass,pass,pass
 timm_nfnet,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1334
+# https://github.com/intel/torch-xpu-ops/issues/1334,,,,,
 timm_regnet,pass,fail_accuracy,pass,pass,pass
 timm_resnest,pass,pass,pass,pass,pass
 timm_vision_transformer,pass,pass,pass,pass,pass
 timm_vision_transformer_large,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
-# https://github.com/intel/torch-xpu-ops/issues/1768
-timm_vovnet,pass,fail_accuracy,pass,pass,pass
+# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
+timm_vovnet,pass,pass,pass,pass,pass
 torch_multimodal_clip,pass,pass,pass,pass,pass
 tts_angular,pass,pass,pass,pass,pass
 vgg16,pass,pass,pass,pass,pass

--- a/.github/ci_expected_accuracy/rolling/inductor_torchbench_training.csv
+++ b/.github/ci_expected_accuracy/rolling/inductor_torchbench_training.csv
@@ -31,9 +31,8 @@ doctr_det_predictor,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_
 doctr_reco_predictor,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 drq,pass,pass,pass,pass,pass
 fastNLP_Bert,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/508,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/508
 functorch_dp_cifar10,fail_accuracy,fail_accuracy,fail_accuracy,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
 functorch_maml_omniglot,pass,pass,pass,pass,pass
 hf_Albert,pass,pass,pass,pass,pass
 hf_Bart,pass,pass,pass,pass,pass
@@ -90,18 +89,17 @@ soft_actor_critic,pass,pass,pass,pass,pass
 speech_transformer,pass,pass,pass,pass,pass
 squeezenet1_1,pass,pass,pass,pass,pass
 stable_diffusion_text_encoder,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1261,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1261
 stable_diffusion_unet,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run,eager_fail_to_run
 tacotron2,fail_to_run,fail_to_run,fail_to_run,fail_to_run,fail_to_run
 timm_efficientdet,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load,model_fail_to_load
 timm_efficientnet,pass,pass,pass,pass,pass
 timm_nfnet,pass,pass,pass,pass,pass
-# https://github.com/intel/torch-xpu-ops/issues/1334,,,,,
+# https://github.com/intel/torch-xpu-ops/issues/1334
 timm_regnet,pass,fail_accuracy,pass,pass,pass
 timm_resnest,pass,pass,pass,pass,pass
 timm_vision_transformer,pass,pass,pass,pass,pass
 timm_vision_transformer_large,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip,pass_due_to_skip
-# https://github.com/intel/torch-xpu-ops/issues/1768,,,,,
 timm_vovnet,pass,pass,pass,pass,pass
 torch_multimodal_clip,pass,pass,pass,pass,pass
 tts_angular,pass,pass,pass,pass,pass


### PR DESCRIPTION
Rolling: 
1. Huggingface: https://github.com/intel/torch-xpu-ops/actions/runs/15962956351
4. Torchbench inference: https://github.com/intel/torch-xpu-ops/actions/runs/15962971535
5. Torchbench training: https://github.com/intel/torch-xpu-ops/actions/runs/15962975733
6. Timm inference: https://github.com/intel/torch-xpu-ops/actions/runs/15962980575
7. Timm training: https://github.com/intel/torch-xpu-ops/actions/runs/15962983533

LTS: 
1. Huggingface and Timm: https://github.com/intel/torch-xpu-ops/actions/runs/15963156995
2. Torchbench inference: https://github.com/intel/torch-xpu-ops/actions/runs/15963160385
3. Torchbench training: https://github.com/intel/torch-xpu-ops/actions/runs/15963163938

disable_ut
disable_distributed
