### PR TITLE
fbgemmops async_complete_cumsum, dense jagged conversion

### DIFF
--- a/src/ATen/native/xpu/FbgemmOps.cpp
+++ b/src/ATen/native/xpu/FbgemmOps.cpp
@@ -147,16 +147,6 @@ class DenseToJaggedOp : public torch::autograd::Function<DenseToJaggedOp> {
     // uncomment when implement backward
 
     // dims of dense tensor: <batch, [maxlen0, maxlen1, ...], embedding_dim>
-    // #if TORCH_VERSION_MAJOR > 2 || \
-    //     (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 1)
-    //     // toSymIntVector support is from a recent PR
-    //     // https://github.com/pytorch/pytorch/pull/101056,
-    //     // so protect it under a version guard for compatibility
-    //     ctx->saved_data["dense_shape"] = dense.sym_sizes();
-    // #else
-    //     ctx->saved_data["dense_shape"] = dense.sizes();
-    // #endif
-
     static auto op =
         c10::Dispatcher::singleton()
             .findSchemaOrThrow("fbgemm::dense_to_jagged_forward", "")

--- a/src/ATen/native/xpu/FbgemmOps.cpp
+++ b/src/ATen/native/xpu/FbgemmOps.cpp
@@ -188,10 +188,6 @@ class JaggedToPaddedDenseOp
       const std::vector<Tensor>& offsets,
       const c10::SymIntArrayRef max_lengths,
       const double padding_value) {
-    // uncomment when implement backward
-    // ctx->save_for_backward(offsets);
-    // ctx->saved_data["total_L"] = values.sym_size(0);
-
     static auto op =
         c10::Dispatcher::singleton()
             .findSchemaOrThrow("fbgemm::jagged_to_padded_dense_forward", "")

--- a/src/ATen/native/xpu/FbgemmOps.cpp
+++ b/src/ATen/native/xpu/FbgemmOps.cpp
@@ -145,7 +145,6 @@ class DenseToJaggedOp : public torch::autograd::Function<DenseToJaggedOp> {
       const std::vector<Tensor>& offsets,
       const std::optional<at::SymInt>& total_L) {
     // uncomment when implement backward
-    // ctx->save_for_backward(offsets);
 
     // dims of dense tensor: <batch, [maxlen0, maxlen1, ...], embedding_dim>
     // #if TORCH_VERSION_MAJOR > 2 || \

--- a/src/ATen/native/xpu/FbgemmOps.cpp
+++ b/src/ATen/native/xpu/FbgemmOps.cpp
@@ -1,0 +1,285 @@
+#include <ATen/ATen.h>
+#include <ATen/DeviceGuard.h>
+#include <ATen/record_function.h>
+#include <torch/csrc/autograd/custom_function.h>
+#include <torch/library.h>
+#include <torch/torch.h>
+
+#include <ATen/native/xpu/sycl/FbgemmKernels.h>
+
+namespace at {
+namespace native {
+namespace xpu {
+
+#define XPU_DEVICE_GUARD(TENSOR) \
+  const OptionalDeviceGuard device_guard(device_of(TENSOR));
+
+Tensor asynchronous_complete_cumsum_xpu(const Tensor& t_in) {
+  TORCH_CHECK(t_in.is_contiguous());
+  TORCH_CHECK(t_in.dtype() == at::kInt || t_in.dtype() == at::kLong);
+  TORCH_CHECK(t_in.dim() == 1 || t_in.dim() == 2);
+
+  if (t_in.dim() == 1) {
+    Tensor t_out = at::zeros({t_in.numel() + 1}, t_in.options());
+    auto r_out = t_out.slice(0, 1);
+    at::cumsum_out(r_out, t_in, 0);
+    return t_out;
+  }
+
+  Tensor t_out = at::zeros({t_in.size(0), t_in.size(1) + 1}, t_in.options());
+  auto r_out = t_out.slice(1, 1);
+  at::cumsum_out(r_out, t_in, 1);
+  return t_out;
+}
+
+Tensor dense_to_jagged_forward_xpu(
+    const Tensor& dense,
+    const std::vector<Tensor>& offsets,
+    std::optional<at::SymInt> total_L) {
+  TORCH_CHECK(dense.is_xpu(), "value must be a xpu tensor");
+  for (auto& offset : offsets) {
+    TORCH_CHECK(offset.is_xpu(), "offset must be a xpu tensor");
+  }
+
+  const int num_jagged_dim = dense.dim() - 2;
+  TORCH_CHECK(
+      offsets.size() == static_cast<size_t>(num_jagged_dim),
+      "x_offsets.size(), ",
+      offsets.size(),
+      " != num_jagged_dim, ",
+      num_jagged_dim);
+
+  // D is the embedding dimension
+  auto D = dense.size(-1);
+
+  // If total_L is not given then compute it
+  at::SymInt total_L_computed;
+  if (total_L.has_value()) {
+    total_L_computed = total_L.value();
+  } else {
+    total_L_computed = (int64_t)offsets.back().max().item<int64_t>();
+  }
+  auto values = at::empty_symint({total_L_computed, D}, dense.options());
+  auto output = at::empty_like(values); // not used
+
+  if (dense.numel() == 0 || values.numel() == 0) {
+    return output;
+  }
+
+  XPU_DEVICE_GUARD(dense);
+
+  dense_to_jagged_forward_xpu_kernel(values, offsets, dense, output);
+
+  return output;
+}
+
+Tensor jagged_to_padded_dense_forward_xpu(
+    const Tensor& values,
+    const std::vector<Tensor>& offsets,
+    c10::SymIntArrayRef max_lengths,
+    const double padding_value) {
+  size_t num_jagged_dim = offsets.size();
+  TORCH_CHECK(
+      max_lengths.size() == num_jagged_dim,
+      "max_lengths.size(), ",
+      max_lengths.size(),
+      " != num_jagged_dim, ",
+      num_jagged_dim);
+
+  TORCH_CHECK(values.is_xpu(), "value must be a xpu tensor");
+  for (auto& offset : offsets) {
+    TORCH_CHECK(offset.is_xpu(), "offset must be a xpu tensor");
+  }
+
+  XPU_DEVICE_GUARD(values);
+
+  const Tensor values_canonicalized = values.view(
+      {values.size(0),
+       std::accumulate(
+           values.sizes().begin() + 1,
+           values.sizes().end(),
+           1,
+           std::multiplies<size_t>())});
+  at::SymDimVector padded_values_shape({at::SymInt(offsets[0].size(0) - 1)});
+  padded_values_shape.insert(
+      padded_values_shape.end(), max_lengths.begin(), max_lengths.end());
+
+  // Canonicalize padded_values by unsqueeze the last dim if the inner dense
+  // dimension is 1 and folded.
+  const bool D_folded = values.dim() == 1;
+  if (!D_folded) {
+    padded_values_shape.push_back(values.size(-1));
+  }
+  Tensor padded_values =
+      at::empty_symint(padded_values_shape, values.options());
+  Tensor padded_values_view =
+      D_folded ? padded_values.unsqueeze(-1) : padded_values;
+
+  num_jagged_dim = padded_values_view.dim() - 2;
+  TORCH_CHECK(
+      offsets.size() == static_cast<size_t>(num_jagged_dim),
+      "x_offsets.size(), ",
+      offsets.size(),
+      " != num_jagged_dim ",
+      num_jagged_dim);
+
+  if (padded_values_view.numel() == 0) {
+    return padded_values;
+  }
+
+  jagged_to_padded_dense_forward_xpu_kernel(
+      values_canonicalized,
+      offsets,
+      padded_values_view,
+      padded_values_view,
+      padding_value);
+
+  return padded_values;
+}
+
+class DenseToJaggedOp : public torch::autograd::Function<DenseToJaggedOp> {
+ public:
+  static torch::autograd::variable_list forward(
+      torch::autograd::AutogradContext* ctx,
+      const Tensor& dense,
+      const std::vector<Tensor>& offsets,
+      const std::optional<at::SymInt>& total_L) {
+    // uncomment when implement backward
+    // ctx->save_for_backward(offsets);
+
+    // dims of dense tensor: <batch, [maxlen0, maxlen1, ...], embedding_dim>
+    // #if TORCH_VERSION_MAJOR > 2 || \
+    //     (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 1)
+    //     // toSymIntVector support is from a recent PR
+    //     // https://github.com/pytorch/pytorch/pull/101056,
+    //     // so protect it under a version guard for compatibility
+    //     ctx->saved_data["dense_shape"] = dense.sym_sizes();
+    // #else
+    //     ctx->saved_data["dense_shape"] = dense.sizes();
+    // #endif
+
+    static auto op =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow("fbgemm::dense_to_jagged_forward", "")
+            .typed<Tensor(
+                const Tensor& dense,
+                const std::vector<Tensor>& offsets,
+                std::optional<at::SymInt> total_L)>();
+    auto output = op.call(dense, offsets, total_L);
+
+    return {output};
+  }
+
+  static torch::autograd::variable_list backward(
+      torch::autograd::AutogradContext* ctx,
+      torch::autograd::variable_list grad_outputs) {
+    // TODO: backward kernel
+    return {
+        torch::autograd::Variable(),
+        torch::autograd::Variable(), // offsets
+        torch::autograd::Variable() // total_L
+    };
+  }
+};
+
+// output = x + y where x is jagged, y is dense, and output is jagged
+std::tuple<Tensor, std::vector<Tensor>> dense_to_jagged(
+    const Tensor& dense,
+    const std::vector<Tensor>& offsets,
+    std::optional<at::SymInt> total_L) {
+  return {DenseToJaggedOp::apply(dense, offsets, total_L)[0], offsets};
+}
+
+class JaggedToPaddedDenseOp
+    : public torch::autograd::Function<JaggedToPaddedDenseOp> {
+ public:
+  static torch::autograd::variable_list forward(
+      torch::autograd::AutogradContext* ctx,
+      const Tensor& values,
+      const std::vector<Tensor>& offsets,
+      const c10::SymIntArrayRef max_lengths,
+      const double padding_value) {
+    // uncomment when implement backward
+    // ctx->save_for_backward(offsets);
+    // ctx->saved_data["total_L"] = values.sym_size(0);
+
+    static auto op =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow("fbgemm::jagged_to_padded_dense_forward", "")
+            .typed<at::Tensor(
+                const Tensor& values,
+                const std::vector<Tensor>& offsets,
+                at::ArrayRef<at::SymInt> max_lengths,
+                const double padding_value)>();
+    Tensor padded_values = op.call(values, offsets, max_lengths, padding_value);
+
+    return {padded_values};
+  }
+
+  static torch::autograd::variable_list backward(
+      torch::autograd::AutogradContext* ctx,
+      torch::autograd::variable_list grad_outputs) {
+    // TODO: backward kernel
+    return {
+        torch::autograd::Variable(),
+        torch::autograd::Variable(), // offsets
+        torch::autograd::Variable(), // max_lengths
+        torch::autograd::Variable(), // padding_value
+    };
+  }
+};
+
+Tensor jagged_to_padded_dense(
+    const Tensor& values,
+    const std::vector<Tensor>& offsets,
+    const c10::SymIntArrayRef max_lengths,
+    const double padding_value = 0.0) {
+  return JaggedToPaddedDenseOp::apply(
+      values, offsets, max_lengths, padding_value)[0];
+}
+
+} // namespace xpu
+} // namespace native
+} // namespace at
+
+namespace {
+
+TORCH_LIBRARY(fbgemm, m) {
+  m.def("asynchronous_complete_cumsum(Tensor t_in) -> Tensor");
+  m.def(
+      "dense_to_jagged(Tensor dense, Tensor[] offsets, SymInt? total_L=None) -> (Tensor, Tensor[])");
+  m.def(
+      "dense_to_jagged_forward(Tensor dense, Tensor[] offsets, SymInt? total_L=None) -> Tensor");
+  m.def(
+      "jagged_to_padded_dense(Tensor values, Tensor[] offsets, SymInt[] max, float padding_value=0.0) -> Tensor");
+  m.def(
+      "jagged_to_padded_dense_forward(Tensor values, Tensor[] offsets, SymInt[] max, float padding_value=0.0) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(fbgemm, XPU, m) {
+  m.impl(
+      "asynchronous_complete_cumsum",
+      &at::native::xpu::asynchronous_complete_cumsum_xpu);
+}
+
+// Autograd backend register in fbgemm
+TORCH_LIBRARY_IMPL(fbgemm, XPU, m) {
+  m.impl("dense_to_jagged", &at::native::xpu::dense_to_jagged);
+}
+
+TORCH_LIBRARY_IMPL(fbgemm, XPU, m) {
+  m.impl(
+      "dense_to_jagged_forward", &at::native::xpu::dense_to_jagged_forward_xpu);
+}
+
+// Autograd backend register in fbgemm
+TORCH_LIBRARY_IMPL(fbgemm, XPU, m) {
+  m.impl("jagged_to_padded_dense", &at::native::xpu::jagged_to_padded_dense);
+}
+
+TORCH_LIBRARY_IMPL(fbgemm, XPU, m) {
+  m.impl(
+      "jagged_to_padded_dense_forward",
+      &at::native::xpu::jagged_to_padded_dense_forward_xpu);
+}
+} // namespace

--- a/src/ATen/native/xpu/sycl/FbgemmKernels.cpp
+++ b/src/ATen/native/xpu/sycl/FbgemmKernels.cpp
@@ -1,0 +1,460 @@
+#include <ATen/ATen.h>
+#include <ATen/native/xpu/sycl/FbgemmKernels.h>
+
+#include <comm/SYCLContext.h>
+
+
+namespace syclext = sycl::ext::oneapi;
+namespace syclexp = sycl::ext::oneapi::experimental;
+
+namespace at {
+namespace native {
+namespace xpu {
+
+template <typename T>
+struct StackArray {
+  T vals[kStackArrayMaxDims];
+  size_t ndim;
+};
+
+#define JAGGED_TENSOR_DISPATCH_DIMS()                                         \
+  AT_DISPATCH_INDEX_TYPES(x_offsets[0].scalar_type(), "jagged_indices", [=] { \
+    switch (num_jagged_dim) {                                                 \
+      case 1:                                                                 \
+        INVOKE_KERNEL_WITH_DIM(1);                                            \
+        break;                                                                \
+      case 2:                                                                 \
+        INVOKE_KERNEL_WITH_DIM(2);                                            \
+        break;                                                                \
+      case 3:                                                                 \
+        INVOKE_KERNEL_WITH_DIM(3);                                            \
+        break;                                                                \
+      case 4:                                                                 \
+        INVOKE_KERNEL_WITH_DIM(4);                                            \
+        break;                                                                \
+      case 5:                                                                 \
+        INVOKE_KERNEL_WITH_DIM(5);                                            \
+        break;                                                                \
+      default:                                                                \
+        TORCH_CHECK(                                                          \
+            false, "unsupported number of jagged dim ", num_jagged_dim);      \
+    }                                                                         \
+  });
+
+template <int NUM_JAGGED_DIM, typename index_t, typename scalar_t>
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<2>))
+void jagged_dense_elementwise_jagged_output_kernel_(
+    GenericPackedTensorAccessor<scalar_t, 2, DefaultPtrTraits, int32_t>
+        x_values,
+    StackArray<index_t*> x_offsets,
+    StackArray<int64_t> x_offsets_sizes,
+    GenericPackedTensorAccessor<scalar_t, 3, DefaultPtrTraits, int32_t> y_0,
+    GenericPackedTensorAccessor<scalar_t, 3, DefaultPtrTraits, int32_t> y_1,
+    GenericPackedTensorAccessor<scalar_t, 2, DefaultPtrTraits, int32_t>
+        output_values,
+    StackArray<int64_t> jagged_dims) {
+  auto output_values_acc = output_values;
+  const int outer_dense_size = y_0.size(0);
+  const int inner_dense_size = y_0.size(2);
+  const int nnz = x_values.size(0);
+
+  auto item = syclext::this_work_item::get_nd_item<2>();
+  const int offset_begin =
+      item.get_group(0) * item.get_local_range(1) + item.get_local_id(1);
+  const int offset_stride = item.get_global_range(0) * item.get_local_range(1);
+  for (int offset = offset_begin; offset < nnz; offset += offset_stride) {
+    int offset_temp = offset;
+    int jidx = 0;
+    bool truncated = false;
+    int dim_prod = 1;
+#pragma unroll
+    for (int d = NUM_JAGGED_DIM - 1; d >= 0; --d) {
+      // Binary search the first that is bigger than offset
+      int count = x_offsets_sizes.vals[d] - 1;
+      int first = 1;
+      while (count > 0) {
+        int idx = first;
+        int step = count / 2;
+        idx += step;
+        if (x_offsets.vals[d][idx] <= offset_temp) {
+          first = ++idx;
+          count -= step + 1;
+        } else {
+          count = step;
+        }
+      }
+
+      --first;
+      int coord = offset_temp - x_offsets.vals[d][first];
+      if (coord >= jagged_dims.vals[d]) {
+        truncated = true;
+        break;
+      }
+      jidx += coord * dim_prod;
+      dim_prod *= jagged_dims.vals[d];
+      offset_temp = first;
+    }
+
+    auto f = [](scalar_t x, scalar_t y, scalar_t z) -> scalar_t { return y; };
+
+    if (offset_temp >= outer_dense_size) {
+      // This can happen when values have more elements than the last element of
+      // offset
+      truncated = true;
+    }
+    if (!truncated) {
+      const int oidx = offset_temp;
+      int iidx;
+      for (iidx = item.get_local_id(0); iidx * 2 + 1 < inner_dense_size;
+           iidx += item.get_local_range(0)) {
+        output_values_acc[offset][2 * iidx] =
+            f(x_values[offset][2 * iidx],
+              y_0[oidx][jidx][2 * iidx],
+              y_1[oidx][jidx][2 * iidx]);
+        output_values_acc[offset][2 * iidx + 1] =
+            f(x_values[offset][2 * iidx + 1],
+              y_0[oidx][jidx][2 * iidx + 1],
+              y_1[oidx][jidx][2 * iidx + 1]);
+      }
+      if (iidx * 2 + 1 == inner_dense_size) {
+        output_values_acc[offset][2 * iidx] =
+            f(x_values[offset][2 * iidx],
+              y_0[oidx][jidx][2 * iidx],
+              y_1[oidx][jidx][2 * iidx]);
+      }
+    } else {
+      int iidx;
+      for (iidx = item.get_local_id(0); iidx * 2 + 1 < inner_dense_size;
+           iidx += item.get_local_range(0)) {
+        output_values_acc[offset][2 * iidx] =
+            f(x_values[offset][2 * iidx], 0, 0);
+        output_values_acc[offset][2 * iidx + 1] =
+            f(x_values[offset][2 * iidx + 1], 0, 0);
+      }
+      if (iidx * 2 + 1 == inner_dense_size) {
+        output_values_acc[offset][2 * iidx] =
+            f(x_values[offset][2 * iidx], 0, 0);
+      }
+    }
+  }
+}
+
+template <int NUM_JAGGED_DIM, typename index_t, typename scalar_t>
+void jagged_dense_elementwise_jagged_output_launch_(
+    GenericPackedTensorAccessor<scalar_t, 2, DefaultPtrTraits, int32_t>
+        x_values, // output
+    StackArray<index_t*> x_offsets,
+    StackArray<int64_t> x_offsets_sizes,
+    GenericPackedTensorAccessor<scalar_t, 3, DefaultPtrTraits, int32_t>
+        y_0, // not used
+    GenericPackedTensorAccessor<scalar_t, 3, DefaultPtrTraits, int32_t> y_1,
+    GenericPackedTensorAccessor<scalar_t, 2, DefaultPtrTraits, int32_t>
+        output_values, // not used
+    StackArray<int64_t> jagged_dims,
+    int64_t wg_0,
+    int64_t wg_1,
+    int64_t wg_num) {
+  sycl_kernel_submit<jagged_dense_elementwise_jagged_output_kernel_<
+      NUM_JAGGED_DIM,
+      index_t,
+      scalar_t>>(
+      sycl::range<2>(wg_0 * wg_num, wg_1),
+      sycl::range<2>(wg_0, wg_1),
+      getCurrentSYCLQueue(),
+      x_values,
+      x_offsets,
+      x_offsets_sizes,
+      y_0,
+      y_1,
+      output_values,
+      jagged_dims);
+}
+
+template <int NUM_JAGGED_DIM, typename index_t>
+bool walk_down_tensor_storage_tree_(
+    int& offset,
+    const int flattened_jagged_idx,
+    const StackArray<int64_t>& jagged_dims,
+    const StackArray<index_t*>& x_offsets) {
+  // compute coorindates
+  int jagged_coords[NUM_JAGGED_DIM];
+  int j_temp = flattened_jagged_idx;
+#pragma unroll
+  for (int d = NUM_JAGGED_DIM - 1; d >= 0; --d) {
+    const int jagged_size = jagged_dims.vals[d];
+    jagged_coords[d] = j_temp % jagged_size;
+    j_temp /= jagged_size;
+  }
+
+  // walk down the tree
+  bool is_zero = false;
+#pragma unroll
+  for (int d = 0; d < NUM_JAGGED_DIM; ++d) {
+    const int begin = x_offsets.vals[d][offset];
+    const int end = x_offsets.vals[d][offset + 1];
+    if (jagged_coords[d] >= end - begin) {
+      is_zero = true;
+      break;
+    }
+    offset = begin + jagged_coords[d];
+  }
+  return is_zero;
+}
+
+inline std::tuple<int64_t, int64_t, int64_t, StackArray<int64_t>>
+check_shape_and_partition_(
+    const Tensor& values,
+    const std::vector<Tensor>& offsets,
+    const Tensor& dense_tensor) {
+  const int32_t outer_dense_size = dense_tensor.size(0);
+  TORCH_CHECK(
+      outer_dense_size == offsets[0].numel() - 1,
+      "outer_dense_size, ",
+      outer_dense_size,
+      " != offsets[0].numel() - 1, ",
+      offsets[0].numel() - 1);
+  const int32_t inner_dense_size = dense_tensor.size(-1);
+  TORCH_CHECK(
+      inner_dense_size == values.size(-1),
+      "inner_dense_size, ",
+      inner_dense_size,
+      " != values.size(-1), ",
+      values.size(-1));
+  const int32_t jagged_folded_size =
+      dense_tensor.numel() / (outer_dense_size * inner_dense_size);
+
+  const int32_t sub_group_size = syclMaxSubGroupSize();
+  const int64_t wg_size_0 = inner_dense_size >= sub_group_size / 2
+      ? sub_group_size
+      : inner_dense_size;
+  const int64_t wg_size_1 = syclDeviceMaxWorkGroupSize() / sub_group_size;
+  const int64_t wg_num =
+      CeilDiv(outer_dense_size * jagged_folded_size, (int32_t)wg_size_1);
+
+  StackArray<int64_t> jagged_dims_tensor;
+  const int32_t num_jagged_dim = dense_tensor.dim() - 2;
+  TORCH_CHECK(num_jagged_dim <= kStackArrayMaxDims);
+  jagged_dims_tensor.ndim = num_jagged_dim;
+  std::memcpy(
+      &(jagged_dims_tensor.vals[0]),
+      dense_tensor.sizes().data() + 1,
+      num_jagged_dim * sizeof(int64_t));
+  return {wg_size_0, wg_size_1, wg_num, jagged_dims_tensor};
+}
+
+template <typename scalar_t>
+void jagged_dense_elementwise_jagged_output_(
+    const Tensor& x_values,
+    const std::vector<Tensor>& x_offsets,
+    const Tensor& y,
+    const Tensor& output_values) {
+  // Canonicalize y to 3D, collapsing jagged dimensions.
+  const int num_jagged_dim = y.dim() - 2;
+  const Tensor y_reshaped = y.view({y.size(0), -1, y.size(-1)});
+#define INVOKE_KERNEL_WITH_DIM(NUM_JAGGED_DIM)                               \
+  {                                                                          \
+    int64_t wg_0, wg_1, wg_num;                                              \
+    StackArray<int64_t> jagged_dims_tensor;                                  \
+    std::tie(wg_0, wg_1, wg_num, jagged_dims_tensor) =                       \
+        check_shape_and_partition_(x_values, x_offsets, y);                  \
+    wg_num = CeilDiv(x_values.size(0), wg_1);                                \
+    std::vector<Tensor> x_offsets_contig;                                    \
+    x_offsets_contig.resize(num_jagged_dim);                                 \
+    StackArray<index_t*> x_offset_ptrs;                                      \
+    x_offset_ptrs.ndim = num_jagged_dim;                                     \
+    StackArray<int64_t> x_offset_sizes;                                      \
+    x_offset_sizes.ndim = num_jagged_dim;                                    \
+    for (int d = 0; d < num_jagged_dim; ++d) {                               \
+      x_offsets_contig[d] = x_offsets[d].contiguous();                       \
+      x_offset_ptrs.vals[d] =                                                \
+          x_offsets_contig[d].template data_ptr<index_t>();                  \
+      x_offset_sizes.vals[d] = x_offsets[d].numel();                         \
+    }                                                                        \
+    jagged_dense_elementwise_jagged_output_launch_<NUM_JAGGED_DIM, index_t>( \
+        x_values.packed_accessor32<scalar_t, 2>(),                           \
+        x_offset_ptrs,                                                       \
+        x_offset_sizes,                                                      \
+        y_reshaped.packed_accessor32<scalar_t, 3>(),                         \
+        y_reshaped.packed_accessor32<scalar_t, 3>(),                         \
+        output_values.packed_accessor32<scalar_t, 2>(),                      \
+        jagged_dims_tensor,                                                  \
+        wg_0,                                                                \
+        wg_1,                                                                \
+        wg_num);                                                             \
+  }
+
+  JAGGED_TENSOR_DISPATCH_DIMS();
+#undef INVOKE_KERNEL_WITH_DIM
+}
+
+void dense_to_jagged_forward_xpu_kernel(
+    const Tensor& x_values,
+    const std::vector<Tensor>& x_offsets,
+    const Tensor& y,
+    const Tensor& output_values) {
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::BFloat16,
+      at::ScalarType::Half,
+      x_values.scalar_type(),
+      "dense_to_jagged_forward_xpu_kernel",
+      [&]() {
+        jagged_dense_elementwise_jagged_output_<scalar_t>(
+            x_values, x_offsets, y, output_values);
+      });
+}
+
+template <int NUM_JAGGED_DIM, typename index_t, typename scalar_t>
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<2>))
+void jagged_dense_elementwise_dense_output_kernel_(
+    GenericPackedTensorAccessor<scalar_t, 2, DefaultPtrTraits, int32_t>
+        x_values,
+    StackArray<index_t*> x_offsets,
+    GenericPackedTensorAccessor<scalar_t, 3, DefaultPtrTraits, int32_t> y,
+    GenericPackedTensorAccessor<scalar_t, 3, DefaultPtrTraits, int32_t> output,
+    StackArray<int64_t> jagged_dims,
+    const scalar_t padding_value) {
+  auto output_acc = output;
+  const int outer_dense_size = y.size(0);
+  const int jagged_folded_size = y.size(1);
+  const int inner_dense_size = y.size(2);
+
+  auto item = syclext::this_work_item::get_nd_item<2>();
+  const int outer_begin =
+      item.get_group(0) * item.get_local_range(1) + item.get_local_id(1);
+  const int outer_stride = item.get_global_range(0) * item.get_local_range(1);
+  for (int outer = outer_begin; outer < outer_dense_size * jagged_folded_size;
+       outer += outer_stride) {
+    const int oidx = outer / jagged_folded_size;
+    const int jidx = outer % jagged_folded_size;
+
+    int offset = oidx;
+    const bool is_zero = walk_down_tensor_storage_tree_<NUM_JAGGED_DIM>(
+        offset, jidx, jagged_dims, x_offsets);
+
+    auto f = [](scalar_t x, scalar_t y) -> scalar_t { return x; };
+
+    if (is_zero) {
+      int iidx;
+      for (iidx = item.get_local_id(0); iidx * 2 + 1 < inner_dense_size;
+           iidx += item.get_local_range(0)) {
+        output_acc[oidx][jidx][2 * iidx] =
+            f(padding_value, y[oidx][jidx][2 * iidx]);
+        output_acc[oidx][jidx][2 * iidx + 1] =
+            f(padding_value, y[oidx][jidx][2 * iidx + 1]);
+      }
+      if (iidx * 2 + 1 == inner_dense_size) {
+        output_acc[oidx][jidx][2 * iidx] =
+            f(padding_value, y[oidx][jidx][2 * iidx]);
+      }
+    } else {
+      int iidx;
+      for (iidx = item.get_local_id(0); iidx * 2 + 1 < inner_dense_size;
+           iidx += item.get_local_range(0)) {
+        output_acc[oidx][jidx][2 * iidx] =
+            f(x_values[offset][2 * iidx], y[oidx][jidx][2 * iidx]);
+        output_acc[oidx][jidx][2 * iidx + 1] =
+            f(x_values[offset][2 * iidx + 1], y[oidx][jidx][2 * iidx + 1]);
+      }
+      if (iidx * 2 + 1 == inner_dense_size) {
+        output_acc[oidx][jidx][2 * iidx] =
+            f(x_values[offset][2 * iidx], y[oidx][jidx][2 * iidx]);
+      }
+    }
+  }
+}
+
+template <int NUM_JAGGED_DIM, typename index_t, typename scalar_t>
+void jagged_dense_elementwise_dense_output_launch_(
+    GenericPackedTensorAccessor<scalar_t, 2, DefaultPtrTraits, int32_t>
+        x_values,
+    StackArray<index_t*> x_offsets,
+    GenericPackedTensorAccessor<scalar_t, 3, DefaultPtrTraits, int32_t> y,
+    GenericPackedTensorAccessor<scalar_t, 3, DefaultPtrTraits, int32_t> output,
+    StackArray<int64_t> jagged_dims,
+    const scalar_t padding_value,
+    int64_t wg_0,
+    int64_t wg_1,
+    int64_t wg_num) {
+  sycl_kernel_submit<jagged_dense_elementwise_dense_output_kernel_<
+      NUM_JAGGED_DIM,
+      index_t,
+      scalar_t>>(
+      sycl::range<2>(wg_0 * wg_num, wg_1),
+      sycl::range<2>(wg_0, wg_1),
+      getCurrentSYCLQueue(),
+      x_values,
+      x_offsets,
+      y,
+      output,
+      jagged_dims,
+      padding_value);
+}
+
+template <typename scalar_t>
+void jagged_dense_elementwise_dense_output_(
+    const Tensor& x_values,
+    const std::vector<Tensor>& x_offsets,
+    const Tensor& y,
+    const Tensor& output,
+    const scalar_t padding_value) {
+  int64_t wg_0, wg_1, wg_num;
+  StackArray<int64_t> jagged_dims_tensor;
+  std::tie(wg_0, wg_1, wg_num, jagged_dims_tensor) =
+      check_shape_and_partition_(x_values, x_offsets, y);
+
+  // Canonicalize y and output to 3D, collapsing jagged dimensions.
+  const int num_jagged_dim = y.dim() - 2;
+  const Tensor y_reshaped = y.view({y.size(0), -1, y.size(-1)});
+  Tensor output_reshaped = output.view(y_reshaped.sizes());
+
+#define INVOKE_KERNEL_WITH_DIM(NUM_JAGGED_DIM)                              \
+  {                                                                         \
+    std::vector<Tensor> x_offsets_contig;                                   \
+    x_offsets_contig.resize(num_jagged_dim);                                \
+    StackArray<index_t*> x_offset_ptrs;                                     \
+    x_offset_ptrs.ndim = num_jagged_dim;                                    \
+    for (int d = 0; d < num_jagged_dim; ++d) {                              \
+      x_offsets_contig[d] = x_offsets[d].contiguous();                      \
+      x_offset_ptrs.vals[d] =                                               \
+          x_offsets_contig[d].template data_ptr<index_t>();                 \
+    }                                                                       \
+    jagged_dense_elementwise_dense_output_launch_<NUM_JAGGED_DIM, index_t>( \
+        x_values.packed_accessor32<scalar_t, 2>(),                          \
+        x_offset_ptrs,                                                      \
+        y_reshaped.packed_accessor32<scalar_t, 3>(),                        \
+        output_reshaped.packed_accessor32<scalar_t, 3>(),                   \
+        jagged_dims_tensor,                                                 \
+        padding_value,                                                      \
+        wg_0,                                                               \
+        wg_1,                                                               \
+        wg_num);                                                            \
+  }
+
+  JAGGED_TENSOR_DISPATCH_DIMS();
+#undef INVOKE_KERNEL_WITH_DIM
+}
+
+void jagged_to_padded_dense_forward_xpu_kernel(
+    const Tensor& x_values,
+    const std::vector<Tensor>& x_offsets,
+    const Tensor& y,
+    const Tensor& output,
+    const double padding_value) {
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::BFloat16,
+      at::ScalarType::Half,
+      x_values.scalar_type(),
+      "jagged_to_padded_dense_forward_xpu_kernel",
+      [&] {
+        jagged_dense_elementwise_dense_output_<scalar_t>(
+            x_values,
+            x_offsets,
+            y, // not used
+            output,
+            static_cast<scalar_t>(padding_value));
+      });
+}
+
+} // namespace xpu
+} // namespace native
+} // namespace at

