### PR TITLE
Roll back to original usage of sycl::get_kernel_bundle

### DIFF
--- a/src/comm/DeviceProperties.h
+++ b/src/comm/DeviceProperties.h
@@ -16,13 +16,8 @@ static int64_t syclMaxWorkGroupSize(
   auto dev = q.get_device();
 
   auto kid = ::sycl::get_kernel_id<KernelClass>();
-  // The kernel won't be built for devices except for the first device.
-  // Launching kernel on devices except for the first device will raise
-  // runtime error. Here is an alternative as a temporary solution to
-  // provide an extra hint to SYCL runtime.
-  // https://github.com/intel/llvm/issues/15127
-  auto kbundle = ::sycl::get_kernel_bundle<::sycl::bundle_state::executable>(
-      ctx, {dev}, {kid});
+  auto kbundle =
+      ::sycl::get_kernel_bundle<::sycl::bundle_state::executable>(ctx, {kid});
 
   ::sycl::kernel k = kbundle.get_kernel(kid);
   return k.get_info<::sycl::info::kernel_device_specific::work_group_size>(dev);


### PR DESCRIPTION
To solve https://github.com/intel/torch-xpu-ops/issues/1121.

The original usage of `sycl::get_kernel_bundle` should not be device-specific. Since the fixing has landed on oneAPI 2025.2, kernel bundle is now created using only the kernel ID (`kid`) instead of both device and kernel ID, removing the workaround for device-specific kernel builds and associated comments.