### PR TITLE
Add launch test log file support for the xpu test utils

### DIFF
--- a/test/xpu/xpu_test_utils.py
+++ b/test/xpu/xpu_test_utils.py
@@ -5,6 +5,7 @@ import copy
 import os
 import sys
 import unittest
+import logging
 
 import torch
 from torch import bfloat16, cuda
@@ -27,6 +28,7 @@ from torch.testing._internal.opinfo.core import (
     UnaryUfuncInfo,
 )
 
+_loggers = {}
 _xpu_computation_op_list = [
     "empty",
     "eye",
@@ -439,6 +441,28 @@ _xpu_tolerance_override = {
         }
     },
 }
+
+
+def create_file_logger(name, log_path=None, level=logging.DEBUG):
+    global _loggers
+    if name in _loggers:
+        return _loggers[name]
+    
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    if not log_path:
+        if 'WORKSPACE' in os.environ:
+            parent = os.environ['WORKSPACE']
+        else:
+            parent = os.path.dirname(os.path.abspath(__file__))
+        log_path = os.path.join(parent, f"{name}.log")
+    
+    log_path = os.path.normpath(log_path)    
+    file_handle = logging.FileHandler(log_path, mode='a', errors='ignore')
+    file_handle.setFormatter(logging.Formatter("%(levelname)s %(asctime)s %(message)s", "%Y%m%d-%H:%M:%S"))
+    logger.addHandler(file_handle)
+    _loggers[name] = logger
+    return logger
 
 
 def get_wrapped_fn(fn):
@@ -1161,6 +1185,7 @@ def copy_tests(
 
 
 def launch_test(test_case, skip_list=None, exe_list=None):
+    logger = create_file_logger('launch_test')
     os.environ["PYTORCH_ENABLE_XPU_FALLBACK"] = "1"
     os.environ["PYTORCH_TEST_WITH_SLOW"] = "1"
     if skip_list is not None:
@@ -1190,4 +1215,5 @@ def launch_test(test_case, skip_list=None, exe_list=None):
             f"pytest --timeout 600 -v --junit-xml=./op_ut_with_skip_{test_case}.xml "
             + test_case
         )
+    logger.info(test_command)
     return os.system(test_command)


### PR DESCRIPTION
# Description
Add a file logger for helping record the launch test process. The log file can be used during the debugging. One of the scenario is in an automation test, the test workflow will be killed after the timeout. It is hard to determine whether is the current test failed lead to the issue or the next following cases. The current pytest output is not contain all the necessary command line parameters to rerun the failed case. 

# Changes
1. Add file logger.
2. Support generate the log directly in the parent folder of the file xpu_test_utils.py.
3. Support generate the log whenever an environment variable WORKSPACE is defined. Then the WORKSPACE will be treat as the parent folder.

disabled_distributed
disable_e2e
