### PR TITLE
[release/2.9] Revert tracking of Work status for FlightRecorder in ProcessGroupXCCL

### DIFF
--- a/src/xccl/ProcessGroupXCCL.hpp
+++ b/src/xccl/ProcessGroupXCCL.hpp
@@ -415,8 +415,6 @@ class TORCH_API ProcessGroupXCCL : public Backend {
 
   const std::vector<uint64_t>& groupRanks() const;
   void setEnqueuedPgStatus(c10::intrusive_ptr<ProcessGroupXCCL::WorkXCCL> work);
-  void setCompletedPgStatus(
-      c10::intrusive_ptr<ProcessGroupXCCL::WorkXCCL> work);
   bool dumpDebuggingInfo(bool includeStackTrace = true);
 
  protected:


### PR DESCRIPTION
See #2076 , this is a cherry-pick for 2.9 release

This is a high impact bug, in many distributed applications this is a large memory leak resulting in OoM error (see https://github.com/intel/torch-xpu-ops/issues/2084)