--- a/src/ATen/native/xpu/sycl/FbgemmKernels.h
+++ b/src/ATen/native/xpu/sycl/FbgemmKernels.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <ATen/ATen.h>
+
+#include <sycl/sycl.hpp>
+
+namespace syclext = sycl::ext::oneapi;
+namespace syclexp = sycl::ext::oneapi::experimental;
+
+namespace at {
+namespace native {
+namespace xpu {
+
+constexpr size_t kStackArrayMaxDims = 5;
+
+template <typename T, typename V>
+inline auto CeilDiv(T a, V b) {
+  return (a + b - 1) / b;
+}
+
+void dense_to_jagged_forward_xpu_kernel(
+    const Tensor& x_values,
+    const std::vector<Tensor>& x_offsets,
+    const Tensor& y,
+    const Tensor& output_values);
+
+void jagged_to_padded_dense_forward_xpu_kernel(
+    const Tensor& x_values,
+    const std::vector<Tensor>& x_offsets,
+    const Tensor& y,
+    const Tensor& output,
+    const double padding_value = 0.0);
+
+// For SYCL free function
+template <auto* kptr, int RANGE_DIM, typename... Kargs>
+inline void sycl_kernel_submit(
+    ::sycl::range<RANGE_DIM> global_range,
+    ::sycl::range<RANGE_DIM> local_range,
+    ::sycl::queue q,
+    Kargs... args) {
+  sycl::context ctxt = q.get_context();
+  auto exe_bndl =
+      syclexp::get_kernel_bundle<kptr, sycl::bundle_state::executable>(ctxt);
+  sycl::kernel ker = exe_bndl.template ext_oneapi_get_kernel<kptr>();
+  syclexp::launch_config cfg{
+      ::sycl::nd_range<RANGE_DIM>(global_range, local_range)};
+  syclexp::nd_launch(q, cfg, ker, args...);
+}
+
+} // namespace xpu
+} // namespace native
+} // namespace at

