### PR TITLE
Fix error handling for BatchLinearAlgebra Ops

### DIFF
--- a/src/ATen/native/xpu/mkl/BatchLinearAlgebra.cpp
+++ b/src/ATen/native/xpu/mkl/BatchLinearAlgebra.cpp
@@ -54,7 +54,7 @@ void error_handle(
     return;
   }
 
-  for (auto i = 0; i < errs.size(); ++i) {
+  for (size_t i = 0; i < errs.size(); ++i) {
     try {
       std::rethrow_exception(errs[i]);
     } catch (const oneapi::mkl::lapack::exception& e) {

--- a/src/ATen/native/xpu/mkl/BatchLinearAlgebra.cpp
+++ b/src/ATen/native/xpu/mkl/BatchLinearAlgebra.cpp
@@ -54,7 +54,7 @@ void error_handle(
     return;
   }
 
-  for (auto& i : ids) {
+  for (auto i = 0; i < errs.size(); ++i) {
     try {
       std::rethrow_exception(errs[i]);
     } catch (const oneapi::mkl::lapack::exception& e) {


### PR DESCRIPTION
This PR is to fix the access to exception vector in error handling. Original implementation may cause a segmentation fault due to out-of-bounds access.