### PR TITLE
Fix codegen dependence bug

### DIFF
--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -72,6 +72,7 @@ if(NOT RETURN_VALUE EQUAL 0)
 endif()
 
 include(${BUILD_TORCH_XPU_ATEN_GENERATED}/xpu_ops_generated_headers.cmake)
+include(${BUILD_TORCH_XPU_ATEN_GENERATED}/ops_generated_headers.cmake)
 
 if(WIN32)
   set(FILE_DISPLAY_CMD type)
@@ -91,6 +92,7 @@ set(OUTPUT_LIST
   ${RegisterNestedTensorXPU_GENERATED}
   ${XPU_AOTI_SHIM_HEADER}
   ${XPU_AOTI_SHIM_SOURCE}
+  ${ops_generated_headers}
 )
 
 # Generate torch-xpu-ops codegen
@@ -135,7 +137,6 @@ endif()
 
 # Ensure that all generated ATen XPU op files are built before compiling the
 # torch-xpu-ops library.
-include(${BUILD_TORCH_XPU_ATEN_GENERATED}/ops_generated_headers.cmake)
 add_custom_target(ATEN_XPU_OPS_FILES_GEN_TARGET DEPENDS
   ${ops_generated_headers} ${OUTPUT_LIST})
 add_library(ATEN_XPU_OPS_FILES_GEN_LIB INTERFACE)

--- a/src/BuildOnLinux.cmake
+++ b/src/BuildOnLinux.cmake
@@ -145,7 +145,7 @@ foreach(lib ${TORCH_XPU_OPS_LIBRARIES})
   target_include_directories(${lib} PUBLIC ${SYCL_INCLUDE_DIR})
 
   target_link_libraries(${lib} PUBLIC ${SYCL_LIBRARY})
-  target_link_libraries(${lib} PRIVATE ${ATEN_XPU_OPS_FILES_GEN_LIB})
+  target_link_libraries(${lib} PRIVATE ATEN_XPU_OPS_FILES_GEN_LIB)
 endforeach()
 
 if(USE_ONEMKL_XPU)

--- a/src/BuildOnWindows.cmake
+++ b/src/BuildOnWindows.cmake
@@ -340,7 +340,7 @@ foreach(lib ${TORCH_XPU_OPS_LIBRARIES})
   target_link_libraries(${lib} PUBLIC ${SYCL_LIBRARY})
   target_link_libraries(${lib} PUBLIC c10_xpu)
   target_link_libraries(${lib} PUBLIC torch_cpu)
-  target_link_libraries(${lib} PRIVATE ${ATEN_XPU_OPS_FILES_GEN_LIB})
+  target_link_libraries(${lib} PRIVATE ATEN_XPU_OPS_FILES_GEN_LIB)
 endforeach()
 
 if(USE_ONEMKL_XPU)


### PR DESCRIPTION
# Motivation
Fix the typo `${ATEN_XPU_OPS_FILES_GEN_LIB}` **->** `ATEN_XPU_OPS_FILES_GEN_LIB`, building the correct dependency ...

see log
```bash
[6517/7393] Linking CXX executable bin\c10_intrusive_ptr_test.exe
[6518/7393] Building CXX object caffe2\CMakeFiles\torch_cpu.dir\__\aten\src\ATen\native\cpu\FlashAttentionKernel.cpp.AVX512.cpp.obj
[6519/7393] Performing build step for 'xpu_mkldnn_proj'
[1/976] Generating gen9_bnorm_header.cpp
[2/976] Generating concat_common_header.cpp
...
[976/976] Linking CXX static library src\dnnl.lib
ignoring unknown argument: -fsycl
ignoring unknown argument: -Wno-unknown-argument
ignoring unknown argument: -Qoption,link,/machine:x64
[6520/7393] No install step for 'xpu_mkldnn_proj'
[6521/7393] Completed 'xpu_mkldnn_proj'
[6522/7393] Linking CXX shared library bin\torch_cpu.dll
[6523/7393] Generating XPU ATen Codegen...
[6524/7393] Building SYCL (Device) object torch_xpu_ops_sycl_common_kernels_gen_ActivationHardshrinkKernels.cpp.obj
Intel(R) oneAPI DPC++/C++ Compiler for applications running on Intel(R) 64, Version 2025.2.0 Build 20250605
Copyright (C) 1985-2025 Intel Corporation. All rights reserved.
```
Currently, `XPU ATen Codegen` happens after `torch-cpu` build completed and before `torch-xpu-ops` starts, which is expected.