### PR TITLE
Revert "Remove clang::optnone attribute for IgammaFunctor (#2351)"

### DIFF
--- a/src/ATen/native/xpu/sycl/IGammaKernel.cpp
+++ b/src/ATen/native/xpu/sycl/IGammaKernel.cpp
@@ -9,27 +9,26 @@ namespace at::native::xpu {
 
 template <typename scalar_t>
 struct IgammaFunctor {
-  scalar_t operator()(scalar_t a, scalar_t b) const {
-    return calc_igamma<scalar_t>(a, b);
-  }
-};
-
-template <typename scalar_t>
-struct IgammacFunctor {
-  scalar_t operator()(scalar_t a, scalar_t b) const {
-    return calc_igammac<scalar_t>(a, b);
+  IgammaFunctor(bool calc_igammac) : calc_igammac_(calc_igammac) {}
+  bool calc_igammac_;
+  [[clang::optnone]] scalar_t operator()(scalar_t a, scalar_t b) const {
+    if (calc_igammac_) {
+      return calc_igammac<scalar_t>(a, b);
+    } else {
+      return calc_igamma<scalar_t>(a, b);
+    }
   }
 };
 
 void igamma_kernel(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "igamma_xpu", [&]() {
-    gpu_kernel(iter, IgammaFunctor<scalar_t>());
+    gpu_kernel(iter, IgammaFunctor<scalar_t>(false));
   });
 }
 
 void igammac_kernel(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "igammac_xpu", [&]() {
-    gpu_kernel(iter, IgammacFunctor<scalar_t>());
+    gpu_kernel(iter, IgammaFunctor<scalar_t>(true));
   });
 }
 


### PR DESCRIPTION
This reverts commit 0c85351b70aecf40718fe01a1f963504cddb1d43.