### PR TITLE
Fix KeyError: 'xpu' for torchbench models

### DIFF
--- a/.ci/benchmarks/torchbench.yaml
+++ b/.ci/benchmarks/torchbench.yaml
@@ -218,7 +218,6 @@ skip:
 
     xpu: []
 
-
   test:
     training:
       - *DETECTRON2_MODELS


### PR DESCRIPTION
Fix following issue:
```
Traceback (most recent call last):
  File "/home/gta/repositories/pytorch/pytorch/benchmarks/dynamo/torchbench.py", line 486, in <module>
    torchbench_main()
  File "/home/gta/repositories/pytorch/pytorch/benchmarks/dynamo/torchbench.py", line 482, in torchbench_main
    main(TorchBenchmarkRunner(), original_dir)
  File "/home/gta/repositories/pytorch/pytorch/benchmarks/dynamo/common.py", line 3716, in main
    process_entry(0, runner, original_dir, args)
  File "/home/gta/repositories/pytorch/pytorch/benchmarks/dynamo/common.py", line 3641, in process_entry
    result = run(runner, args, original_dir)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gta/repositories/pytorch/pytorch/benchmarks/dynamo/common.py", line 3935, in run
    runner.skip_models.update(runner.skip_models_for_xpu)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gta/repositories/pytorch/pytorch/benchmarks/dynamo/torchbench.py", line 129, in skip_models_for_xpu
    return self._skip["device"]["xpu"]
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^
KeyError: 'xpu'
```