### PR TITLE
Fix ProcessGroupXCCL options initialization

### DIFF
--- a/src/xccl/ProcessGroupXCCL.cpp
+++ b/src/xccl/ProcessGroupXCCL.cpp
@@ -369,7 +369,7 @@ ProcessGroupXCCL::ProcessGroupXCCL(
     int size,
     c10::intrusive_ptr<Options> options)
     : Backend(rank, size),
-      store_(store),
+      store_(std::move(store)),
       xcclCommCounter_(0),
       local_id_(process_group_id++),
       options_(std::move(options)) {

--- a/src/xccl/ProcessGroupXCCL.hpp
+++ b/src/xccl/ProcessGroupXCCL.hpp
@@ -128,8 +128,6 @@ class TORCH_API ProcessGroupXCCL : public Backend {
       return c10::make_intrusive<Options>(is_high_priority_stream);
     }
     bool is_high_priority_stream;
-    std::vector<uint64_t> global_ranks_in_group;
-    std::string group_name;
   };
 
   ProcessGroupXCCL(


### PR DESCRIPTION
Group UID needs to be set before creating the LogPrefix, and the initialization list order is fixed now.

In addition, we remove the redefinition of certain members in ProcessGroupXCCL.hpp which then allows the existing python bindings to work properly.