### PR TITLE
Fix random build failure on codegen

### DIFF
--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -109,6 +109,7 @@ add_custom_command(
   COMMAND
     ${XPU_INSTALL_HEADER_COMMAND}
   DEPENDS
+    torch_cpu
     ATEN_CPU_FILES_GEN_TARGET
     ATEN_XPU_FILES_GEN_TARGET
     ${XPUFallback_TEMPLATE}


### PR DESCRIPTION
# Motivation
Currently, XPU ATen codegen has a potential race condition. So, we need to ensure torch_cpu has been completed before starting XPU ATen codegen.