### PR TITLE
Activate FP8 cases in test_ops

### DIFF
--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -1,9 +1,6 @@
 skip_dict = {
     "test_ops_xpu.py": (
         # Skip list of base line
-        # XPU implementation doesn't claimn FP8 now
-        # https://github.com/intel/torch-xpu-ops/issues/461
-        "float8",
         # To be removed from this file.
         # CUDA and XPU both XFAIL now.
         "test_out_narrow_copy_xpu_float32",


### PR DESCRIPTION
Since more FP8 Ops will be supported on XPU recently, basic FP8 cases should be activated. This PR will remove the following cases from skip list:
```
TestCommonXPU::test_compare_cpu_torch__scaled_mm_xpu_float8_e4m3fn SKIPPED (test doesn't work on XPU backend)
TestCommonXPU::test_out_torch__scaled_mm_xpu_float8_e4m3fn SKIPPED (Skipped!)
TestCommonXPU::test_python_ref__refs_eye_xpu_float8_e4m3fn SKIPPED (test doesn't work on XPU backend)
TestCommonXPU::test_python_ref__refs_eye_xpu_float8_e4m3fnuz SKIPPED (test doesn't work on XPU backend)
TestCommonXPU::test_python_ref__refs_eye_xpu_float8_e5m2 SKIPPED (test doesn't work on XPU backend)
TestCommonXPU::test_python_ref__refs_eye_xpu_float8_e5m2fnuz SKIPPED (test doesn't work on XPU backend)
TestCommonXPU::test_python_ref_executor__refs_eye_executor_aten_xpu_float8_e4m3fn PASSED
TestCommonXPU::test_python_ref_executor__refs_eye_executor_aten_xpu_float8_e4m3fnuz PASSED
TestCommonXPU::test_python_ref_executor__refs_eye_executor_aten_xpu_float8_e5m2 PASSED
TestCommonXPU::test_python_ref_executor__refs_eye_executor_aten_xpu_float8_e5m2fnuz PASSED
TestCommonXPU::test_python_ref_meta__refs_eye_xpu_float8_e4m3fn SKIPPED (test doesn't work on XPU backend)
TestCommonXPU::test_python_ref_meta__refs_eye_xpu_float8_e4m3fnuz SKIPPED (test doesn't work on XPU backend)
TestCommonXPU::test_python_ref_meta__refs_eye_xpu_float8_e5m2 SKIPPED (test doesn't work on XPU backend)
TestCommonXPU::test_python_ref_meta__refs_eye_xpu_float8_e5m2fnuz SKIPPED (test doesn't work on XPU backend)
TestCommonXPU::test_python_ref_torch_fallback__refs_eye_xpu_float8_e4m3fn SKIPPED (test doesn't work on XPU backend)
TestCommonXPU::test_python_ref_torch_fallback__refs_eye_xpu_float8_e4m3fnuz SKIPPED (test doesn't work on XPU backend)
TestCommonXPU::test_python_ref_torch_fallback__refs_eye_xpu_float8_e5m2 SKIPPED (test doesn't work on XPU backend)
TestCommonXPU::test_python_ref_torch_fallback__refs_eye_xpu_float8_e5m2fnuz SKIPPED (test doesn't work on XPU backend)
```