--- a/test/xpu/test_fbgemm_ops_xpu.py
+++ b/test/xpu/test_fbgemm_ops_xpu.py
@@ -204,11 +204,6 @@ with XPUPatchForImport(False):
             torch.testing.assert_close(dense, dense2)
 
             # verify backward
-            # dense.retain_grad()
-            # ref_output_values = jagged_values.clone().detach().requires_grad_(True)
-            # ref_values = dense.clone().detach().requires_grad_(True)
-            # jagged_values.backward(ref_output_values)
-            # torch.testing.assert_close(dense.grad, ref_values)
 
         @given(
             num_jagged_dim=st.integers(1, 5),

--- a/test/xpu/test_fbgemm_ops_xpu.py
+++ b/test/xpu/test_fbgemm_ops_xpu.py
@@ -1,0 +1,476 @@
+# Owner(s): ["module: intel"]
+from typing import Tuple, Type, List
+import itertools
+
+import torch
+from torch.testing._internal.common_device_type import (
+    dtypes,
+    instantiate_device_type_tests,
+)
+from torch.testing._internal.common_utils import TestCase, run_tests, parametrize as parametrize_test
+
+import numpy as np
+import numpy.typing as npt
+
+from hypothesis import assume, given, settings, Verbosity
+import hypothesis.strategies as st
+
+try:
+    from xpu_test_utils import XPUPatchForImport
+except Exception as e:
+    from .xpu_test_utils import XPUPatchForImport
+    
+
+def generate_jagged_tensor(
+    num_jagged_dim: int,
+    outer_dense_size: int,
+    inner_dense_size: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    fold_inner_dense: bool = False,
+    # dynamo to mark the input as dynamic shape to make sure symbolic
+    # shape is generated
+    mark_dynamic: bool = False,
+) -> Tuple[torch.Tensor, List[torch.LongTensor], npt.NDArray]:
+    max_lengths = np.random.randint(low=1, high=10, size=(num_jagged_dim,))
+    x_offsets: List[torch.LongTensor] = []
+    num_lengths = outer_dense_size
+    for d in range(num_jagged_dim):
+        # Sometimes length[i] exceed max_L meaning jagged->dense will be
+        # truncation vs. padding
+        lengths = torch.randint(
+            # PT2 specialize 0/1 dims as non-symbolic shape. So we need
+            # to make it non 0/1 for testing. In real cases it'll likelyl
+            # not 0/1 anyway (if so, they'll be recompiled)
+            low=0 if not mark_dynamic else 1,
+            high=max_lengths[d] * 2,
+            # pyre-fixme[6]: For 3rd param expected `Union[List[int], Size,
+            #  typing.Tuple[int, ...]]` but got `Tuple[Union[bool, float, int]]`.
+            size=(num_lengths,),
+            device=device,
+        )
+        offset = torch.ops.fbgemm.asynchronous_complete_cumsum(lengths)
+        if mark_dynamic:
+            torch._dynamo.mark_dynamic(offset, 0)
+        x_offsets.append(offset)
+        num_lengths = x_offsets[-1][-1].item()
+
+    x_values = torch.rand(
+        # pyre-fixme[6]: For 1st param expected `Union[List[int], Size,
+        #  typing.Tuple[int, ...]]` but got `Tensor`.
+        x_offsets[-1][-1] * inner_dense_size,
+        dtype=dtype,
+        device=device,
+    )
+    if inner_dense_size != 1 or not fold_inner_dense:
+        # pyre-fixme[6]: For 1st param expected `int` but got `Union[bool, float, int]`.
+        x_values = x_values.reshape(x_offsets[-1][-1].item(), inner_dense_size)
+
+    if mark_dynamic:
+        for i in range(inner_dense_size):
+            torch._dynamo.mark_dynamic(x_values, i)
+
+    return x_values, x_offsets, max_lengths
+
+def to_padded_dense(
+    values: torch.Tensor,
+    offsets: List[torch.LongTensor],
+    max_lengths: npt.NDArray,
+    padding_value: float = 0,
+) -> torch.Tensor:
+    outer_dense_size = len(offsets[0]) - 1
+    # canonicalize by unsqueeze the last dim if the inner dense dimension
+    # is 1 and folded.
+    inner_dense_size = 1 if values.ndim == 1 else values.size(-1)
+    dense = torch.empty(
+        (outer_dense_size,) + tuple(max_lengths) + (inner_dense_size,),
+        dtype=values.dtype,
+        device=values.device,
+    )
+    for i in range(outer_dense_size):
+        for jagged_coord in itertools.product(
+            *(list(range(max_l)) for max_l in max_lengths)
+        ):
+            cur_offset = i
+            is_zero = False
+            for d in range(len(max_lengths)):
+                # pyre-fixme[6]: For 1st argument expected `Union[None, _NestedSe...
+                begin = offsets[d][cur_offset].item()
+                # pyre-fixme[6]: For 1st argument expected `Union[None, _NestedSe...
+                end = offsets[d][cur_offset + 1].item()
+                # pyre-fixme[6]: For 1st param expected `int` but got
+                #  `Union[bool, float, int]`.
+                if jagged_coord[d] >= end - begin:
+                    is_zero = True
+                    break
+                cur_offset = begin + jagged_coord[d]
+            dense[(i,) + jagged_coord] = (
+                padding_value
+                if is_zero
+                # pyre-fixme[6]: For 1st argument expected `Union[None, _NestedSe...
+                else values[cur_offset]
+            )
+    return dense.squeeze(-1) if values.ndim == 1 else dense
+
+
+with XPUPatchForImport(False):
+
+    class CumSumTest(TestCase):
+        @given(
+            n=st.integers(min_value=0, max_value=10),
+            index_types=st.sampled_from(
+                [
+                    (torch.int64, np.int64),
+                    (torch.int32, np.int32),
+                    (torch.float32, np.float32),
+                ]
+            ),
+            device=st.just(torch.device("xpu")),
+        )
+        @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+        def test_cumsum(
+            self,
+            n: int,
+            index_types: Tuple[Type[object], Type[object]],
+            device: torch.device,
+        ) -> None:
+            (pt_index_dtype, np_index_dtype) = index_types
+
+            # The CPU variants of asynchronous_*_cumsum support floats, since some
+            # downstream tests appear to be relying on this behavior.  As such, the
+            # test is disabled for GPU + float test cases.
+            if device == torch.device("xpu") and pt_index_dtype is torch.float32:
+                return
+
+            # pyre-ignore-errors[16]
+            x = torch.randint(low=0, high=100, size=(n,)).type(pt_index_dtype).to(device)
+            zc = torch.ops.fbgemm.asynchronous_complete_cumsum(x)
+
+            torch.testing.assert_close(
+                torch.from_numpy(
+                    (np.cumsum([0] + x.cpu().numpy().tolist())).astype(np_index_dtype)
+                ),
+                zc.cpu(),
+            )
+
+
+    class DenseToJaggedTest(TestCase):
+        def _test_dense_to_jagged(
+            self,
+            num_jagged_dim: int,
+            outer_dense_size: int,
+            inner_dense_size: int,
+            dtype: torch.dtype,
+            device: torch.device,
+            precompute_total_L: bool,
+        ) -> None:
+            
+            # import debugpy
+            # debugpy.listen(("0.0.0.0", 5678))
+            # debugpy.wait_for_client()
+            
+            # Generate multi-dim jagged tensor
+            values_2d, offsets, max_lengths = generate_jagged_tensor(
+                num_jagged_dim, outer_dense_size, inner_dense_size, dtype, device
+            )
+            # values_2d = values_2d.clone().detach().requires_grad_(True)
+
+            # jagged -> dense
+            dense = torch.ops.fbgemm.jagged_to_padded_dense(values_2d, offsets, max_lengths)
+
+            # dense -> jagged (op which is being tested)
+            if precompute_total_L:
+                total_L = values_2d.size(0)
+                jagged_values, jagged_offsets = torch.ops.fbgemm.dense_to_jagged(
+                    dense, offsets, total_L
+                )
+                jagged_values_f = torch.ops.fbgemm.dense_to_jagged_forward(
+                    dense, offsets, total_L
+                )
+                torch.testing.assert_close(jagged_values, jagged_values_f)
+            else:
+                jagged_values, jagged_offsets = torch.ops.fbgemm.dense_to_jagged(
+                    dense, offsets
+                )
+                jagged_values_f = torch.ops.fbgemm.dense_to_jagged_forward(
+                    dense, offsets
+                )
+                torch.testing.assert_close(jagged_values, jagged_values_f)
+
+            # jagged -> dense
+            dense2 = torch.ops.fbgemm.jagged_to_padded_dense(
+                jagged_values, jagged_offsets, max_lengths
+            )
+
+            # verify forward
+            torch.testing.assert_close(dense, dense2)
+
+            # verify backward
+            # dense.retain_grad()
+            # ref_output_values = jagged_values.clone().detach().requires_grad_(True)
+            # ref_values = dense.clone().detach().requires_grad_(True)
+            # jagged_values.backward(ref_output_values)
+            # torch.testing.assert_close(dense.grad, ref_values)
+
+        @given(
+            num_jagged_dim=st.integers(1, 5),
+            outer_dense_size=st.integers(0, 5),
+            inner_dense_size=st.integers(0, 5),
+            # num_jagged_dim=st.integers(4, 5),
+            # outer_dense_size=st.integers(4, 5),
+            # inner_dense_size=st.integers(4, 5),
+            dtype=st.sampled_from([torch.float, torch.half, torch.bfloat16]),
+            device=st.just(torch.device("xpu")),
+            precompute_total_L=st.booleans(),
+        )
+        @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+        def test_dense_to_jagged(
+            self,
+            num_jagged_dim: int,
+            outer_dense_size: int,
+            inner_dense_size: int,
+            dtype: torch.dtype,
+            device: torch.device,
+            precompute_total_L: bool,
+        ) -> None:
+            self._test_dense_to_jagged(
+                num_jagged_dim,
+                outer_dense_size,
+                inner_dense_size,
+                dtype,
+                device,
+                precompute_total_L,
+            )
+
+        @given(
+            num_jagged_dim=st.just(1),
+            outer_dense_size=st.integers(0, 6000),
+            inner_dense_size=st.sampled_from([8, 16, 23, 24, 48, 50, 64, 72, 96, 192]),
+            dtype=st.just(torch.half),
+            device=st.just(torch.device("xpu")),
+            precompute_total_L=st.booleans(),
+        )
+        @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+        def test_dense_to_jagged_opt(
+            self,
+            num_jagged_dim: int,
+            outer_dense_size: int,
+            inner_dense_size: int,
+            dtype: torch.dtype,
+            device: torch.device,
+            precompute_total_L: bool,
+        ) -> None:
+            self._test_dense_to_jagged(
+                num_jagged_dim,
+                outer_dense_size,
+                inner_dense_size,
+                dtype,
+                device,
+                precompute_total_L,
+            )
+
+        # (8000+1) * 8 (size of the element of LongTensor/int64_t offsets)
+        # = ~62.5KB > 48KB default shared memory on V100/A100.
+        @given(
+            num_jagged_dim=st.just(1),
+            outer_dense_size=st.just(8000),
+            inner_dense_size=st.just(16),
+            dtype=st.just(torch.half),
+            device=st.just(torch.device("xpu")),
+            precompute_total_L=st.booleans(),
+        )
+        @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+        def test_dense_to_jagged_opt_large_batch(
+            self,
+            num_jagged_dim: int,
+            outer_dense_size: int,
+            inner_dense_size: int,
+            dtype: torch.dtype,
+            device: torch.device,
+            precompute_total_L: bool,
+        ) -> None:
+            self._test_dense_to_jagged(
+                num_jagged_dim,
+                outer_dense_size,
+                inner_dense_size,
+                dtype,
+                device,
+                precompute_total_L,
+            )
+
+        @given(
+            num_jagged_dim=st.integers(1, 5),
+            # TODO: size = 0/1 will be incorrectly specialized
+            outer_dense_size=st.integers(2, 5),
+            inner_dense_size=st.integers(2, 5),
+            dtype=st.sampled_from([torch.float, torch.half, torch.bfloat16]),
+            device=st.just(torch.device("xpu")),
+        )
+        @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+        def test_dense_to_jagged_dynamic_shape(
+            self,
+            num_jagged_dim: int,
+            outer_dense_size: int,
+            inner_dense_size: int,
+            dtype: torch.dtype,
+            device: torch.device,
+        ) -> None:
+            # Start a fresh compile for each parameter of the test case
+            torch._dynamo.reset()
+
+            values_2d, offsets, max_lengths = generate_jagged_tensor(
+                num_jagged_dim,
+                outer_dense_size,
+                inner_dense_size,
+                dtype,
+                device,
+                mark_dynamic=True,
+            )
+            # values_2d = values_2d.clone().detach().requires_grad_(True)
+
+            def jagged_to_dense(
+                values: torch.Tensor,
+                offsets: List[torch.LongTensor],
+                max_lengths: List[int],
+            ) -> torch.Tensor:
+                return torch.ops.fbgemm.jagged_to_padded_dense(values, offsets, max_lengths)
+
+            # jagged -> dense
+            dense = jagged_to_dense(values_2d, offsets, max_lengths.tolist())
+
+            # dense -> jagged, it is required to pre-compute totalL
+            total_L = values_2d.size(0)
+            dense = dense.clone().detach().to(device)
+
+            torch._dynamo.mark_dynamic(dense, 0)
+            torch._dynamo.mark_dynamic(dense, -1)
+
+            def dense_to_jagged_withL(
+                dense: torch.Tensor, offsets: List[torch.LongTensor], total_L: List[int]
+            ) -> Tuple[torch.Tensor, torch.Tensor]:
+                jagged_values, jagged_offsets = torch.ops.fbgemm.dense_to_jagged(dense, offsets, total_L)
+                jagged_values_f = torch.ops.fbgemm.dense_to_jagged_forward(dense, offsets, total_L)
+                torch.testing.assert_close(jagged_values, jagged_values_f)
+                return jagged_values, jagged_offsets
+
+            def dense_to_jagged_noL(
+                dense: torch.Tensor, offsets: List[torch.LongTensor]
+            ) -> Tuple[torch.Tensor, torch.Tensor]:
+                jagged_values, jagged_offsets = torch.ops.fbgemm.dense_to_jagged(dense, offsets)
+                jagged_values_f = torch.ops.fbgemm.dense_to_jagged_forward(dense, offsets)
+                torch.testing.assert_close(jagged_values, jagged_values_f)
+                return jagged_values, jagged_offsets 
+
+            jagged_values, jagged_offsets = dense_to_jagged_noL(dense, offsets)
+            jagged_values, jagged_offsets = dense_to_jagged_withL(dense, offsets, total_L)
+
+            jagged_values.to(device)
+            # jagged -> dense
+            dense2 = torch.ops.fbgemm.jagged_to_padded_dense(
+                jagged_values, jagged_offsets, max_lengths
+            )
+
+            # verify forward
+            assert dense.size() == dense2.size()            
+            
+
+    class JaggedToPaddedDenseTest(TestCase):
+        @given(
+            num_jagged_dim=st.integers(1, 5),
+            outer_dense_size=st.integers(0, 5),
+            inner_dense_size=st.integers(0, 5),
+            fold_inner_dense=st.booleans(),
+            padding_value=st.sampled_from([0, -1e-8]),
+            dtype=st.sampled_from([torch.float, torch.half, torch.bfloat16]),
+            device_type=st.just("xpu"),
+        )
+        @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+        def test_jagged_to_padded_dense(
+            self,
+            num_jagged_dim: int,
+            outer_dense_size: int,
+            inner_dense_size: int,
+            fold_inner_dense: bool,
+            padding_value: float,
+            dtype: torch.dtype,
+            device_type: str,
+        ) -> None:
+            # CPU doesn't support bfloat16
+            assume(device_type != "cpu" or dtype != torch.bfloat16)
+            assume(not fold_inner_dense or inner_dense_size == 1)
+
+            # Testing with a basic crafted example.
+            # dense representation is
+            # [[[[0, 1], [ 0,  0], [0, 0]],
+            #   [[2, 3], [ 4,  5], [6, 7]],
+            #   [[0, 0], [ 0,  0], [0, 0]],
+            #   [[0, 0], [ 0,  0], [0, 0]]],
+            #  [[[0, 0], [ 0,  0], [0, 0]],
+            #   [[0, 0], [ 0,  0], [0, 0]],
+            #   [[0, 0], [ 0,  0], [0, 0]],
+            #   [[0, 0], [ 0,  0], [0, 0]]],
+            #  [[[8, 9], [10, 11], [0, 0]],
+            #   [[0, 0], [ 0,  0], [0, 0]],
+            #   [[0, 0], [ 0,  0], [0, 0]],
+            #   [[0, 0], [ 0,  0], [0, 0]]]],
+            # inner_dense_size = 2
+            # x_offsets = [
+            #     torch.LongTensor([0, 2, 2, 3]),  # lengths torch.Tensor([2, 0, 1]),
+            #     torch.LongTensor([0, 1, 4, 6]),  # lengths torch.Tensor([1, 3, 2]),
+            # ]
+            # outer_dense_size = len(x_offsets[0]) - 1
+            # max_lengths = [4, 3]
+
+            device = torch.device(device_type)
+
+            x_values, x_offsets, max_lengths = generate_jagged_tensor(
+                num_jagged_dim,
+                outer_dense_size,
+                inner_dense_size,
+                torch.float,
+                device,
+                fold_inner_dense,
+            )
+
+            output_ref = to_padded_dense(
+                x_values, x_offsets, max_lengths, padding_value=padding_value
+            )
+            output = torch.ops.fbgemm.jagged_to_padded_dense(
+                x_values,
+                x_offsets,
+                max_lengths,
+                padding_value=padding_value,
+            )
+            
+            output_f = torch.ops.fbgemm.jagged_to_padded_dense_forward(
+                x_values,
+                x_offsets,
+                max_lengths,
+                padding_value=padding_value,
+            )
+
+            torch.testing.assert_close(output, output_ref)
+            torch.testing.assert_close(output_f, output_ref)
+
+            # gradcheck(
+            #     torch.ops.fbgemm.jagged_to_padded_dense,
+            #     (
+            #         x_values.float().requires_grad_(True),
+            #         x_offsets,
+            #         max_lengths,
+            #         padding_value,
+            #     ),
+            #     eps=1e-2,
+            #     atol=1e-3,
+            #     rtol=1e-3,
+            # )
+
+
+instantiate_device_type_tests(CumSumTest, globals(), only_for="xpu", allow_xpu=True)
+
+instantiate_device_type_tests(DenseToJaggedTest, globals(), only_for="xpu", allow_xpu=True)
+
+instantiate_device_type_tests(JaggedToPaddedDenseTest, globals(), only_for="xpu", allow_xpu=True)
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/xpu/test_fbgemm_ops_xpu.py
+++ b/test/xpu/test_fbgemm_ops_xpu.py
@@ -319,7 +319,6 @@ with XPUPatchForImport(False):
                 device,
                 mark_dynamic=True,
             )
