### PR TITLE
[CI] Port test/functorch/test_ops.py and test/test_unary_ufuncs.py from pytorch

### DIFF
--- a/.github/actions/linux-uttest/action.yml
+++ b/.github/actions/linux-uttest/action.yml
@@ -77,7 +77,7 @@ runs:
           tee ${{ github.workspace }}/ut_log/op_ut/op_ut_with_skip_test.log
         ls -al
         cp *.xml ${{ github.workspace }}/ut_log
-        find op_ut_with_skip_nn op_ut_with_skip_quantization/core -type f -exec sh -c '
+        find op_ut_with_skip_nn op_ut_with_skip_quantization/core op_ut_with_all_functorch -type f -exec sh -c '
             dir_path=$(dirname "$1");
             case "$dir_path" in
                 *"op_ut_with_skip_quantization/core"*)
@@ -90,6 +90,7 @@ runs:
         ls -al op_ut_with_skip_nn op_ut_with_skip_quantization/core
         cp op_ut_with_skip_nn/*.xml ${{ github.workspace }}/ut_log
         cp op_ut_with_skip_quantization/core/*.xml ${{ github.workspace }}/ut_log
+        cp op_ut_with_all_functorch/*.xml ${{ github.workspace }}/ut_log
         # Cases run with a on-demand white list, since some suites are too
         # slow to go through all operators on CPU. So add cases on-demand
         # when XPU implementatoin is done.

--- a/test/xpu/functorch/test_ops_functorch_xpu.py
+++ b/test/xpu/functorch/test_ops_functorch_xpu.py
@@ -1,0 +1,3035 @@
+# Owner(s): ["module: functorch"]
+# ruff: noqa: F841
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import functools
+import itertools
+import sys
+import unittest
+
+sys.path.append("../../../../test/functorch")
+
+import torch
+import torch.autograd.forward_ad as fwAD
+from common_utils import (
+    check_vmap_fallback,
+    decorate,
+    expectedFailureIf,
+    generate_vmap_inputs,
+    get_fallback_and_vmap_exhaustive,
+    is_batch_norm_training,
+    is_valid_inplace_sample_input,
+    loop,
+    loop2,
+    opsToleranceOverride,
+    skip,
+    skipOps,
+    tol1,
+    tol2,
+    xfail,
+)
+from functorch import grad, jacfwd, jacrev, vjp, vmap
+from functorch_additional_op_db import additional_op_db
+from torch import Tensor
+from torch._functorch.eager_transforms import _as_tuple, jvp
+from torch.testing._internal.autograd_function_db import autograd_function_db
+from torch.testing._internal.common_cuda import with_tf32_off
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    ops,
+    tol,
+    toleranceOverride,
+)
+from torch.testing._internal.common_methods_invocations import op_db
+from torch.testing._internal.common_utils import (
+    is_iterable_of_tensors,
+    noncontiguous_like,
+    parametrize,
+    run_tests,
+    runOnRocm,
+    skipIfRocm,
+    TEST_WITH_ASAN,
+    TEST_WITH_ROCM,
+    TestCase,
+    unMarkDynamoStrictTest,
+)
+from torch.testing._internal.opinfo.core import SampleInput
+from torch.utils import _pytree as pytree
+from torch.utils._pytree import tree_flatten, tree_map, tree_unflatten
+
+aten = torch.ops.aten
+
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
+
+# Version of autograd.grad with some differences:
+#   - pytree inputs is allowed (but leaves of the pytree have to all
+#     be tensors)
+#   - if an input is not used as part of derivatives, we will return a
+#     zero-filled tensor for the result
+def _autograd_grad(
+    outputs, inputs, grad_outputs=None, retain_graph=False, create_graph=True
+):
+    inputs, inputs_spec = tree_flatten(inputs)
+    diff_inputs = tuple(inp for inp in inputs if inp.requires_grad)
+    if grad_outputs is None:
+        diff_outputs = tuple(out for out in outputs if out.requires_grad)
+    else:
+        diff_grad_outputs = [
+            (out, go) for out, go in zip(outputs, grad_outputs) if out.requires_grad
+        ]
+        if len(diff_grad_outputs) == 0:
+            diff_outputs, grad_outputs = (), ()
+        else:
+            diff_outputs, grad_outputs = zip(*diff_grad_outputs)
+    grad_inputs = torch.autograd.grad(
+        diff_outputs,
+        diff_inputs,
+        grad_outputs,
+        retain_graph=retain_graph,
+        create_graph=create_graph,
+        allow_unused=True,
+    )
+    result = []
+    grad_inputs_iter = iter(grad_inputs)
+    for inp in inputs:
+        if inp.requires_grad:
+            grad_input = next(grad_inputs_iter)
+            if grad_input is None:
+                result.append(torch.zeros_like(inp))
+            else:
+                result.append(grad_input)
+        else:
+            result.append(torch.zeros_like(inp))
+    return tree_unflatten(result, inputs_spec)
+
+
+def diff_arg(arg, requires_grad=True):
+    def is_differentiable_arg(arg):
+        if requires_grad:
+            return arg.requires_grad
+        else:
+            return arg.is_floating_point() or arg.is_complex()
+
+    if is_iterable_of_tensors(arg):
+        if all(is_differentiable_arg(a) for a in arg):
+            return True
+        if all(not is_differentiable_arg(a) for a in arg):
+            return False
+        raise RuntimeError("NYI: The test runner can't handle this")
+    return isinstance(arg, Tensor) and is_differentiable_arg(arg)
+
+
+# Given f, returns an f' such that:
+# - f' takes only positional arguments
+# - All arguments to f' are floating-point Tensors
+# - All outputs of f' are floating-point Tensors
+def normalize_op_input_output2(
+    f, args, kwargs, output_process_fn_grad=None, requires_grad=True
+):
+    flat_args, args_spec = tree_flatten(args)
+    diff_argnums = tuple(
+        i
+        for i, arg in enumerate(flat_args)
+        if diff_arg(arg, requires_grad=requires_grad)
+    )
+    assert len(diff_argnums) > 0
+    primals = tuple(flat_args[i] for i in diff_argnums)
+
+    @functools.wraps(f)
+    def wrapped(*primals):
+        _args = list(flat_args)
+        for num, arg in zip(diff_argnums, primals):
+            _args[num] = arg
+        _args = tree_unflatten(_args, args_spec)
+        result = f(*_args, **kwargs)
+        if output_process_fn_grad is not None:
+            result = output_process_fn_grad(result)
+        if isinstance(result, tuple):
+            result = tuple(r for r in result if torch.is_floating_point(r))
+            assert len(result) > 0
+        return result
+
+    return wrapped, primals
+
+
+# TODO: consolidate with normalize_op_input_output2
+def normalize_op_input_output3(
+    f, args, kwargs, sample_args, output_process_fn_grad=None
+):
+    flat_args, args_spec = tree_flatten(args)
+    flat_sample_args = pytree.tree_leaves(sample_args)
+    diff_argnums = tuple(
+        i
+        for i, (arg, sample) in enumerate(zip(flat_args, flat_sample_args))
+        if diff_arg(sample, requires_grad=True)
+    )
+    assert len(diff_argnums) > 0
+    primals = tuple(flat_args[i] for i in diff_argnums)
+
+    @functools.wraps(f)
+    def wrapped(*primals):
+        _args = list(flat_args)
+        for num, arg in zip(diff_argnums, primals):
+            _args[num] = arg
+        _args = tree_unflatten(_args, args_spec)
+        result = f(*_args, **kwargs)
+        if output_process_fn_grad is not None:
+            result = output_process_fn_grad(result)
+        if isinstance(result, tuple):
+            result = tuple(r for r in result if torch.is_floating_point(r))
+            assert len(result) > 0
+        return result
+
+    return wrapped, primals
+
+
+def normalize_op_input_output(f, sample, requires_grad=True):
+    args = tuple([sample.input] + list(sample.args))
+    return normalize_op_input_output2(
+        f,
+        args,
+        sample.kwargs,
+        sample.output_process_fn_grad,
+        requires_grad=requires_grad,
+    )
+
+
+def ref_vjp(f, *primals):
+    result = f(*primals)
+
+    def wrapped(cotangents):
+        return _autograd_grad(_as_tuple(result), primals, _as_tuple(cotangents))
+
+    return result, wrapped
+
+
+def simulate_jvp(f, primals, tangents):
+    primals_out, tangents_out = torch.autograd.functional.jvp(f, primals, tangents)
+    return primals_out, tangents_out
+
+
+def ref_jvp(f, primals, tangents):
+    with fwAD.dual_level():
+        duals = tuple(fwAD.make_dual(p, t) for p, t in zip(primals, tangents))
+        result_duals = f(*duals)
+        result_duals, spec = tree_flatten(result_duals)
+        primals_out, tangents_out = zip(*(fwAD.unpack_dual(d) for d in result_duals))
+        return tree_unflatten(primals_out, spec), tree_unflatten(tangents_out, spec)
+
+
+def get_sample_cotangents(f, sample):
+    fn, primals = normalize_op_input_output(f, sample)
+    output = fn(*primals)
+    return tree_map(torch.randn_like, output)
+
+
+# returns a new function g(*args, *cotangents)
+# that computes vjps and (*args, cotangents)
+def get_vjp_fn_and_args_with_cotangents(f, sample, cotangents):
+    args = tuple([sample.input] + list(sample.args))
+    kwargs = sample.kwargs
+    flat_args, args_spec = tree_flatten(args)
+    flat_cotangents, cotangents_spec = tree_flatten(cotangents)
+
+    @functools.wraps(f)
+    def wrapped(*args):
+        assert len(args) == len(flat_args) + len(flat_cotangents)
+        actual_args = args[: len(flat_args)]
+        cotangents = args[len(flat_args) :]
+        actual_args = tree_unflatten(actual_args, args_spec)
+        cotangents = tree_unflatten(cotangents, cotangents_spec)
+
+        fn, primals = normalize_op_input_output3(
+            f, actual_args, kwargs, flat_args, sample.output_process_fn_grad
+        )
+        _, vjp_fn = vjp(fn, *primals)
+        return vjp_fn(cotangents)
+
+    return wrapped, tuple(flat_args + flat_cotangents)
+
+
+# Returns a new function g(*args, *cotangents) that computes vjps and
+# sample (*args, *cotangents)
+def get_vjpfull_variant(f, sample):
+    fn, primals = normalize_op_input_output(f, sample)
+    return _get_vjpfull_variant(fn, primals)
+
+
+def get_vjpfull_variant2(f, args, kwargs):
+    fn, primals = normalize_op_input_output2(f, args, kwargs)
+    return _get_vjpfull_variant(fn, primals)
+
+
+def _get_vjpfull_variant(fn, primals):
+    result = fn(*primals)
+    cotangents = _as_tuple(
+        tree_map(lambda x: torch.randn_like(x, requires_grad=True), result)
+    )
+    num_primals = len(primals)
+    args = (*primals, *cotangents)
+
+    @functools.wraps(fn)
+    def wrapped(*args):
+        primals = args[:num_primals]
+        cotangents = args[num_primals:]
+        result, vjp_fn = vjp(fn, *primals)
+        if isinstance(result, torch.Tensor):
+            assert len(cotangents) == 1
+            cotangents = cotangents[0]
+        return vjp_fn(cotangents)
+
+    return wrapped, args
+
+
+def get_jvp_variant(f, sample):
+    # We want this higher-order variant of jvp, so that it can
+    # be used to wrap vmap
+    fn, primals = normalize_op_input_output(f, sample, requires_grad=False)
+    tangents = _as_tuple(tree_map(lambda x: torch.randn_like(x), primals))
+
+    @functools.wraps(f)
+    def wrapped(*args):
+        tangents = args
+        primals_out, tangents_out = jvp(fn, primals, tangents)
+
+        if isinstance(primals_out, torch.Tensor):
+            return (primals_out, tangents_out)
+        else:
+            flat_primals_out = pytree.tree_leaves(primals_out)
+            flat_tangents_out = pytree.tree_leaves(tangents_out)
+            return tuple(flat_primals_out + flat_tangents_out)
+
+    return wrapped, tangents
+
+
+def get_jvp_variant_primals_tangents2(
+    f, args, kwargs, output_process_fn_grad=None, requires_grad=False
+):
+    fn, primals = normalize_op_input_output2(
+        f, args, kwargs, output_process_fn_grad, requires_grad
+    )
+    tangents = _as_tuple(tree_map(lambda x: torch.randn_like(x), primals))
+    return _get_jvp_variant(fn, primals, tangents)
+
+
+def get_jvp_variant_primals_tangents(f, sample):
+    # We want this higher-order variant of jvp, so that it can
+    # be used to wrap vmap
+    fn, primals = normalize_op_input_output(f, sample, requires_grad=False)
+    tangents = _as_tuple(tree_map(lambda x: torch.randn_like(x), primals))
+    return _get_jvp_variant(fn, primals, tangents)
+
+
+def _get_jvp_variant(fn, primals, tangents):
+    @functools.wraps(fn)
+    def wrapped(*args):
+        primals_in = args[: len(primals)]
+        tangents_in = args[len(primals) :]
+        primals_out, tangents_out = jvp(fn, primals_in, tangents_in)
+
+        if isinstance(primals_out, torch.Tensor):
+            return (primals_out, tangents_out)
+        else:
+            flat_primals_out = pytree.tree_leaves(primals_out)
+            flat_tangents_out = pytree.tree_leaves(tangents_out)
+            return tuple(flat_primals_out + flat_tangents_out)
+
+    return wrapped, primals + tangents
+
+
+def is_inplace(op, variant):
+    if hasattr(variant, "__wrapped__"):
+        return variant.__wrapped__ is op.get_inplace()
+    return variant is op.get_inplace()
+
+
+vjp_fail = {
+    xfail("tensor_split"),  # data_ptr composite compliance
+    # Very minor accuracy issue on ROCm
+    decorate("nn.functional.scaled_dot_product_attention", decorator=skipIfRocm),
+}
+
+aliasing_ops = {
+    "T",
+    "broadcast_to",
+    "conj",
+    "contiguous",
+    "diagonal",  # linalg.diagonal is an alias
+    "expand",
+    "flatten",
+    "imag",
+    "mH",  # adjoint is an alias
+    "mT",
+    "movedim",  # moveaxis is an alias
+    "narrow",
+    "permute",
+    "positive",
+    # 'ravel', is composite implicit autograd and may call clone
+    "real",
+    "reshape",
+    "resolve_conj",
+    "resolve_neg",
+    "select",
+    "squeeze",
+    "transpose",  # swapdims and swapaxes are aliases
+    "unflatten",
+    "unfold",
+    "unsqueeze",
+    "view",
+    "view_as",
+    "view_as_complex",
+    "view_as_real",
+}
+
+aliasing_ops_list_return = {
+    "chunks",
+    "dsplit",
+    "hsplit",
+    "split",
+    "unbind",
+    "vsplit",
+    # 'tensor_split' not composite compliant, see vjp_fail
+}
+
+skip_noncontig = {
+    "_batch_norm_with_update",
+    "as_strided_copy",
+}
+
+bool_unsupported_ordered_ops = {
+    "topk",
+    "argmin",
+    "ceil",
+    "argmax",
+    "floor",
+}
+bool_ordered_op_db = tuple(
+    filter(lambda op: op.name in bool_unsupported_ordered_ops, op_db)
+)
+
+complex_unsupported_ordered_ops = {
+    "sort",
+    "topk",
+    "lt",
+    "argmin",
+    "le",
+    "ge",
+    "amax",
+    "maximum",
+    "minimum",
+    "clamp",
+    "amin",
+    "gt",
+    "ceil",
+    "argmax",
+    "floor",
+}
+complex_ordered_op_db = tuple(
+    filter(lambda op: op.name in complex_unsupported_ordered_ops, op_db)
+)
+
+
+@unittest.skipIf(TEST_WITH_ASAN, "tests time out with asan, are probably redundant")
+@unMarkDynamoStrictTest
+class TestOperators(TestCase):
+    @with_tf32_off  # https://github.com/pytorch/pytorch/issues/86798
+    @ops(op_db + additional_op_db + autograd_function_db, allowed_dtypes=(torch.float,))
+    @skipOps(
+        "TestOperators",
+        "test_grad",
+        vjp_fail.union(
+            {
+                xfail(
+                    "chalf", "", device_type="cpu"
+                ),  # RuntimeError: "sum_cpu" not implemented for 'ComplexHalf'
+                xfail(
+                    "sparse.sampled_addmm", ""
+                ),  # RuntimeError: Sparse CSR tensors do not have strides
+                xfail(
+                    "sparse.mm", "reduce"
+                ),  # RuntimeError: Sparse CSR tensors do not have strides
+                # Non-contiguous Bugs
+                #
+                # AssertionError: Tensor-likes are not close!
+                xfail("as_strided"),
+                xfail("as_strided", "partial_views"),
+                # RuntimeError: !self.requires_grad() || self.is_contiguous()
+                xfail("as_strided_scatter"),
+                # RuntimeError: Tensor must have a last dimension with stride 1
+                xfail("view_as_complex"),
+                # query: last dimension must be contiguous
+                # Fused attention kernels require last dim to be contiguous
+                decorate(
+                    "nn.functional.scaled_dot_product_attention",
+                    decorator=expectedFailureIf(not TEST_WITH_ROCM),
+                ),  # Works on ROCm
+                xfail("torch.ops.aten._flash_attention_forward"),
+                xfail("torch.ops.aten._efficient_attention_forward"),
+            }
+        ),
+    )
+    @opsToleranceOverride(
+        "TestOperators",
+        "test_grad",
+        (
+            tol1(
+                "nn.functional.binary_cross_entropy_with_logits",
+                {torch.float32: tol(atol=1e-04, rtol=1e-04)},
+            ),
+            tol1("masked.cumprod", {torch.float32: tol(atol=1e-05, rtol=1e-05)}),
+            tol1("svd_lowrank", {torch.float32: tol(atol=3e-04, rtol=3e-04)}),
+            tol1(
+                "linalg.multi_dot",
+                {torch.float32: tol(atol=1e-05, rtol=8e-04)},
+                device_type=device_type,
+            ),
+            tol1(
+                "linalg.tensorsolve",
+                {torch.float32: tol(atol=3e-04, rtol=3e-04)},
+                device_type=device_type,
+            ),
+            tol1(
+                "nn.functional.multi_head_attention_forward",
+                {torch.float32: tol(atol=8e-04, rtol=1e-03)},
+            ),
+            tol1(
+                "__rmatmul__",
+                {torch.float32: tol(atol=3e-04, rtol=3e-04)},
+                device_type=device_type,
+            ),
+            tol1(
+                "matmul",
+                {torch.float32: tol(atol=3e-04, rtol=3e-04)},
+                device_type=device_type,
+            ),
+            tol1(
+                "pca_lowrank",
+                {torch.float32: tol(atol=3e-05, rtol=4e-06)},
+                device_type="cpu",
+            ),
+        ),
+    )
+    def test_grad(self, device, dtype, op):
+        if op.name in vjp_fail:
+            self.skipTest("Skipped; Expected failures")
+            return
+
+        if not op.supports_autograd:
+            self.skipTest("Skipped! Autograd not supported.")
+            return
+
+        samples = op.sample_inputs(device, dtype, requires_grad=True)
+
+        if is_inplace(op, op.get_op()):
+            self.skipTest("Skipped for redundancy. test_vjp handles in-place testing.")
+            return
+
+        for sample in samples:
+            args = [sample.input] + list(sample.args)
+            kwargs = sample.kwargs
+
+            if op.name not in skip_noncontig:
+                noncontig_sample = sample.noncontiguous()
+                noncontig_args = [noncontig_sample.input] + list(noncontig_sample.args)
+                noncontig_kwargs = noncontig_sample.kwargs
+
+            diff_argnums = tuple(i for i, arg in enumerate(args) if diff_arg(arg))
+            assert len(diff_argnums) > 0
+            diff_args = tuple(args[i] for i in diff_argnums)
+
+            def wrapped_fn(*args, **kwargs):
+                result = op(*args, **kwargs)
+                if sample.output_process_fn_grad is not None:
+                    result = sample.output_process_fn_grad(result)
+
+                def abs_if_complex(t):
+                    if t.dtype.is_complex:
+                        return t.abs()
+                    return t
+
+                # Reduce into single value for grad
+                if isinstance(result, torch.Tensor):
+                    return abs_if_complex(result.sum())
+                result = sum(abs_if_complex(res.sum()) for res in result)
+                return result
+
+            result = grad(wrapped_fn, diff_argnums)(*args, **kwargs)
+            expected = _autograd_grad(_as_tuple(wrapped_fn(*args, **kwargs)), diff_args)
+            self.assertEqual(result, expected)
+
+            if op.name not in skip_noncontig:
+                result_noncontig = grad(wrapped_fn, diff_argnums)(
+                    *noncontig_args, **noncontig_kwargs
+                )
+                self.assertEqual(result_noncontig, expected)
+
+    @with_tf32_off  # https://github.com/pytorch/pytorch/issues/86798
+    @ops(op_db + additional_op_db + autograd_function_db, allowed_dtypes=(torch.float,))
+    @skipOps(
+        "TestOperators",
+        "test_jvp",
+        set(
+            {
+                # Composite ops that do bad things. Need to be fixed in PyTorch core.
+                # RuntimeError: Cannot access data pointer of Tensor that doesn't have storage
+                xfail("tensor_split"),
+                # BUG: silent incorrectness: runs and produces numerical differences
+                skip("nn.functional.max_unpool1d"),  # fails everywhere except on mac
+                skip(
+                    "nn.functional.max_unpool2d"
+                ),  # fails everywhere except on windows
+                skip("nn.functional.max_unpool3d"),  # fails everywhere except on mac
+                xfail(
+                    "native_batch_norm"
+                ),  # TODO: fails comparing None to tensor of 0s for saved_mean/var tangents
+                xfail(
+                    "_native_batch_norm_legit"
+                ),  # TODO: fails comparing None to tensor of 0s for saved_mean/var tangents
+                xfail(
+                    "_batch_norm_with_update"
+                ),  # TODO: fails comparing None to tensor of 0s for saved_mean/var tangents
+                xfail("nn.functional.scaled_dot_product_attention"),
+                xfail("torch.ops.aten._flash_attention_forward"),
+                xfail("torch.ops.aten._efficient_attention_forward"),
+                xfail(
+                    "nn.functional.rrelu"
+                ),  # in-place test errors out with no formula implemented
+                xfail(
+                    "NumpyExpMarkDirtyAutogradFunction"
+                ),  # TODO: https://github.com/pytorch/pytorch/issues/91280
+                # --- Non-Contiguous Failures! ---
+                # This is expected to fail as the operator
+                # expects last dim to have stride=1
+                xfail("view_as_complex"),
+                # BUG
+                # AssertionError: Tensor-likes are not close!
+                xfail("as_strided"),
+                xfail("as_strided", "partial_views"),
+                xfail("as_strided_scatter"),
+            }
+        ),
+    )
+    @opsToleranceOverride(
+        "TestOperators",
+        "test_jvp",
+        (
+            tol1(
+                "nn.functional.conv_transpose3d",
+                {torch.float32: tol(atol=1e-04, rtol=1.3e-06)},
+                device_type=device_type,
+            ),
+            tol1(
+                "linalg.tensorsolve",
+                {torch.float32: tol(atol=1e-04, rtol=1.3e-05)},
+                device_type=device_type,
+            ),
+            tol1(
+                "masked.prod",
+                {torch.float32: tol(atol=1e-05, rtol=1.3e-05)},
+                device_type=device_type,
+            ),
+            tol1(
+                "nn.functional.binary_cross_entropy_with_logits",
+                {torch.float32: tol(atol=4e-04, rtol=4e-04)},
+            ),
+            tol1(
+                "nn.functional.batch_norm", {torch.float32: tol(atol=4e-05, rtol=5e-05)}
+            ),
+            tol1("nn.functional.conv2d", {torch.float32: tol(atol=4e-05, rtol=5e-05)}),
+            tol1("svd_lowrank", {torch.float32: tol(atol=5e-05, rtol=5e-05)}),
+            tol1("pca_lowrank", {torch.float32: tol(atol=5e-05, rtol=5e-05)}),
+            tol1(
+                "nn.functional.multi_head_attention_forward",
+                {torch.float32: tol(atol=6e-05, rtol=2e-05)},
+            ),
+            tol2(
+                "linalg.pinv", "hermitian", {torch.float32: tol(atol=5e-5, rtol=2e-5)}
+            ),
+        ),
+    )
+    def test_jvp(self, device, dtype, op):
+        # TODO: get rid of vjp_decomp when we add decomposition support to
+        # PyTorch's forward-mode ad. Currently the decomposition support only
+        # works for functorch.jvp
+        VJP_DECOMP = {
+            "nn.functional.logsigmoid",
+        }
+        if op.name in VJP_DECOMP:
+            fixme_ref_jvp_local = simulate_jvp
+        else:
+            fixme_ref_jvp_local = ref_jvp
+
+        if not op.supports_forward_ad and op.name not in VJP_DECOMP:
+            self.skipTest("Skipped! Forward AD not supported.")
+            return
+
+        samples = op.sample_inputs(device, dtype, requires_grad=True)
+
+        outplace_variant = op if not is_inplace(op, op.get_op()) else None
+        inplace_variant = op.inplace_variant if op.supports_inplace_autograd else None
+
+        for sample in samples:
+            if outplace_variant:
+                self.jvp_opinfo_test(
+                    outplace_variant,
+                    sample,
+                    sample.output_process_fn_grad,
+                    clone_inputs=False,
+                    fixme_ref_jvp_local=fixme_ref_jvp_local,
+                    test_noncontig=op.name not in skip_noncontig,
+                )
+            if is_valid_inplace_sample_input(sample, op, inplace_variant):
+                self.jvp_opinfo_test(
+                    inplace_variant,
+                    sample,
+                    sample.output_process_fn_grad,
+                    clone_inputs=True,
+                    fixme_ref_jvp_local=fixme_ref_jvp_local,
+                    test_noncontig=op.name not in skip_noncontig,
+                )
+
+    def jvp_opinfo_test(
+        self,
+        fn,
+        sample,
+        output_process_fn,
+        clone_inputs,
+        fixme_ref_jvp_local,
+        test_noncontig,
+    ):
+        # NB: we used requires_grad=True to determine where the primals are,
+        # but don't need that information otherwise
+        args = (sample.input,) + sample.args
+        kwargs = sample.kwargs
+        contig_fn, primals = normalize_op_input_output2(
+            fn, args, kwargs, output_process_fn, requires_grad=True
+        )
+        orig_primals = tree_map(lambda x: x.detach(), primals)
+        orig_tangents = tree_map(lambda x: torch.randn_like(x), primals)
+
+        def maybe_clone_inputs():
+            if clone_inputs:
+                primals = tree_map(torch.clone, orig_primals)
+                tangents = tree_map(torch.clone, orig_tangents)
+                return primals, tangents
+            return orig_primals, orig_tangents
+
+        primals, tangents = maybe_clone_inputs()
+        expected_primal_outs, expected_tangent_outs = fixme_ref_jvp_local(
+            contig_fn, primals, tangents
+        )
+
+        primals, tangents = maybe_clone_inputs()
+        primal_outs, tangent_outs = jvp(contig_fn, primals, tangents)
+
+        self.assertEqual(primal_outs, expected_primal_outs)
+        self.assertEqual(tangent_outs, expected_tangent_outs)
+
+        if test_noncontig:
+            noncontig_sample = sample.noncontiguous()
+            noncontig_args = (noncontig_sample.input,) + noncontig_sample.args
+            noncontig_kwargs = sample.kwargs
+            noncontig_fn, primals = normalize_op_input_output2(
+                fn,
+                noncontig_args,
+                noncontig_kwargs,
+                output_process_fn,
+                requires_grad=True,
+            )
+            noncontig_primals = tree_map(lambda x: x.detach(), primals)
+            noncontig_tangents = tree_map(
+                lambda x: noncontiguous_like(x), orig_tangents
+            )
+            noncontig_primal_outs, noncontig_tangent_outs = jvp(
+                noncontig_fn, noncontig_primals, noncontig_tangents
+            )
+
+            self.assertEqual(noncontig_primal_outs, expected_primal_outs)
+            self.assertEqual(noncontig_tangent_outs, expected_tangent_outs)
+
+    @with_tf32_off  # https://github.com/pytorch/pytorch/issues/86798
+    @ops(op_db + additional_op_db + autograd_function_db, allowed_dtypes=(torch.float,))
+    @skipOps(
+        "TestOperators",
+        "test_vjp",
+        vjp_fail.union(
+            {
+                xfail("sparse.sampled_addmm", ""),
+                xfail("sparse.mm", "reduce"),
+                # ---- Non-Contiguous Failures ----
+                # This is expected to fail as the operator
+                # expects last dim to have stride=1
+                xfail("view_as_complex"),
+                # RuntimeError: query: last dimension must be contiguous
+                # The fused attention kernels require the last dim to be contiguous
+                decorate(
+                    "nn.functional.scaled_dot_product_attention",
+                    decorator=expectedFailureIf(not TEST_WITH_ROCM),
+                ),  # Works on ROCm
+                xfail("torch.ops.aten._flash_attention_forward"),
+                xfail("torch.ops.aten._efficient_attention_forward"),
+                # BUG
+                # AssertionError: Tensor-likes are not close!
+                xfail("as_strided"),
+                xfail("as_strided_scatter"),
+                xfail("as_strided", "partial_views"),
+            }
+        ),
+    )
+    @opsToleranceOverride(
+        "TestOperators",
+        "test_vjp",
+        (
+            tol1(
+                "nn.functional.conv_transpose3d",
+                {torch.float32: tol(atol=5e-05, rtol=9e-05)},
+                device_type=device_type,
+            ),
+            tol1(
+                "nn.functional.binary_cross_entropy_with_logits",
+                {torch.float32: tol(atol=1e-04, rtol=1e-04)},
+            ),
+            tol1(
+                "nn.functional.multi_head_attention_forward",
+                {torch.float32: tol(atol=2e-03, rtol=2e-04)},
+            ),
+            tol1("__rmatmul__", {torch.float32: tol(atol=1e-05, rtol=1e-05)}),
+            tol1("matmul", {torch.float32: tol(atol=1e-05, rtol=1e-05)}),
+            tol2(
+                "linalg.pinv", "hermitian", {torch.float32: tol(atol=1e-05, rtol=1e-05)}
+            ),
+            tol1("linalg.tensorsolve", {torch.float32: tol(atol=9e-03, rtol=2e-04)}),
+            tol1("linalg.multi_dot", {torch.float32: tol(atol=1e-04, rtol=1e-04)}),
+            tol1("svd_lowrank", {torch.float32: tol(atol=1e-04, rtol=1e-04)}),
+            tol1("pca_lowrank", {torch.float32: tol(atol=1e-04, rtol=1e-04)}),
+        ),
+    )
+    def test_vjp(self, device, dtype, op):
+        if not op.supports_autograd:
+            self.skipTest("Skipped! Autograd not supported.")
+            return
+
+        samples = op.sample_inputs(device, dtype, requires_grad=True)
+
+        def _test(_op, inplace=False):
+            for sample in samples:
+                if inplace and not is_valid_inplace_sample_input(
+                    sample, op, op.inplace_variant
+                ):
+                    continue
+                fn, primals = normalize_op_input_output(_op, sample)
+                result = fn(*primals)
+                cotangents = tree_map(lambda x: torch.randn_like(x), result)
+
+                out, vjp_fn = vjp(fn, *primals)
+                self.assertEqual(out, result)
+                result_vjps = vjp_fn(cotangents)
+
+                _, vjp_fn = ref_vjp(fn, *primals)
+                expected_vjps = vjp_fn(cotangents)
+
+                self.assertEqual(result_vjps, expected_vjps)
+
+                if op.name not in skip_noncontig:
+                    noncontig_fn, noncontig_primals = normalize_op_input_output(
+                        _op, sample.noncontiguous()
+                    )
+                    noncontig_cotangents = tree_map(
+                        lambda x: noncontiguous_like(x), cotangents
+                    )
+                    out_noncontig, vjp_fn = vjp(noncontig_fn, *noncontig_primals)
+                    self.assertEqual(out_noncontig, result)
+                    noncontig_result_vjps = vjp_fn(noncontig_cotangents)
+                    self.assertEqual(noncontig_result_vjps, expected_vjps)
+
+        _test(op)
+        for a_op in op.aliases:
+            _test(a_op)
+        if op.inplace_variant:
+
+            def f(inp, *args, **kwargs):
+                return op.inplace_variant(inp.clone(), *args, **kwargs)
+
+            _test(f, inplace=True)
+
+    @ops(op_db + additional_op_db + autograd_function_db, allowed_dtypes=(torch.float,))
+    @skipOps(
+        "TestOperators",
+        "test_vjpvjp",
+        vjp_fail.union(
+            {
+                skip("nn.functional.max_unpool1d"),  # silent incorrectness; Flaky
+                skip("nn.functional.max_unpool2d"),  # silent incorrectness; Flaky
+                xfail("nn.functional.ctc_loss"),  # Not Implemented
+                xfail(
+                    "native_layer_norm", ""
+                ),  # Expected a proper Tensor but got None for argument #1 'other'
+                xfail("sparse.sampled_addmm", ""),  # sparse tensors have no strides
+                xfail("sparse.mm", "reduce"),  # sparse tensors have no strides
+                skip("nn.functional.scaled_dot_product_attention"),
+                xfail("torch.ops.aten._flash_attention_forward"),
+                xfail("torch.ops.aten._efficient_attention_forward"),
+                # AssertionError: Tensor-likes are not close!
+                # Mismatched elements: 1 / 15 (6.7%)
+                # Greatest absolute difference: 24.0 at index (2, 4) (up to 1e-05 allowed)
+                # Greatest relative difference: 1.7933241714393998e-06 at index (2, 4) (up to 1.3e-06 allowed)
+                # The failure occurred for item [0]
+                xfail("masked.prod"),
+            }
+        ),
+    )
+    @opsToleranceOverride(
+        "TestOperators",
+        "test_vjpvjp",
+        (
+            tol1(
+                "nn.functional.conv_transpose3d",
+                {torch.float32: tol(atol=5e-05, rtol=9e-05)},
+                device_type=device_type,
+            ),
+            tol1("prod", {torch.float32: tol(atol=2e-05, rtol=1e-04)}),
+            tol1("masked.cumprod", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
+            tol1("cumprod", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
+            tol1("linalg.vander", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
+        ),
+    )
+    def test_vjpvjp(self, device, dtype, op):
+        if not op.supports_autograd:
+            self.skipTest("Skipped! Autograd not supported.")
+            return
+        if not op.supports_gradgrad:
+            self.skipTest("Skipped! Operation does not support gradgrad")
+            return
+
+        samples = op.sample_inputs(device, dtype, requires_grad=True)
+
+        def test(_op, inplace=False):
+            for sample in samples:
+                if inplace and not is_valid_inplace_sample_input(
+                    sample, op, op.inplace_variant
+                ):
+                    continue
+                fn, args = get_vjpfull_variant(_op, sample)
+                result = fn(*args)
+                cotangents = tree_map(lambda x: torch.randn_like(x), result)
+
+                # Compute vjp of vjp
+                _, vjp_fn = vjp(fn, *args)
+                result_vjps = vjp_fn(cotangents)
+
+                # Compute ref_vjp of vjp. We could have done ref_vjp of ref_vjp,
+                # but since we're confident that vjp works by itself, this is
+                # an equivalent way to test that.
+                _, vjp_fn = ref_vjp(fn, *args)
+                expected_vjps = vjp_fn(cotangents)
+
+                self.assertEqual(result_vjps, expected_vjps)
+
+        test(op)
+        if op.inplace_variant:
+
+            def fn(inp, *args, **kwargs):
+                return op.inplace_variant(inp.clone(), *args, **kwargs)
+
+            test(fn, inplace=True)
+
+    @with_tf32_off  # https://github.com/pytorch/pytorch/issues/86798
+    @skipOps(
+        "TestOperators",
+        "test_vmapvjpvjp",
+        vjp_fail.union(
+            {
+                skip("atleast_1d"),  # Takes too long
+                skip("atleast_2d"),  # Takes too long
+                skip("atleast_3d"),  # Takes too long
+                skip("ormqr"),  # Takes too long
+                xfail("as_strided"),  # incorrect output
+                xfail("as_strided", "partial_views"),  # incorrect output
+                xfail("as_strided_scatter"),  # incorrect output
+                skip("bernoulli"),  # calls random op
+                xfail("bfloat16"),  # rank 4 tensor for channels_last
+                xfail("cdouble"),  # rank 4 tensor for channels_last
+                xfail("cfloat"),  # rank 4 tensor for channels_last
+                xfail("chalf"),  # rank 4 tensor for channels_last
+                xfail("double"),  # rank 4 tensor for channels_last
+                xfail("float"),  # rank 4 tensor for channels_last
+                xfail("half"),  # rank 4 tensor for channels_last
+                xfail(
+                    "NumpyCubeNotComposableAutogradFunction"
+                ),  # Not composable autograd.Function
+                # It looks like you're either (1) calling .item() on a Tensor or
+                # (2) attempting to use a Tensor in some data-dependent control flow or
+                # (3) encountering this error in PyTorch internals.
+                xfail("index_reduce", "prod"),
+                decorate(
+                    "linalg.householder_product", decorator=runOnRocm
+                ),  # works on ROCm
+                xfail(
+                    # nans
+                    "masked.softmax",
+                    device_type="cpu",
+                ),
+                xfail(
+                    "nanquantile", device_type="cpu"
+                ),  # vmap not implemented for at::equal.
+                xfail("native_layer_norm"),  # vmap: inplace into a regular tensor
+                # got a batched tensor as input while the running_mean or running_var,
+                # which will be updated in place, were not batched.
+                xfail("nn.functional.batch_norm"),
+                xfail(
+                    "nn.functional.binary_cross_entropy"
+                ),  # vmap: inplace into a regular tensor
+                xfail(
+                    "nn.functional.ctc_loss"
+                ),  # derivate not implemented for _ctc_loss_backward
+                # flaky on ROCM needs investigation
+                decorate("nn.functional.conv_transpose2d", decorator=skipIfRocm),
+                skip("nn.functional.dropout"),  # calls random op
+                skip("nn.functional.dropout2d"),  # calls random op
+                skip("nn.functional.dropout3d"),  # calls random op
+                skip("nn.functional.alpha_dropout"),  # calls random op
+                skip(
+                    "nn.functional.feature_alpha_dropout", "with_train"
+                ),  # calls random op
+                skip("nn.functional.fractional_max_pool2d"),  # calls random op
+                skip("nn.functional.fractional_max_pool3d"),  # calls random op
+                xfail("nn.functional.scaled_dot_product_attention"),  # randomness
+                xfail("torch.ops.aten._efficient_attention_forward"),  # outputs ints
+                xfail("nn.functional.multi_head_attention_forward"),  # randomness
+                # It looks like you're either (1) calling .item() on a Tensor or
+                # (2) attempting to use a Tensor in some data-dependent control flow or
+                # (3) encountering this error in PyTorch internals.
+                xfail("nn.functional.gaussian_nll_loss"),
+                # got a batched tensor as input while the running_mean or running_var,
+                # which will be updated in place, were not batched.
+                xfail("nn.functional.instance_norm"),
+                xfail(
+                    "nn.functional.layer_norm"
+                ),  # vmap: inplace into a regular tensor
+                # RuntimeError: NYI: querying is_contiguous inside of vmap
+                # for memory_format other than torch.contiguous_formats
+                xfail("nn.functional.max_pool2d"),
+                # RuntimeError: NYI: Tensor.clone(memory_format) inside vmap is only
+                # supported with memory_format torch.preserve_format or
+                # torch.contiguous_format (got ChannelsLast)
+                xfail("nn.functional.max_unpool2d"),
+                # RuntimeError: NYI: Tensor.clone(memory_format) inside vmap is only
+                # supported with memory_format torch.preserve_format
+                # or torch.contiguous_format (got ChannelsLast)s
+                xfail("nn.functional.max_unpool2d", "grad"),
+                xfail(
+                    "nn.functional.rrelu"
+                ),  # RuntimeError: vmap: we do not yet support aten::rrelu_with_noise.
+                xfail("normal"),  # calls random op
+                xfail("normal", "number_mean"),  # calls random op
+                xfail("pca_lowrank"),  # calls random op
+                xfail(
+                    "quantile", device_type="cpu"
+                ),  # Batching rule not implemented for `at::equal`
+                xfail(
+                    "scatter_reduce", "prod"
+                ),  # vmap (looks like you are calling item/data-dependent)
+                xfail(
+                    "sparse.sampled_addmm"
+                ),  # RuntimeError: Sparse CSR tensors do not have strides
+                xfail(
+                    "sparse.mm", "reduce"
+                ),  # RuntimeError: Sparse CSR tensors do not have strides
+                xfail("svd_lowrank"),  # calls random op
+                xfail("to"),  # rank 4 tensor for channels_last
+                xfail(
+                    "view_as_complex"
+                ),  # RuntimeError: Tensor must have a last dimension with stride 1
+                # got a batched tensor as input while the running_mean or running_var,
+                # which will be updated in place, were not batched.
+                xfail("nn.functional.batch_norm", "without_cudnn"),
+                # view doesn't work on sparse
+                xfail("to_sparse"),
+                xfail("native_batch_norm"),
+                xfail("_native_batch_norm_legit"),
+                # TODO: implement batching rule
+                xfail("_batch_norm_with_update"),
+                xfail(
+                    "unbind_copy"
+                ),  # Batching rule not implemented for aten::unbind_copy.int.
+            }
+        ),
+    )
+    @ops(op_db + additional_op_db + autograd_function_db, allowed_dtypes=(torch.float,))
+    @toleranceOverride({torch.float32: tol(atol=1e-04, rtol=1e-04)})
+    @opsToleranceOverride(
+        "TestOperators",
+        "test_vmapvjpvjp",
+        (
+            tol1("linalg.svd", {torch.float32: tol(atol=1e-03, rtol=5e-04)}),
+            tol1("linalg.lu", {torch.float32: tol(atol=5e-04, rtol=7e-04)}),
+            tol1("linalg.lu_factor", {torch.float32: tol(atol=2e-03, rtol=2e-02)}),
+            tol1("linalg.multi_dot", {torch.float32: tol(atol=2e-03, rtol=2e-04)}),
+            tol1("svd", {torch.float32: tol(atol=1e-03, rtol=5e-04)}),
+            tol1("matrix_exp", {torch.float32: tol(atol=1e-03, rtol=5e-04)}),
+            tol1("masked.prod", {torch.float32: tol(atol=2e-03, rtol=2e-04)}),
+        ),
+    )
+    @skipOps(
+        "TestOperators",
+        "test_vmapvjpvjp",
+        {
+            xfail("as_strided", "partial_views"),
+            xfail("as_strided_copy"),
+        },
+    )
+    def test_vmapvjpvjp(self, device, dtype, op):
+        # Since, we test `vjpvjp` independently,
+        # for this test, we just verify that vmap
+        # of `vjpvjp` is correct.
+        if not op.supports_autograd:
+            self.skipTest("Skipped! Autograd not supported.")
+            return
+        if not op.supports_gradgrad:
+            self.skipTest("Skipped! Operation does not support gradgrad")
+            return
+
+        samples = op.sample_inputs(device, dtype, requires_grad=True)
+
+        # TODO: test in-place
+        if is_inplace(op, op.get_op()):
+            self.skipTest("Skipped! NYI: inplace-testing not supported.")
+            return
+
+        for sample in samples:
+            fn, args = get_vjpfull_variant(op, sample)
+            result = fn(*args)
+            cotangents = tree_map(lambda x: torch.randn_like(x), result)
+            cotangents = pytree.tree_leaves(cotangents)
+            num_args = len(args)
+
+            args_and_cotangents = tuple(args) + tuple(cotangents)
+
+            def vjp_of_vjp(*args_and_cotangents):
+                args = args_and_cotangents[:num_args]
+                cotangents = args_and_cotangents[num_args:]
+                result, vjp_fn = vjp(fn, *args)
+                result_vjps = vjp_fn(cotangents)
+                result = pytree.tree_leaves(result)
+                result_vjps = pytree.tree_leaves(result_vjps)
+                return (*result, *result_vjps)
+
+            is_batch_norm_and_training = is_batch_norm_training(op.name, sample.kwargs)
+            generator = get_fallback_and_vmap_exhaustive(
+                vjp_of_vjp,
+                args_and_cotangents,
+                {},
+                is_batch_norm_and_training=is_batch_norm_and_training,
+            )
+            for loop_out, batched_out in generator:
+                self.assertEqual(loop_out, batched_out)
+
+    vmapvjp_fail = vjp_fail.union(
+        {
+            # -------------------- ALLOWED FAILURES --------------------------------
+            # The following are not bugs and are expected behavior
+            xfail("masked_select"),  # Not possible due to dynamic shapes
+            skip("bernoulli"),  # randomness
+            skip("normal", ""),  # randomness
+            skip("normal", "number_mean"),  # randomness
+            skip("nn.functional.rrelu"),  # randomness
+            skip("nn.functional.feature_alpha_dropout", "with_train"),  # randomness
+            skip("nn.functional.feature_alpha_dropout", "without_train"),  # randomness
+            skip("nn.functional.dropout"),  # randomness
+            skip("nn.functional.dropout2d"),  # randomness
+            skip("nn.functional.dropout3d", ""),  # randomness
+            skip("nn.functional.alpha_dropout"),  # randomness
+            skip("nn.functional.scaled_dot_product_attention"),  # randomness
+            xfail("torch.ops.aten._efficient_attention_forward"),  # outputs ints
+            skip("nn.functional.multi_head_attention_forward"),  # randomness
+            xfail(
+                "index_put", ""
+            ),  # not possible due to dynamic shapes; we support a subset
+            xfail("nn.functional.fractional_max_pool2d"),  # random
+            xfail("nn.functional.fractional_max_pool3d"),  # random
+            xfail("pca_lowrank", ""),  # randomness
+            xfail("svd_lowrank", ""),  # randomness
+            xfail("to_sparse", ""),  # non-dense output
+            skip(
+                "to"
+            ),  # RuntimeError: required rank 4 tensor to use channels_last format
+            xfail("as_strided", "partial_views"),
+            xfail(
+                "NumpyCubeNotComposableAutogradFunction"
+            ),  # Not composable autograd.Function
+            # ----------------------------------------------------------------------
+            # ---------------------------- BUGS ------------------------------------
+            # All of the following are bugs and need to be fixed
+            skip(
+                "linalg.svdvals"
+            ),  # # really annoying thing where it passes correctness check but not has_batch_rule
+            skip("native_batch_norm"),
+            skip("_native_batch_norm_legit"),
+            # TODO: implement batching rule
+            skip("_batch_norm_with_update"),
+            xfail("__getitem__", ""),  # dynamic error
+            xfail("nanquantile", device_type="cpu"),  # checks q via a .item() call
+            xfail("nn.functional.gaussian_nll_loss"),  # checks var for if any value < 0
+            xfail("narrow"),  # .item() call
+            xfail("quantile", device_type="cpu"),  # checks q via a .item() call
+            xfail("view_as_complex"),  # Tensor must have a last dimension with stride 1
+            # required rank 4 tensor to use channels_last format
+            xfail("bfloat16"),
+            xfail("double"),
+            xfail("float"),
+            xfail("half"),
+            xfail("cdouble", ""),
+            xfail("cfloat", ""),
+            xfail("chalf", ""),
+            xfail("scatter_reduce", "prod"),  # item call
+            # Batching rule not implemented for aten::_use_cudnn_ctc_loss.Tensor
+            xfail("nn.functional.ctc_loss", device_type=device_type),
+            # NYI: querying is_contiguous inside of vmap for memory_format other than torch.contiguous_format
+            xfail("nn.functional.max_unpool2d"),
+            xfail("nn.functional.max_unpool2d", "grad"),
+            xfail("sparse.sampled_addmm", ""),
+            xfail("sparse.mm", "reduce"),
+            xfail("as_strided_scatter", ""),  # calls as_strided
+            xfail("index_reduce", "prod"),  # .item() call
+            xfail(
+                "unbind_copy"
+            ),  # Batching rule not implemented for aten::unbind_copy.int.
+            # ---------------------------------------------------------------------
+        }
+    )
+
+    @with_tf32_off  # https://github.com/pytorch/pytorch/issues/86798
+    @ops(op_db + additional_op_db + autograd_function_db, allowed_dtypes=(torch.float,))
+    @toleranceOverride({torch.float32: tol(atol=1e-04, rtol=1e-04)})
+    @opsToleranceOverride(
+        "TestOperators",
+        "test_vmapvjp",
+        (
+            tol1(
+                "linalg.svd",
+                {torch.float32: tol(atol=5e-04, rtol=1e-04)},
+                device_type=device_type,
+            ),
+            tol1(
+                "svd",
+                {torch.float32: tol(atol=5e-04, rtol=1e-04)},
+                device_type=device_type,
+            ),
+            tol1(
+                "linalg.householder_product",
+                {torch.float32: tol(atol=3e-04, rtol=9e-04)},
+            ),
+            tol1(
+                "matrix_exp",
+                {torch.float32: tol(atol=5e-04, rtol=1e-04)},
+                device_type=device_type,
+            ),
+            tol1(
+                "nn.functional.layer_norm",
+                {torch.float32: tol(atol=3e-4, rtol=1e-4)},
+                device_type="cpu",
+            ),
+            tol1(
+                "native_layer_norm",
+                {torch.float32: tol(atol=3e-4, rtol=1e-4)},
+                device_type="cpu",
+            ),
+        ),
+    )
+    @skipOps(
+        "TestOperators",
+        "test_vmapvjp",
+        vmapvjp_fail.union(
+            {
+                xfail("as_strided"),
+                xfail("as_strided_copy"),
+                xfail("as_strided", "partial_views"),
+            }
+        ),
+    )
+    def test_vmapvjp(self, device, dtype, op):
+        if not op.supports_autograd:
+            self.skipTest("Skipped! Autograd not supported.")
+            return
+
+        samples = op.sample_inputs(device, dtype, requires_grad=True)
+
+        # TODO: test in-place
+        if is_inplace(op, op.get_op()):
+            self.skipTest("Skipped! NYI: inplace-testing not supported.")
+            return
+        for sample in samples:
+            cotangents = get_sample_cotangents(op, sample)
+            fn, args = get_vjp_fn_and_args_with_cotangents(op, sample, cotangents)
+            is_batch_norm_and_training = is_batch_norm_training(op.name, sample.kwargs)
+            generator = get_fallback_and_vmap_exhaustive(
+                fn, args, {}, is_batch_norm_and_training=is_batch_norm_and_training
+            )
+            for loop_out, batched_out in generator:
+                self.assertEqual(loop_out, batched_out)
+
+    vmapjvpall_fail = {
+        # -------------------- ALLOWED FAILURES --------------------------------
+        # The following are expected (not a bug)
+        skip("bernoulli", ""),  # randomness
+        skip("nn.functional.dropout"),  # randomness
+        skip("nn.functional.rrelu"),  # randomness
+        skip("nn.functional.dropout2d", ""),
+        skip("nn.functional.dropout3d", ""),
+        skip("nn.functional.scaled_dot_product_attention"),  # randomness
+        xfail("torch.ops.aten._efficient_attention_forward"),  # outputs ints
+        skip("nn.functional.multi_head_attention_forward"),  # randomness
+        skip("nn.functional.alpha_dropout"),  # randomness
+        skip("nn.functional.feature_alpha_dropout", "without_train"),
+        skip("nn.functional.feature_alpha_dropout", "with_train"),
+        xfail(
+            "nn.functional.fractional_max_pool2d"
+        ),  # Cannot access data pointer of Tensor that doesn't have storage
+        xfail(
+            "nn.functional.fractional_max_pool3d"
+        ),  # Cannot access data pointer of Tensor that doesn't have storage
+        # Not actually a problem: embedding with max_norm mutates the weight
+        # and causes different runs to produce different results.
+        # skip because this is flaky depending on what the max_norm is!
+        skip("nn.functional.embedding", ""),
+        skip("to"),  # RuntimeError: required rank 4 tensor to use channels_last format
+        xfail(
+            "NumpyExpMarkDirtyAutogradFunction"
+        ),  # vmap: inplace into a regular tensor
+        # ----------------------------------------------------------------------
+        # ---------------------------- BUGS ------------------------------------
+        # The following are bugs that we should fix
+        xfail("masked.mean"),  # silent incorrectness (nan difference)
+        xfail("as_strided", "partial_views"),  # Tensor-likes are not close!
+        xfail(
+            "nn.functional.soft_margin_loss", ""
+        ),  # soft_margin_loss_backward does not support forward-ad
+        xfail("tensor_split"),  # data_ptr composite compliance
+        xfail("quantile"),  # at::equal batching rule (cpu), also, in-place vmap (cuda)
+        skip("as_strided"),  # Test runner cannot handle this
+        # requires special handling, and does not yet have a batching rule. Feel free to file a github issue!
+        xfail("as_strided_scatter"),
+        xfail(
+            "nn.functional.gaussian_nll_loss"
+        ),  # .item or data-dependent control flow
+        xfail("scatter"),  # forward-mode AD does not support at::scatter
+        xfail(
+            "nanquantile"
+        ),  # at::equal batching rule (cpu), also, in-place vmap (cuda)
+        xfail("view_as_complex"),  # Tensor must have a last dimension with stride 1
+        skip("pca_lowrank", ""),  # randomness
+        skip("svd_lowrank", ""),  # randomness
+        xfail("double"),  # required rank 4 tensor to use channels_last format
+        xfail("cdouble"),  # required rank 4 tensor to use channels_last format
+        # potential silent incorrectness
+        skip(
+            "nn.functional.max_unpool1d"
+        ),  # Flaky, seems to sometimes his max_unpool2d
+        skip("nn.functional.max_unpool2d"),  # fails everywhere except on mac
+        skip("nn.functional.max_unpool3d"),  # fails everywhere except on mac
+        # erroring because running_mean and running_var aren't differentiable
+        xfail("nn.functional.batch_norm"),
+        xfail("nn.functional.batch_norm", "without_cudnn"),
+        xfail("native_batch_norm"),
+        xfail("_native_batch_norm_legit"),
+        # TODO: implement batching rule
+        xfail("_batch_norm_with_update"),
+        xfail(
+            "unbind_copy"
+        ),  # Batching rule not implemented for aten::unbind_copy.int.
+        # ----------------------------------------------------------------------
+    }
+
+    @with_tf32_off  # https://github.com/pytorch/pytorch/issues/86798
+    @ops(op_db + additional_op_db + autograd_function_db, allowed_dtypes=(torch.float,))
+    @toleranceOverride({torch.float32: tol(atol=1e-04, rtol=1e-04)})
+    @opsToleranceOverride(
+        "TestOperators",
+        "test_vmapjvpall",
+        (
+            tol1(
+                "nn.functional.conv_transpose3d",
+                {torch.float32: tol(atol=2e-04, rtol=9e-3)},
+                device_type=device_type,
+            ),
+            tol1(
+                "linalg.householder_product",
+                {torch.float32: tol(atol=2e-04, rtol=9e-3)},
+            ),
+        ),
+    )
+    @skipOps(
+        "TestOperators",
+        "test_vmapjvpall",
+        vmapjvpall_fail.union(
+            {
+                xfail("as_strided_copy"),
+            }
+        ),
+    )
+    # This is technically a superset of test_vmapjvp. We should either delete test_vmapjvp
+    # or figure out if we can split vmapjvpall. It's useful to keep test_vmapjvp intact
+    # because that corresponds to "batched forward-mode AD" testing in PyTorch core
+    def test_vmapjvpall(self, device, dtype, op):
+        if is_inplace(op, op.get_op()):
+            # TODO: test in-place
+            self.skipTest("Skipped! NYI: inplace-testing not supported.")
+            return
+
+        samples = op.sample_inputs(device, dtype, requires_grad=False)
+
+        if not op.supports_forward_ad:
+            self.skipTest("Skipped! Forward AD not supported.")
+            return
+
+        for sample in samples:
+            arg_values = [sample.input] + list(sample.args)
+            kwarg_values = sample.kwargs
+            args = tuple(arg_values) + tuple(kwarg_values)
+            fn, args = get_jvp_variant_primals_tangents(op, sample)
+            is_batch_norm_and_training = is_batch_norm_training(op.name, kwarg_values)
+            generator = get_fallback_and_vmap_exhaustive(
+                fn, args, {}, is_batch_norm_and_training=is_batch_norm_and_training
+            )
+            for loop_out, batched_out in generator:
+                self.assertEqual(loop_out, batched_out)
+
+    @ops(op_db + additional_op_db + autograd_function_db, allowed_dtypes=(torch.float,))
+    @skipOps(
+        "TestOperators",
+        "test_vmapjvpall_has_batch_rule",
+        vmapjvpall_fail.union(
+            {
+                skip(
+                    "to"
+                ),  # RuntimeError: required rank 4 tensor to use channels_last format
+                xfail(
+                    "cdouble"
+                ),  # RuntimeError: required rank 4 tensor to use channels_last format
+                xfail("cumprod"),
+                xfail("masked_fill"),
+                xfail("fill"),
+                skip("masked.mean"),  # ???
+                xfail("masked_scatter"),
+                xfail("put"),
+                xfail("take"),
+                xfail("nn.functional.feature_alpha_dropout", "without_train"),
+                xfail("nn.functional.dropout2d", ""),
+                xfail("pca_lowrank", ""),
+                xfail("svd_lowrank", ""),
+                xfail("nn.functional.feature_alpha_dropout", "with_train"),
+                xfail("special.log_ndtr", ""),
+                xfail("fft.ihfft2"),  # conj_physical fallback
+                xfail("fft.ihfftn"),  # conj_physical fallback
+                xfail("nn.functional.max_unpool3d", "grad"),
+                xfail("nn.functional.max_unpool2d", "grad"),
+                xfail("nn.functional.soft_margin_loss", ""),
+                xfail("nn.functional.max_unpool1d", "grad"),
+                xfail("nn.functional.embedding", ""),
+                xfail("nn.functional.glu"),
+                xfail("nn.functional.bilinear"),  # trilinear doesn't have batching rule
+                xfail("linalg.lu", ""),
+                xfail("nn.functional.dropout3d", ""),
+                xfail("as_strided_scatter", ""),
+                xfail("masked.cumprod", ""),
+                xfail("permute_copy"),
+                xfail("renorm"),  # hit vmap fallback, which is disabled
+                xfail("squeeze_copy"),
+                xfail("t_copy"),
+                xfail("transpose_copy"),
+                xfail("unsqueeze_copy"),
+            }
+        ),
+    )
+    @toleranceOverride({torch.float32: tol(atol=1e-04, rtol=1e-04)})
+    def test_vmapjvpall_has_batch_rule(self, device, dtype, op):
+        if is_inplace(op, op.get_op()):
+            # TODO: test in-place
+            self.skipTest("Skipped! NYI: inplace-testing not supported.")
+            return
+
+        samples = op.sample_inputs(device, dtype, requires_grad=False)
+
+        if not op.supports_forward_ad:
+            self.skipTest("Skipped! Forward AD not supported.")
+            return
+
+        def test():
+            for sample in samples:
+                arg_values = [sample.input] + list(sample.args)
+                kwarg_values = sample.kwargs
+                args = tuple(arg_values) + tuple(kwarg_values)
+                fn, args = get_jvp_variant_primals_tangents(op, sample)
+                is_batch_norm_and_training = is_batch_norm_training(
+                    op.name, kwarg_values
+                )
+                for loop_out, batched_out in get_fallback_and_vmap_exhaustive(
+                    fn,
+                    args,
+                    {},
+                    is_batch_norm_and_training=is_batch_norm_and_training,
+                    compute_loop_out=False,
+                ):
+                    pass
+
+        check_vmap_fallback(self, test, op, dry_run=False)
+
+    @ops(op_db + additional_op_db + autograd_function_db, allowed_dtypes=(torch.float,))
+    @toleranceOverride({torch.float32: tol(atol=1e-04, rtol=1e-04)})
+    @skipOps(
+        "TestOperators",
+        "test_vmapvjp_has_batch_rule",
+        vmapvjp_fail.union(
+            {
+                skip(
+                    "to"
+                ),  # RuntimeError: required rank 4 tensor to use channels_last format
+                xfail("view_as_complex"),
+                xfail("cummax"),
+                xfail("cummin"),
+                xfail("fill"),
+                xfail(
+                    "narrow"
+                ),  # Batching rule not implemented for `narrow.Tensor` (and view op)
+                xfail("special.log_ndtr"),
+                xfail("linalg.householder_product"),
+                xfail("masked_fill"),
+                xfail("masked_scatter"),
+                xfail("masked_select"),
+                xfail("nanquantile"),
+                xfail("ormqr"),
+                xfail("permute_copy"),
+                xfail("put"),
+                xfail("quantile"),
+                xfail("renorm"),
+                xfail("squeeze_copy"),
+                xfail("take"),
+                xfail("tensor_split"),
+                xfail("to_sparse"),
+                xfail("unfold"),
+                xfail("unfold_copy"),
+                xfail("nn.functional.dropout"),
+                xfail("fft.ihfft2"),
+                xfail("fft.ihfftn"),
+                xfail("nn.functional.gaussian_nll_loss"),
+                xfail("nn.functional.bilinear"),
+                xfail("nn.functional.fractional_max_pool3d"),
+                xfail("nn.functional.ctc_loss"),
+                xfail("nn.functional.rrelu"),
+                xfail("nn.functional.embedding_bag"),
+                xfail("nn.functional.fractional_max_pool2d"),
+                xfail("nn.functional.feature_alpha_dropout", "with_train"),
+                xfail("pca_lowrank", ""),
+                xfail("nn.functional.dropout2d", ""),
+                xfail("nn.functional.feature_alpha_dropout", "without_train"),
+                xfail("svd_lowrank", ""),
+                xfail("nn.functional.max_unpool2d", ""),
+                xfail("nn.functional.multi_margin_loss", ""),
+                xfail("nn.functional.multilabel_margin_loss", ""),
+                xfail("nn.functional.pdist", ""),
+                xfail("nn.functional.max_unpool1d", ""),
+                xfail("nn.functional.max_unpool3d", ""),
+                xfail("nn.functional.max_unpool3d", "grad"),
+                xfail("nn.functional.soft_margin_loss", ""),
+                xfail("nn.functional.max_unpool1d", "grad"),
+                xfail("nn.functional.max_unpool2d", "grad"),
+                xfail("linalg.lu", ""),
+                xfail("cdouble", ""),
+                xfail("cfloat", ""),
+                xfail("chalf", ""),
+                xfail(
+                    "index_reduce", "prod"
+                ),  # aten::index_reduce hit the vmap fallback which is currently disabled
+                xfail(
+                    "index_reduce", "mean"
+                ),  # aten::index_reduce hit the vmap fallback which is currently disabled
+                xfail(
+                    "index_reduce", "amax"
+                ),  # aten::index_reduce hit the vmap fallback which is currently disabled
+                xfail(
+                    "index_reduce", "amin"
+                ),  # aten::index_reduce hit the vmap fallback which is currently disabled
+                xfail("nn.functional.dropout3d", ""),
+                xfail("as_strided_scatter", ""),
+                xfail("_segment_reduce", "offsets"),
+                xfail("_segment_reduce", "lengths"),
+                xfail("sparse.sampled_addmm", ""),
+                xfail("sparse.mm", "reduce"),
+                xfail("native_batch_norm"),
+                xfail("_native_batch_norm_legit"),
+                # TODO: implement batching rule
+                xfail("_batch_norm_with_update"),
+                xfail(
+                    "index_fill"
+                ),  # aten::_unique hit the vmap fallback which is currently disabled
+                xfail("squeeze_copy"),
+                xfail("t_copy"),
+                xfail("transpose_copy"),
+                xfail("unsqueeze_copy"),
+            }
+        ),
+    )
+    def test_vmapvjp_has_batch_rule(self, device, dtype, op):
+        if not op.supports_autograd:
+            self.skipTest("Skipped! Autograd not supported.")
+            return
+
+        samples = op.sample_inputs(device, dtype, requires_grad=True)
+
+        # TODO: test in-place
+        if is_inplace(op, op.get_op()):
+            self.skipTest("Skipped! NYI: inplace-testing not supported.")
+            return
+
+        def test():
+            for sample in samples:
+                cotangents = get_sample_cotangents(op, sample)
+                fn, args = get_vjp_fn_and_args_with_cotangents(op, sample, cotangents)
+                is_batch_norm_and_training = is_batch_norm_training(
+                    op.name, sample.kwargs
+                )
+                for loop_out, batched_out in get_fallback_and_vmap_exhaustive(
+                    fn,
+                    args,
+                    {},
+                    is_batch_norm_and_training=is_batch_norm_and_training,
+                    compute_loop_out=False,
+                ):
+                    pass
+                for a_op in op.aliases:
+                    fn, args = get_vjp_fn_and_args_with_cotangents(
+                        a_op, sample, cotangents
+                    )
+                    for loop_out, batched_out in get_fallback_and_vmap_exhaustive(
+                        fn,
+                        args,
+                        {},
+                        is_batch_norm_and_training=is_batch_norm_and_training,
+                        compute_loop_out=False,
+                    ):
+                        pass
+
+        check_vmap_fallback(self, test, op, dry_run=False)
+
+    @ops(op_db + additional_op_db + autograd_function_db, allowed_dtypes=(torch.float,))
+    @skipOps(
+        "TestOperators",
+        "test_vjpvmap",
+        vjp_fail.union(
+            {
+                skip("bernoulli", ""),  # vjpvmap testing can't handle randomness
+                skip("normal", ""),  # vjpvmap testing can't handle randomness
+                skip(
+                    "normal", "number_mean"
+                ),  # vjpvmap testing can't handle randomness
+                skip("nn.functional.rrelu"),  # randomness
+                skip("nn.functional.feature_alpha_dropout", "with_train"),  # randomness
+                skip(
+                    "nn.functional.feature_alpha_dropout", "without_train"
+                ),  # randomness
+                skip("nn.functional.scaled_dot_product_attention"),
+                xfail("torch.ops.aten._efficient_attention_forward"),  # outputs ints
+                skip("nn.functional.multi_head_attention_forward"),  # randomness
+                skip("nn.functional.alpha_dropout"),  # randomness
+                skip(
+                    "to"
+                ),  # RuntimeError: required rank 4 tensor to use channels_last format
+                skip("to_sparse", ""),  # non-dense output
+                skip("ormqr", ""),  # takes too long
+                xfail(
+                    "NumpyCubeNotComposableAutogradFunction"
+                ),  # Not composable autograd.Function
+                # fallback path doesn't work
+                # All of the following are bugs and need to be fixed
+                xfail("__getitem__", ""),
+                xfail("index_put", ""),
+                xfail("view_as_complex"),
+                xfail(
+                    "unbind_copy"
+                ),  # Batching rule not implemented for aten::unbind_copy.int.
+                xfail("nn.functional.gaussian_nll_loss"),
+                xfail("masked_select"),
+                xfail(
+                    "narrow"
+                ),  # Batching rule not implemented for `narrow.Tensor` (and view op)
+                skip(
+                    "nn.functional.fractional_max_pool3d"
+                ),  # generator works on cpu, fails on cuda
+                skip(
+                    "nn.functional.fractional_max_pool2d"
+                ),  # generator works on cpu, fails on cuda
+                xfail("column_stack", ""),
+                xfail("nn.functional.dropout2d", ""),
+                xfail("svd_lowrank", ""),
+                xfail("pca_lowrank", ""),
+                xfail("clamp"),
+                # something weird happening with channels_last
+                xfail("bfloat16"),
+                xfail("double"),
+                xfail("float"),
+                xfail("half"),
+                xfail("cdouble"),
+                xfail("cfloat"),
+                xfail("nn.functional.dropout3d", ""),
+                xfail("as_strided_scatter", ""),
+                xfail("sparse.sampled_addmm", ""),
+                xfail("sparse.mm", "reduce"),
+                xfail("native_batch_norm"),
+                xfail("_native_batch_norm_legit"),
+                # TODO: implement batching rule
+                xfail("_batch_norm_with_update"),
+                xfail("as_strided", "partial_views"),
+            }
+        ),
+    )
+    def test_vjpvmap(self, device, dtype, op):
+        # NB: there is no vjpvmap_has_batch_rule test because that is almost
+        # certainly redundant with the vmap_has_batch_rule test in test_vmap.py
+
+        # one-off skip
+        if op.name == "nn.functional.dropout":
+            self.skipTest("Skipped!")
+
+        if not op.supports_autograd:
+            # If the op doesn't support autograd, vmap(op) won't either
+            self.skipTest("Skipped! Autograd not supported.")
+            return
+
+        # TODO: test in-place
+        if is_inplace(op, op.get_op()):
+            self.skipTest("Skipped! NYI: inplace-testing not supported.")
+            return
+
+        samples = op.sample_inputs(device, dtype, requires_grad=True)
+        batch_norm_fns = (
+            "nn.functional.batch_norm",
+            "nn.functional.instance_norm",
+        )  # instance norm calls batch norm
+        is_batch_norm = op.name in batch_norm_fns
+
+        for sample in samples:
+            args = [sample.input] + list(sample.args)
+            kwargs = sample.kwargs
+
+            is_batch_norm_and_training = is_batch_norm and is_batch_norm_training(
+                op.name, kwargs
+            )
+            generator = generate_vmap_inputs(
+                args, kwargs, is_batch_norm_and_training=is_batch_norm_and_training
+            )
+
+            for batched_args, in_dims, kwargs in generator:
+                vmapped_op = vmap(op, in_dims)
+                fn, primals = normalize_op_input_output2(
+                    vmapped_op, batched_args, kwargs, sample.output_process_fn_grad
+                )
+                result = fn(*primals)
+                cotangents = tree_map(lambda x: torch.randn_like(x), result)
+
+                _, vjp_fn = vjp(fn, *primals)
+                result_vjps = vjp_fn(cotangents)
+
+                _, vjp_fn = ref_vjp(fn, *primals)
+                expected_vjps = vjp_fn(cotangents)
+
+                self.assertEqual(result_vjps, expected_vjps)
+
+    def _compare_jacobians_of_vjp(
+        self, fn, cotangents_and_primals, argnums=None, atol_rtol=None
+    ):
+        if argnums is None:
+            argnums = tuple(range(len(cotangents_and_primals)))
+
+        def get_vjp(cotangents, *primals):
+            _, vjp_fn = vjp(fn, *primals)
+            return vjp_fn(cotangents)
+
+        jacobian_jvp = jacfwd(get_vjp, argnums)(*cotangents_and_primals)
+        jacobian_vjp = jacrev(get_vjp, argnums)(*cotangents_and_primals)
+
+        # For dtype changing operations, the jacobians have different dtype.
+        jacobian_jvp = tree_map(lambda x: x.to(torch.float), jacobian_jvp)
+        jacobian_vjp = tree_map(lambda x: x.to(torch.float), jacobian_vjp)
+
+        if atol_rtol is not None:
+            (atol, rtol) = atol_rtol
+            self.assertEqual(jacobian_jvp, jacobian_vjp, atol=atol, rtol=rtol)
+        else:
+            self.assertEqual(jacobian_jvp, jacobian_vjp)
+
+    @ops(op_db + additional_op_db + autograd_function_db, allowed_dtypes=(torch.float,))
+    @skipOps(
+        "TestOperators",
+        "test_jvpvjp",
+        vjp_fail.union(
+            {
+                xfail("to_sparse", ""),  # NYI
+                # RuntimeError: Trying to set a forward gradient that has a different size than that of the original Tensor,
+                # this is not supported. Tensor is of size [5, 2, 3] while the given forward gradient is of size [1, 2, 3].
+                xfail("normal", ""),
+                xfail("cdist", ""),  # NYI: forward-AD for _cdist_forward
+                xfail("cholesky", ""),  # NYI: forward-AD for cholesky
+                xfail(
+                    "nn.functional.embedding_bag", ""
+                ),  # NYI: forward-AD for _embedding_bag
+                xfail(
+                    "nn.functional.grid_sample", ""
+                ),  # NYI: forward AD for grid_sampler_2d
+                xfail("grid_sampler_2d", ""),  # NYI: forward AD for grid_sampler_2d
+                xfail(
+                    "nn.functional.hardsigmoid", ""
+                ),  # NYI: forward AD for hardsigmoid_backward
+                xfail(
+                    "nn.functional.huber_loss", ""
+                ),  # NYI: forward AD for huber_loss_backward
+                xfail("NumpyCubeNotComposableAutogradFunction"),  # not composable
+                xfail("ormqr", ""),  # NYI: forward AD for ormqr
+                xfail(
+                    "nn.functional.multilabel_margin_loss", ""
+                ),  # NYI: multilabel_margin_loss_forward
+                xfail(
+                    "nn.functional.soft_margin_loss", ""
+                ),  # NYI: forward-AD for soft_margin_loss_backward
+                xfail("nn.functional.ctc_loss", ""),  # NYI: forward-AD for _ctc_loss
+                xfail("nn.functional.pdist", ""),  # NYI: forward-AD with _pdist_forward
+                skip("nn.functional.scaled_dot_product_attention"),
+                xfail("torch.ops.aten._efficient_attention_forward"),  # outputs ints
+                xfail(
+                    "nn.functional.multi_margin_loss", ""
+                ),  # NYI: forward AD with multi_margin_loss
+                skip(
+                    "linalg.householder_product", "", device_type=device_type
+                ),  # flaky, I'm not sure why
+                xfail("sparse.sampled_addmm", ""),  # Sparse tensors have no strides
+                xfail(
+                    "_segment_reduce", "offsets"
+                ),  # NYI: forward-AD for _segment_reduce
+                xfail("sparse.mm", "reduce"),  # Sparse tensors have no strides
+                xfail("index_reduce", "prod"),  # NYI: forward-AD for index_reduce
+                xfail("index_reduce", "mean"),  # NYI: forward-AD for index_reduce
+                xfail("index_reduce", "amax"),  # NYI: forward-AD for index_reduce
+                xfail("index_reduce", "amin"),  # NYI: forward-AD for index_reduce
+                xfail(
+                    "_segment_reduce", "lengths"
+                ),  # NYI: forward-AD for _segment_reduce
+                xfail("native_dropout_backward"),  # NYI
+            }
+        ),
+    )
+    @opsToleranceOverride(
+        "TestOperators",
+        "test_jvpvjp",
+        (
+            tol1("masked.prod", {torch.float32: tol(atol=1e-04, rtol=1.3e-05)}),
+            tol1("masked.cumprod", {torch.float32: tol(atol=1e-04, rtol=5e-04)}),
+            tol1(
+                "cumprod",
+                {torch.float32: tol(atol=1e-03, rtol=5e-04)},
+                device_type=device_type,
+            ),
+            tol1(
+                "linalg.det",
+                {torch.float32: tol(atol=3e-05, rtol=5e-06)},
+                device_type=device_type,
+            ),
+            tol1(
+                "linalg.vander",
+                {torch.float32: tol(atol=1e-04, rtol=1.3e-05)},
+                device_type=device_type,
+            ),
+            tol1(
+                "nn.functional.group_norm", {torch.float32: tol(atol=1e-03, rtol=1e-03)}
+            ),
+            tol2(
+                "linalg.pinv", "hermitian", {torch.float32: tol(atol=5e-03, rtol=5e-03)}
+            ),
+        ),
+    )
+    def test_jvpvjp(self, device, dtype, op):
+        if not op.supports_autograd:
+            self.skipTest("Skipped! Autograd not supported.")
+            return
+
+        samples = op.sample_inputs(device, dtype, requires_grad=True)
+
+        # TODO: test in-place
+        if is_inplace(op, op.get_op()):
+            self.skipTest("Skipped! NYI: inplace-testing not supported.")
+            return
+
+        for sample in samples:
+            fn, primals = normalize_op_input_output(op, sample)
+            result = fn(*primals)
+            cotangents = tree_map(lambda x: torch.randn_like(x), result)
+
+            primals_tangents = tree_map(lambda x: torch.randn_like(x), primals)
+            cotangents_tangents = tree_map(lambda x: torch.randn_like(x), cotangents)
+
+            def push_vjp(primals, cotangents):
+                _, vjp_fn = vjp(fn, *primals)
+                return vjp_fn(cotangents)
+
+            result = jvp(
+                push_vjp, (primals, cotangents), (primals_tangents, cotangents_tangents)
+            )
+            self.assertEqual(len(result), 2)
+
+            def tree_map2(fn, first, second):
+                flat_first, spec_first = tree_flatten(first)
+                flat_second, spec_second = tree_flatten(second)
+                assert spec_first == spec_second
+                flat_result = [fn(f, s) for f, s in zip(flat_first, flat_second)]
+                return tree_unflatten(flat_result, spec_first)
+
+            def reference(primals, cotangents, primals_tangents, cotangents_tangents):
+                with fwAD.dual_level():
+                    primal_duals = tree_map2(fwAD.make_dual, primals, primals_tangents)
+                    _, vjp_fn = ref_vjp(fn, *primal_duals)
+
+                    cotangent_duals = tree_map2(
+                        fwAD.make_dual, cotangents, cotangents_tangents
+                    )
+                    result = vjp_fn(cotangent_duals)
+
+                    flat_result, spec = tree_flatten(result)
+                    primals_out, tangents_out = zip(
+                        *[fwAD.unpack_dual(r) for r in flat_result]
+                    )
+                    tangents_out = [
+                        t if t is not None else torch.zeros_like(p)
+                        for p, t in zip(primals_out, tangents_out)
+                    ]
+                    expected = (
+                        tree_unflatten(primals_out, spec),
+                        tree_unflatten(tangents_out, spec),
+                    )
+                return expected
+
+            expected = reference(
+                primals, cotangents, primals_tangents, cotangents_tangents
+            )
+            self.assertEqual(result, expected)
+
+    @with_tf32_off  # https://github.com/pytorch/pytorch/issues/86798
+    @skipOps(
+        "TestOperators",
+        "test_vmapjvpvjp",
+        vjp_fail.union(
+            {
+                # Following operators take too long, hence skipped
+                skip("atleast_1d"),
+                skip("atleast_2d"),
+                skip("atleast_3d"),
+                skip("meshgrid", "list_of_tensors"),
+                skip("meshgrid", "variadic_tensors"),
+                skip("broadcast_tensors"),
+                skip("linalg.lstsq"),
+                skip("nn.functional.bilinear"),
+                skip("native_layer_norm"),
+                skip("ormqr"),
+                # Not actually a problem
+                xfail("NumpyCubeNotComposableAutogradFunction"),  # not composable
+                xfail(
+                    "NumpyExpMarkDirtyAutogradFunction"
+                ),  # vmap: inplace into a regular tensor
+                # Potential bugs/errors
+                xfail("as_strided"),  # AssertionError: Tensor-likes are not close!
+                xfail(
+                    "as_strided", "partial_views"
+                ),  # AssertionError: Tensor-likes are not close!
+                xfail("as_strided_copy"),  # AssertionError: Tensor-likes are not close!
+                xfail(
+                    "as_strided_scatter"
+                ),  # AssertionError: Tensor-likes are not close!
+                xfail(
+                    "unbind_copy"
+                ),  # Batching rule not implemented for aten::unbind_copy.int.
+                xfail("bernoulli"),  # calls random op
+                xfail("bfloat16"),  # required rank 4 tensor to use channels_last format
+                xfail("cdist"),  # Forward AD not implemented and no decomposition
+                xfail("cdouble"),  # required rank 4 tensor to use channels_last format
+                xfail("cfloat"),  # required rank 4 tensor to use channels_last format
+                xfail("chalf"),  # required rank 4 tensor to use channels_last format
+                xfail("cholesky"),  # Forward AD not implemented and no decomposition
+                xfail("ormqr"),  # Forward AD not implemented and no decomposition
+                xfail("double"),  # required rank 4 tensor to use channels_last format
+                xfail("float"),  # required rank 4 tensor to use channels_last format
+                xfail("half"),  # required rank 4 tensor to use channels_last format
+                xfail("index_reduce", "prod"),  # NYI: forward AD for index_reduce
+                xfail("index_reduce", "mean"),  # NYI: forward AD for index_reduce
+                xfail("index_reduce", "amax"),  # NYI: forward AD for index_reduce
+                xfail("index_reduce", "amin"),  # NYI: forward AD for index_reduce
+                xfail(
+                    "mvlgamma", "mvlgamma_p_1"
+                ),  # vmap: inplace into a regular tensor
+                xfail(
+                    "mvlgamma", "mvlgamma_p_3"
+                ),  # vmap: inplace into a regular tensor
+                xfail(
+                    "mvlgamma", "mvlgamma_p_5"
+                ),  # vmap: inplace into a regular tensor
+                xfail("nanquantile"),  # Batching rule not implemented for aten::equal
+                # RuntimeError: Batch norm got a batched tensor as input while the
+                # running_mean or running_var, which will be updated in place,
+                # were not batched.
+                xfail("nn.functional.batch_norm"),
+                xfail("nn.functional.batch_norm", "without_cudnn"),
+                xfail(
+                    "nn.functional.ctc_loss"
+                ),  # ForwardAD not implemented and no decomposition
+                xfail("nn.functional.dropout2d"),  # calls random op
+                xfail("nn.functional.dropout3d"),  # calls random op
+                xfail("nn.functional.dropout"),  # calls random op
+                xfail("nn.functional.scaled_dot_product_attention"),  # randomness
+                xfail("torch.ops.aten._efficient_attention_forward"),  # outputs ints
+                xfail("nn.functional.multi_head_attention_forward"),  # randomness
+                xfail(
+                    "nn.functional.embedding_bag"
+                ),  # Forward AD not implemented and no decomposition
+                xfail("nn.functional.alpha_dropout"),  # calls randomn op
+                xfail(
+                    "nn.functional.feature_alpha_dropout", "with_train"
+                ),  # calls random op
+                xfail("nn.functional.fractional_max_pool2d"),  # calls random op
+                xfail("nn.functional.fractional_max_pool3d"),  # calls random op
+                xfail("nn.functional.gaussian_nll_loss"),  # data depenedant flow
+                xfail(
+                    "nn.functional.grid_sample"
+                ),  # Forward AD not implemented and no decomposition
+                xfail(
+                    "grid_sampler_2d"
+                ),  # Forward AD not implemented and no decomposition
+                xfail(
+                    "nn.functional.hardsigmoid"
+                ),  # Forward AD not implemented and no decomposition
+                xfail(
+                    "nn.functional.hinge_embedding_loss"
+                ),  # vmap: inplace into a regular tensor
+                xfail(
+                    "nn.functional.huber_loss"
+                ),  # Forward AD not implemented and no decomposition
+                # RuntimeError: Batch norm got a batched tensor as input while the
+                # running_mean or running_var, which will be updated in place,
+                # were not batched.
+                xfail("nn.functional.instance_norm"),
+                # NYI: Tensor.clone(memory_format) inside vmap is only supported with
+                # memory_format torch.preserve_format or torch.contiguous_format (got ChannelsLast)
+                xfail("nn.functional.max_unpool2d"),
+                xfail("nn.functional.max_unpool2d", "grad"),
+                xfail(
+                    "nn.functional.multi_margin_loss"
+                ),  # Forward AD not implemented and no decomposition
+                xfail(
+                    "nn.functional.multilabel_margin_loss"
+                ),  # Forward AD not implemented and no decomposition
+                xfail(
+                    "nn.functional.pdist"
+                ),  # Forward AD not implemented and no decomposition
+                xfail(
+                    "nn.functional.rrelu"
+                ),  # vmap: we do not yet support aten::rrelu_with_noise.
+                xfail(
+                    "nn.functional.soft_margin_loss"
+                ),  # Forward AD not implemented and no decomposition
+                xfail("normal"),  # calls random op
+                xfail("normal", "number_mean"),  # calls random op
+                xfail("pca_lowrank"),  # calls random op
+                xfail("quantile"),  # Batching rule not implemented for aten::equal
+                xfail(
+                    "scatter_reduce", "prod"
+                ),  # Forward AD not implemented and no decomposition
+                xfail(
+                    "_segment_reduce", "lengths"
+                ),  # Forward AD not implemented and no decomposition
+                xfail(
+                    "_segment_reduce", "offsets"
+                ),  # Forward AD not implemented and no decomposition
+                xfail(
+                    "sparse.sampled_addmm"
+                ),  # RuntimeError: Sparse CSR tensors do not have strides
+                xfail(
+                    "sparse.mm", "reduce"
+                ),  # RuntimeError: Sparse CSR tensors do not have strides
+                xfail("svd_lowrank"),  # calls random op
+                xfail(
+                    "to"
+                ),  # RuntimeError: required rank 4 tensor to use channels_last format
+                xfail("to_sparse"),  # Forward AD not implemented and no decomposition
+                xfail(
+                    "view_as_complex"
+                ),  # RuntimeError: Tensor must have a last dimension with stride 1
+                # RuntimeError: Batch norm got a batched tensor as
+                # input while the running_mean or running_var, which will be updated in
+                # place, were not batched.
+                xfail("native_batch_norm"),
+                xfail("_native_batch_norm_legit"),
+                # TODO: implement batching rule
+                xfail("_batch_norm_with_update"),
+                xfail("native_dropout_backward"),
+            }
+        ),
+    )
+    @ops(op_db + additional_op_db + autograd_function_db, allowed_dtypes=(torch.float,))
+    @toleranceOverride({torch.float32: tol(atol=1e-04, rtol=1e-04)})
+    @opsToleranceOverride(
+        "TestOperators",
+        "test_vmapjvpvjp",
+        (
+            tol1("linalg.svd", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
+            tol1(
+                "linalg.householder_product",
+                {torch.float32: tol(atol=5e-03, rtol=5e-03)},
+            ),
+            tol1("linalg.multi_dot", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
+            tol2(
+                "linalg.pinv", "hermitian", {torch.float32: tol(atol=5e-04, rtol=5e-04)}
+            ),
+            tol1(
+                "nn.functional.conv_transpose2d",
+                {torch.float32: tol(atol=5e-04, rtol=5e-04)},
+            ),
+            tol1("svd", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
+            tol1("matrix_exp", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
+        ),
+    )
+    def test_vmapjvpvjp(self, device, dtype, op):
+        # Since we test `jvpvjp` separately,
+        # in this we just check that vmap of `jvpvjp`
+        # is correct.
+        if not op.supports_autograd:
+            self.skipTest("Skipped! Autograd not supported.")
+            return
+
+        samples = op.sample_inputs(device, dtype, requires_grad=True)
+
+        # TODO: test in-place
+        if is_inplace(op, op.get_op()):
+            self.skipTest("Skipped! NYI: inplace-testing not supported.")
+            return
+
+        for sample in samples:
+            fn, primals = normalize_op_input_output(op, sample)
+            result = fn(*primals)
+            cotangents = tree_map(lambda x: torch.randn_like(x), result)
+
+            primals_tangents = tree_map(lambda x: torch.randn_like(x), primals)
+            cotangents_tangents = tree_map(lambda x: torch.randn_like(x), cotangents)
+
+            def push_vjp(primals, cotangents):
+                _, vjp_fn = vjp(fn, *primals)
+                return vjp_fn(cotangents)
+
+            args, spec = tree_flatten(
+                ((primals, cotangents), (primals_tangents, cotangents_tangents))
+            )
+
+            def jvp_of_vjp(*args):
+                (primals, tangents) = tree_unflatten(args, spec)
+                primals_out, tangents_out = jvp(push_vjp, primals, tangents)
+
+                flat_primals_out = pytree.tree_leaves(primals_out)
+                flat_tangents_out = pytree.tree_leaves(tangents_out)
+                return tuple(flat_primals_out + flat_tangents_out)
+
+            is_batch_norm_and_training = is_batch_norm_training(op, sample.kwargs)
+            generator = get_fallback_and_vmap_exhaustive(
+                jvp_of_vjp,
+                args,
+                {},
+                is_batch_norm_and_training=is_batch_norm_and_training,
+            )
+            for loop_out, batched_out in generator:
+                self.assertEqual(loop_out, batched_out)
+
+    def _make_extremal_inputs(self, shape, device):
+        if shape is None:
+            return (None,)
+        return (
+            torch.full(shape, -1000.0, device=device),
+            torch.zeros(shape, device=device),
+            torch.full(shape, 1000.0, device=device),
+        )
+
+    def _arg_and_kwarg_options(self, args_options, kwargs_options):
+        return itertools.product(*args_options, kwargs_options)
+
+    def test_extremal_numerics_nll_loss(self, device):
+        N, C = 3, 4
+        d1, d2, d3 = 5, 6, 7
+        shapes = (
+            ((N, C), (N,), (C,)),
+            ((N, C), (N,), None),
+            ((N, C, d1, d2, d3), (N, d1, d2, d3), (C,)),
+            ((N, C, d1, d2, d3), (N, d1, d2, d3), None),
+        )
+        kwargs_options = (
+            {"ignore_index": 0, "reduction": "mean"},
+            {"reduction": "sum"},
+            {"reduction": "none"},
+            {},
+        )
+        for input_shape, target_shape, weight_shape in shapes:
+            input_options = self._make_extremal_inputs(input_shape, device)
+            for input, kwargs in self._arg_and_kwarg_options(
+                (input_options,), kwargs_options
+            ):
+                if weight_shape is None:
+                    weight = None
+                else:
+                    weight = torch.randn(weight_shape, device=device)
+                target = torch.randint(0, C, target_shape, device=device)
+                target[
+                    0
+                ] = 1  # since we're ignoring index 0, at least one element must be non-zero
+
+                fn = functools.partial(
+                    torch.nn.functional.nll_loss, target=target, weight=weight, **kwargs
+                )
+                result = fn(input)
+                cotangents = torch.randn_like(result, device=device)
+                self._compare_jacobians_of_vjp(fn, (cotangents, input))
+
+    def test_extremal_numerics_l1_loss(self, device):
+        N, C, H, W = 3, 4, 5, 6
+        shapes = ((N, C), (N, C, H), (N, C, H, W))
+        kwargs_options = ({"reduction": "sum"}, {"reduction": "none"}, {})
+        for shape in shapes:
+            input_options = self._make_extremal_inputs(shape, device)
+            target_options = self._make_extremal_inputs(shape, device)
+            for input, target, kwargs in self._arg_and_kwarg_options(
+                (input_options, target_options), kwargs_options
+            ):
+                result = torch.nn.functional.l1_loss(input, target)
+                cotangents = torch.randn_like(result, device=device)
+                self._compare_jacobians_of_vjp(
+                    torch.nn.functional.l1_loss, (cotangents, input, target)
+                )
+
+    def test_extremal_numerics_mse_loss(self, device):
+        N, C, H, W = 3, 4, 5, 6
+        shapes = ((N, C), (N, C, H), (N, C, H, W))
+        kwargs_options = ({"reduction": "sum"}, {"reduction": "none"}, {})
+        for shape in shapes:
+            input_options = self._make_extremal_inputs(shape, device)
+            target_options = self._make_extremal_inputs(shape, device)
+            for input, target, kwargs in self._arg_and_kwarg_options(
+                (input_options, target_options), kwargs_options
+            ):
+                result = torch.nn.functional.mse_loss(input, target)
+                cotangents = torch.randn_like(result, device=device)
+                self._compare_jacobians_of_vjp(
+                    torch.nn.functional.mse_loss, (cotangents, input, target)
+                )
+
+    def test_extremal_numerics_softmax(self, device):
+        N, C, H, W = 3, 4, 5, 6
+        shapes = ((N, C), (N, C, H), (N, C, H, W))
+        kwargs_options = ({"dim": 1}, {})
+        for shape in shapes:
+            input_options = self._make_extremal_inputs(shape, device)
+            for input, kwargs in self._arg_and_kwarg_options(
+                (input_options,), kwargs_options
+            ):
+                result = torch.nn.functional.softmax(input)
+                cotangents = torch.randn_like(result, device=device)
+                self._compare_jacobians_of_vjp(
+                    torch.nn.functional.softmax, (cotangents, input)
+                )
+
+    def test_extremal_numerics_log_softmax(self, device):
+        N, C, H, W = 3, 4, 5, 6
+        shapes = ((N, C), (N, C, H), (N, C, H, W))
+        kwargs_options = ({"dim": 1}, {})
+        for shape in shapes:
+            input_options = self._make_extremal_inputs(shape, device)
+            for input, kwargs in self._arg_and_kwarg_options(
+                (input_options,), kwargs_options
+            ):
+                result = torch.nn.functional.log_softmax(input)
+                cotangents = torch.randn_like(result, device=device)
+                self._compare_jacobians_of_vjp(
+                    torch.nn.functional.log_softmax, (cotangents, input)
+                )
+
+    def test_extremal_numerics_cross_entropy(self, device):
+        N, C = 3, 4
+        d1, d2, d3 = 5, 6, 7
+        shapes = (
+            ((N, C), (N,), (C,)),
+            ((N, C), (N,), None),
+            ((N, C), (N, C), (C,)),
+            ((N, C), (N, C), None),
+            ((C,), (), (C,)),
+            ((C,), (), None),
+            ((C,), (C,), (C,)),
+            ((C,), (C,), None),
+            ((N, C, d1, d2, d3), (N, d1, d2, d3), (C,)),
+            ((N, C, d1, d2, d3), (N, d1, d2, d3), None),
+            ((N, C, d1, d2, d3), (N, C, d1, d2, d3), (C,)),
+            ((N, C, d1, d2, d3), (N, C, d1, d2, d3), None),
+        )
+        for input_shape, target_shape, weight_shape in shapes:
+            input_options = self._make_extremal_inputs(input_shape, device)
+            kwargs_options = [{"reduction": "sum"}, {"reduction": "none"}, {}]
+            if input_shape != target_shape:
+                kwargs_options.append({"ignore_index": 0, "reduction": "mean"})
+
+            for input, kwargs in self._arg_and_kwarg_options(
+                (input_options,), kwargs_options
+            ):
+                if weight_shape is None:
+                    weight = None
+                else:
+                    weight = torch.randn(weight_shape, device=device)
+
+                if input_shape == target_shape:
+                    target = torch.rand(target_shape, device=device)
+                elif len(target_shape) == 0:
+                    target = torch.tensor(
+                        1, device=device
+                    )  # must be non-zero since ignore_index may be 0
+                else:
+                    target = torch.randint(0, C, target_shape, device=device)
+
+                fn = functools.partial(
+                    torch.nn.functional.cross_entropy,
+                    target=target,
+                    weight=weight,
+                    **kwargs,
+                )
+                result = fn(input)
+                cotangents = torch.randn_like(result, device=device)
+                self._compare_jacobians_of_vjp(
+                    fn, (cotangents, input), atol_rtol=(1e-4, 1e-5)
+                )
+
+    def test_extremal_numerics_binary_cross_entropy(self, device):
+        N, C, H, W = 3, 4, 5, 6
+        shapes = ((N, C), (N, C, H), (N, C, H, W))
+        for shape in shapes:
+            weight_options = self._make_extremal_inputs(shape, device)
+            kwargs_options = [{"reduction": "sum"}, {"reduction": "none"}, {}]
+
+            for weight, kwargs in self._arg_and_kwarg_options(
+                (weight_options,), kwargs_options
+            ):
+                input = torch.rand(shape, device=device)
+                target = torch.rand(shape, device=device)
+                fn = functools.partial(
+                    torch.nn.functional.binary_cross_entropy,
+                    target=target,
+                    weight=weight,
+                    **kwargs,
+                )
+                result = fn(input)
+                cotangents = torch.randn_like(result, device=device)
+                self._compare_jacobians_of_vjp(
+                    fn, (cotangents, input), atol_rtol=(1e-4, 2e-5)
+                )
+
+    def test_extremal_numerics_layer_norm(self, device):
+        N, C, H, W = 3, 4, 5, 6
+        shapes = ((N, C), (N, C, H), (N, C, H, W))
+        for shape in shapes:
+            input_options = self._make_extremal_inputs(shape, device)
+            normalized_shape = shape[1:]
+            weight_options = self._make_extremal_inputs(normalized_shape, device)
+            bias_options = self._make_extremal_inputs(normalized_shape, device)
+
+            for input, bias, weight in self._arg_and_kwarg_options(
+                (input_options, bias_options, weight_options), ()
+            ):
+
+                def fn(input, weight, bias):
+                    return torch.nn.functional.layer_norm(
+                        input, normalized_shape, weight=weight, bias=bias
+                    )
+
+                result = fn(input, weight, bias)
+                cotangents = torch.randn_like(result, device=device)
+                self._compare_jacobians_of_vjp(fn, (cotangents, input, weight, bias))
+
+    @with_tf32_off  # https://github.com/pytorch/pytorch/issues/86798
+    @ops(
+        op_db + additional_op_db + autograd_function_db,
+        allowed_dtypes=(torch.float32, torch.double),
+    )
+    @skipOps(
+        "TestOperators",
+        "test_vmap_autograd_grad",
+        {
+            # The size of tensor a (4) must match the size of tensor b (10) at non-singleton dimension 0
+            xfail("masked_select"),
+            xfail("nn.functional.max_unpool2d", "grad"),  # contiguous call
+            xfail("nn.functional.max_unpool2d"),  # contiguous call
+            xfail("to_sparse"),  # dispatch key issue
+            xfail("torch.ops.aten._efficient_attention_forward"),  # outputs ints
+            # https://github.com/pytorch/pytorch/issues/96560#issuecomment-2151063723
+            # ** minor accuracy issue for float32 on ROCm
+            decorate("xlogy", decorator=skipIfRocm),
+            # numerical inconsistencies, look like bugs
+            skip(
+                "matrix_exp", dtypes=(torch.float32,), device_type=device_type
+            ),  # fails on linux, passes on windows
+            skip(
+                "ldexp", dtypes=(torch.float32,), device_type="cpu"
+            ),  # fails on all but mac
+            skip("__rmatmul__"),  # flaky needs investigation
+            skip("matmul"),  # flaky needs investigation
+            skip("nn.functional.conv_transpose3d"),  # flaky needs investigation
+            skip("nn.functional.conv_transpose2d"),  # flaky needs investigation
+            skip("nn.functional.conv_transpose1d"),  # flaky needs investigation
+            skip(
+                "nn.functional.layer_norm", dtypes=(torch.float32,), device_type="cpu"
+            ),  # fails on windows
+            skip(
+                "linalg.lu_factor", dtypes=(torch.float32,), device_type=device_type
+            ),  # fails on all but windows
+            skip(
+                "linalg.lu_factor_ex", dtypes=(torch.float32,), device_type=device_type
+            ),  # fails on all but windows
+            skip("linalg.multi_dot", "", device_type="cpu"),
+            skip("sparse.sampled_addmm", ""),
+            skip("sparse.mm", "reduce"),
+            skip("native_layer_norm", "", device_type="cpu"),
+        },
+    )
+    @opsToleranceOverride(
+        "TestOperators",
+        "test_vmap_autograd_grad",
+        (
+            tol1(
+                "ldexp",
+                {torch.float32: tol(atol=3e-04, rtol=1.6e-06)},
+                device_type=device_type,
+            ),
+            tol1(
+                "linalg.householder_product",
+                {torch.float32: tol(atol=5e-04, rtol=9e-03)},
+                device_type=device_type,
+            ),
+            tol1(
+                "linalg.householder_product",
+                {torch.float32: tol(atol=6e-03, rtol=1e-03)},
+                device_type="cpu",
+            ),
+            tol1(
+                "linalg.multi_dot",
+                {torch.float32: tol(atol=2e-04, rtol=1e-04)},
+                device_type=device_type,
+            ),
+            tol2(
+                "linalg.pinv", "hermitian", {torch.float32: tol(atol=5e-06, rtol=5e-06)}
+            ),
+            tol1("nn.functional.conv3d", {torch.float32: tol(atol=5e-04, rtol=9e-03)}),
+            tol1(
+                "nn.functional.conv2d",
+                {torch.float32: tol(atol=5e-05, rtol=5e-05)},
+                device_type=device_type,
+            ),
+            tol1("svd_lowrank", {torch.float32: tol(atol=5e-05, rtol=5e-05)}),
+            tol1("pca_lowrank", {torch.float32: tol(atol=5e-05, rtol=5e-05)}),
+        ),
+    )
+    def test_vmap_autograd_grad(self, device, dtype, op):
+        def is_differentiable(inp):
+            return isinstance(inp, Tensor) and (
+                inp.grad_fn is not None or inp.requires_grad
+            )
+
+        def get_flat_differentiable(tree):
+            flattened = pytree.tree_leaves(tree)
+            return tuple(i for i in flattened if is_differentiable(i))
+
+        def get_differentiable_linked(list1, list2):
+            paired_list = zip(list1, list2)
+            paired_list = tuple(
+                (first, second)
+                for (first, second) in paired_list
+                if is_differentiable(first)
+            )
+            return zip(*paired_list)
+
+        def filter_none(out):
+            flattened = pytree.tree_leaves(out)
+            return tuple(o for o in flattened if o is not None)
+
+        if not op.supports_autograd:
+            self.skipTest("Skipped! Autograd not supported.")
+            return
+
+        sample_inputs = op.sample_inputs(device, dtype, requires_grad=True)
+
+        for sample_input in sample_inputs:
+            fn, primals = normalize_op_input_output(op, sample_input)
+            out = fn(*primals)
+            cotangents = tree_map(torch.randn_like, out)
+
+            def compute_grad(cotangents):
+                out_flattened = out
+                cotangents_flattened = cotangents
+                if not isinstance(out_flattened, torch.Tensor):
+                    out_flattened = pytree.tree_leaves(out)
+                    cotangents_flattened = pytree.tree_leaves(cotangents)
+                    out_flattened, cotangents_flattened = get_differentiable_linked(
+                        out_flattened, cotangents_flattened
+                    )
+
+                return filter_none(
+                    torch.autograd.grad(
+                        out_flattened,
+                        get_flat_differentiable(primals),
+                        cotangents_flattened,
+                        retain_graph=True,
+                        allow_unused=True,
+                    )
+                )
+
+            is_batch_norm_and_training = is_batch_norm_training(op, sample_input.kwargs)
+            generator = get_fallback_and_vmap_exhaustive(
+                compute_grad,
+                (cotangents,),
+                {},
+                is_batch_norm_and_training=is_batch_norm_and_training,
+            )
+            for loop_out, batched_out in generator:
+                self.assertEqual(loop_out, batched_out)
+
+    def test_vmapvmapjvp_linalg_solve(self):
+        ops = [op for op in op_db if op.name == "linalg.solve"]
+        assert len(ops) > 0
+
+        # this specializes a lot of code from the get_fallback_and_vmap_exhaustive test. If we need this more
+        # generally, this could go for a refactor
+
+        B0 = 2
+        B1 = 3
+
+        # we want to check the case where A will be seen as contiguous by jvp but during the vmap calls will become
+        # non-contiguous because vmap will expand. This will happen during both levels of vmap
+        A = torch.randn(4, 4)
+        k = torch.randn(4, 5, B1, B0)
+        fn, args = get_jvp_variant_primals_tangents(
+            torch.linalg.solve, SampleInput(A, args=(k,))
+        )
+
+        in_dims_all = (None, -1, None, -1)
+        batched_out = vmap(vmap(fn, in_dims=in_dims_all), in_dims=in_dims_all)(*args)
+        loop_out = loop2(fn, in_dims_all, in_dims_all, 0, 0, B0, B1, *args)
+        self.assertEqual(loop_out, batched_out)
+
+    @ops(
+        filter(lambda op: op.name in aliasing_ops, op_db + additional_op_db),
+        allowed_dtypes=(torch.float,),
+    )
+    @parametrize("grad_op", ["jvp", "vjp"])
+    def test_view_then_inplace(self, device, dtype, op, grad_op):
+        for sample_input in op.sample_inputs(device, dtype):
+
+            def f(x):
+                op(sample_input.input, *sample_input.args, **sample_input.kwargs).copy_(
+                    x
+                )
+                return x
+
+            without_grad = op(
+                sample_input.input, *sample_input.args, **sample_input.kwargs
+            )
+            if grad_op == "jvp":
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "During a grad .* attempted to call in-place operation",
+                ):
+                    jvp(
+                        f,
+                        (torch.randn_like(without_grad),),
+                        (torch.randn_like(without_grad),),
+                    )
+            else:
+                assert grad_op == "vjp"
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "During a grad .* attempted to call in-place operation",
+                ):
+                    vjp(f, torch.randn_like(without_grad))
+
+    @ops(
+        filter(
+            lambda op: op.name in aliasing_ops_list_return, op_db + additional_op_db
+        ),
+        allowed_dtypes=(torch.float,),
+    )
+    @parametrize("grad_op", ["jvp", "vjp"])
+    def test_view_then_inplace_list_return(self, device, dtype, op, grad_op):
+        for sample_input in op.sample_inputs(device, dtype):
+
+            def f(x):
+                op(sample_input.input, *sample_input.args, **sample_input.kwargs)[
+                    0
+                ].copy_(x)
+                return x
+
+            without_grad = op(
+                sample_input.input, *sample_input.args, **sample_input.kwargs
+            )[0]
+            with self.assertRaisesRegex(
+                RuntimeError, "During a grad .* attempted to call in-place operation"
+            ):
+                if grad_op == "jvp":
+                    jvp(
+                        f,
+                        (torch.randn_like(without_grad),),
+                        (torch.randn_like(without_grad),),
+                    )
+                else:
+                    assert grad_op == "vjp"
+                    vjp(f, torch.randn_like(without_grad))
+
+    @parametrize("grad_op", ["jvp", "vjp"])
+    def test_view_then_inplace_special(self, grad_op):
+        # some things in __getitem__ use at::index, which doesn't alias, so this tests a subset of them that do alias
+        ops = [
+            lambda x: x[0],
+            lambda x: x[0, 0, 0],
+            lambda x: x[:1],
+            lambda x: x[:, :1],
+            lambda x: x[:, :1, :],
+        ]
+
+        for op in ops:
+
+            def f(x):
+                op(captured).copy_(x)
+                return x
+
+            captured = torch.randn(4, 3, 3)
+            without_grad = op(captured)
+            if grad_op == "jvp":
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "During a grad .* attempted to call in-place operation",
+                ):
+                    jvp(
+                        f,
+                        (torch.randn_like(without_grad),),
+                        (torch.randn_like(without_grad),),
+                    )
+            else:
+                assert grad_op == "vjp"
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "During a grad .* attempted to call in-place operation",
+                ):
+                    vjp(f, torch.randn_like(without_grad))
+
+    @with_tf32_off  # https://github.com/pytorch/pytorch/issues/86798
+    # NOTE: [three-transform testing]
+    # We only test the autograd_function_db tests here.
+    #
+    # Usually testing the composition of two transforms is sufficient to convince
+    # ourselves that an operator is correctly implemented. For the following cases,
+    # we want to be extra sure, so we send those through some three-transform tests:
+    # - autograd.Function. The mechanism is via PyDispatcher/HigherOrderOperator, not the
+    #   regular PyTorch dispatcher, so it's good to exercise more caution.
+    @ops(autograd_function_db, allowed_dtypes=(torch.float32,))
+    @skipOps(
+        "TestOperators",
+        "test_vmapvjpvmap",
+        {
+            xfail("NumpyCubeNotComposableAutogradFunction"),  # Not composable
+        },
+    )
+    def test_vmapvjpvmap(self, device, dtype, op):
+        samples = op.sample_inputs(device, dtype, requires_grad=True)
+        B = 2
+        for sample in samples:
+            args = [sample.input] + list(sample.args)
+            kwargs = sample.kwargs
+            generator = generate_vmap_inputs(args, kwargs, batch_size=B)
+            for batched_args, in_dims, kwargs in generator:
+                inner_vmapped_op = vmap(op, in_dims)
+                inner_mapped_op = functools.partial(loop, op, in_dims, 0, B)
+
+                inner_vmapped_fn, primals = normalize_op_input_output2(
+                    inner_vmapped_op,
+                    batched_args,
+                    kwargs,
+                    sample.output_process_fn_grad,
+                )
+                inner_mapped_fn, _ = normalize_op_input_output2(
+                    inner_mapped_op, batched_args, kwargs, sample.output_process_fn_grad
+                )
+                result = inner_mapped_fn(*primals)
+                cotangents = tree_map(lambda x: torch.rand_like(x), result)
+
+                def apply_vjp(fn):
+                    def inner(primals, cotangents):
+                        _, vjp_fn = vjp(fn, *primals)
+                        return vjp_fn(cotangents)
+
+                    return inner
+
+                vjpvmap_fn = apply_vjp(inner_vmapped_fn)
+                vjpmap_fn = apply_vjp(inner_mapped_fn)
+                batched_args = (primals, cotangents)
+                generator = generate_vmap_inputs(batched_args, {})
+
+                for batched_args, in_dims, _ in generator:
+                    # strategy: compare vmap(vjp(vmap(op)) vs map(vjp(map(op))
+                    vmapvjpvmap_fn = vmap(vjpvmap_fn, in_dims)
+                    mapvjpmap_fn = functools.partial(loop, vjpmap_fn, in_dims, 0, B)
+
+                    result = vmapvjpvmap_fn(*batched_args)
+                    expected = mapvjpmap_fn(*batched_args)
+                    self.assertEqual(result, expected)
+
+    # See NOTE: [three-transform testing]
+    @ops(autograd_function_db, allowed_dtypes=(torch.float32,))
+    @skipOps(
+        "TestOperators",
+        "test_vjpvmapvmap",
+        {
+            xfail("NumpyCubeNotComposableAutogradFunction"),  # Not composable
+        },
+    )
+    def test_vjpvmapvmap(self, device, dtype, op):
+        samples = op.sample_inputs(device, dtype, requires_grad=True)
+        B = 2
+        for sample in samples:
+            args = [sample.input] + list(sample.args)
+            kwargs = sample.kwargs
+            generator = generate_vmap_inputs(args, kwargs, batch_size=B)
+            for batched_args, inner_in_dims, kwargs in generator:
+                inner_vmapped_op = vmap(op, inner_in_dims)
+                inner_mapped_op = functools.partial(loop, op, inner_in_dims, 0, B)
+                generator = generate_vmap_inputs(batched_args, kwargs)
+                for batched_args, in_dims, kwargs in generator:
+                    # strategy: compare vjp(vmap(vmap(op)) vs vjp(map(map(op))
+                    vmapped_op = vmap(inner_vmapped_op, in_dims)
+                    mapped_op = functools.partial(loop, inner_mapped_op, in_dims, 0, B)
+
+                    vmapped_fn, primals = normalize_op_input_output2(
+                        vmapped_op, batched_args, kwargs, sample.output_process_fn_grad
+                    )
+                    mapped_fn, _ = normalize_op_input_output2(
+                        mapped_op, batched_args, kwargs, sample.output_process_fn_grad
+                    )
+
+                    result = mapped_fn(*primals)
+                    cotangents = tree_map(lambda x: torch.rand_like(x), result)
+
+                    _, vjp_fn = vjp(mapped_fn, *primals)
+                    expected_vjps = vjp_fn(cotangents)
+
+                    _, vjp_fn = vjp(vmapped_fn, *primals)
+                    result_vjps = vjp_fn(cotangents)
+
+                    self.assertEqual(result_vjps, expected_vjps)
+
+    # See NOTE: [three-transform testing]
+    @ops(autograd_function_db, allowed_dtypes=(torch.float32,))
+    @skipOps(
+        "TestOperators",
+        "test_vjpvjpvmap",
+        {
+            xfail("NumpyCubeNotComposableAutogradFunction"),  # Not composable
+        },
+    )
+    def test_vjpvjpvmap(self, device, dtype, op):
+        samples = op.sample_inputs(device, dtype, requires_grad=True)
+        B = 2
+        for sample in samples:
+            args = [sample.input] + list(sample.args)
+            kwargs = sample.kwargs
+            generator = generate_vmap_inputs(args, kwargs, batch_size=B)
+            for batched_args, in_dims, kwargs in generator:
+                inner_vmapped_op = vmap(op, in_dims)
+                inner_mapped_op = functools.partial(loop, op, in_dims, 0, B)
+
+                vjpmap_fn, args = get_vjpfull_variant2(
+                    inner_mapped_op, batched_args, kwargs
+                )
+                vjpvmap_fn, _ = get_vjpfull_variant2(
+                    inner_vmapped_op, batched_args, kwargs
+                )
+
+                vjpvjpvmap_fn, new_args = get_vjpfull_variant2(vjpvmap_fn, args, {})
+                vjpvjpmap_fn, _ = get_vjpfull_variant2(vjpmap_fn, args, {})
+
+                expected = vjpvjpmap_fn(*new_args)
+                result = vjpvjpvmap_fn(*new_args)
+                self.assertEqual(result, expected)
+
+    # We're generally convinced that jvp x vmap works (vmap turns an operator
+    # into another operator and we test jvp support for operators). So
+    # we only test it on the things we're not sure about:
+    # - the autograd.Function <> functorch interaction
+    @ops(autograd_function_db, allowed_dtypes=(torch.float32,))
+    @skipOps(
+        "TestOperators",
+        "test_jvpvmap",
+        {
+            xfail("NumpyCubeNotComposableAutogradFunction"),  # Not composable
+        },
+    )
+    def test_jvpvmap(self, device, dtype, op):
+        samples = op.sample_inputs(device, dtype, requires_grad=True)
+        B = 2
+        for sample in samples:
+            args = [sample.input] + list(sample.args)
+            kwargs = sample.kwargs
+            generator = generate_vmap_inputs(args, kwargs, batch_size=B)
+            for batched_args, in_dims, kwargs in generator:
+                inner_vmapped_op = vmap(op, in_dims)
+                inner_mapped_op = functools.partial(loop, op, in_dims, 0, B)
+
+                jvpvmap_op, primals = get_jvp_variant_primals_tangents2(
+                    inner_vmapped_op,
+                    batched_args,
+                    kwargs,
+                    sample.output_process_fn_grad,
+                )
+                jvpmap_op, _ = get_jvp_variant_primals_tangents2(
+                    inner_mapped_op, batched_args, kwargs, sample.output_process_fn_grad
+                )
+
+                expected = jvpmap_op(*primals)
+                result = jvpvmap_op(*primals)
+                self.assertEqual(result, expected)
+
+    # See NOTE: [three-transform testing]
+    @ops(autograd_function_db, allowed_dtypes=(torch.float32,))
+    @skipOps(
+        "TestOperators",
+        "test_jvpvmapvmap",
+        {
+            xfail("NumpyCubeNotComposableAutogradFunction"),  # Not composable
+        },
+    )
+    def test_jvpvmapvmap(self, device, dtype, op):
+        samples = op.sample_inputs(device, dtype, requires_grad=True)
+        B = 2
+        for sample in samples:
+            args = [sample.input] + list(sample.args)
+            kwargs = sample.kwargs
+            generator = generate_vmap_inputs(args, kwargs, batch_size=B)
+            for batched_args, inner_in_dims, kwargs in generator:
+                inner_vmapped_op = vmap(op, inner_in_dims)
+                inner_mapped_op = functools.partial(loop, op, inner_in_dims, 0, B)
+                generator = generate_vmap_inputs(batched_args, kwargs)
+                for batched_args, in_dims, kwargs in generator:
+                    # strategy: compare jvp(vmap(vmap(op)) vs jvp(map(map(op))
+                    vmapped_op = vmap(inner_vmapped_op, in_dims)
+                    mapped_op = functools.partial(loop, inner_mapped_op, in_dims, 0, B)
+
+                    jvpvmapvmap_fn, primals = get_jvp_variant_primals_tangents2(
+                        vmapped_op, batched_args, kwargs, sample.output_process_fn_grad
+                    )
+                    jvpmapmap_fn, _ = get_jvp_variant_primals_tangents2(
+                        mapped_op, batched_args, kwargs, sample.output_process_fn_grad
+                    )
+
+                    expected = jvpmapmap_fn(*primals)
+                    result = jvpvmapvmap_fn(*primals)
+                    self.assertEqual(result, expected)
+
+    # See NOTE: [three-transform testing]
+    @with_tf32_off  # https://github.com/pytorch/pytorch/issues/86798
+    @ops(autograd_function_db, allowed_dtypes=(torch.float32,))
+    @skipOps(
+        "TestOperators",
+        "test_vmapjvpvmap",
+        {
+            xfail("NumpyCubeNotComposableAutogradFunction"),  # Not composable
+        },
+    )
+    def test_vmapjvpvmap(self, device, dtype, op):
+        samples = op.sample_inputs(device, dtype, requires_grad=True)
+        B = 2
+        for sample in samples:
+            args = [sample.input] + list(sample.args)
+            kwargs = sample.kwargs
+            generator = generate_vmap_inputs(args, kwargs, batch_size=B)
+            for batched_args, in_dims, kwargs in generator:
+                inner_vmapped_op = vmap(op, in_dims)
+                inner_mapped_op = functools.partial(loop, op, in_dims, 0, B)
+
+                jvpvmap_fn, primals = get_jvp_variant_primals_tangents2(
+                    inner_vmapped_op,
+                    batched_args,
+                    kwargs,
+                    sample.output_process_fn_grad,
+                )
+                jvpmap_fn, _ = get_jvp_variant_primals_tangents2(
+                    inner_mapped_op, batched_args, kwargs, sample.output_process_fn_grad
+                )
+
+                generator = generate_vmap_inputs(primals, {})
+
+                for batched_args, in_dims, _ in generator:
+                    # strategy: compare vmap(jvp(vmap(op)) vs map(jvp(map(op))
+                    vmapjvpvmap_fn = vmap(jvpvmap_fn, in_dims)
+                    mapjvpmap_fn = functools.partial(loop, jvpmap_fn, in_dims, 0, B)
+
+                    result = vmapjvpvmap_fn(*batched_args)
+                    expected = mapjvpmap_fn(*batched_args)
+                    self.assertEqual(result, expected)
+
+    # See NOTE: [three-transform testing]
+    @ops(autograd_function_db, allowed_dtypes=(torch.float32,))
+    @skipOps(
+        "TestOperators",
+        "test_jvpjvpvmap",
+        {
+            xfail("NumpyCubeNotComposableAutogradFunction"),  # Not composable
+        },
+    )
+    def test_jvpjvpvmap(self, device, dtype, op):
+        samples = op.sample_inputs(device, dtype, requires_grad=True)
+        B = 2
+        for sample in samples:
+            args = [sample.input] + list(sample.args)
+            kwargs = sample.kwargs
+            generator = generate_vmap_inputs(args, kwargs, batch_size=B)
+            for batched_args, in_dims, kwargs in generator:
+                inner_vmapped_op = vmap(op, in_dims)
+                inner_mapped_op = functools.partial(loop, op, in_dims, 0, B)
+
+                jvpmap_fn, args = get_jvp_variant_primals_tangents2(
+                    inner_mapped_op, batched_args, kwargs, sample.output_process_fn_grad
+                )
+                jvpvmap_fn, _ = get_jvp_variant_primals_tangents2(
+                    inner_vmapped_op,
+                    batched_args,
+                    kwargs,
+                    sample.output_process_fn_grad,
+                )
+
+                jvpjvpvmap_fn, new_args = get_jvp_variant_primals_tangents2(
+                    jvpvmap_fn, args, {}
+                )
+                jvpjvpmap_fn, _ = get_jvp_variant_primals_tangents2(jvpmap_fn, args, {})
+
+                expected = jvpjvpmap_fn(*new_args)
+                result = jvpjvpvmap_fn(*new_args)
+                self.assertEqual(result, expected)
+
+    # See NOTE: [three-transform testing]
+    @ops(autograd_function_db, allowed_dtypes=(torch.float32,))
+    @skipOps(
+        "TestOperators",
+        "test_jvpvjpvmap",
+        {
+            xfail("NumpyCubeNotComposableAutogradFunction"),  # Not composable
+        },
+    )
+    def test_jvpvjpvmap(self, device, dtype, op):
+        samples = op.sample_inputs(device, dtype, requires_grad=True)
+        B = 2
+        for sample in samples:
+            args = [sample.input] + list(sample.args)
+            kwargs = sample.kwargs
+            generator = generate_vmap_inputs(args, kwargs, batch_size=B)
+            for batched_args, in_dims, kwargs in generator:
+                inner_vmapped_op = vmap(op, in_dims)
+                inner_mapped_op = functools.partial(loop, op, in_dims, 0, B)
+
+                vjpmap_fn, args = get_vjpfull_variant2(
+                    inner_mapped_op, batched_args, kwargs
+                )
+                vjpvmap_fn, _ = get_vjpfull_variant2(
+                    inner_vmapped_op, batched_args, kwargs
+                )
+
+                jvpvjpvmap_fn, new_args = get_jvp_variant_primals_tangents2(
+                    vjpvmap_fn, args, {}
+                )
+                jvpvjpmap_fn, _ = get_jvp_variant_primals_tangents2(vjpmap_fn, args, {})
+
+                expected = jvpvjpmap_fn(*new_args)
+                result = jvpvjpvmap_fn(*new_args)
+                self.assertEqual(result, expected)
+
+    def test_data_write_errors_under_transform(self, device):
+        t = torch.randn(3, 3, device=device)
+
+        def fn(t):
+            t.data = torch.randn(3, 3)
+            return t.sum()
+
+        msg = "mutating directly with `.data` inside functorch transform"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            grad(fn)(t)
+
+        with self.assertRaisesRegex(RuntimeError, msg):
+            vjp(fn, t)
+
+        with self.assertRaisesRegex(RuntimeError, msg):
+            jvp(fn, (t,), (torch.randn_like(t),))
+
+    def test_tensor_with_scalar_list(self, device):
+        x = torch.randn((), device=device)
+
+        def func_list_of_scalar(x):
+            return torch.tensor([x], device=device)
+
+        def func(x):
+            return torch.tensor(x, device=device).view(1)
+
+        actual_o, actual_fn = vjp(func_list_of_scalar, x)
+        expected_o, expected_fn = vjp(func, x)
+
+        self.assertEqual(actual_o, expected_o)
+        self.assertEqual(
+            expected_fn(torch.ones_like(expected_o)),
+            actual_fn(torch.ones_like(actual_o)),
+        )
+
+    @ops(bool_ordered_op_db, dtypes=[torch.bool])
+    def test_ordered_bool_raises(self, device, dtype, op):
+        # Generate sample inputs for the op
+        sample_inputs = op.sample_inputs(device, dtype)
+
+        for sample_input in sample_inputs:
+            # Check that the op raises NotImplementedError or appropriate failure
+            self.assertRaises(
+                RuntimeError,
+                op,
+                sample_input.input,
+                *sample_input.args,
+                **sample_input.kwargs,
+            )
+
+    @ops(
+        complex_ordered_op_db,
+        dtypes=[torch.complex32, torch.complex64, torch.complex128],
+    )
+    def test_ordered_complex_raises(self, device, dtype, op):
+        # Generate sample inputs for the op
+        sample_inputs = op.sample_inputs(device, dtype)
+
+        for sample_input in sample_inputs:
+            # Check that the op raises NotImplementedError or appropriate failure
+            self.assertRaises(
+                RuntimeError,
+                op,
+                sample_input.input,
+                *sample_input.args,
+                **sample_input.kwargs,
+            )
+
+
+instantiate_device_type_tests(
+    TestOperators, globals(), only_for=("xpu"), allow_xpu=True
+)
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -297,35 +297,7 @@ skip_dict = {
         "test_dataparallel_saved_tensors_hooks",
     ),
     "test_reductions_xpu.py": None,
-    "test_unary_ufuncs_xpu.py": (
-        # AssertionError: Jiterator is only supported on CUDA and ROCm GPUs, none are available.
-        "_jiterator_",
-        # For extreme value processing, Numpy and XPU results are inconsistent
-        # std operations get different behavior on std::complex operarands for extremal cases
-        "test_reference_numerics_large__refs_asinh_xpu_complex32",
-        "test_reference_numerics_large_asinh_xpu_complex32",
-        # AssertionError: Tensor-likes are not close!
-        # exceeded maximum allowed difference
-        # Greatest absolute difference: 6.266784475883469e-05 at index (463, 204) (up to 1e-05 allowed)
-        # Greatest relative difference: 1.9145216356264427e-05 at index (463, 204) (up to 1.3e-06 allowed)
-        # Unexpected success: CUDA uses thrust::sqrt and has accuracy issue. XPU use std::sqrt and has no issue.
-        "test_reference_numerics_large_rsqrt_xpu_complex32",
-        # Numeric difference
-        # https://github.com/intel/torch-xpu-ops/issues/544
-        # Expected 0.00497517 but got 0.00497520063072443.
-        # Absolute difference: 3.063072442997111e-08 (up to 0.0 allowed)
-        # Relative difference: 6.156719153309558e-06 (up to 1e-06 allowed)
-        # Issue: https://github.com/intel/torch-xpu-ops/issues/622
-        # Mismatched elements: 8 / 943593 (0.0%)
-        # Greatest absolute difference: inf at index (9, 860) (up to 0.001 allowed)
-        # Greatest relative difference: inf at index (9, 860) (up to 0.0012 allowed)
-        "test_reference_numerics_normal_polygamma_polygamma_n_1_xpu_float16",
-        "test_reference_numerics_normal_polygamma_polygamma_n_2_xpu_float16",
-        "test_reference_numerics_normal_polygamma_polygamma_n_3_xpu_float16",
-        "test_reference_numerics_normal_polygamma_polygamma_n_4_xpu_float16",
-        # CUDA XFAIL
-        "test_reference_numerics_large__refs_rsqrt_xpu_complex32",
-    ),
+    "test_unary_ufuncs_xpu.py": None,
     "test_masked_xpu.py": None,
     "test_view_ops_xpu.py": (
         # Need quantization support, NotImplementedError: Could not run 'aten::_empty_affine_quantized' with arguments from the 'QuantizedXPU' backend.
@@ -889,4 +861,5 @@ skip_dict = {
         "test_sparse_matmul_xpu_float64",  # - RuntimeError: Double and complex datatype matmul is not supported in oneDNN
         "test_sparse_mm_xpu_float64",  # - NotImplementedError: Could not run 'aten::addmm' with arguments from the 'SparseXPU' backend. This could be because the operator doesn't exist for this backend, or wa...
     ),
+    "functorch/test_ops_functorch_xpu.py": None,
 }

--- a/test/xpu/test_unary_ufuncs_xpu.py
+++ b/test/xpu/test_unary_ufuncs_xpu.py
@@ -1,22 +1,1771 @@
-# Owner(s): ["module: intel"]
+# Owner(s): ["module: tests"]
 
+import math
+import random
+import unittest
+from numbers import Number
+
+import numpy as np
 import torch
+from torch import inf, nan
+from torch.testing import make_tensor
 from torch.testing._internal.common_device_type import (
+    dtypes,
+    dtypesIfCPU,
+    dtypesIfCUDA,
     instantiate_device_type_tests,
-    onlyXPU,
+    largeTensorTest,
+    onlyCPU,
+    onlyNativeDeviceTypes,
+    ops,
+    precisionOverride,
 )
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_dtype import (
+    all_types_and_complex_and,
+    complex_types,
+    floating_and_complex_types_and,
+    floating_types_and,
+    get_all_math_dtypes,
+    integral_types_and,
+)
+from torch.testing._internal.common_methods_invocations import (
+    generate_elementwise_unary_extremal_value_tensors,
+    generate_elementwise_unary_large_value_tensors,
+    generate_elementwise_unary_small_value_tensors,
+    generate_elementwise_unary_tensors,
+    unary_ufuncs,
+)
+from torch.testing._internal.common_utils import (
+    gradcheck,
+    is_iterable_of_tensors,
+    IS_WINDOWS,
+    numpy_to_torch_dtype_dict,
+    run_tests,
+    skipIfNoSciPy,
+    skipIfRocm,
+    slowTest,
+    slowTestIf,
+    suppress_warnings,
+    TEST_SCIPY,
+    TestCase,
+    torch_to_numpy_dtype_dict,
+    xfailIfTorchDynamo,
+)
+from torch.utils import _pytree as pytree
 
-try:
-    from xpu_test_utils import XPUPatchForImport
-except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+if TEST_SCIPY:
+    import scipy
 
-with XPUPatchForImport(False):
-    from test_unary_ufuncs import TestUnaryUfuncs
+# Refer [scipy reference filter]
+# Filter operators for which the reference function
+# is available in the current environment (for reference_numerics tests).
+reference_filtered_ops = list(filter(lambda op: op.ref is not None, unary_ufuncs))
 
-    @onlyXPU
-    def _nonzero_static_large(self, device):
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
+# Tests for unary "universal functions (ufuncs)" that accept a single
+# tensor and have common properties like:
+#   - they are elementwise functions
+#   - the input shape is the output shape
+#   - they typically have method and inplace variants
+#   - they typically support the out kwarg
+#   - they typically have NumPy or SciPy references
+
+# See NumPy's universal function documentation
+# (https://numpy.org/doc/1.18/reference/ufuncs.html) for more details
+# about the concept of ufuncs.
+
+
+# TODO: port test_unary_out_op_mem_overlap
+# TODO: add test for inplace variants erroring on broadcasted inputs
+class TestUnaryUfuncs(TestCase):
+    exact_dtype = True
+    device = acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+
+    @ops(
+        [_fn for _fn in unary_ufuncs if _fn.domain != (None, None)],
+        allowed_dtypes=floating_types_and(torch.bfloat16, torch.half),
+    )
+    def test_float_domains(self, device, dtype, op):
+        eps = (1e-5, 1e-3, 1e-1, 1, 2, 10, 20, 50, 100)
+
+        low, high = op.domain
+        # NOTE: the following two loops are separated for readability
+        if low is not None:
+            low_tensor = torch.tensor(low, device=device, dtype=dtype)
+            for epsilon in eps:
+                lower_tensor = low_tensor - epsilon
+
+                # Skips the test if the difference is not representable,
+                #   which can occur if, for example, the difference is small
+                #   and the dtype is imprecise (like bfloat16 is)
+                if lower_tensor.item() == low_tensor.item():
+                    continue
+
+                result = op(lower_tensor)
+                self.assertEqual(
+                    result.item(),
+                    float("nan"),
+                    msg=(
+                        f"input of {lower_tensor.item()} outside lower domain boundary"
+                        f" {low} produced {result.item()}, not nan!"
+                    ),
+                )
+
+        if high is not None:
+            high_tensor = torch.tensor(high, device=device, dtype=dtype)
+            for epsilon in eps:
+                higher_tensor = high_tensor + epsilon
+
+                # See above comment
+                if higher_tensor.item() == high_tensor.item():
+                    continue
+
+                result = op(higher_tensor)
+                self.assertEqual(
+                    result.item(),
+                    float("nan"),
+                    msg=(
+                        f"input of {higher_tensor.item()} outside upper domain boundary"
+                        f" {high} produced {result.item()}, not nan!"
+                    ),
+                )
+
+    # Helper for comparing torch tensors and numpy arrays
+    # TODO: should this or assertEqual also validate that strides are equal?
+    def assertEqualHelper(
+        self, actual, expected, msg, *, dtype, exact_dtype=True, **kwargs
+    ):
+        assert isinstance(actual, torch.Tensor)
+
+        # Some NumPy functions return scalars, not arrays
+        if isinstance(expected, Number):
+            self.assertEqual(actual.item(), expected, msg, **kwargs)
+        elif isinstance(expected, np.ndarray):
+            # Handles exact dtype comparisons between arrays and tensors
+            if exact_dtype:
+                if (
+                    actual.dtype is torch.bfloat16
+                    or expected.dtype != torch_to_numpy_dtype_dict[actual.dtype]
+                ):
+                    # Allows array dtype to be float32 when comparing with bfloat16 tensors
+                    #   since NumPy doesn't support the bfloat16 dtype
+                    # Also ops like scipy.special.erf, scipy.special.erfc, etc, promote float16
+                    # to float32
+                    if expected.dtype == np.float32:
+                        assert actual.dtype in (
+                            torch.float16,
+                            torch.bfloat16,
+                            torch.float32,
+                        )
+                    elif expected.dtype == np.float64:
+                        assert actual.dtype in (
+                            torch.float16,
+                            torch.bfloat16,
+                            torch.float32,
+                            torch.float64,
+                        )
+                    else:
+                        self.fail(
+                            f"Expected dtype {expected.dtype} but got {actual.dtype}!"
+                        )
+
+            self.assertEqual(
+                actual,
+                torch.from_numpy(expected).to(actual.dtype),
+                msg,
+                exact_device=False,
+                **kwargs,
+            )
+        else:
+            self.assertEqual(actual, expected, msg, exact_device=False, **kwargs)
+
+    # Tests that the function and its (array-accepting) reference produce the same
+    #   values on given tensors
+    def _test_reference_numerics(self, dtype, op, tensors, equal_nan=True):
+        def _helper_reference_numerics(
+            expected, actual, msg, exact_dtype, equal_nan=True
+        ):
+            if not torch.can_cast(
+                numpy_to_torch_dtype_dict[expected.dtype.type], dtype
+            ):
+                exact_dtype = False
+
+            if dtype in [torch.uint8, torch.int8, torch.bool]:
+                # NOTE: For these dtypes, PyTorch computes in the default scalar type (float)
+                # while NumPy computes in float16
+                self.assertEqualHelper(
+                    actual,
+                    expected,
+                    msg,
+                    dtype=dtype,
+                    exact_dtype=exact_dtype,
+                    rtol=1e-3,
+                    atol=1e-2,
+                )
+            elif dtype is torch.bfloat16:
+                # Ref: https://github.com/pytorch/pytorch/blob/master/torch/testing/_internal/common_utils.py#L1149
+                self.assertEqualHelper(
+                    actual,
+                    expected,
+                    msg,
+                    dtype=dtype,
+                    exact_dtype=exact_dtype,
+                    rtol=16e-3,
+                    atol=1e-5,
+                )
+            elif dtype is torch.half:
+                self.assertEqualHelper(
+                    actual,
+                    expected,
+                    msg,
+                    dtype=dtype,
+                    exact_dtype=exact_dtype,
+                    rtol=1.2e-03,
+                    atol=1e-03,
+                )
+            else:
+                self.assertEqualHelper(
+                    actual,
+                    expected,
+                    msg,
+                    dtype=dtype,
+                    equal_nan=equal_nan,
+                    exact_dtype=exact_dtype,
+                )
+
+        for t in tensors:
+            t = t.input
+            torch_kwargs, numpy_kwargs = op.sample_kwargs(t.device, dtype, t)
+            if dtype is torch.bfloat16:
+                a = t.cpu().to(torch.float32).numpy()
+            elif dtype is torch.complex32:
+                a = t.cpu().to(torch.complex64).numpy()
+            else:
+                a = t.cpu().numpy()
+
+            actual = op(t, **torch_kwargs)
+            expected = op.ref(a, **numpy_kwargs)
+
+            # Crafts a custom error message for smaller, printable tensors
+            if t.numel() < 10:
+                msg = (
+                    "Failed to produce expected results! Input tensor was"
+                    f" {t}, torch result is {actual}, and reference result is"
+                    f" {expected}."
+                )
+            else:
+                msg = None
+
+            exact_dtype = True
+            if isinstance(actual, torch.Tensor):
+                _helper_reference_numerics(
+                    expected, actual, msg, exact_dtype, equal_nan
+                )
+            else:
+                for x, y in zip(expected, actual):
+                    # testing multi-outputs results
+                    _helper_reference_numerics(x, y, msg, exact_dtype, equal_nan)
+
+    # Tests that the function and its (array-accepting) reference produce the same
+    #   values on a range of tensors, including empty tensors, scalar tensors,
+    #   1D tensors and a large 2D tensor with interesting and extremal values
+    #   and noncontiguities.
+    @suppress_warnings
+    @ops(reference_filtered_ops)
+    @slowTestIf(IS_WINDOWS)
+    def test_reference_numerics_normal(self, device, dtype, op):
+        tensors = generate_elementwise_unary_tensors(
+            op, device=device, dtype=dtype, requires_grad=False
+        )
+        self._test_reference_numerics(dtype, op, tensors)
+
+    @suppress_warnings
+    @ops(reference_filtered_ops)
+    @slowTestIf(IS_WINDOWS)
+    def test_reference_numerics_small(self, device, dtype, op):
+        if dtype in (torch.bool,):
+            raise self.skipTest("bool has no small values")
+
+        tensors = generate_elementwise_unary_small_value_tensors(
+            op, device=device, dtype=dtype, requires_grad=False
+        )
+        self._test_reference_numerics(dtype, op, tensors)
+
+    @suppress_warnings
+    @ops(reference_filtered_ops)
+    @slowTestIf(IS_WINDOWS)
+    def test_reference_numerics_large(self, device, dtype, op):
+        if dtype in (torch.bool, torch.uint8, torch.int8):
+            raise self.skipTest("bool, uint8, and int8 dtypes have no large values")
+
+        tensors = generate_elementwise_unary_large_value_tensors(
+            op, device=device, dtype=dtype, requires_grad=False
+        )
+        self._test_reference_numerics(dtype, op, tensors)
+
+    @suppress_warnings
+    @ops(
+        reference_filtered_ops,
+        allowed_dtypes=floating_and_complex_types_and(torch.bfloat16, torch.half),
+    )
+    @slowTestIf(IS_WINDOWS)
+    def test_reference_numerics_extremal(self, device, dtype, op):
+        tensors = generate_elementwise_unary_extremal_value_tensors(
+            op, device=device, dtype=dtype, requires_grad=False
+        )
+        self._test_reference_numerics(dtype, op, tensors)
+
+    # Tests for testing (non)contiguity consistency
+    @ops(unary_ufuncs)
+    @slowTestIf(IS_WINDOWS)
+    def test_contig_vs_every_other(self, device, dtype, op):
+        contig = make_tensor(
+            (1026,), device=device, dtype=dtype, low=op.domain[0], high=op.domain[1]
+        )
+        non_contig = contig[::2]
+
+        self.assertTrue(contig.is_contiguous())
+        self.assertFalse(non_contig.is_contiguous())
+
+        torch_kwargs, _ = op.sample_kwargs(device, dtype, non_contig)
+        expected = op(non_contig, **torch_kwargs)
+        result = op(contig, **torch_kwargs)
+        result = pytree.tree_map(lambda x: x[::2], result)
+        self.assertEqual(result, expected)
+
+    @ops(unary_ufuncs)
+    @slowTestIf(IS_WINDOWS)
+    def test_contig_vs_transposed(self, device, dtype, op):
+        contig = make_tensor(
+            (789, 357), device=device, dtype=dtype, low=op.domain[0], high=op.domain[1]
+        )
+        non_contig = contig.T
+
+        self.assertTrue(contig.is_contiguous())
+        self.assertFalse(non_contig.is_contiguous())
+
+        torch_kwargs, _ = op.sample_kwargs(device, dtype, contig)
+        expected = op(non_contig, **torch_kwargs)
+        result = op(contig, **torch_kwargs)
+        result = pytree.tree_map(lambda x: x.T, result)
+        self.assertEqual(result, expected)
+
+    @ops(unary_ufuncs)
+    @slowTestIf(IS_WINDOWS)
+    def test_non_contig(self, device, dtype, op):
+        shapes = [(5, 7), (1024,)]
+        for shape in shapes:
+            contig = make_tensor(
+                shape, dtype=dtype, device=device, low=op.domain[0], high=op.domain[1]
+            )
+            non_contig = torch.empty(shape + (2,), device=device, dtype=dtype)[..., 0]
+            non_contig.copy_(contig)
+
+            self.assertTrue(contig.is_contiguous())
+            self.assertFalse(non_contig.is_contiguous())
+
+            torch_kwargs, _ = op.sample_kwargs(device, dtype, contig)
+            self.assertEqual(op(contig, **torch_kwargs), op(non_contig, **torch_kwargs))
+
+    @ops(unary_ufuncs)
+    @slowTestIf(IS_WINDOWS)
+    def test_non_contig_index(self, device, dtype, op):
+        contig = make_tensor(
+            (2, 2, 1, 2),
+            dtype=dtype,
+            device=device,
+            low=op.domain[0],
+            high=op.domain[1],
+        )
+        non_contig = contig[:, 1, ...]
+        contig = non_contig.contiguous()
+
+        self.assertTrue(contig.is_contiguous())
+        self.assertFalse(non_contig.is_contiguous())
+
+        torch_kwargs, _ = op.sample_kwargs(device, dtype, contig)
+        self.assertEqual(op(contig, **torch_kwargs), op(non_contig, **torch_kwargs))
+
+    @ops(unary_ufuncs)
+    @slowTestIf(IS_WINDOWS)
+    def test_non_contig_expand(self, device, dtype, op):
+        shapes = [(1, 3), (1, 7), (5, 7)]
+        for shape in shapes:
+            contig = make_tensor(
+                shape, dtype=dtype, device=device, low=op.domain[0], high=op.domain[1]
+            )
+            non_contig = contig.clone().expand(3, -1, -1)
+
+            self.assertTrue(contig.is_contiguous())
+            self.assertFalse(non_contig.is_contiguous())
+
+            torch_kwargs, _ = op.sample_kwargs(device, dtype, contig)
+            contig = op(contig, **torch_kwargs)
+            non_contig = op(non_contig, **torch_kwargs)
+            for i in range(3):
+                non_contig_i = pytree.tree_map(lambda x: x[i], non_contig)
+                self.assertEqual(
+                    contig, non_contig_i, msg="non-contiguous expand[" + str(i) + "]"
+                )
+
+    @ops(unary_ufuncs)
+    @slowTestIf(IS_WINDOWS)
+    def test_contig_size1(self, device, dtype, op):
+        contig = make_tensor(
+            (5, 100), dtype=dtype, device=device, low=op.domain[0], high=op.domain[1]
+        )
+        contig = contig[:1, :50]
+        contig2 = torch.empty(contig.size(), device=device, dtype=dtype)
+        contig2.copy_(contig)
+
+        self.assertTrue(contig.is_contiguous())
+        self.assertTrue(contig2.is_contiguous())
+
+        torch_kwargs, _ = op.sample_kwargs(device, dtype, contig)
+        self.assertEqual(op(contig, **torch_kwargs), op(contig2, **torch_kwargs))
+
+    @ops(unary_ufuncs)
+    @slowTestIf(IS_WINDOWS)
+    def test_contig_size1_large_dim(self, device, dtype, op):
+        contig = make_tensor(
+            (5, 2, 3, 1, 4, 5, 3, 2, 1, 2, 3, 4),
+            dtype=dtype,
+            device=device,
+            low=op.domain[0],
+            high=op.domain[1],
+        )
+        contig = contig[:1, :, :, :, :, :, :, :, :, :, :, :]
+        contig2 = torch.empty(contig.size(), device=device, dtype=dtype)
+        contig2.copy_(contig)
+
+        self.assertTrue(contig.is_contiguous())
+        self.assertTrue(contig2.is_contiguous())
+
+        torch_kwargs, _ = op.sample_kwargs(device, dtype, contig)
+        self.assertEqual(op(contig, **torch_kwargs), op(contig2, **torch_kwargs))
+
+    # Tests that computation on a multiple batches is the same as
+    # per-batch computation.
+    @ops(unary_ufuncs)
+    @slowTestIf(IS_WINDOWS)
+    def test_batch_vs_slicing(self, device, dtype, op):
+        input = make_tensor(
+            (1024, 512), dtype=dtype, device=device, low=op.domain[0], high=op.domain[1]
+        )
+
+        torch_kwargs, _ = op.sample_kwargs(device, dtype, input)
+        actual = op(input, **torch_kwargs)
+
+        all_outs = [op(slice, **torch_kwargs) for slice in input]
+        if is_iterable_of_tensors(actual):
+            expected = [
+                torch.stack([out[i] for out in all_outs]) for i in range(len(actual))
+            ]
+        else:
+            expected = torch.stack(all_outs)
+
+        self.assertEqual(actual, expected)
+
+    @dtypes(*all_types_and_complex_and(torch.bool, torch.half))
+    def test_nan_to_num(self, device, dtype):
+        for contiguous in [False, True]:
+            x = make_tensor((64, 64), low=0.0, high=100.0, dtype=dtype, device=device)
+
+            if dtype.is_floating_point:
+                # Add extremal values.
+                extremals = [float("nan"), float("inf"), -float("inf")]
+                for idx, extremal in zip(torch.randint(0, 63, (3,)), extremals):
+                    x[idx, :] = extremal
+
+            if not contiguous:
+                x = x.T
+
+            # With args
+            nan = random.random()
+            posinf = random.random() * 5
+            neginf = random.random() * 10
+
+            self.compare_with_numpy(
+                lambda x: x.nan_to_num(nan=nan, posinf=posinf),
+                lambda x: np.nan_to_num(x, nan=nan, posinf=posinf),
+                x,
+            )
+            self.compare_with_numpy(
+                lambda x: x.nan_to_num(posinf=posinf, neginf=neginf),
+                lambda x: np.nan_to_num(x, posinf=posinf, neginf=neginf),
+                x,
+            )
+
+            # Out Variant
+            out = torch.empty_like(x)
+            result = torch.nan_to_num(x)
+            torch.nan_to_num(x, out=out)
+            self.assertEqual(result, out)
+
+            result = torch.nan_to_num(x, nan=nan, posinf=posinf, neginf=neginf)
+            torch.nan_to_num(x, out=out, nan=nan, posinf=posinf, neginf=neginf)
+            self.assertEqual(result, out)
+
+    @onlyCPU
+    def test_nan_to_num_bfloat16(self, device):
+        def test_dtype(fn, input, dtype):
+            input = input.detach().clone().to(dtype=dtype).requires_grad_(True)
+            input2 = input.detach().clone().float().requires_grad_(True)
+            out = fn(input)
+            out.sum().backward()
+            out2 = fn(input2)
+            out2.sum().backward()
+            self.assertEqual(out.dtype, dtype)
+            self.assertEqual(input.grad.dtype, dtype)
+            self.assertEqual(out, out2, exact_dtype=False)
+            self.assertEqual(input.grad, input2.grad, exact_dtype=False)
+
+        def func():
+            return torch.nan_to_num
+
+        shapes = [[1, 3, 6, 6], [1, 3, 6, 128], [1, 3, 256, 256]]
+        for shape in shapes:
+            x = torch.randn(shape, device=device)
+            extremals = [float("nan"), float("inf"), -float("inf")]
+            for id1, id2, extremal in zip(
+                torch.randint(0, 2, (3,)), torch.randint(0, 5, (3,)), extremals
+            ):
+                x[0, id1, id2, :] = extremal
+            test_dtype(func(), x, torch.bfloat16)
+
+    @dtypes(torch.complex64, torch.complex128)
+    def test_nan_to_num_complex(self, device, dtype):
+        value_dtype = torch.tensor([], dtype=dtype).real.dtype
+
+        def gen_tensor(a):
+            return torch.view_as_complex(
+                torch.tensor(a, dtype=value_dtype, device=device)
+            )
+
+        for extremal, kwarg_name in zip(
+            ["nan", "inf", "-inf"], ["nan", "posinf", "neginf"]
+        ):
+            a = gen_tensor([123, float(extremal)])
+            res = torch.nan_to_num(a, **{kwarg_name: 12})
+            res_check = gen_tensor([123, 12])
+            self.assertEqual(res, res_check)
+
+            a = gen_tensor([float(extremal), 456])
+            res = torch.nan_to_num(a, **{kwarg_name: 21})
+            res_check = gen_tensor([21, 456])
+            self.assertEqual(res, res_check)
+
+    @dtypes(torch.cdouble)
+    def test_complex_edge_values(self, device, dtype):
+        # sqrt Test Reference: https://github.com/pytorch/pytorch/pull/47424
+        x = torch.tensor(0.0 - 1.0e20j, dtype=dtype, device=device)
+        self.compare_with_numpy(torch.sqrt, np.sqrt, x)
+        # acos test reference: https://github.com/pytorch/pytorch/issues/42952
+        if not (dtype == torch.cdouble and device_type in device):
+            self.compare_with_numpy(torch.acos, np.arccos, x)
+
+        x = torch.tensor(
+            (-1.0e60 if dtype == torch.cdouble else -1.0e20) - 4988429.2j,
+            dtype=dtype,
+            device=device,
+        )
+        self.compare_with_numpy(torch.sqrt, np.sqrt, x)
+
+    @unittest.skipIf(not TEST_SCIPY, "Requires SciPy")
+    @dtypes(torch.float, torch.double)
+    def test_digamma_special(self, device, dtype):
+        # Based on SciPy test for the following special values.
+        # Reference:
+        # https://github.com/scipy/scipy/blob/3a8a3a1d4657254a6611e77e9c28feafa26e6645/scipy/special/tests/test_digamma.py#L22
+        euler = 0.57721566490153286
+        dataset = [
+            (0.0, -0.0),
+            (1, -euler),
+            (0.5, -2 * math.log(2) - euler),
+            (1 / 3, -math.pi / (2 * math.sqrt(3)) - 3 * math.log(3) / 2 - euler),
+            (1 / 4, -math.pi / 2 - 3 * math.log(2) - euler),
+            (
+                1 / 6,
+                -math.pi * math.sqrt(3) / 2
+                - 2 * math.log(2)
+                - 3 * math.log(3) / 2
+                - euler,
+            ),
+            (
+                1 / 8,
+                -math.pi / 2
+                - 4 * math.log(2)
+                - (math.pi + math.log(2 + math.sqrt(2)) - math.log(2 - math.sqrt(2)))
+                / math.sqrt(2)
+                - euler,
+            ),
+        ]
+        x = torch.tensor(dataset, device=device, dtype=dtype)
+        self.compare_with_numpy(torch.digamma, scipy.special.digamma, x)
+
+    @unittest.skipIf(not TEST_SCIPY, "Requires SciPy")
+    @dtypes(torch.float, torch.double)
+    def test_digamma(self, device, dtype):
+        # Tests pole behavior
+        tensor = torch.tensor(
+            [
+                -0.999999994,
+                -1.999999994,
+                -2.0000000111,
+                -100.99999994,
+                0.000000111,
+                -1931.99999994,
+                -0.000000111,
+                0,
+                -0,
+                -1,
+                -2,
+                -931,
+            ],
+            dtype=dtype,
+            device=device,
+        )
+        self.compare_with_numpy(torch.digamma, scipy.special.digamma, tensor)
+
+    @dtypes(*floating_types_and(torch.half))
+    def test_frexp(self, device, dtype):
+        input = make_tensor((50, 50), dtype=dtype, device=device)
+        mantissa, exponent = torch.frexp(input)
+        np_mantissa, np_exponent = np.frexp(input.cpu().numpy())
+
+        self.assertEqual(mantissa, np_mantissa)
+        self.assertEqual(exponent, np_exponent)
+
+        # torch.frexp returns exponent in int32 to be compatible with np.frexp
+        self.assertTrue(exponent.dtype == torch.int32)
+        self.assertTrue(torch_to_numpy_dtype_dict[exponent.dtype] == np_exponent.dtype)
+
+    def test_frexp_assert_raises(self, device):
+        invalid_input_dtypes = integral_types_and(torch.bool) + complex_types()
+        for dtype in invalid_input_dtypes:
+            input = make_tensor((50, 50), dtype=dtype, device=device)
+            with self.assertRaisesRegex(
+                RuntimeError, r"torch\.frexp\(\) only supports floating-point dtypes"
+            ):
+                torch.frexp(input)
+
+        for dtype in floating_types_and(torch.half):
+            input = make_tensor((50, 50), dtype=dtype, device=device)
+
+            dtypes = list(
+                all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16)
+            )
+            dtypes.remove(dtype)
+            for mantissa_dtype in dtypes:
+                mantissa = torch.empty_like(input, dtype=mantissa_dtype)
+                exponent = torch.empty_like(input, dtype=torch.int)
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    r"torch\.frexp\(\) expects mantissa to have dtype .+ but got .+",
+                ):
+                    torch.frexp(input, out=(mantissa, exponent))
+
+            dtypes.append(dtype)
+            dtypes.remove(torch.int)
+            for exponent_dtype in dtypes:
+                mantissa = torch.empty_like(input)
+                exponent = torch.empty_like(input, dtype=exponent_dtype)
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    r"torch\.frexp\(\) expects exponent to have int dtype but got .+",
+                ):
+                    torch.frexp(input, out=(mantissa, exponent))
+
+    def test_polygamma_neg(self, device):
+        with self.assertRaisesRegex(
+            RuntimeError, r"polygamma\(n, x\) does not support negative n\."
+        ):
+            torch.polygamma(-1, torch.tensor([1.0, 2.0], device=device))
+
+    # TODO resolve with opinfos
+    @onlyCPU
+    def test_op_invert(self, device):
+        res = 0xFFFF - torch.arange(127, dtype=torch.int8)
+        for dtype in (torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64):
+            a = torch.arange(127, dtype=dtype)
+            self.assertEqual(res.to(dtype), ~a)
+
+        self.assertEqual(torch.tensor([True, False]), ~torch.tensor([False, True]))
+
+        # test exceptions
+        for dtype in (torch.half, torch.float, torch.double):
+            a = torch.zeros(10, dtype=dtype)
+            with self.assertRaises(TypeError):
+                ~a
+
+    @dtypes(torch.complex64, torch.complex128)
+    def test_abs_angle_complex_to_float(self, device, dtype):
+        # Constructs random complex values
+        from random import random
+
+        random_vals = []
+        for multiplier in (-1, 1, -10, 10, -100, 100):
+            for _ in range(10):
+                random_vals.append(
+                    complex(random() * multiplier, random() * multiplier)
+                )
+
+        for vals in (random_vals, []):
+            a = np.array(vals, dtype=torch_to_numpy_dtype_dict[dtype])
+            t = torch.tensor(vals, device=device, dtype=dtype)
+
+            for fn_name in ("abs", "angle"):
+                torch_fn = getattr(torch, fn_name)
+                np_fn = getattr(np, fn_name)
+
+                # Tests function
+                np_result = torch.from_numpy(np_fn(a))
+                torch_result = torch_fn(t).cpu()
+                self.assertEqual(np_result, torch_result, exact_dtype=True)
+
+                # Tests float out
+                float_dtype = (
+                    torch.float32 if dtype is torch.complex64 else torch.float64
+                )
+                np_float_out = np_fn(a).astype(torch_to_numpy_dtype_dict[float_dtype])
+                float_out = torch.empty_like(t, dtype=float_dtype)
+                torch_fn(t, out=float_out)
+                self.assertEqual(torch.from_numpy(np_float_out), float_out.cpu())
+
+                # Tests float out (resized out)
+                float_out = torch.empty(1, device=device, dtype=float_dtype)
+                torch_fn(t, out=float_out)
+                self.assertEqual(torch.from_numpy(np_float_out), float_out.cpu())
+
+                # Tests complex out
+                np_complex_out = np_fn(a).astype(torch_to_numpy_dtype_dict[dtype])
+                complex_out = torch.empty_like(t)
+                torch_fn(t, out=complex_out)
+                self.assertEqual(torch.from_numpy(np_complex_out), complex_out.cpu())
+
+                # Tests complex out (resized out)
+                complex_out = torch.empty(0, device=device, dtype=dtype)
+                torch_fn(t, out=complex_out)
+                self.assertEqual(torch.from_numpy(np_complex_out), complex_out.cpu())
+
+                # Tests long out behavior (expected failure)
+                long_out = torch.empty(0, device=device, dtype=torch.long)
+                with self.assertRaises(RuntimeError):
+                    torch_fn(t, out=long_out)
+
+                # Tests inplace
+                if fn_name == "abs":
+                    torch_inplace_method = getattr(torch.Tensor, fn_name + "_")
+                    np_fn(a, out=a)
+                    if dtype.is_complex:
+                        with self.assertRaisesRegex(
+                            RuntimeError,
+                            "In-place abs is not supported for complex tensors.",
+                        ):
+                            torch_inplace_method(t)
+                        return
+                    torch_inplace_method(t)
+                    self.assertEqual(torch.from_numpy(a), t.cpu())
+
+                # Note: angle does not have an in-place variant
+                if fn_name == "angle":
+                    with self.assertRaises(AttributeError):
+                        torch_inplace_method = getattr(torch.Tensor, fn_name + "_")
+
+    def check_internal_mem_overlap(
+        self, inplace_op, num_inputs, dtype, device, expected_failure=False
+    ):
+        if isinstance(inplace_op, str):
+            inplace_op = getattr(torch.Tensor, inplace_op)
+        input = torch.randn(1, dtype=dtype, device=device).expand(3, 3)
+        inputs = [input] + [torch.randn_like(input) for i in range(num_inputs - 1)]
+        if not expected_failure:
+            with self.assertRaisesRegex(RuntimeError, "single memory location"):
+                inplace_op(*inputs)
+        else:
+            with self.assertRaises(AssertionError):
+                with self.assertRaisesRegex(RuntimeError, "single memory location"):
+                    inplace_op(*inputs)
+
+    def unary_check_input_output_mem_overlap(
+        self, data, sz, op, expected_failure=False
+    ):
+        def _test(op, output, input):
+            output_exp = torch.empty_like(output)
+            op(input, out=output_exp)
+            self.assertEqual(op(input, out=output), output_exp, msg=op.__name__)
+
+        # output is identical to input:
+        _test(op, output=data[0:sz], input=data[0:sz])
+        # output and input are independent:
+        _test(op, output=data[0:sz], input=data[sz : 2 * sz])
+        # output partially overlaps with input:
+        if not expected_failure:
+            with self.assertRaisesRegex(RuntimeError, "unsupported operation"):
+                _test(op, data[0:sz], data[1 : sz + 1])
+        else:
+            with self.assertRaises(AssertionError):
+                with self.assertRaisesRegex(RuntimeError, "unsupported operation"):
+                    _test(op, data[0:sz], data[1 : sz + 1])
+
+    # TODO: run on non-native device types
+    # https://github.com/pytorch/pytorch/issues/126474
+    @xfailIfTorchDynamo
+    @dtypes(torch.double)
+    def test_unary_out_op_mem_overlap(self, device, dtype):
+        sz = 3
+        doubles = torch.randn(2 * sz, dtype=dtype, device=device)
+        positives = torch.randint(1, 100, (2 * sz,), device=device).double()
+        ints = torch.randint(-100, 100, (2 * sz,), device=device)
+        unary_mem_overlap_cases = [
+            ("abs", doubles, True, True, "cpu"),
+            ("abs", doubles, True, True, "cuda"),
+            ("abs", doubles, True, True, "xpu"),
+            ("acos", doubles, True, True, "cpu"),
+            ("acos", doubles, True, True, "cuda"),
+            ("acos", doubles, True, True, "xpu"),
+            ("asin", doubles, True, True, "cpu"),
+            ("asin", doubles, True, True, "cuda"),
+            ("asin", doubles, True, True, "xpu"),
+            ("atan", doubles, True, True, "cpu"),
+            ("atan", doubles, True, True, "cuda"),
+            ("atan", doubles, True, True, "xpu"),
+            ("acosh", doubles, True, True, "cpu"),
+            ("acosh", doubles, True, True, "cuda"),
+            ("acosh", doubles, True, True, "xpu"),
+            ("asinh", doubles, True, True, "cpu"),
+            ("asinh", doubles, True, True, "cuda"),
+            ("asinh", doubles, True, True, "xpu"),
+            ("atanh", doubles, True, True, "cpu"),
+            ("atanh", doubles, True, True, "cuda"),
+            ("atanh", doubles, True, True, "xpu"),
+            ("bitwise_not", ints, True, True, "cpu"),
+            ("bitwise_not", ints, True, True, "cuda"),
+            ("bitwise_not", ints, True, True, "xpu"),
+            ("ceil", doubles, True, True, "cpu"),
+            ("ceil", doubles, True, True, "cuda"),
+            ("ceil", doubles, True, True, "xpu"),
+            ("cos", doubles, True, True, "cpu"),
+            ("cos", doubles, True, True, "cuda"),
+            ("cos", doubles, True, True, "xpu"),
+            ("cosh", doubles, True, True, "cpu"),
+            ("cosh", doubles, True, True, "cuda"),
+            ("cosh", doubles, True, True, "xpu"),
+            ("digamma", doubles, True, True, "cpu"),
+            ("digamma", doubles, True, True, "xpu"),
+            ("erf", doubles, True, True, "cpu"),
+            ("erf", doubles, True, True, "cuda"),
+            ("erf", doubles, True, True, "xpu"),
+            ("erfc", doubles, True, True, "cpu"),
+            ("erfc", doubles, True, True, "cuda"),
+            ("erfc", doubles, True, True, "xpu"),
+            ("erfinv", doubles, True, True, "cpu"),
+            ("erfinv", doubles, True, True, "cuda"),
+            ("erfinv", doubles, True, True, "xpu"),
+            ("exp", doubles, True, True, "cpu"),
+            ("exp", doubles, True, True, "cuda"),
+            ("exp", doubles, True, True, "xpu"),
+            ("exp2", doubles, True, True, "cpu"),
+            ("exp2", doubles, True, True, "cuda"),
+            ("exp2", doubles, True, True, "xpu"),
+            ("expm1", doubles, True, True, "cpu"),
+            ("expm1", doubles, True, True, "cuda"),
+            ("expm1", doubles, True, True, "xpu"),
+            ("floor", doubles, True, True, "cpu"),
+            ("floor", doubles, True, True, "cuda"),
+            ("floor", doubles, True, True, "xpu"),
+            ("frac", doubles, True, True, "cpu"),
+            ("frac", doubles, True, True, "cuda"),
+            ("frac", doubles, True, True, "xpu"),
+            ("i0", doubles, True, True, "cpu"),
+            ("i0", doubles, True, True, "cuda"),
+            ("i0", doubles, True, True, "xpu"),
+            ("log", positives, True, True, "cpu"),
+            ("log", positives, True, True, "cuda"),
+            ("log", positives, True, True, "xpu"),
+            ("log10", positives, True, True, "cpu"),
+            ("log10", positives, True, True, "cuda"),
+            ("log10", positives, True, True, "xpu"),
+            ("log1p", positives, True, True, "cpu"),
+            ("log1p", positives, True, True, "cuda"),
+            ("log1p", positives, True, True, "xpu"),
+            ("log2", positives, True, True, "cpu"),
+            ("log2", positives, True, True, "cuda"),
+            ("log2", positives, True, True, "xpu"),
+            ("neg", doubles, True, True, "cpu"),
+            ("neg", doubles, True, True, "cuda"),
+            ("neg", doubles, True, True, "xpu"),
+            ("reciprocal", doubles, True, True, "cpu"),
+            ("reciprocal", doubles, True, True, "cuda"),
+            ("reciprocal", doubles, True, True, "xpu"),
+            ("round", doubles, True, True, "cpu"),
+            ("round", doubles, True, True, "cuda"),
+            ("round", doubles, True, True, "xpu"),
+            ("rsqrt", positives, True, True, "cpu"),
+            ("rsqrt", positives, True, True, "cuda"),
+            ("rsqrt", positives, True, True, "xpu"),
+            ("sin", doubles, True, True, "cpu"),
+            ("sin", doubles, True, True, "cuda"),
+            ("sin", doubles, True, True, "xpu"),
+            ("sinh", doubles, True, True, "cpu"),
+            ("sinh", doubles, False, True, "cuda"),
+            ("sinh", doubles, False, True, "xpu"),
+            ("sigmoid", doubles, True, True, "cpu"),
+            ("sigmoid", doubles, True, True, "cuda"),
+            ("sigmoid", doubles, True, True, "xpu"),
+            ("logit", doubles, True, True, "cpu"),
+            ("logit", doubles, True, True, "cuda"),
+            ("logit", doubles, True, True, "xpu"),
+            ("sqrt", doubles, True, True, "cpu"),
+            ("sqrt", doubles, False, True, "cuda"),
+            ("sqrt", doubles, False, True, "xpu"),
+            ("tan", doubles, True, True, "cpu"),
+            ("tan", doubles, True, True, "cuda"),
+            ("tan", doubles, True, True, "xpu"),
+            ("tanh", doubles, True, True, "cpu"),
+            ("tanh", doubles, True, True, "cuda"),
+            ("tanh", doubles, True, True, "xpu"),
+            ("trunc", doubles, True, True, "cpu"),
+            ("trunc", doubles, True, True, "cuda"),
+            ("trunc", doubles, True, True, "xpu"),
+        ]
+
+        for (
+            fn,
+            inputs,
+            has_input_output_mem_overlap_check,
+            has_internal_mem_overlap_check,
+            dev,
+        ) in unary_mem_overlap_cases:
+            if dev != device:
+                continue
+            out_fn = getattr(torch, fn)
+            in_fn = getattr(torch.Tensor, fn + "_")
+
+            self.unary_check_input_output_mem_overlap(
+                inputs,
+                sz,
+                out_fn,
+                expected_failure=not has_input_output_mem_overlap_check,
+            )
+
+            self.check_internal_mem_overlap(
+                in_fn,
+                1,
+                dtype,
+                dev,
+                expected_failure=not has_internal_mem_overlap_check,
+            )
+
+    # TODO: opinfo hardshrink
+    @onlyCPU
+    @dtypes(torch.float, torch.double, torch.bfloat16)
+    def test_hardshrink(self, device, dtype):
+        data = torch.tensor([1, 0.5, 0.3, 0.6], dtype=dtype, device=device).view(2, 2)
+        self.assertEqual(
+            torch.tensor([1, 0.5, 0, 0.6], dtype=dtype, device=device).view(2, 2),
+            data.hardshrink(0.3),
+        )
+        self.assertEqual(
+            torch.tensor([1, 0, 0, 0.6], dtype=dtype, device=device).view(2, 2),
+            data.hardshrink(0.5),
+        )
+
+        # test default lambd=0.5
+        self.assertEqual(data.hardshrink(), data.hardshrink(0.5))
+
+        # test non-contiguous case
+        self.assertEqual(
+            torch.tensor([1, 0, 0.5, 0.6], dtype=dtype, device=device).view(2, 2),
+            data.t().hardshrink(0.3),
+        )
+
+    @onlyCPU
+    @dtypes(torch.float, torch.double, torch.bfloat16)
+    def test_hardshrink_edge_cases(self, device, dtype) -> None:
+        def h(values, l_expected):
+            for l, expected in l_expected.items():
+                values_tensor = torch.tensor(
+                    [float(v) for v in values], dtype=dtype, device=device
+                )
+                expected_tensor = torch.tensor(
+                    [float(v) for v in expected], dtype=dtype, device=device
+                )
+                self.assertEqual(
+                    expected_tensor == values_tensor.hardshrink(l),
+                    torch.ones_like(values_tensor, dtype=torch.bool),
+                )
+
+        def test_helper(min, max):
+            h(
+                [0.0, min, -min, 0.1, -0.1, 1.0, -1.0, max, -max, inf, -inf],
+                {
+                    0.0: [0.0, min, -min, 0.1, -0.1, 1.0, -1.0, max, -max, inf, -inf],
+                    min: [0.0, 0.0, 0.0, 0.1, -0.1, 1.0, -1.0, max, -max, inf, -inf],
+                    0.1: [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, -1.0, max, -max, inf, -inf],
+                    1.0: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, max, -max, inf, -inf],
+                    max: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, inf, -inf],
+                    inf: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                },
+            )
+
+        test_helper(torch.finfo(dtype).tiny, torch.finfo(dtype).max)
+
+    @onlyCPU
+    @slowTest
+    @dtypes(torch.float)
+    @unittest.skipIf(True, "Insufficient memory on linux.(2|4)xlarge")
+    def test_exp_slow(self, device, dtype):
+        # Test for https://github.com/pytorch/pytorch/issues/17271
+        # This is pretty slow on my Macbook but it only takes a few
+        # seconds on a beefy Xeon server
+        a = torch.exp(torch.ones(2**31, dtype=dtype, device=device))
+        b = torch.exp(torch.ones(1, dtype=dtype, device=device))
+        self.assertEqual(a, b.expand(2**31))
+
+    @precisionOverride(
+        {torch.bfloat16: 1e-2, torch.float: 0.0002, torch.double: 0.0002}
+    )
+    @dtypes(torch.float, torch.double, torch.bfloat16)
+    def test_hardswish(self, device, dtype):
+        inputValues = [-1000, -4, -3, -2, 0, 2, 3, 4, 1000]
+        expectedOutput = np.multiply(
+            inputValues, np.minimum(np.maximum((np.add(inputValues, 3)), 0), 6) / 6.0
+        )
+
+        inputTensor = torch.tensor(inputValues, dtype=dtype, device=device)
+        expectedOutputTensor = torch.tensor(expectedOutput, dtype=dtype, device=device)
+
+        # normal
+        self.assertEqual(
+            torch.nn.functional.hardswish(inputTensor), expectedOutputTensor
+        )
+
+        # inplace
+        inputTensorCpy = inputTensor.detach().clone()
+        torch.nn.functional.hardswish(inputTensorCpy, inplace=True)
+        self.assertEqual(inputTensorCpy, expectedOutputTensor)
+
+    @precisionOverride(
+        {torch.bfloat16: 1e-2, torch.float: 0.0002, torch.double: 0.0002}
+    )
+    @dtypes(torch.float, torch.double, torch.bfloat16)
+    def test_hardsigmoid(self, device, dtype):
+        inputValues = [-1000, -4, -3, -2, 0, 2, 3, 4, 1000]
+        expectedOutput = np.minimum(np.maximum((np.add(inputValues, 3)), 0), 6) / 6.0
+
+        inputTensor = torch.tensor(inputValues, dtype=dtype, device=device)
+
+        # normal
+        self.assertEqual(
+            torch.nn.functional.hardsigmoid(inputTensor),
+            torch.tensor(expectedOutput, dtype=dtype, device=device),
+        )
+
+        # inplace
+        inputTensorCpy = inputTensor.detach().clone()
+        self.assertEqual(
+            torch.nn.functional.hardsigmoid(inputTensorCpy, inplace=True),
+            torch.tensor(expectedOutput, dtype=dtype, device=device),
+        )
+
+    @precisionOverride(
+        {torch.bfloat16: 1e-2, torch.float: 0.0002, torch.double: 0.0002}
+    )
+    @dtypes(torch.float, torch.double, torch.bfloat16)
+    def test_hardsigmoid_backward(self, device, dtype):
+        inputValues = [-3.0, 3.0, -2.0, 2.0, -6.0, 6.0]
+        expectedValues = [0.0, 0.0, 1.0 / 6.0, 1.0 / 6.0, 0.0, 0.0]
+        inputTensor = torch.tensor(
+            inputValues, dtype=dtype, device=device
+        ).requires_grad_()
+        expetedTensor = torch.tensor(expectedValues, dtype=dtype, device=device)
+        out = torch.nn.functional.hardsigmoid(inputTensor)
+        out.backward(torch.ones_like(inputTensor))
+        self.assertEqual(inputTensor.grad, expetedTensor)
+
+    @skipIfNoSciPy
+    @dtypes(torch.float, torch.double)
+    def test_silu(self, device, dtype):
+        input_np = np.random.randn(5, 8)
+        special_input = [[-1000, -1, -0.1, 0, 0.5, 1, 2, 1000]]
+        input_np = np.concatenate((input_np, special_input), axis=0).astype(
+            torch_to_numpy_dtype_dict[dtype]
+        )
+        expected_output_np = input_np * scipy.special.expit(input_np)
+
+        expected_output = torch.from_numpy(expected_output_np).to(device)
+        expected_output_noncontig = expected_output.transpose(0, 1)
+
+        atol = 1e-6
+        rtol = 1e-6
+
+        input = torch.from_numpy(input_np).clone().contiguous().to(device)
+        self.assertEqual(
+            torch.nn.functional.silu(input), expected_output, atol=atol, rtol=rtol
+        )
+        self.assertEqual(
+            torch.nn.functional.silu(input, inplace=True),
+            expected_output,
+            atol=atol,
+            rtol=rtol,
+        )
+
+        input = torch.from_numpy(input_np).clone().to(device)
+        input_noncontig = input.transpose(0, 1)
+        self.assertEqual(
+            torch.nn.functional.silu(input_noncontig),
+            expected_output_noncontig,
+            atol=atol,
+            rtol=rtol,
+        )
+        self.assertEqual(
+            torch.nn.functional.silu(input_noncontig, inplace=True),
+            expected_output_noncontig,
+            atol=atol,
+            rtol=rtol,
+        )
+
+    @dtypes(torch.complex64, torch.complex128)
+    def test_silu_complex(self, device, dtype):
+        atol = 1e-6
+        rtol = 1e-6
+        inp_outs = [
+            (0.2 + 0.3j, 0.08775215595960617065 + 0.18024823069572448730j),
+            (1e-19 + 1e-18j, 4.99999984132761269448e-20 + 5.00000022906852482872e-19j),
+            (-1.0 + 2.0j, -0.78546208143234252930 + -0.44626939296722412109j),
+            (0.0 + 0.5j, -0.06383547931909561157 + 0.25000000000000000000j),
+            (2.0j, -1.55740761756896972656 + 0.99999988079071044922j),
+        ]
+
+        for inp, out in inp_outs:
+            res = torch.nn.functional.silu(
+                torch.tensor(inp, dtype=dtype, device=device)
+            )
+            self.assertFalse(torch.any(torch.isnan(res)))
+            self.assertEqual(res.real, out.real, atol=atol, rtol=rtol)
+            self.assertEqual(res.imag, out.imag, atol=atol, rtol=rtol)
+
+        for inp, out in inp_outs:
+            res = torch.nn.functional.silu(
+                torch.tensor(inp, dtype=dtype, device=device), inplace=True
+            )
+            self.assertFalse(torch.any(torch.isnan(res)))
+            self.assertEqual(res.real, out.real, atol=atol, rtol=rtol)
+            self.assertEqual(res.imag, out.imag, atol=atol, rtol=rtol)
+
+    # It is not obvious how to merge this into OpInfo because these inputs
+    # succeed for gradcheck but are expected to fail for gradgradcheck
+    @dtypes(torch.double)
+    def test_sinc(self, device, dtype):
+        # The derivative of sinc(x) at x=0 has to be special cased.
+        # A naive computation will result in 0/0 -> NaN.
+        # We also need to be careful when we are very close to 0, as the
+        # derivative's denominator is squared, and there are some floats
+        # that are positive and whose squares are zero.
+        a = torch.tensor(
+            [0.0, torch.finfo(torch.double).tiny, 1.0],
+            dtype=dtype,
+            requires_grad=True,
+            device=device,
+        )
+        gradcheck(torch.sinc, a)
+
+    @skipIfNoSciPy
+    @dtypes(torch.float, torch.double)
+    def test_mish(self, device, dtype):
+        input_np = np.random.randn(5, 8)
+        special_input = [[-1000, -1, -0.1, 0, 0.5, 1, 2, 1000]]
+        input_np = np.concatenate((input_np, special_input), axis=0).astype(
+            torch_to_numpy_dtype_dict[dtype]
+        )
+        expected_output_np = input_np * np.tanh(np.log1p(np.exp(input_np)))
+
+        expected_output = torch.from_numpy(expected_output_np).to(device)
+        expected_output_noncontig = expected_output.transpose(0, 1)
+
+        atol = 1e-6
+        rtol = 1e-6
+
+        input = torch.from_numpy(input_np).clone().contiguous().to(device)
+        self.assertEqual(
+            torch.nn.functional.mish(input), expected_output, atol=atol, rtol=rtol
+        )
+        self.assertEqual(
+            torch.nn.functional.mish(input, inplace=True),
+            expected_output,
+            atol=atol,
+            rtol=rtol,
+        )
+
+        input = torch.from_numpy(input_np).clone().to(device)
+        input_noncontig = input.transpose(0, 1)
+        self.assertEqual(
+            torch.nn.functional.mish(input_noncontig),
+            expected_output_noncontig,
+            atol=atol,
+            rtol=rtol,
+        )
+        self.assertEqual(
+            torch.nn.functional.mish(input_noncontig, inplace=True),
+            expected_output_noncontig,
+            atol=atol,
+            rtol=rtol,
+        )
+
+    @dtypes(torch.complex64, torch.complex128)
+    def test_log1p_complex(self, device, dtype):
+        # The output values here were obtained using arbitrary precision math (mpmath)
+        # and double checked with WolframAlpha.
+        # Not using numpy's log1p here because by the time of writing this,
+        # np.log1p has precision problems for small complex input values, see here:
+        # https://github.com/numpy/numpy/issues/22609
+        inp_outs = [
+            (0.2 + 0.3j, 0.21263386770217202 + 0.24497866312686414j),
+            (1e-19 + 1e-18j, 1e-19 + 1e-18j),
+            (1e-18 + 0.1j, 0.00497517 + 0.0996687j),
+            (0.1 + 1e-18j, 0.0953102 + 9.090909090909090909e-19j),
+            (0.5 + 0j, 0.40546510810816 + 0j),
+            (0.0 + 0.5j, 0.111571776 + 0.463647609j),
+            (2.0 + 1.0j, 1.151292546497023 + 0.3217505543966422j),
+            (-1.0 + 2.0j, 0.6931471805599453 + 1.570796326794897j),
+            (2.0j, 0.80471895621705014 + 1.1071487177940904j),
+            (-2.0j, 0.80471895621705014 - 1.1071487177940904j),
+        ]
+        # test the extreme values
+        if dtype == torch.complex128:
+            inp_outs += [
+                (-1 + 1e250j, 575.6462732485114 + 1.5707963267948966j),
+                (1e250 + 1j, 575.6462732485114 + 1e-250j),
+                (1e250 + 1e250j, 575.9928468387914 + 0.7853981633974483j),
+                (1e-250 + 1e250j, 575.6462732485114 + 1.5707963267948966j),
+                (1e-250 + 2e-250j, 1e-250 + 2e-250j),
+                (1e250 + 1e-250j, 575.6462732485114 + 0.0j),
+            ]
+        elif dtype == torch.complex64:
+            inp_outs += [
+                (-1 + 1e30j, 69.07755278982137 + 1.5707963267948966j),
+                (1e30 + 1j, 69.07755278982137 + 1e-30j),
+                (1e30 + 1e30j, 69.42412638010134 + 0.7853981633974483j),
+                (1e-30 + 1e30j, 69.07755278982137 + 1.5707963267948966j),
+                (1e-30 + 2e-30j, 1e-30 + 2e-30j),
+                (1e30 + 1e-30j, 69.07755278982137 + 0.0j),
+            ]
+
+        # test the log1p individually
+        for inp, out in inp_outs:
+            res = torch.log1p(torch.tensor(inp, dtype=dtype, device=device))
+            self.assertFalse(torch.any(torch.isnan(res)))
+            # setting up atol == 0.0 because some part has very small values
+            self.assertEqual(res.real, out.real, atol=0.0, rtol=1e-6)
+            self.assertEqual(res.imag, out.imag, atol=0.0, rtol=1e-6)
+
+        # test the log1p in tensor
+        inp_lst, out_lst = (list(elmt) for elmt in zip(*inp_outs))
+        inp_tens = torch.tensor(inp_lst, dtype=dtype, device=device)
+        out_tens = torch.tensor(out_lst, dtype=dtype, device=device)
+        res_tens = torch.log1p(inp_tens)
+        self.assertEqual(res_tens.real, out_tens.real, atol=0.0, rtol=1e-6)
+        self.assertEqual(res_tens.imag, out_tens.imag, atol=0.0, rtol=1e-6)
+
+    # do ops like threshold need a test_unary(_nonufunc) test suite?
+    @onlyCPU
+    @dtypes(*get_all_math_dtypes("cpu"))
+    def test_threshold(self, device, dtype):
+        if dtype != torch.uint8 and dtype != torch.float16 and not dtype.is_complex:
+            # 100 is wide enough to use AVX2 instructions for all types
+            x = (
+                torch.randn(100, dtype=torch.float, device=device)
+                .sign()
+                .to(dtype=dtype)
+            )
+            y = torch.threshold(x, 0, 0)
+            self.assertTrue(y.le(0).any())
+
+    def _helper_test_igamma(self, loglo, loghi, device, dtype, torch_fcn, scipy_fcn):
+        exp1 = 2.71828182846
+        vec1 = torch.logspace(
+            loglo, loghi, steps=500, base=exp1, dtype=torch.float64, device=device
+        ).unsqueeze(-1)
+        vec1 = vec1.to(dtype)
+        inputs = [
+            (vec1, vec1.transpose(0, 1)),
+            (vec1, vec1),  # for large number, it should approach 0.5
+            (vec1, 0.5 * vec1),  # test for considerable ratio
+            (vec1, 2.0 * vec1),
+            (vec1[::2, :], vec1[::2, :]),  # contiguous/noncontiguous tests
+            (vec1[::2, :], vec1[: vec1.shape[0] // 2, :]),
+            (vec1[: vec1.shape[0] // 2, :], vec1[::2, :]),
+        ]
+        half_prec = dtype in [torch.bfloat16, torch.float16]
+        for input0, input1 in inputs:
+            actual = torch_fcn(input0, input1)
+            if half_prec:
+                input0 = input0.to(torch.float)
+                input1 = input1.to(torch.float)
+            expected = scipy_fcn(input0.cpu().numpy(), input1.cpu().numpy())
+            expected = torch.from_numpy(expected).to(dtype)
+            self.assertEqual(actual, expected)
+
+    @dtypesIfCPU(torch.float16, torch.bfloat16, torch.float32, torch.float64)
+    @dtypes(torch.float32, torch.float64)
+    @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
+    @onlyNativeDeviceTypes
+    def test_igamma_common(self, device, dtype):
+        # test igamma for reasonable range of values
+        loglo = -4  # approx 0.018
+        loghi = 4  # approx 54.6
+        self._helper_test_igamma(
+            loglo, loghi, device, dtype, torch.igamma, scipy.special.gammainc
+        )
+
+    @dtypesIfCPU(torch.float16, torch.bfloat16, torch.float32, torch.float64)
+    @dtypes(torch.float32, torch.float64)
+    @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
+    @onlyNativeDeviceTypes
+    def test_igammac_common(self, device, dtype):
+        # test igammac for reasonable range of values
+        loglo = -4  # approx 0.018
+        loghi = 4  # approx 54.6
+        self._helper_test_igamma(
+            loglo, loghi, device, dtype, torch.igammac, scipy.special.gammaincc
+        )
+
+    @dtypesIfCPU(torch.float16, torch.bfloat16, torch.float32, torch.float64)
+    @dtypes(torch.float32, torch.float64)
+    @onlyNativeDeviceTypes
+    def test_igamma_edge_cases(self, device, dtype):
+        tkwargs = {"dtype": dtype, "device": device}
+        infs = torch.zeros((3,), **tkwargs) + float("inf")
+        zeros = torch.zeros((3,), **tkwargs)
+        ones = torch.ones((3,), **tkwargs)
+        zero_to_large = torch.tensor([0.0, 1.0, 1e3], **tkwargs)
+        small_to_inf = torch.tensor([1e-3, 1.0, float("inf")], **tkwargs)
+        nans = torch.zeros((3,), **tkwargs) + float("nan")
+        inp_outs = [
+            # (a    ,    x),       out
+            ((zeros, small_to_inf), ones),
+            ((small_to_inf, zeros), zeros),
+            ((infs, zero_to_large), zeros),
+            ((zero_to_large, infs), ones),
+            ((zeros, zeros), nans),
+            ((infs, infs), nans),
+            ((-small_to_inf, small_to_inf), nans),
+        ]
+        for inputs, output in inp_outs:
+            input0, input1 = inputs
+            calc = torch.igamma(input0, input1)
+            if torch.all(torch.isnan(output)):
+                self.assertTrue(torch.all(torch.isnan(calc)))
+            else:
+                self.assertEqual(calc, output)
+
+    @dtypesIfCPU(torch.float16, torch.bfloat16, torch.float32, torch.float64)
+    @dtypes(torch.float32, torch.float64)
+    @onlyNativeDeviceTypes
+    def test_igammac_edge_cases(self, device, dtype):
+        tkwargs = {"dtype": dtype, "device": device}
+        infs = torch.zeros((3,), **tkwargs) + float("inf")
+        zeros = torch.zeros((3,), **tkwargs)
+        ones = torch.ones((3,), **tkwargs)
+        zero_to_large = torch.tensor([0.0, 1.0, 1e3], **tkwargs)
+        small_to_inf = torch.tensor([1e-3, 1.0, float("inf")], **tkwargs)
+        nans = torch.zeros((3,), **tkwargs) + float("nan")
+        inp_outs = [
+            # (a    ,    x),       out
+            ((zeros, small_to_inf), zeros),
+            ((small_to_inf, zeros), ones),
+            ((infs, zero_to_large), ones),
+            ((zero_to_large, infs), zeros),
+            ((zeros, zeros), nans),
+            ((infs, infs), nans),
+            ((-small_to_inf, small_to_inf), nans),
+        ]
+        for inputs, output in inp_outs:
+            input0, input1 = inputs
+            calc = torch.igammac(input0, input1)
+            if torch.all(torch.isnan(output)):
+                self.assertTrue(torch.all(torch.isnan(calc)))
+            else:
+                self.assertEqual(calc, output)
+
+    def _i0_helper(self, t):
+        # Test by comparing to scipy
+        dtype = t.dtype
+        actual = torch.i0(t)
+        if dtype is torch.bfloat16:
+            t = t.to(torch.float32)
+        expected = scipy.special.i0(t.cpu().numpy())
+        # Casting down for dtype float16 is required since scipy upcasts to float32
+        if dtype is torch.bfloat16 or dtype is torch.float16:
+            expected = torch.from_numpy(expected).to(dtype)
+        self.assertEqual(actual, expected)
+
+    def _i0_range_helper(self, range, device, dtype):
+        # i0 tests are broken up by the domain for which the function does not overflow for each dtype
+        # This is done to ensure that the function performs well across all possible input values, without worrying
+        # about inf or nan possibilities
+        for r in (range, -range):
+            t = torch.rand(1000, device=device).to(dtype) * r
+            self._i0_helper(t)
+
+    @dtypesIfCUDA(*floating_types_and(torch.half, torch.bfloat16))
+    @dtypes(torch.bfloat16, torch.float32, torch.float64)
+    @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
+    def test_i0_range1(self, device, dtype):
+        # This tests the domain for i0 for which float16 does not overflow
+        # The domain is (-13.25, 13.25)
+        self._i0_range_helper(13.25, device, dtype)
+
+    @dtypesIfCUDA(*floating_types_and(torch.half, torch.bfloat16))
+    @dtypes(torch.bfloat16, torch.float32, torch.float64)
+    @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
+    def test_i0_range2(self, device, dtype):
+        # This tests the domain for i0 for which float32 and bfloat16 does not overflow
+        # The domain is (-88.5, 88.5)
+        self._i0_range_helper(88.5, device, dtype)
+
+    @dtypes(torch.float64)
+    @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
+    def test_i0_range3(self, device, dtype):
+        # This tests the domain for i0 for which float64 does not overflow
+        # The domain is (-709.75, 709.75)
+        self._i0_range_helper(709.75, device, dtype)
+
+    @dtypesIfCUDA(*floating_types_and(torch.half, torch.bfloat16))
+    @dtypes(torch.bfloat16, torch.float32, torch.float64)
+    @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
+    def test_i0_special(self, device, dtype):
+        t = torch.tensor([], device=device, dtype=dtype)
+        self._i0_helper(t)
+
+        t = torch.tensor([inf, -inf, nan], device=device, dtype=dtype)
+        self.assertTrue(torch.i0(t).isnan().all())
+
+    @dtypesIfCUDA(*floating_types_and(torch.half, torch.bfloat16))
+    @dtypes(torch.bfloat16, torch.float32, torch.float64)
+    @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
+    def test_special_i0_i1_vs_scipy(self, device, dtype):
+        def check_equal(t, torch_fn, scipy_fn):
+            # Test by comparing to scipy
+            actual = torch_fn(t)
+            if dtype is torch.bfloat16:
+                t = t.to(torch.float32)
+            expected = scipy_fn(t.cpu().numpy())
+
+            # Casting down for dtype float16 is required since scipy upcasts to float32
+            if dtype is torch.bfloat16 or dtype is torch.float16:
+                expected = torch.from_numpy(expected).to(dtype)
+            self.assertEqual(actual, expected)
+
+        t = torch.tensor([], device=device, dtype=dtype)
+        check_equal(t, torch.i0, scipy.special.i0)
+        check_equal(t, torch.special.i0e, scipy.special.i0e)
+        if dtype not in [torch.half, torch.bfloat16]:
+            check_equal(t, torch.special.i1, scipy.special.i1)
+            check_equal(t, torch.special.i1e, scipy.special.i1e)
+
+        range = (-1e7, 1e7)
+        if dtype == torch.half:
+            range = (-65000, 65000)
+
+        t = torch.linspace(*range, int(1e4), device=device, dtype=dtype)
+        check_equal(t, torch.i0, scipy.special.i0)
+        check_equal(t, torch.special.i0e, scipy.special.i0e)
+        if dtype not in [torch.half, torch.bfloat16]:
+            check_equal(t, torch.special.i1, scipy.special.i1)
+            check_equal(t, torch.special.i1e, scipy.special.i1e)
+
+        # NaN, inf, -inf are tested in reference_numerics tests.
+        info = torch.finfo(dtype)
+        min, max, eps, tiny = info.min, info.max, info.eps, info.tiny
+        t = torch.tensor([min, max, eps, tiny], dtype=dtype, device=device)
+        check_equal(t, torch.i0, scipy.special.i0)
+        check_equal(t, torch.special.i0e, scipy.special.i0e)
+        if dtype not in [torch.half, torch.bfloat16]:
+            check_equal(t, torch.special.i1, scipy.special.i1)
+            check_equal(t, torch.special.i1e, scipy.special.i1e)
+
+    @dtypes(torch.float32, torch.float64)
+    @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
+    def test_special_ndtr_vs_scipy(self, device, dtype):
+        def check_equal(t):
+            # Test by comparing to scipy
+            actual = torch.special.ndtr(t)
+            expected = scipy.special.ndtr(t.cpu().numpy())
+            self.assertEqual(actual, expected)
+
+        range = (-10, 10)
+        t = torch.linspace(*range, 1, device=device, dtype=dtype)
+        check_equal(t)
+
+        # Skip testing NaN, inf, -inf since they are tested in reference_numerics tests.
+        info = torch.finfo(dtype)
+        min, max, eps, tiny = info.min, info.max, info.eps, info.tiny
+        t = torch.tensor([min, max, eps, tiny], dtype=dtype, device=device)
+        check_equal(t)
+
+    @dtypes(torch.float32, torch.float64)
+    @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
+    def test_special_log_ndtr_vs_scipy(self, device, dtype):
+        def check_equal(t):
+            # Test by comparing with scipy
+            actual = torch.special.log_ndtr(t)
+            expected = scipy.special.log_ndtr(t.cpu().numpy())
+            self.assertEqual(actual, expected)
+
+        # Skip testing NaN, inf, -inf since they are tested in reference_numerics tests.
+        info = torch.finfo(dtype)
+        min, max, eps, tiny = info.min, info.max, info.eps, info.tiny
+        t = torch.tensor([min, max, eps, tiny], dtype=dtype, device=device)
+        check_equal(t)
+
+    # TODO: allow large opinfo values to be opted-into via metadata
+    @dtypes(torch.long)
+    def test_abs_big_number(self, device, dtype):
+        bignumber = 2**31 + 1
+        res = torch.tensor([bignumber], device=device, dtype=dtype)
+        self.assertGreater(res.abs()[0], 0)
+
+    # TODO: add signed zero testing to opinfos
+    @dtypes(torch.float, torch.double)
+    def test_abs_signed_zero(self, device, dtype):
+        # Both abs(0.0) and abs(-0.0) should result in 0.0
+        size = 128 + 1  # pick a large enough number with remainder so that
+        # both vectorized and nonvectorized op is tested
+        inp = torch.zeros(size, device=device, dtype=dtype)
+        inp[::2] = -0.0
+        inp = inp.abs()
+        for v in inp:
+            self.assertGreater(math.copysign(1.0, v), 0.0)
+
+    # TODO: update to compare against NumPy by rationalizing with OpInfo
+
+    @dtypes(torch.float, torch.double)
+    def test_abs_zero(self, device, dtype):
+        # Both abs(0.0) and abs(-0.0) should result in 0.0
+        abs_zeros = torch.tensor([0.0, -0.0], device=device, dtype=dtype).abs().tolist()
+        for num in abs_zeros:
+            self.assertGreater(math.copysign(1.0, num), 0.0)
+
+    @dtypes(torch.bool, torch.int8)
+    def test_narrow_dtypes(self, device, dtype):
+        x_int = torch.randint(2, (8 * 1024,), device=device, dtype=torch.int)
+        x = x_int.to(dtype)
+        # check normal conversion
+        self.assertEqual(x_int, x.int())
+        x.fill_(0)
+        self.assertEqual(x.sum(), 0)
+        # test unaligned tensor with non-round number of elements
+        x[1:4000].fill_(1)
+        self.assertEqual(x.sum(), 3999)
+
+    @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16))
+    def test_isposinf_isneginf_non_boolean_output(self, device, dtype):
+        # test non-boolean tensors as the `out=` parameters
+        # boolean outputs are tested in the above testcases
+        vals = (float("inf"), -float("inf"), 1.2)
+        t = torch.tensor(vals, device=device)
+        for torch_op in (torch.isposinf, torch.isneginf):
+            out = torch.empty_like(t, dtype=dtype)
+            with self.assertRaisesRegex(
+                RuntimeError, "does not support non-boolean outputs"
+            ):
+                torch_op(t, out=out)
+
+    def test_nonzero_empty(self, device):
+        def assert_tuple_empty(tup, dim):
+            self.assertEqual(dim, len(tup))
+            for t in tup:
+                self.assertEqual(torch.Size([0]), t.shape)
+
+        x = torch.randn(0, 2, 0, 5, 0, device=device)
+        y = torch.nonzero(x)
+        z = torch.nonzero(x, as_tuple=True)
+
+        self.assertEqual(0, y.numel())
+        self.assertEqual(torch.Size([0, 5]), y.shape)
+        assert_tuple_empty(z, 5)
+
+        x = torch.tensor(0.5, device=device)
+        y = torch.nonzero(x)
+        # nonzero with as_tuple returns a
+        # tuple of len 1 for a zero-dim tensor.
+        # This is done to match Numpy behavior.
+        z = torch.nonzero(x, as_tuple=True)
+        self.assertEqual(1, len(z))
+        self.assertEqual(torch.zeros(1, dtype=torch.long), z[0])
+
+        x = torch.zeros((), device=device)
+        y = torch.nonzero(x)
+        z = torch.nonzero(x, as_tuple=True)
+        self.assertEqual(torch.Size([0, 0]), y.shape)
+        self.assertEqual(1, len(z))
+        self.assertEqual(torch.empty(0, dtype=torch.long), z[0])
+
+    @dtypes(torch.int8)
+    @largeTensorTest("8GB")
+    @skipIfRocm(msg="ROCM tries to allocate 60GB")
+    def test_nonzero_large(self, device, dtype):
+        indices = (
+            torch.tensor((0, 2, 3, 4, 6, 100, 103, 2**30, 2**31 - 3, 2**31 - 2)),
+            torch.tensor((0, 1, 1, 1, 0, 1, 0, 1, 0, 0)),
+        )
+
+        x = torch.zeros(2**31 - 1, 2, device=device, dtype=dtype)
+        x[indices[0], indices[1]] = 1
+        y = torch.nonzero(x, as_tuple=True)
+        self.assertEqual(y, indices)
+        x = x.view(-1).fill_(0)
+        indices = indices[0] * 2
+        x[indices] = 1
+        y = torch.nonzero(x)
+        self.assertEqual(y.view(-1), indices)
+
+    def test_nonzero_static(self, device):
+        # invalid size
+        with self.assertRaisesRegex(
+            RuntimeError, "nonzero_static: 'size' must be an non-negative integer"
+        ):
+            torch.nonzero_static(torch.tensor([8], device=device), size=-2)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "nonzero_static: 'size' must be an non-negative integer"
+        ):
+            torch.nonzero_static(
+                torch.tensor([8], device=device),
+                size=-2,
+                out=torch.tensor(0, device=device),
+            )
+
+        # nonzero_static.out: out dtype mismatch
+        input_tensor = torch.tensor([8], device=device)
+        static_size = 1
+        out_tensor = torch.empty(
+            (static_size, input_tensor.dim()), dtype=torch.float, device=device
+        )
+        with self.assertRaisesRegex(
+            RuntimeError, "nonzero_static: Expected out tensor to have scalar type Long"
+        ):
+            torch.nonzero_static(input_tensor, size=static_size, out=out_tensor)
+
+        # nonzero_static.out: out resize (shrink)
+        input_tensor = torch.tensor([8], device=device)
+        static_size = 1
+        out_tensor = torch.empty((10, 10, 10, 10), dtype=torch.long, device=device)
+        ref = torch.tensor([[0]], device=device)
+        self.assertEqual(
+            torch.nonzero_static(input_tensor, size=static_size, out=out_tensor), ref
+        )
+        self.assertEqual(out_tensor, ref)
+
+        # nonzero_static.out: out resize (enlarge)
+        input_tensor = torch.tensor([8], device=device)
+        static_size = 1
+        out_tensor = torch.empty((0), dtype=torch.long, device=device)
+        self.assertEqual(
+            torch.nonzero_static(input_tensor, size=static_size, out=out_tensor), ref
+        )
+        self.assertEqual(out_tensor, ref)
+
+        # 0 rank
+        input_tensor = torch.tensor(6, device=device)
+        static_size = 2
+        self.assertEqual(
+            torch.nonzero_static(input_tensor, size=static_size),
+            torch.empty(
+                (static_size, input_tensor.dim()), device=device, dtype=torch.long
+            ),
+        )
+
+        # 0 size
+        input_tensor = torch.tensor([[[1]]], device=device)
+        static_size = 0
+        self.assertEqual(
+            torch.nonzero_static(input_tensor, size=static_size),
+            torch.empty(
+                (static_size, input_tensor.dim()), device=device, dtype=torch.long
+            ),
+        )
+
+        # empty input
+        # https://github.com/pytorch/pytorch/issues/162473
+        input_tensor = torch.tensor([], device=device)
+        static_size = 1
+        self.assertEqual(
+            torch.nonzero_static(input_tensor, size=static_size),
+            torch.tensor([[-1]], device=device),
+        )
+
+        # 1D input
+        input_tensor = torch.tensor([0, 8], device=device)
+        static_size = 1
+        self.assertEqual(
+            torch.nonzero_static(input_tensor, size=static_size),
+            torch.tensor([[1]], device=device),
+        )
+
+        input_tensor = torch.tensor([8, 0], device=device)
+        static_size = 2
+        self.assertEqual(
+            torch.nonzero_static(input_tensor, size=static_size),
+            torch.tensor(
+                [[0], [-1]], device=device
+            ),  # padded with default fill_value "-1"
+        )
+
+        # 2D input
+        input_tensor = torch.tensor([[1.2, 0], [3.4, 5.6]], device=device)
+        static_size = 5
+        fill_value = -100
+        self.assertEqual(
+            torch.nonzero_static(input_tensor, size=static_size, fill_value=fill_value),
+            torch.tensor(
+                [
+                    [0, 0],
+                    [1, 0],
+                    [1, 1],
+                    [fill_value, fill_value],
+                    [fill_value, fill_value],
+                ],
+                device=device,
+            ),
+        )
+        input_tensor = torch.tensor([[1.2, 0], [3.4, 5.6]], device=device)
+        static_size = 2
+        fill_value = -100
+        self.assertEqual(
+            torch.nonzero_static(input_tensor, size=static_size, fill_value=fill_value),
+            torch.tensor([[0, 0], [1, 0]], device=device),
+        )
+
+        # 3D input
+        input_tensor = torch.tensor(
+            [[[0, 0], [0, -3]], [[0, 0], [5, 0]]], device=device
+        )
+        static_size = 4
+        fill_value = -999
+        self.assertEqual(
+            torch.nonzero_static(
+                input_tensor,
+                size=static_size,
+                fill_value=fill_value,
+            ),
+            torch.tensor(
+                [
+                    [0, 1, 1],
+                    [1, 1, 0],
+                    [fill_value, fill_value, fill_value],
+                    [fill_value, fill_value, fill_value],
+                ],
+                device=device,
+            ),
+        )
+
+    def test_nonzero_static_large(self, device):
         # large enough to have multiple iters per SM even on H100
         # with 132 sms
         size_inp = 1024 * 16 * 132 + 1024 * 16
@@ -33,7 +1782,7 @@ with XPUPatchForImport(False):
         self.assertEqual(out[: size_inp // 4], sorted[: size_inp // 4])
         self.assertEqual(
             out[size_inp // 4 :],
-            torch.tensor(10, device="xpu").expand_as(out[size_inp // 4 :]),
+            torch.tensor(10, device=device_type).expand_as(out[size_inp // 4 :]),
         )
         # correct fill for 2d
         x = x.view(2, size_inp // 2)
@@ -43,10 +1792,95 @@ with XPUPatchForImport(False):
         self.assertEqual(ref, res[: size_inp // 2])
         self.assertEqual(
             res[size_inp // 2 :],
-            torch.tensor(-1, device="xpu").expand_as(res[size_inp // 2 :]),
+            torch.tensor(-1, device=device_type).expand_as(res[size_inp // 2 :]),
         )
 
-    TestUnaryUfuncs.test_nonzero_static_large = _nonzero_static_large
+    # TODO: rationalize with exp OpInfo
+
+    @dtypes(*floating_and_complex_types_and(torch.bfloat16))
+    @dtypesIfCUDA(*floating_and_complex_types_and(torch.half, torch.bfloat16))
+    def test_exp(self, device, dtype):
+        for v in (2, -2) + ((1j, 1 + 1j) if dtype.is_complex else ()):
+            a = (
+                torch.tensor(v, dtype=dtype, device=device)
+                * torch.arange(18, device=device)
+                / 3
+                * math.pi
+            )
+            a = a.to(dtype)
+            # bfloat16 overflows
+            if dtype == torch.bfloat16:
+                return
+            self.compare_with_numpy(torch.exp, np.exp, a)
+
+            if dtype.is_complex:
+                inf_real_zero_imag_in = torch.tensor(
+                    complex(float("inf"), 0), device=device, dtype=dtype
+                )
+                inf_real_zero_imag_out = torch.exp(inf_real_zero_imag_in).item()
+                self.assertTrue(math.isinf(inf_real_zero_imag_out.real))
+                if self.device_type == "cpu":
+                    pass
+                    # These are commented out because it cannot be consistently reproduced.
+                    # This is incorrect. It should be zero. Need fix!
+                    # https://github.com/pytorch/pytorch/issues/40590
+                    # self.assertNotEqual(inf_real_zero_imag_out.imag, 0)
+                    # This is incorrect. They should equal. Need fix!
+                    # https://github.com/pytorch/pytorch/issues/40590
+                    # with self.assertRaises(AssertionError):
+                    #     self.compare_with_numpy(torch.exp, np.exp, inf_real_zero_imag_in)
+                else:
+                    self.assertEqual(inf_real_zero_imag_out.imag, 0, atol=0, rtol=0)
+                    self.compare_with_numpy(torch.exp, np.exp, inf_real_zero_imag_in)
+
+                zero_real_inf_imag_in = torch.tensor(
+                    complex(0, float("inf")), device=device, dtype=dtype
+                )
+                zero_real_inf_imag_out = torch.exp(zero_real_inf_imag_in).item()
+                self.assertTrue(math.isnan(zero_real_inf_imag_out.real))
+                self.assertTrue(math.isnan(zero_real_inf_imag_out.imag))
+                # Ensure we are notified when NumPy changes its behavior
+                self.compare_with_numpy(torch.exp, np.exp, zero_real_inf_imag_in)
+
+                inf_real_imag_in = torch.tensor(
+                    complex(float("inf"), float("inf")), device=device, dtype=dtype
+                )
+                inf_real_imag_out = torch.exp(inf_real_imag_in).item()
+                if self.device_type == "cpu":
+                    pass
+                    # This is incorrect. Need fix! https://github.com/pytorch/pytorch/issues/40590
+                    # This is commented out because it cannot be consistently reproduced.
+                    # with self.assertRaises(AssertionError):
+                    #     self.compare_with_numpy(torch.exp, np.exp, inf_real_imag_in)
+                else:
+                    self.assertTrue(math.isinf(inf_real_imag_out.real))
+                    self.assertTrue(math.isnan(inf_real_imag_out.imag))
+                    self.compare_with_numpy(torch.exp, np.exp, inf_real_imag_in)
+
+                inf_real_nan_imag_in = torch.tensor(
+                    complex(float("inf"), float("nan")), device=device, dtype=dtype
+                )
+                inf_real_nan_imag_out = torch.exp(inf_real_nan_imag_in).item()
+                if self.device_type == "cpu":
+                    pass
+                    # This is incorrect. It should be inf. Need fix! https://github.com/pytorch/pytorch/issues/40590
+                    # This is commented out because it cannot be consistently reproduced.
+                    # with self.assertRaises(AssertionError):
+                    #     self.compare_with_numpy(torch.exp, np.exp, inf_real_nan_imag_in)
+                else:
+                    self.assertTrue(math.isinf(inf_real_nan_imag_out.real))
+                    self.assertTrue(math.isnan(inf_real_nan_imag_out.imag))
+                    self.compare_with_numpy(torch.exp, np.exp, inf_real_nan_imag_in)
+
+                nan_real_inf_imag_in = torch.tensor(
+                    complex(float("nan"), float("inf")), device=device, dtype=dtype
+                )
+                nan_real_inf_imag_out = torch.exp(nan_real_inf_imag_in).item()
+                self.assertTrue(math.isnan(nan_real_inf_imag_out.real))
+                self.assertTrue(math.isnan(nan_real_inf_imag_out.imag))
+                # Ensure we are notified when NumPy changes its behavior
+                self.compare_with_numpy(torch.exp, np.exp, nan_real_inf_imag_in)
+
 
 instantiate_device_type_tests(
     TestUnaryUfuncs, globals(), only_for=("xpu"), allow_xpu=True


### PR DESCRIPTION
Case num change:
|test file|increased total|increased pass|increased skipped|
|-|-|-|-|
|test/xpu/functorch/test_ops_functorch_xpu.py|10221|7478|2743|
|test/xpu/test_unary_ufuncs_xpu.py|4614|4357|257|

disable_distributed
disable_e2e