### PR TITLE
[AOT] Add PTL in the default AOT target list for both Win and Lin

### DIFF
--- a/cmake/BuildFlags.cmake
+++ b/cmake/BuildFlags.cmake
@@ -127,9 +127,9 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"
   set(SYCL_OFFLINE_COMPILER_CG_OPTIONS "${SYCL_OFFLINE_COMPILER_CG_OPTIONS} -options -cl-intel-greater-than-4GB-buffer-required")
 
   if(WIN32)
-    set(AOT_TARGETS "mtl,mtl-h,bmg,dg2,arl-h,lnl-m")
+    set(AOT_TARGETS "mtl,mtl-h,bmg,dg2,arl-h,lnl-m,ptl")
   else()
-    set(AOT_TARGETS "pvc,bmg,dg2,arl-h,mtl-h,lnl-m")
+    set(AOT_TARGETS "pvc,bmg,dg2,arl-h,mtl-h,lnl-m,ptl-h,ptl-u")
   endif()
   if(TORCH_XPU_ARCH_LIST)
     set(AOT_TARGETS "${TORCH_XPU_ARCH_LIST}")


### PR DESCRIPTION
This PR adds PTL (Panther Lake) architecture support to the Ahead-of-Time (AOT) compilation target lists for both Windows and Linux platforms in the CMake build configuration.

- Windows builds now include ptl target
- Linux builds now include ptl-h and ptl-u targets