### PR TITLE
Update to recommended shortcut API for kernel specific max work group size

### DIFF
--- a/src/comm/DeviceProperties.h
+++ b/src/comm/DeviceProperties.h
@@ -34,17 +34,9 @@ static int64_t syclMaxWorkGroupSize(
   auto& ctx = c10::xpu::get_device_context();
   auto& dev = c10::xpu::get_raw_device(dev_id);
 
-  auto kid = ::sycl::get_kernel_id<KernelClass>();
-  // The kernel won't be built for devices except for the first device.
-  // Launching kernel on devices except for the first device will raise
-  // runtime error. Here is an alternative as a temporary solution to
-  // provide an extra hint to SYCL runtime.
-  // https://github.com/intel/llvm/issues/15127
-  auto kbundle = ::sycl::get_kernel_bundle<::sycl::bundle_state::executable>(
-      ctx, {dev}, {kid});
-
-  ::sycl::kernel k = kbundle.get_kernel(kid);
-  return k.get_info<::sycl::info::kernel_device_specific::work_group_size>(dev);
+  return ::sycl::ext::oneapi::get_kernel_info<
+      KernelClass,
+      ::sycl::info::kernel_device_specific::work_group_size>(ctx, dev);
 }
 
 template <class KernelClass>


### PR DESCRIPTION
This PR refactors how the maximum work group size for a SYCL kernel is retrieved in the `syclMaxWorkGroupSize` function. The manual construction and querying of a kernel bundle is replaced with `sycl::ext::oneapi::get_kernel_info` for directly obtaining the work group size, simplifying the code and improving clarity.
