### PR TITLE
ci: revert breaking changes in accelerate and transformers tests

### DIFF
--- a/.github/workflows/_linux_accelerate.yml
+++ b/.github/workflows/_linux_accelerate.yml
@@ -46,30 +46,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  conditions-filter:
-    name: conditions-filter
-    if: ${{ github.event.pull_request.draft == false }}
-    runs-on: ubuntu-22.04
-    timeout-minutes: 10
-    env:
-      GH_TOKEN: ${{ github.token }}
-    outputs:
-      disabled_tests: ${{ steps.check-pr-desc.outputs.disabled_tests }}
-    steps:
-      - name: Check PR infos
-        id: check-pr-desc
-        run: |
-          set -x -e -o pipefail
-          sudo apt update && sudo apt install -y dos2unix
-          gh --repo ${GITHUB_REPOSITORY} pr view ${{ github.event.pull_request.number }} 2>&1 |tee pr-info.txt
-          dos2unix pr-info.txt
-          disabled_tests="$(awk '/disable_/{printf("%s ", $0)}' pr-info.txt)"
-          echo "disabled_tests=${disabled_tests}" |tee "${GITHUB_OUTPUT}"
-
   Torch-XPU-Accelerate-Tests:
     runs-on: ${{ inputs.runner != '' && inputs.runner || 'linux.idc.xpu' }}
-    needs: conditions-filter
-    if: ${{ !(contains(needs.conditions-filter.outputs.disabled_tests, 'disable_all') || contains(needs.conditions-filter.outputs.disabled_tests, 'disable_accelerate')) }}
     env:
       WORK_DIR: 'accelerate'
       NEOReadDebugKeys: 0

--- a/.github/workflows/_linux_transformers.yml
+++ b/.github/workflows/_linux_transformers.yml
@@ -74,30 +74,8 @@ env:
   TORCH_INDEX: '--pre --index-url https://download.pytorch.org/whl/nightly/xpu'
 
 jobs:
-  conditions-filter:
-    name: conditions-filter
-    if: ${{ github.event.pull_request.draft == false }}
-    runs-on: ubuntu-22.04
-    timeout-minutes: 10
-    env:
-      GH_TOKEN: ${{ github.token }}
-    outputs:
-      disabled_tests: ${{ steps.check-pr-desc.outputs.disabled_tests }}
-    steps:
-      - name: Check PR infos
-        id: check-pr-desc
-        run: |
-          set -x -e -o pipefail
-          sudo apt update && sudo apt install -y dos2unix
-          gh --repo ${GITHUB_REPOSITORY} pr view ${{ github.event.pull_request.number }} 2>&1 |tee pr-info.txt
-          dos2unix pr-info.txt
-          disabled_tests="$(awk '/disable_/{printf("%s ", $0)}' pr-info.txt)"
-          echo "disabled_tests=${disabled_tests}" |tee "${GITHUB_OUTPUT}"
-
   prepare:
     runs-on: ${{ inputs.runner != '' && inputs.runner || 'linux.idc.xpu' }}
-    needs: conditions-filter
-    if: ${{ !(contains(needs.conditions-filter.outputs.disabled_tests, 'disable_all') || contains(needs.conditions-filter.outputs.disabled_tests, 'disable_transformers')) }}
     outputs:
       torch: ${{ steps.getver.outputs.torch }}
       torchvision: ${{ steps.getver.outputs.torchvision }}


### PR DESCRIPTION
This commit reverts some changes introduced in d9b81b8b. The changes:
* Introduce some undocumented mechanism to enable/disable CI checks
* Did not account that workflow might be triggered per schedule

The changes can be reintroduced if 1) documented, 2) work properly.

Fixes: d9b81b8b ("[CI] Set read-all for workflows top-level token-permissions (#1777)")