-            # values_2d = values_2d.clone().detach().requires_grad_(True)
 
             def jagged_to_dense(
                 values: torch.Tensor,

--- a/test/xpu/test_fbgemm_ops_xpu.py
+++ b/test/xpu/test_fbgemm_ops_xpu.py
@@ -444,20 +444,6 @@ with XPUPatchForImport(False):
             torch.testing.assert_close(output, output_ref)
             torch.testing.assert_close(output_f, output_ref)
 
-            # gradcheck(
-            #     torch.ops.fbgemm.jagged_to_padded_dense,
-            #     (
-            #         x_values.float().requires_grad_(True),
-            #         x_offsets,
-            #         max_lengths,
-            #         padding_value,
-            #     ),
-            #     eps=1e-2,
-            #     atol=1e-3,
-            #     rtol=1e-3,
-            # )
-
-
 instantiate_device_type_tests(CumSumTest, globals(), only_for="xpu", allow_xpu=True)
 
 instantiate_device_type_tests(DenseToJaggedTest, globals(), only_for="xpu", allow_xpu=True)

--- a/test/xpu/test_fbgemm_ops_xpu.py
+++ b/test/xpu/test_fbgemm_ops_xpu.py
@@ -163,11 +163,6 @@ with XPUPatchForImport(False):
             device: torch.device,
             precompute_total_L: bool,
         ) -> None:
