### PR TITLE
Make torch-xpu-ops build depends on ATen XPU Codegen

### DIFF
--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -133,6 +133,17 @@ if(WIN32)
   )
 endif()
 
+# Ensure that all generated ATen XPU op files are built before compiling the
+# torch-xpu-ops library.
+include(${BUILD_TORCH_XPU_ATEN_GENERATED}/ops_generated_headers.cmake)
+add_custom_target(ATEN_XPU_OPS_FILES_GEN_TARGET DEPENDS
+  ${ops_generated_headers} ${OUTPUT_LIST})
+add_library(ATEN_XPU_OPS_FILES_GEN_LIB INTERFACE)
+add_dependencies(ATEN_XPU_OPS_FILES_GEN_LIB ATEN_XPU_OPS_FILES_GEN_TARGET)
+if(USE_PER_OPERATOR_HEADERS)
+  target_compile_definitions(ATEN_XPU_OPS_FILES_GEN_LIB INTERFACE AT_PER_OPERATOR_HEADERS)
+endif()
+
 set(ATen_XPU_GEN_SRCS
   ${RegisterXPU_GENERATED}
   ${RegisterSparseXPU_GENERATED}

--- a/src/BuildOnLinux.cmake
+++ b/src/BuildOnLinux.cmake
@@ -145,6 +145,7 @@ foreach(lib ${TORCH_XPU_OPS_LIBRARIES})
   target_include_directories(${lib} PUBLIC ${SYCL_INCLUDE_DIR})
 
   target_link_libraries(${lib} PUBLIC ${SYCL_LIBRARY})
+  target_link_libraries(${lib} PRIVATE ${ATEN_XPU_OPS_FILES_GEN_LIB})
 endforeach()
 
 if(USE_ONEMKL_XPU)

--- a/src/BuildOnWindows.cmake
+++ b/src/BuildOnWindows.cmake
@@ -340,6 +340,7 @@ foreach(lib ${TORCH_XPU_OPS_LIBRARIES})
   target_link_libraries(${lib} PUBLIC ${SYCL_LIBRARY})
   target_link_libraries(${lib} PUBLIC c10_xpu)
   target_link_libraries(${lib} PUBLIC torch_cpu)
+  target_link_libraries(${lib} PRIVATE ${ATEN_XPU_OPS_FILES_GEN_LIB})
 endforeach()
 
 if(USE_ONEMKL_XPU)


### PR DESCRIPTION
# Motivation
This PR aims to ensure ATen XPU Codegen is completed before torch-xpu-ops start to build.