### PR TITLE
Remove clang::optnone attribute for IgammaFunctor

### DIFF
--- a/src/ATen/native/xpu/sycl/IGammaKernel.cpp
+++ b/src/ATen/native/xpu/sycl/IGammaKernel.cpp
@@ -9,26 +9,27 @@ namespace at::native::xpu {
 
 template <typename scalar_t>
 struct IgammaFunctor {
-  IgammaFunctor(bool calc_igammac) : calc_igammac_(calc_igammac) {}
-  bool calc_igammac_;
   scalar_t operator()(scalar_t a, scalar_t b) const {
-    if (calc_igammac_) {
-      return calc_igammac<scalar_t>(a, b);
-    } else {
-      return calc_igamma<scalar_t>(a, b);
-    }
+    return calc_igamma<scalar_t>(a, b);
+  }
+};
+
+template <typename scalar_t>
+struct IgammacFunctor {
+  scalar_t operator()(scalar_t a, scalar_t b) const {
+    return calc_igammac<scalar_t>(a, b);
   }
 };
 
 void igamma_kernel(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "igamma_xpu", [&]() {
-    gpu_kernel(iter, IgammaFunctor<scalar_t>(false));
+    gpu_kernel(iter, IgammaFunctor<scalar_t>());
   });
 }
 
 void igammac_kernel(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "igammac_xpu", [&]() {
-    gpu_kernel(iter, IgammaFunctor<scalar_t>(true));
+    gpu_kernel(iter, IgammacFunctor<scalar_t>());
   });
 }
 


### PR DESCRIPTION
This "clang::optnone" attribute was added by commit https://github.com/intel/torch-xpu-ops/pull/1031/commits/c303e58a904774ad812dae68000525fa84fb4f9e, which may be a work-around to solve compiler issue at that time. Now we don't need it anymore.