### PR TITLE
Use PyTorch p2p API in Copy kernel

### DIFF
--- a/src/ATen/native/xpu/Copy.cpp
+++ b/src/ATen/native/xpu/Copy.cpp
@@ -3,6 +3,7 @@
 #include <ATen/native/Resize.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/xpu/CachingHostAllocator.h>
+#include <ATen/xpu/PeerToPeerAccess.h>
 #include <ATen/xpu/XPUContext.h>
 #include <ATen/xpu/XPUEvent.h>
 #include <ATen/xpu/detail/XPUHooks.h>
@@ -56,12 +57,7 @@ static bool maybe_enable_p2p_access(Device dst_device, Device src_device) {
     return false;
   }
 
-  auto dst_queue = getCurrentXPUStream(dst_device.index()).queue();
-  auto src_queue = getCurrentXPUStream(src_device.index()).queue();
-  auto dst_dev = dst_queue.get_device();
-  auto src_dev = src_queue.get_device();
-  return src_dev.ext_oneapi_can_access_peer(
-      dst_dev, sycl::ext::oneapi::peer_access::access_supported);
+  return at::xpu::get_p2p_access(src_device.index(), dst_device.index());
 }
 
 void memcpyAsync(


### PR DESCRIPTION
# Motivation
https://github.com/pytorch/pytorch/pull/166424 introduces `at::xpu::get_p2p_access` API to query/enable peer to peer feature using a cached value. This PR aims to use it directly in Copy kernel instead of always quring it at runtime.