-
-            # import debugpy
-            # debugpy.listen(("0.0.0.0", 5678))
-            # debugpy.wait_for_client()
-
             # Generate multi-dim jagged tensor
             values_2d, offsets, max_lengths = generate_jagged_tensor(
                 num_jagged_dim, outer_dense_size, inner_dense_size, dtype, device
@@ -457,6 +452,7 @@ with XPUPatchForImport(False):
 
             torch.testing.assert_close(output, output_ref)
             torch.testing.assert_close(output_f, output_ref)
+
 
 instantiate_device_type_tests(CumSumTest, globals(), only_for="xpu", allow_xpu=True)
 

--- a/test/xpu/test_fbgemm_ops_xpu.py
+++ b/test/xpu/test_fbgemm_ops_xpu.py
@@ -1,19 +1,17 @@
 # Owner(s): ["module: intel"]
-from typing import Tuple, Type, List
 import itertools
+from typing import Tuple, Type, List
 
+import hypothesis.strategies as st
+import numpy as np
+import numpy.typing as npt
 import torch
+from hypothesis import assume, given, settings, Verbosity
 from torch.testing._internal.common_device_type import (
     dtypes,
     instantiate_device_type_tests,
 )
-from torch.testing._internal.common_utils import TestCase, run_tests, parametrize as parametrize_test
-
-import numpy as np
-import numpy.typing as npt
-
-from hypothesis import assume, given, settings, Verbosity
-import hypothesis.strategies as st
+from torch.testing._internal.common_utils import TestCase, run_tests
 
 try:
     from xpu_test_utils import XPUPatchForImport

--- a/test/xpu/test_fbgemm_ops_xpu.py
+++ b/test/xpu/test_fbgemm_ops_xpu.py
@@ -19,7 +19,7 @@ try:
     from xpu_test_utils import XPUPatchForImport
 except Exception as e:
     from .xpu_test_utils import XPUPatchForImport
-    
+
 
 def generate_jagged_tensor(
     num_jagged_dim: int,
@@ -164,11 +164,11 @@ with XPUPatchForImport(False):
             device: torch.device,
             precompute_total_L: bool,
         ) -> None:
-            
+
             # import debugpy
             # debugpy.listen(("0.0.0.0", 5678))
             # debugpy.wait_for_client()
-            
+
             # Generate multi-dim jagged tensor
             values_2d, offsets, max_lengths = generate_jagged_tensor(
                 num_jagged_dim, outer_dense_size, inner_dense_size, dtype, device
@@ -359,7 +359,7 @@ with XPUPatchForImport(False):
                 jagged_values, jagged_offsets = torch.ops.fbgemm.dense_to_jagged(dense, offsets)
                 jagged_values_f = torch.ops.fbgemm.dense_to_jagged_forward(dense, offsets)
                 torch.testing.assert_close(jagged_values, jagged_values_f)
-                return jagged_values, jagged_offsets 
+                return jagged_values, jagged_offsets
 
             jagged_values, jagged_offsets = dense_to_jagged_noL(dense, offsets)
             jagged_values, jagged_offsets = dense_to_jagged_withL(dense, offsets, total_L)
@@ -371,8 +371,8 @@ with XPUPatchForImport(False):
             )
 
             # verify forward
-            assert dense.size() == dense2.size()            
-            
+            assert dense.size() == dense2.size()
+
 
     class JaggedToPaddedDenseTest(TestCase):
         @given(
@@ -441,7 +441,7 @@ with XPUPatchForImport(False):
                 max_lengths,
                 padding_value=padding_value,
             )
-            
+
             output_f = torch.ops.fbgemm.jagged_to_padded_dense_forward(
                 x_values,
                 x_offsets,


### PR DESCRIPTION
supported below four fbgemm ops on xpu.

fbgemm::asynchronous_complete_cumsum
fbgemm::jagged_to_padded_dense_forward
fbgemm::jagged_to_padded_dense
fbgemm::dense_to_jagged_forward 

Please make sure you have below env vars set correctly for running the UT.

```
# make sure ONEAPI_ROOT is set since it's referenced in umf's vars.sh. Otherwise, you may not able to see any device.
export ONEAPI_ROOT=.../intel/oneapi/
# DPCPP 2025.3
source .../DPCPP/env/vars.sh
source ~/intel/oneapi/mkl/latest/env/vars.sh
source .../pti_0.12/env/vars.sh
source .../umf/1.0.2/env/vars.sh
export BUILD_SEPARATE_OPS=ON
export BUILD_WITH_CPU=ON
export TORCH_XPU_ARCH_LIST='pvc'
export USE_PTI=ON
export USE_KINETO=ON
export USE_XETLA=OFF
```