### PR TITLE
Use sycl::group_barrier, a SYCL2020 API, rather than item.barrier

### DIFF
--- a/src/ATen/native/xpu/sycl/AdaptiveAveragePooling2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/AdaptiveAveragePooling2dKernels.cpp
@@ -145,7 +145,7 @@ struct AdaptiveAvgPool2dBwdSLMKernelFunctor
                      native::start_index(_ow, ow_, iw_));
     }
 
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     for (int64_t i = gi; i < numel_; i += global_range_) {
       int64_t _iw, _ih, _ic, _ib;
@@ -289,7 +289,7 @@ struct AdaptiveAvgPool2dBwdSLMChannelsLastKernelFunctor
       out_cached[i] = scalar_t(0.0);
     }
 
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     auto gradInput = gradInput_ + batch_id * isizeH_ * isizeW_ * sizeC_;
     auto gradOutput = gradOutput_ + batch_id * ostrideB_;

--- a/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
@@ -286,7 +286,7 @@ static inline void group_reduce(
     if (lane_id == 0) {
       local_data[0] = val;
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
     val = local_data[0];
 
     return;
@@ -297,7 +297,7 @@ static inline void group_reduce(
   if (lane_id == 0) {
     local_data[sg_id] = val;
   }
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
 
   // use one subgroup to reduce WGroupSize/subGroupSize elements
   // into the final result
@@ -324,7 +324,7 @@ static inline void group_reduce(
     }
   }
 
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
   val = local_data[0];
 }
 
@@ -362,7 +362,7 @@ scalar_t plane_reduce(
   if (item.get_local_linear_id() == 0) {
     shared[0] = sum_value;
   }
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
   // Everyone picks it up, should be broadcast into the whole grad_input
   return shared[0];
 }
@@ -483,7 +483,7 @@ struct BatchNormCollectStatisticsKernelFunctor
       shared_avg_var_[sg_id * 2] = avg;
       shared_avg_var_[sg_id * 2 + 1] = var_n;
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
     // now have a second subgroupSum to reduce the intermediate values
     // from shared memory to a single number. The very first
     // thread writes it to shared memory.
@@ -675,7 +675,7 @@ inline void welford_merge_group_vertical(
       shmem_m2n[address_base] = m2n;
       shmem_count[address_base] = count;
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
     if (item.get_local_id(0) < offset &&
         item.get_local_id(0) + offset < item.get_local_range(0)) {
       auto address = address_base + offset * item.get_local_range(1);
@@ -782,7 +782,7 @@ struct BatchNormCollectStatisticsChannelsLastKernelFunctor
         staging_count[address_base] = count_th;
       }
 
-      item.barrier(sycl_local_fence);
+      sycl::group_barrier(item.get_group());
 
       // mark group done
       if (item.get_local_linear_id() == 0) {
@@ -794,7 +794,7 @@ struct BatchNormCollectStatisticsChannelsLastKernelFunctor
         is_last_group_done_[0] = (old == (item.get_group_range(0) - 1));
       }
 
-      item.barrier(sycl_local_fence);
+      sycl::group_barrier(item.get_group());
 
       // check that all data is now available in global memory
       if (is_last_group_done_[0]) {
@@ -2146,7 +2146,7 @@ inline void merge_group_vertical_backward(
       shmem_sum_dy[address_base] = sum_dy;
       shmem_sum_dy_xmu[address_base] = sum_dy_xmu;
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
     if (local_id_y < offset && local_id_y + offset < item.get_local_range(0)) {
       auto address = address_base + offset * item.get_local_range(1);
 
@@ -2244,7 +2244,7 @@ struct BatchNormBackwardReduceChannelsLastKernelFunctor
         staging_sum_dy_xmu[address_base] = sum_dy_xmu_th;
       }
 
-      item.barrier(sycl_local_fence);
+      sycl::group_barrier(item.get_group());
 
       // mark group done
       if (item.get_local_linear_id() == 0) {
@@ -2256,7 +2256,7 @@ struct BatchNormBackwardReduceChannelsLastKernelFunctor
         is_last_group_done_[0] = (old == (nwg_y - 1));
       }
 
-      item.barrier(sycl_local_fence);
+      sycl::group_barrier(item.get_group());
 
       // check that all data is now available in global memory
       if (is_last_group_done_[0]) {

--- a/src/ATen/native/xpu/sycl/DepthwiseConv3dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/DepthwiseConv3dKernels.cpp
@@ -369,7 +369,7 @@ struct ConvDepthwise3dXpuBackwardWeightFunctor
 
     sdata[item.get_local_id(0)] = grad;
 
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
 #pragma unroll
     for (int i = item.get_local_range(0) / 2; i >= 1; i >>= 1) {
@@ -377,7 +377,7 @@ struct ConvDepthwise3dXpuBackwardWeightFunctor
         sdata[item.get_local_id(0)] += sdata[item.get_local_id(0) + i];
       }
 
-      item.barrier(sycl_local_fence);
+      sycl::group_barrier(item.get_group());
     }
 
     if (item.get_local_id(0) == 0) {

--- a/src/ATen/native/xpu/sycl/DistanceKernels.cpp
+++ b/src/ATen/native/xpu/sycl/DistanceKernels.cpp
@@ -221,11 +221,11 @@ static inline scalar_t group_reduce_agg_without_broadcast(
         item, agg, sg_size);
     if (num_active_sg == 1)
       return agg;
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
     if (0 == lane_id) {
       local_shared_mem[sg_id] = agg;
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
     agg =
         local_id < num_active_sg ? local_shared_mem[local_id] : (scalar_t)0.0f;
     if (num_active_sg > sg_size)
@@ -233,7 +233,7 @@ static inline scalar_t group_reduce_agg_without_broadcast(
   } while (num_active_sg > sg_size);
 
   // num of active sgs < sg_size
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
   if (0 == sg_id) {
     agg = subgroup_reduce_agg_without_broadcast<scalar_t, F, nd_item>(
         item, agg, sg_size);

--- a/src/ATen/native/xpu/sycl/Embedding.cpp
+++ b/src/ATen/native/xpu/sycl/Embedding.cpp
@@ -128,7 +128,7 @@ struct RenormKernelFunctor {
     if (tid == 0) {
       smem_[0] = std::pow(v, static_cast<accscalar_t>(1.0 / norm_type_));
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     if (smem_[0] > max_norm_) {
       auto factor = static_cast<scalar_t>(

--- a/src/ATen/native/xpu/sycl/GroupNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/GroupNormKernels.cpp
@@ -686,7 +686,7 @@ struct GammaBeta1dBackwardLargeKernel : public __SYCL_KER_CONFIG_CONVENTION__ {
     g_shared_[tid_y + item.get_local_range(0)][tid_x] = dg_sum2;
     b_shared_[tid_y][tid_x] = db_sum1;
     b_shared_[tid_y + item.get_local_range(0)][tid_x] = db_sum2;
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     // Do subgroup reduce for the 1st 16 cols in the tile.
     T_ACC sum1 = g_shared_[tid_x][tid_y];
@@ -1232,7 +1232,7 @@ struct GammaBetaBackwardFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
     g_shared_[tid_y + group_size_y][tid_x] = dg_sum2;
     b_shared_[tid_y][tid_x] = db_sum1;
     b_shared_[tid_y + group_size_y][tid_x] = db_sum2;
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     // Do subgroup reduce for the 1st 16 cols in the tile.
     T_ACC sum1 = g_shared_[tid_x][tid_y];

--- a/src/ATen/native/xpu/sycl/GroupReduceUtils.h
+++ b/src/ATen/native/xpu/sycl/GroupReduceUtils.h
@@ -63,7 +63,7 @@ inline T& GroupReduceSumWithoutBroadcast(
   int sg_id = sg.get_group_linear_id();
   int n_sg = get_local_linear_range<DIM>(item) / SIMD;
   val = SubgroupReduceSumWithoutBroadcast<T, SIMD, DIM>(item, val);
-  item.barrier(sycl_local_fence); // prevent races when GroupReduceSum are
+  sycl::group_barrier(item.get_group()); // prevent races when GroupReduceSum are
                                   // called in a row.
   if (n_sg == 1) {
     return val;
@@ -71,7 +71,7 @@ inline T& GroupReduceSumWithoutBroadcast(
   if (sg_tid == 0) {
     shared[sg_id] = val;
   }
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
   val = 0;
   if (sg_id == 0) {
     for (int i = sg_tid; i < n_sg; i += SIMD) {
@@ -106,7 +106,7 @@ inline T& GroupReduceMaxWithoutBroadcast(
   int sg_id = sg.get_group_linear_id();
   int n_sg = get_local_linear_range<DIM>(item) / SIMD;
   val = SubgroupReduceMaxWithoutBroadcast<T, SIMD, DIM>(item, val);
-  item.barrier(sycl_local_fence); // prevent races when GroupReduceSum are
+  sycl::group_barrier(item.get_group()); // prevent races when GroupReduceSum are
                                   // called in a row.
   if (n_sg == 1) {
     return val;
@@ -114,7 +114,7 @@ inline T& GroupReduceMaxWithoutBroadcast(
   if (sg_tid == 0) {
     shared[sg_id] = val;
   }
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
   if (sg_id == 0) {
     for (int i = 1; i < n_sg; i++) {
       val = max_impl(val, shared[i]);
@@ -151,7 +151,7 @@ inline T& GroupReduceWithoutBroadcast(
   int sg_id = sg.get_group_linear_id();
   int n_sg = get_local_linear_range<DIM>(item) / SIMD;
   val = SubgroupReduceWithoutBroadcast<T, ReduceOp, SIMD, DIM>(item, val, op);
-  item.barrier(sycl_local_fence); // prevent races when GroupReduce
+  sycl::group_barrier(item.get_group()); // prevent races when GroupReduce
                                   // are called in a row.
   if (n_sg == 1) {
     return val;
@@ -159,7 +159,7 @@ inline T& GroupReduceWithoutBroadcast(
   if (sg_tid == 0) {
     shared[sg_id] = val;
   }
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
   if (sg_id == 0) {
     for (int i = 1; i < n_sg; i++) {
       val = op.combine(val, shared[i]);

--- a/src/ATen/native/xpu/sycl/HistogramddKernels.cpp
+++ b/src/ATen/native/xpu/sycl/HistogramddKernels.cpp
@@ -61,7 +61,7 @@ struct HistogramddKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
     if (active && batch_local_id == 0) {
       slm_[batch_idx] = 0;
     }
-    item_id.barrier(sycl_local_fence);
+    sycl::group_barrier(item_id.get_group());
 
     // loop if wg_size_ is smaller than total_bin_size_
     for (int s = 0; active && s < scan_size_; ++s) {
@@ -112,7 +112,7 @@ struct HistogramddKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
             bin_idx * hist_strides_[dim]);
       }
     }
-    item_id.barrier(sycl_local_fence);
+    sycl::group_barrier(item_id.get_group());
 
     if (active && batch_local_id == 0) {
       auto hist_idx = slm_[batch_idx];

--- a/src/ATen/native/xpu/sycl/Indexing.h
+++ b/src/ATen/native/xpu/sycl/Indexing.h
@@ -416,7 +416,7 @@ struct SmallIndexKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
     }
     auto out_ptr = out_data_;
     auto in_ptr = in_data_;
-    item_id.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item_id.get_group());
 
     // compute the in/out/indices offsets and perform memory copy
     for (int64_t local_index = local_id; local_index < group_numel_range;

--- a/src/ATen/native/xpu/sycl/LossCTCKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LossCTCKernels.cpp
@@ -137,7 +137,7 @@ struct CTCLossLogAlphaKernelFunctor {
         have_three = false;
       }
       for (int64_t t = 1; t < max_input_length_; t++) {
-        item.barrier(sycl_global_and_local_fence);
+        sycl::group_barrier(item.get_group());
         if (valid && (t < input_length) && (s < 2 * target_length + 1)) {
           // only for valid t, s. This is equation (6) and (7), la1, la2, la3
           // are the three summands, lamax is the maximum for the logsumexp
@@ -187,7 +187,7 @@ struct CTCLossLogAlphaKernelFunctor {
         }
       }
     }
-    item.barrier(sycl_global_and_local_fence);
+    sycl::group_barrier(item.get_group());
 
     if (!valid)
       return;
@@ -524,7 +524,7 @@ struct CTCLossBackwardLogBetaKernelFunctor {
       // now go backward in t. Note that we need to skip the last timestep that
       // we did above.
       for (int64_t t = max_input_length_ - 2; t >= 0; t--) {
-        item.barrier(sycl_global_and_local_fence);
+        sycl::group_barrier(item.get_group());
         if (valid && (t < input_length - 1) && (s < 2 * target_length + 1)) {
           scalar_t lb1 = log_beta_data_
               [lb_batch_offset + lb_input_stride_ * (t + 1) +

--- a/src/ATen/native/xpu/sycl/LossNLLKernel.cpp
+++ b/src/ATen/native/xpu/sycl/LossNLLKernel.cpp
@@ -161,14 +161,14 @@ struct NllLossForwardReduce2DKernelFunctor
       }
     }
 
-    item.barrier(sycl_global_and_local_fence);
+    sycl::group_barrier(item.get_group());
 
     for (int stride = local_range / 2; stride > 0; stride >>= 1) {
       if (local_id < stride) {
         sh_inputs[local_id] += sh_inputs[local_id + stride];
         acc_weight[local_id] += acc_weight[local_id + stride];
       }
-      item.barrier(sycl_global_and_local_fence);
+      sycl::group_barrier(item.get_group());
     }
 
     if (local_id == 0) {

--- a/src/ATen/native/xpu/sycl/MultiLabelMarginLossKernels.cpp
+++ b/src/ATen/native/xpu/sycl/MultiLabelMarginLossKernels.cpp
@@ -72,7 +72,7 @@ struct MultilabelMarginLossForwardKernelFunctor
          d += item.get_local_range(0)) {
       is_target_k[d] = static_cast<scalar_t>(0);
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     if (item.get_local_linear_id() == 0) {
       for (int dt = 0; dt < dim_; dt++) {
@@ -83,7 +83,7 @@ struct MultilabelMarginLossForwardKernelFunctor
         is_target_k[target_idx] = static_cast<scalar_t>(1);
       }
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     accscalar_t sum = 0;
     for (int dt = 0; dt < dim_; dt++) {
@@ -181,7 +181,7 @@ struct MultilabelMarginLossBackwardKernelFunctor
     for (int d = item.get_local_id(0); d < dim_; d += item.get_local_range(0)) {
       grad_input_k[d] = static_cast<scalar_t>(0);
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     // iterate over targets
     for (int dt = 0; dt < dim_; dt++) {
@@ -207,7 +207,7 @@ struct MultilabelMarginLossBackwardKernelFunctor
           }
         }
       }
-      item.barrier(sycl_local_fence);
+      sycl::group_barrier(item.get_group());
 
       sum = GroupReduceSumWithoutBroadcast<
           accscalar_t,

--- a/src/ATen/native/xpu/sycl/MultiMarginLossKernels.cpp
+++ b/src/ATen/native/xpu/sycl/MultiMarginLossKernels.cpp
@@ -88,7 +88,7 @@ struct MultiMarginLossForwardKernelFunctor
         smem_[item.get_local_linear_id()] += h;
       }
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     // reduce
     if (item.get_local_linear_id() == 0) {
@@ -175,7 +175,7 @@ struct MultiMarginLossBackwardKernelFunctor
         gradInput_k[i] = static_cast<scalar_t>(0);
       }
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     // reduce
     if (item.get_local_linear_id() == 0) {

--- a/src/ATen/native/xpu/sycl/MultinomialKernel.cpp
+++ b/src/ATen/native/xpu/sycl/MultinomialKernel.cpp
@@ -56,7 +56,7 @@ inline void renormRowsL1(
     if (thread_idx == 0) {
       smem[0] = sum;
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     sum = smem[0];
     if (sum > zero) {
@@ -288,11 +288,11 @@ struct SampleMultinomialOnceFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
         smem[0] = sum;
         smem[1] = sampled_[curDist];
       }
-      item.barrier(sycl_local_fence);
+      sycl::group_barrier(item.get_group());
 
       sum = smem[0];
       scalar_t sample = static_cast<scalar_t>(smem[1]);
-      item.barrier(sycl_local_fence);
+      sycl::group_barrier(item.get_group());
 
       if (sum == accZero) {
         // Choose the first element
@@ -318,7 +318,7 @@ struct SampleMultinomialOnceFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
             : accZero;
 
         smem[local_id] = dist_val;
-        item.barrier(sycl_local_fence);
+        sycl::group_barrier(item.get_group());
 
         // Perform an inclusive prefix sum of the shared memory contents
         for (int offset = 1; offset < local_range; offset *= 2) {
@@ -328,11 +328,11 @@ struct SampleMultinomialOnceFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
             val = smem[local_id - offset] + smem[local_id];
           }
 
-          item.barrier(sycl_local_fence);
+          sycl::group_barrier(item.get_group());
           if (local_id >= offset) {
             smem[local_id] = val;
           }
-          item.barrier(sycl_local_fence);
+          sycl::group_barrier(item.get_group());
         }
 
         // Each thread will check to see if the sample falls in its
@@ -362,7 +362,7 @@ struct SampleMultinomialOnceFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
         // Store the previous scan's high value for future use
         prevHighProb = prevHighProb + smem[local_range - 1];
 
-        item.barrier(sycl_local_fence);
+        sycl::group_barrier(item.get_group());
       }
 
       if (local_id == 0) {

--- a/src/ATen/native/xpu/sycl/NMSKernel.cpp
+++ b/src/ATen/native/xpu/sycl/NMSKernel.cpp
@@ -64,7 +64,7 @@ struct NMSKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
       block_boxes[item.get_local_id(1) * 4 + 3] = dets_sorted_ptr_
           [(nms_items_per_group * col_start + item.get_local_id(1)) * 4 + 3];
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     if (item.get_local_id(1) < row_size) {
       const int cur_box_idx =
@@ -116,11 +116,11 @@ struct GatherKeepFromMask : public __SYCL_KER_CONFIG_CONVENTION__ {
     for (int i = thread_id; i < col_blocks_; i += nms_items_per_group) {
       removed_[i] = 0;
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     for (int nblock = 0; nblock < col_blocks_; nblock++) {
       auto removed_val = removed_[nblock];
-      item.barrier(sycl_local_fence);
+      sycl::group_barrier(item.get_group());
       const int i_offset = nblock * nms_items_per_group;
 
       for (int inblock = 0; inblock < nms_items_per_group; inblock++) {
@@ -140,7 +140,7 @@ struct GatherKeepFromMask : public __SYCL_KER_CONFIG_CONVENTION__ {
             if (j >= nblock)
               removed_[j] |= p[j];
           }
-          item.barrier(sycl_local_fence);
+          sycl::group_barrier(item.get_group());
           removed_val = removed_[nblock];
         }
       }

--- a/src/ATen/native/xpu/sycl/Norm.h
+++ b/src/ATen/native/xpu/sycl/Norm.h
@@ -68,7 +68,7 @@ static inline void norm_group_reduce(
     local_data1[sg_id] = sum1;
     local_data2[sg_id] = sum2;
   }
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
 
   // use one subgroup to reduce WGroupSize/subGroupSize elements
   // into the final result
@@ -99,7 +99,7 @@ static inline void norm_group_reduce(
       local_data2[0] = sum2;
     }
   }
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
 
   sum1 = local_data1[0];
   sum2 = local_data2[0];
@@ -127,7 +127,7 @@ static inline void norm_group_reduce_row(
     local_data1[local_row_id][local_col_id][j] = input1[j];
     local_data2[local_row_id][local_col_id][j] = input2[j];
   }
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
 
   int k = 1;
   while (k < block_row) {
@@ -143,7 +143,7 @@ static inline void norm_group_reduce_row(
       }
     }
     k *= 2;
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
   }
 }
 
@@ -182,14 +182,14 @@ static void norm_global_reduce(
       scratchpad_ptr[workgroup_num_foreach + idx] = sum2;
     }
   }
-  item.barrier(sycl_global_fence);
+  sycl::group_barrier(item.get_group());
 
   if (local_id == 0) {
     sycl_atomic_ref_rlx_dev_global_t<int> count(semaphores_ptr[group_id]);
     int prev_groups_finished = count.fetch_add(1);
     last_workgroup[0] = (prev_groups_finished == workgroup_num_foreach - 1);
   }
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
 
   // use the last workgroup for reduction
   if (last_workgroup[0]) {

--- a/src/ATen/native/xpu/sycl/Reduce.h
+++ b/src/ATen/native/xpu/sycl/Reduce.h
@@ -69,7 +69,7 @@ inline at::detail::Array<arg_t, out_vec_sz> group_reduce(
   if (sg_lid == 0) {
     shared_[sg_gid] = value;
   }
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
 
   if (sg_range <= sg_size) {
     // sub-group reduce
@@ -102,7 +102,7 @@ inline at::detail::Array<arg_t, out_vec_sz> group_reduce(
         }
         shared_[l_x] = value;
       }
-      item.barrier(sycl_local_fence);
+      sycl::group_barrier(item.get_group());
     }
   }
   return value;
@@ -126,7 +126,7 @@ inline at::detail::Array<arg_t, out_vec_sz> group_x_reduce(
     int base = l_x + l_y * g_x;
     shared_[base] = value;
     for (int offset = dim_x / 2; offset >= sg_size; offset >>= 1) {
-      item.barrier(sycl_local_fence);
+      sycl::group_barrier(item.get_group());
       if (l_x < offset && l_x + offset < g_x) {
         vec_t other = shared_[base + offset];
 #pragma unroll(out_vec_sz)
@@ -168,7 +168,7 @@ inline at::detail::Array<arg_t, out_vec_sz> group_y_reduce(
 
   shared_[slm_off(0)] = value;
   for (int offset = dim_y / 2; offset > 0; offset >>= 1) {
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
     if (l_y < offset && l_y + offset < dim_y) {
       vec_t other = shared_[slm_off(offset)];
 #pragma unroll(out_vec_sz)
@@ -835,7 +835,7 @@ struct ReduceOp {
   // In/out from slm pointers
   void mark_group_finished(sycl::nd_item<2> pos, sycl_local_ptr<bool> finished)
       const {
-    pos.barrier(sycl_local_fence);
+    sycl::group_barrier(pos.get_group());
 
     if (pos.get_local_linear_id() == 0) {
       sycl_atomic_ref_rlx_dev_global_t<int> count(semaphores[pos.get_group(1)]);
@@ -844,7 +844,7 @@ struct ReduceOp {
           /* , default memory scope is device */);
       finished[0] = (prev_groups_finished == (int)(pos.get_group_range(0) - 1));
     }
-    pos.barrier(sycl_local_fence);
+    sycl::group_barrier(pos.get_group());
   }
 
   template <int output_vec_size, bool can_acc>

--- a/src/ATen/native/xpu/sycl/RoiAlignKernels.cpp
+++ b/src/ATen/native/xpu/sycl/RoiAlignKernels.cpp
@@ -98,7 +98,7 @@ struct RoiAlignForwardKernel : public __SYCL_KER_CONFIG_CONVENTION__ {
       cached_roi_[3] = current_roi[3] * spatial_scale_ - offset;
       cached_roi_[4] = current_roi[4] * spatial_scale_ - offset;
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     if (output_index_on_batch_n < items_per_roi_) {
       int pw = output_index_on_batch_n % pooled_width_;

--- a/src/ATen/native/xpu/sycl/SYCLGroupAlgorithm.h
+++ b/src/ATen/native/xpu/sycl/SYCLGroupAlgorithm.h
@@ -36,11 +36,11 @@ inline T GroupReduceSumSGSizeEqualstoNumSG(item_t& item, T val, T* shared) {
   int lid = thread_idx % sg_size;
   int wid = thread_idx / sg_size;
   val = GroupReduceSumSGSizeEqualstoNumSG(sg, val);
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
   if (lid == 0) {
     shared[wid] = val;
   }
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
   val = (thread_idx < group_size / sg_size) ? shared[lid] : T(0);
   if (wid == 0) {
     val = GroupReduceSumSGSizeEqualstoNumSG(sg, val);

--- a/src/ATen/native/xpu/sycl/ScanUtils.h
+++ b/src/ATen/native/xpu/sycl/ScanUtils.h
@@ -124,7 +124,7 @@ T inline group_x_scan_by_uds_for_loop_scan(
           cfg.func_(slm[liy * rx * 2 + lix], pre_max_carr);
     }
   }
-  item.barrier(sycl::access::fence_space::local_space);
+  sycl::group_barrier(item.get_group());
 
   // Parallel reduction (Up-sweep)
   for (uint32_t s = rx, d = 1; s >= 1; s >>= 1, d <<= 1) {
@@ -133,7 +133,7 @@ T inline group_x_scan_by_uds_for_loop_scan(
       slm[offset + d] = cfg.func_(slm[offset], slm[offset + d]);
     }
     if (sub_group_size != cfg.wg_range_x_) {
-      item.barrier(sycl::access::fence_space::local_space);
+      sycl::group_barrier(item.get_group());
     }
   }
 
@@ -144,7 +144,7 @@ T inline group_x_scan_by_uds_for_loop_scan(
       slm[offset + d] = cfg.func_(slm[offset], slm[offset + d]);
     }
     if (sub_group_size != cfg.wg_range_x_) {
-      item.barrier(sycl::access::fence_space::local_space);
+      sycl::group_barrier(item.get_group());
     }
   }
 
@@ -259,7 +259,7 @@ void inline group_x_scan_by_uds_for_loop_scan_with_indices(
           pre_max_carr, slm[offset], pre_idx_carr, slm_idx[offset], cfg.func_);
     }
   }
-  item.barrier(sycl::access::fence_space::local_space);
+  sycl::group_barrier(item.get_group());
 
   // Parallel reduction (Up-sweep)
   for (uint32_t s = rx, d = 1; s >= 1; s >>= 1, d <<= 1) {
@@ -273,7 +273,7 @@ void inline group_x_scan_by_uds_for_loop_scan_with_indices(
           cfg.func_);
     }
     if (sub_group_size != cfg.wg_range_x_) {
-      item.barrier(sycl::access::fence_space::local_space);
+      sycl::group_barrier(item.get_group());
     }
   }
 
@@ -289,7 +289,7 @@ void inline group_x_scan_by_uds_for_loop_scan_with_indices(
           cfg.func_);
     }
     if (sub_group_size != cfg.wg_range_x_) {
-      item.barrier(sycl::access::fence_space::local_space);
+      sycl::group_barrier(item.get_group());
     }
   }
 
@@ -565,10 +565,10 @@ T group_x_scan(
 
   slm[liy * rx + lix] = value;
   for (size_t offset = 1; offset < rx; offset <<= 1) {
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
     if (lix >= offset)
       value = func(slm[liy * rx + (lix - offset)], slm[liy * rx + lix]);
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     if (lix >= offset)
       slm[liy * rx + lix] = value;
@@ -593,7 +593,7 @@ void group_x_scan_with_indices(
   slm[liy * rx + lix] = value;
   slm_idx[liy * rx + lix] = idx;
   for (int offset = 1; offset < rx; offset <<= 1) {
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
     if (lix >= offset) {
       binary_op_update(
           slm[liy * rx + (lix - offset)],
@@ -602,7 +602,7 @@ void group_x_scan_with_indices(
           idx,
           func);
     }
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     if (lix >= offset) {
       slm[liy * rx + lix] = value;
@@ -624,10 +624,10 @@ T group_y_scan(
 
   temp[liy * rx + lix] = value;
   for (size_t offset = 1; offset < ry; offset <<= 1) {
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
     if (liy >= offset)
       value = func(temp[(liy - offset) * rx + lix], temp[liy * rx + lix]);
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     if (liy >= offset)
       temp[liy * rx + lix] = value;
@@ -652,7 +652,7 @@ void group_y_scan_with_indices(
   temp[liy * rx + lix] = value;
   temp_idx[liy * rx + lix] = idx;
   for (int offset = 1; offset < ry; offset <<= 1) {
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
     if (liy >= offset) {
       binary_op_update(
           temp[(liy - offset) * rx + lix],
@@ -661,7 +661,7 @@ void group_y_scan_with_indices(
           idx,
           func);
     }
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     if (liy >= offset) {
       temp[liy * rx + lix] = value;

--- a/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
+++ b/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
@@ -71,7 +71,7 @@ static inline void softmax_group_reduce(
   if (sg_local_id == 0) {
     local_data[lid_row][idx] = val;
   }
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
 
   // use one subgroup to reduce WGroupSize/subGroupSize elements
   // into the final result
@@ -97,7 +97,7 @@ static inline void softmax_group_reduce(
     }
   }
 
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
   val = local_data[lid_row][0];
 }
 
@@ -120,7 +120,7 @@ static inline void softmax_group_reduce_spatial(
   for (int j = 0; j < vec_size; ++j) {
     local_data[local_row_id][local_col_id][j] = input[j];
   }
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
 
   int k = 1;
   while (k < block_row) {
@@ -132,7 +132,7 @@ static inline void softmax_group_reduce_spatial(
             local_data[local_row_id + k][local_col_id][j]);
       }
     k *= 2;
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
   }
 }
 
@@ -748,7 +748,7 @@ struct SpatialSoftmaxForwardKernelFunctor
       for (int j = 0; j < vec_size; ++j) {
         max_value[j] = local_data_[0][local_col_id][j];
       }
-      item.barrier(sycl_local_fence);
+      sycl::group_barrier(item.get_group());
     }
 
     // get sum value

--- a/src/ATen/native/xpu/sycl/Sorting.cpp
+++ b/src/ATen/native/xpu/sycl/Sorting.cpp
@@ -200,7 +200,7 @@ struct GatherMedianKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
       num_nan_[0] = 0;
     }
 
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
     if (nan_count > 0) {
       atomicAdd(
           (sycl_local_ptr<index_t>)(num_nan_
@@ -209,7 +209,7 @@ struct GatherMedianKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
                                         .get()),
           nan_count);
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     // For torch.median, if we found nan set k to last index so the computed
     // value is nan, otherwise set k to the middle element of the non-nan

--- a/src/ATen/native/xpu/sycl/SortingCommon.h
+++ b/src/ATen/native/xpu/sycl/SortingCommon.h
@@ -321,12 +321,12 @@ inline T group_cumsum(T* storage, sycl::nd_item<1>& item) {
       lane_all_sum,
       subgroup_inclusive_sum,
       subgroup_exclusive_sum);
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
 
   // Write to storage
   if (subgroup_local_id == (SUBGROUP_SIZE - 1))
     storage[subgroup_id] = subgroup_inclusive_sum;
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
 
   // Get group prefix
   T group_all_sum = 0, group_exclusive_sum;
@@ -336,7 +336,7 @@ inline T group_cumsum(T* storage, sycl::nd_item<1>& item) {
       group_exclusive_sum = group_all_sum;
     group_all_sum += storage[i];
   }
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
 
   // Write to storage
   subgroup_exclusive_sum += group_exclusive_sum;
@@ -344,7 +344,7 @@ inline T group_cumsum(T* storage, sycl::nd_item<1>& item) {
   for (int lane = 0; lane < COUNTER_LANES; ++lane) {
     storage_lanes[lane] = subgroup_exclusive_sum + lane_temp_values[lane];
   }
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
 
   return group_all_sum;
 }

--- a/src/ATen/native/xpu/sycl/SortingKernels.h
+++ b/src/ATen/native/xpu/sycl/SortingKernels.h
@@ -481,13 +481,13 @@ struct SegmentedGroupRadixSelectPairsFunctor
     int num_start = method_t::PROCESSING_LENGTH;
     while (num_start < nelements_) {
       method.topk(KeyTraits<key_t>::endbit(), 0, k_, keys_temp, values_temp);
-      item.barrier(sycl_local_fence);
+      sycl::group_barrier(item.get_group());
       method.topk_append_keys(
           keys_in_seg, keys_temp, nelements_, num_start, k_);
       method.topk_append_values(
           values_in_seg, values_temp, nelements_, num_start, k_);
       num_start += method_t::PROCESSING_LENGTH - k_;
-      item.barrier(sycl_local_fence);
+      sycl::group_barrier(item.get_group());
     }
 
     method.topk(

--- a/src/ATen/native/xpu/sycl/SortingRadixSelect.h
+++ b/src/ATen/native/xpu/sycl/SortingRadixSelect.h
@@ -294,7 +294,7 @@ void countRadixUsingMask(
     smem[local_id] = 0;
   }
 
-  item_id.barrier(sycl_local_fence);
+  sycl::group_barrier(item_id.get_group());
   // Scan over all the data. Upon a read, the warp will accumulate
   // counts per each digit in the radix using warp voting.
   for (index_t i = local_id; i < sliceSize; i += item_id.get_local_range(0)) {
@@ -315,14 +315,14 @@ void countRadixUsingMask(
     atomicAdd(smem_ptr + i, counts[i]);
   }
 
-  item_id.barrier(sycl_local_fence);
+  sycl::group_barrier(item_id.get_group());
 
   // For each thread, read in the total counts
   for (uint32_t i = 0; i < RadixSize; ++i) {
     counts[i] = smem[i];
   }
 
-  item_id.barrier(sycl_local_fence);
+  sycl::group_barrier(item_id.get_group());
 }
 
 // Over what radix we are selecting values
@@ -348,7 +348,7 @@ scalar_t findPattern(
     smem_ptr[RADIX_SIZE] = static_cast<scalar_t>(0);
   }
 
-  item_id.barrier(sycl_local_fence);
+  sycl::group_barrier(item_id.get_group());
 
   // All threads participate in the loop, in order to sync on the flag
   index_t numIterations =
@@ -367,12 +367,12 @@ scalar_t findPattern(
       smem_ptr[1] = v; // can't use val as the flag, since it could be 0
     }
 
-    item_id.barrier(sycl_local_fence);
+    sycl::group_barrier(item_id.get_group());
 
     scalar_t found = smem_ptr[0];
     scalar_t val = smem_ptr[1];
 
-    item_id.barrier(sycl_local_fence);
+    sycl::group_barrier(item_id.get_group());
 
     // Check to see if a thread found the value
     if (found != static_cast<scalar_t>(0)) {

--- a/src/ATen/native/xpu/sycl/SortingRadixSort.h
+++ b/src/ATen/native/xpu/sycl/SortingRadixSort.h
@@ -98,7 +98,7 @@ class GroupRadixSort {
       bin_offset_ = counts[group_id + bin_idx * num_groups];
     }
     enable_bin_offsets_ = true;
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
   }
 
   inline GroupRadixSort(sycl::nd_item<1>& item, sycl_local_acc_t<char> buffer)
@@ -157,7 +157,7 @@ class GroupRadixSort {
       local_storage_.exchange_ukeys[lid_ * KEYS_PER_THREAD + ITEM] =
           ukeys_[ITEM];
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
 #pragma unroll
     for (int ITEM = 0; ITEM < KEYS_PER_THREAD; ++ITEM) {
       int offset = lid_ + ITEM * GROUP_THREADS;
@@ -166,7 +166,7 @@ class GroupRadixSort {
             KeyTraits<KeyT>::deconvert(local_storage_.exchange_ukeys[offset]);
       }
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
   }
 
   inline void store_keys(KeyT* out, int offset_select, int num_selected) {
@@ -185,7 +185,7 @@ class GroupRadixSort {
       local_storage_.exchange_values[lid_ * KEYS_PER_THREAD + ITEM] =
           values_[ITEM];
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
 #pragma unroll
     for (int ITEM = 0; ITEM < KEYS_PER_THREAD; ++ITEM) {
       int offset = lid_ + ITEM * GROUP_THREADS;
@@ -193,7 +193,7 @@ class GroupRadixSort {
         values_group_out[offset] = local_storage_.exchange_values[offset];
       }
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
   }
 
   inline void store_values(ValueT* out, int offset_select, int num_selected) {
@@ -210,7 +210,7 @@ class GroupRadixSort {
     for (int ITEM = 0; ITEM < KEYS_PER_THREAD; ++ITEM) {
       local_storage_.exchange_ukeys[ranks_[ITEM]] = ukeys_[ITEM];
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
 #pragma unroll
     for (int ITEM = 0; ITEM < KEYS_PER_THREAD; ++ITEM) {
       int offset = lid_ + ITEM * GROUP_THREADS;
@@ -222,7 +222,7 @@ class GroupRadixSort {
         keys_out[offset] = KeyTraits<KeyT>::deconvert(ukey);
       }
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
   }
 
   inline void exchange_and_store_values(ValueT* values_out, int num_elements) {
@@ -230,7 +230,7 @@ class GroupRadixSort {
     for (int ITEM = 0; ITEM < KEYS_PER_THREAD; ++ITEM) {
       local_storage_.exchange_values[ranks_[ITEM]] = values_[ITEM];
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
 #pragma unroll
     for (int ITEM = 0; ITEM < KEYS_PER_THREAD; ++ITEM) {
       int offset = lid_ + ITEM * GROUP_THREADS;
@@ -240,7 +240,7 @@ class GroupRadixSort {
         values_out[offset] = value;
       }
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
   }
 
   inline void exchange_keys() {
@@ -248,13 +248,13 @@ class GroupRadixSort {
     for (int ITEM = 0; ITEM < KEYS_PER_THREAD; ++ITEM) {
       local_storage_.exchange_ukeys[ranks_[ITEM]] = ukeys_[ITEM];
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
 #pragma unroll
     for (int ITEM = 0; ITEM < KEYS_PER_THREAD; ++ITEM) {
       int offset = lid_ * KEYS_PER_THREAD + ITEM;
       ukeys_[ITEM] = local_storage_.exchange_ukeys[offset];
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
   }
 
   inline void exchange_keys(
@@ -268,7 +268,7 @@ class GroupRadixSort {
             ukeys_[ITEM];
       }
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
     *mask = 0u;
     int new_length = upper_offset - lower_offset;
 #pragma unroll
@@ -279,7 +279,7 @@ class GroupRadixSort {
         ukeys_[ITEM] = local_storage_.exchange_ukeys[offset];
       }
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
   }
 
   inline void exchange_values() {
@@ -287,13 +287,13 @@ class GroupRadixSort {
     for (int ITEM = 0; ITEM < KEYS_PER_THREAD; ++ITEM) {
       local_storage_.exchange_values[ranks_[ITEM]] = values_[ITEM];
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
 #pragma unroll
     for (int ITEM = 0; ITEM < KEYS_PER_THREAD; ++ITEM) {
       int offset = lid_ * KEYS_PER_THREAD + ITEM;
       values_[ITEM] = local_storage_.exchange_values[offset];
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
   }
 
   inline void exchange_values(int lower_offset, int upper_offset) {
@@ -304,7 +304,7 @@ class GroupRadixSort {
             values_[ITEM];
       }
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
     int new_length = upper_offset - lower_offset;
 #pragma unroll
     for (int ITEM = 0; ITEM < KEYS_PER_THREAD; ++ITEM) {
@@ -313,7 +313,7 @@ class GroupRadixSort {
         values_[ITEM] = local_storage_.exchange_values[offset];
       }
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
   }
 
   inline DigitT extract_digit(KeyTraitsT key) {
@@ -331,7 +331,7 @@ class GroupRadixSort {
     for (int ITEM = 0; ITEM < COUNTER_LANES; ++ITEM) {
       local_storage_.rank_storage.counters[ITEM][lid_] = 0;
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
 
 #pragma unroll
     for (int ITEM = 0; ITEM < KEYS_PER_THREAD; ++ITEM) {
@@ -347,7 +347,7 @@ class GroupRadixSort {
       ranks_[ITEM] = *digit_counters[ITEM];
       *digit_counters[ITEM] = ranks_[ITEM] + 1;
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
 
     CounterT exclusive = group_exclusive_cumsum<
         CounterT,
@@ -366,14 +366,14 @@ class GroupRadixSort {
     for (int INDEX = 0; INDEX < COUNTER_LANES; ++INDEX) {
       local_storage_.rank_storage.counters[INDEX][lid_] += c;
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
 
     // inc rank
 #pragma unroll
     for (int ITEM = 0; ITEM < KEYS_PER_THREAD; ++ITEM) {
       ranks_[ITEM] += *digit_counters[ITEM];
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
 
     if (enable_bin_offsets_) {
       int digit = lid_;
@@ -386,7 +386,7 @@ class GroupRadixSort {
             local_storage_.rank_storage.buckets[counter_lane][0][sub_counter];
         local_storage_.relative_bin_offsets[lid_] = bin_offset_ - digit_offset;
       }
-      item_.barrier(sycl_local_fence);
+      sycl::group_barrier(item_.get_group());
     }
   }
 
@@ -429,7 +429,7 @@ class GroupRadixSort {
     for (int ITEM = 0; ITEM < COUNTER_LANES; ++ITEM) {
       local_storage_.rank_storage.counters[ITEM][lid_] = 0;
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
 
 #pragma unroll
     for (int ITEM = 0; ITEM < KEYS_PER_THREAD; ++ITEM) {
@@ -448,7 +448,7 @@ class GroupRadixSort {
         *digit_counters[ITEM] = ranks_[ITEM] + 1;
       }
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
 
     CounterT exclusive = group_exclusive_cumsum<
         CounterT,
@@ -474,19 +474,19 @@ class GroupRadixSort {
     for (int INDEX = 0; INDEX < COUNTER_LANES; ++INDEX) {
       local_storage_.rank_storage.counters[INDEX][lid_] += c;
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
 
     // inc rank
 #pragma unroll
     for (int ITEM = 0; ITEM < KEYS_PER_THREAD; ++ITEM) {
       ranks_[ITEM] += *digit_counters[ITEM];
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
 
     find_select_offset(
         carry, num_to_select, out_offset_select, out_offset_active);
 
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
   }
 
   inline void topk(
@@ -681,7 +681,7 @@ class RadixSortUpsweep {
       keys[ITEM] = KeyTraits<KeyT>::convert(
           c10::load(&group_ptr[lid_ + ITEM * GROUP_THREADS]));
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
 #pragma unroll
     for (int ITEM = 0; ITEM < KEYS_PER_THREAD; ++ITEM) {
       auto digit = extract_digit(keys[ITEM]);
@@ -757,7 +757,7 @@ class RadixSortUpsweep {
       }
     }
 
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
 
     if ((RADIX_BUCKETS % GROUP_THREADS != 0) && (lid_ < RADIX_BUCKETS)) {
       int bin_idx = lid_;
@@ -783,9 +783,9 @@ class RadixSortUpsweep {
         process_full_tile(group_offset);
         group_offset += PROCESSING_LENGTH;
       }
-      item_.barrier(sycl_local_fence);
+      sycl::group_barrier(item_.get_group());
       unpack_digit_counts();
-      item_.barrier(sycl_local_fence);
+      sycl::group_barrier(item_.get_group());
       reset_digit_counters();
     }
 
@@ -795,9 +795,9 @@ class RadixSortUpsweep {
     }
 
     process_partial_tile(group_offset, group_end);
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
     unpack_digit_counts();
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
     extract_counts();
   }
 };
@@ -853,7 +853,7 @@ class RadixSortScanBins {
         partial_output[ITEM] = d_local[offset];
       }
     }
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
     // Thread reduce
     int thread_partial = partial_output[0];
 #pragma unroll
@@ -874,7 +874,7 @@ class RadixSortScanBins {
         subgroup_exclusive_sum);
     if (subgroup_tid == (SUBGROUP_SIZE - 1))
       slm_[subgroup_id] = subgroup_inclusive_sum;
-    item_.barrier(sycl_local_fence);
+    sycl::group_barrier(item_.get_group());
     // Group scan
     int group_all_sum = 0, subgroup_prefix_sum;
 #pragma unroll

--- a/src/ATen/native/xpu/sycl/TensorModeKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorModeKernel.cpp
@@ -118,7 +118,7 @@ inline void bitonicSortKeys(
   for (unsigned int size = 2; size < Power2SortSize; size *= 2) {
     bool flag = ((tx & (size / 2)) != 0);
     for (unsigned int stride = size / 2; stride > 0; stride /= 2) {
-      item.barrier(sycl_local_fence);
+      sycl::group_barrier(item.get_group());
       unsigned int pos = 2 * tx - (tx & (stride - 1));
       bitonicSwapKeys<Comparator, K>(
           keys[pos],
@@ -131,7 +131,7 @@ inline void bitonicSortKeys(
   }
 #pragma unroll
   for (unsigned int stride = Power2SortSize / 2; stride > 0; stride /= 2) {
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
     unsigned int pos = 2 * tx - (tx & (stride - 1));
     bitonicSwapKeys<Comparator, K>(
         keys[pos],
@@ -141,7 +141,7 @@ inline void bitonicSortKeys(
         false,
         comp);
   }
-  item.barrier(sycl_local_fence);
+  sycl::group_barrier(item.get_group());
 }
 
 template <typename T>
@@ -197,7 +197,7 @@ inline void inclusivePrefixScan(
     if (index < Power2ScanSize) {
       smem[index] = binop(smem[index], smem[index - stride]);
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
   }
 
   // Post-reduce step ("downsweep")
@@ -207,7 +207,7 @@ inline void inclusivePrefixScan(
     if ((index + stride) < Power2ScanSize) {
       smem[index + stride] = binop(smem[index + stride], smem[index]);
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
   }
 }
 
@@ -283,14 +283,14 @@ struct ComputeModeKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
     // valid components in the smem buffer
     bmem[tidx] = tidx < sliceSize_;
     bmem[stidx] = stidx < sliceSize_;
-    item.barrier(sycl_local_fence); // barrier for smem, bmem initialization
+    sycl::group_barrier(item.get_group()); // barrier for smem, bmem initialization
 
     // First, sort the input slice in ascending order. smem contains the input
     // elements, and bmem marks the valid indices
     bitonicSortKeys<T, unsigned int, Power2Size>(
         item, smem, bmem, BitonicSortFn<T>());
-    item.barrier(
-        sycl_local_fence); // make no assumptions that the sort syncs at end
+    sycl::group_barrier(
+        item.get_group()); // make no assumptions that the sort syncs at end
 
     // The next step of our algorithm is performing a group-wide comparison of
     // neighboring elements. In particular, given an sorted input slice A, we
@@ -332,7 +332,7 @@ struct ComputeModeKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
           smem[((tidx + 1) * 2) - 1] != smem[(tidx + 1) * 2];
       ubpmem[(tidx + 1) * 2].val = !ubpmem[(tidx + 1) * 2].flag;
     }
-    item.barrier(sycl_local_fence); // barrier for ubpmem initialization
+    sycl::group_barrier(item.get_group()); // barrier for ubpmem initialization
 
     // Next, we perform a segmented prefix sum on the neighboring elements,
     // where
@@ -383,7 +383,7 @@ struct ComputeModeKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
     uup[0].val = ubpmem[tidx * 2].val;
     uup[1].index = tidx * 2 + 1;
     uup[1].val = ubpmem[tidx * 2 + 1].val;
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     struct ModeUnsignedPair max = {0, 0};
 
@@ -402,7 +402,7 @@ struct ComputeModeKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
     if (tidx == 0) {
       mode_[0] = smem[max.index];
     }
-    item.barrier(sycl_local_fence); // broadcast mode
+    sycl::group_barrier(item.get_group()); // broadcast mode
 
     // Finally, we need to find "an" index of the mode in the input
     // Tensor. The API does not constrain which index we pick, but here

--- a/src/ATen/native/xpu/sycl/UpSampleBilinear2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleBilinear2dKernels.cpp
@@ -1153,7 +1153,7 @@ struct UpsampleGen2dAaKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
       }
     }
 
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     if (output_x < output_width_ && output_y < output_height_) {
       const scalar_t* buffer1;
@@ -1292,7 +1292,7 @@ struct UpsampleGen2dAaBackwardKernelFunctor
       }
     }
 
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     if (output_x < output_width_ && output_y < output_height_) {
       // Parallelized across batch/channels

--- a/src/ATen/native/xpu/sycl/WeightNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/WeightNormKernels.cpp
@@ -290,7 +290,7 @@ struct WeightNormKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
     }
     // Here using slm instead. If using ugm, need fence w/
     // order:acq_rel & scope:workgroup & space:global_mem.
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     if (id.glb_batch < cfg_.problem_batch_) {
       for (int pi_ = pi; pi_ < cfg_.problem_; pi_ += cfg_.problem_wg_range_) {
@@ -766,7 +766,7 @@ struct WeightNormBackwardKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
     if (id.glb_batch < cfg_.problem_batch_ && id.chunk_off == 0) {
       shared_[n_slid] = value;
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
 
     if (id.glb_batch < cfg_.problem_batch_) {
       for (int pi_ = pi; pi_ < cfg_.problem_; pi_ += cfg_.problem_wg_range_) {

--- a/src/ATen/native/xpu/sycl/WelfordNorm.h
+++ b/src/ATen/native/xpu/sycl/WelfordNorm.h
@@ -83,7 +83,7 @@ inline void welford_vertical_merge(
       shmem_m2n[address_base] = m2n;
       shmem_count[address_base] = count;
     }
-    item.barrier(sycl_local_fence);
+    sycl::group_barrier(item.get_group());
     if (item.get_local_id(0) < offset &&
         item.get_local_id(0) + offset < item.get_local_range(0)) {
       auto address = address_base + offset * item.get_local_range(1);
@@ -164,7 +164,7 @@ struct WelfordBatchNormStatChannelsLastVecKernelFunctor
         *reinterpret_cast<acc_vec_t*>(&staging_m2n[address_vec_base]) = m2n;
         *reinterpret_cast<int_vec_t*>(&staging_count[address_vec_base]) = count;
       }
-      item.barrier(sycl_local_fence);
+      sycl::group_barrier(item.get_group());
 
       // mark group done
       if (item.get_local_linear_id() == 0) {
@@ -174,7 +174,7 @@ struct WelfordBatchNormStatChannelsLastVecKernelFunctor
             /* , default memory scope is device */);
         is_last_group_done_[0] = (old == (num_cooperative_groups - 1));
       }
-      item.barrier(sycl_local_fence);
+      sycl::group_barrier(item.get_group());
 
       // check that all data is now available in global memory
       if (is_last_group_done_[0]) {

--- a/src/ATen/native/xpu/sycl/pstl/PSTLFunctions.h
+++ b/src/ATen/native/xpu/sycl/pstl/PSTLFunctions.h
@@ -130,14 +130,14 @@ struct KSScanKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
     }
     if (local_id == 0)
       local_scan_[local_id] += cur_init;
-    item_id.barrier(sycl_local_fence);
+    sycl::group_barrier(item_id.get_group());
 
     // body of KS algo
     for (auto __k = 1; __k < N_; __k <<= 1) {
       auto tmp = (local_id >= __k) ? local_scan_[local_id - __k] : 0;
-      item_id.barrier(sycl_local_fence);
+      sycl::group_barrier(item_id.get_group());
       local_scan_[local_id] += tmp;
-      item_id.barrier(sycl_local_fence);
+      sycl::group_barrier(item_id.get_group());
     }
 
     // flush result into dst
@@ -183,14 +183,14 @@ struct KSScanWithCarrierKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
         carry_ptr_[group_id] = c10::load(&first_[global_id]);
       }
     }
-    item_id.barrier(sycl_local_fence);
+    sycl::group_barrier(item_id.get_group());
 
     // body of KS algo
     for (auto __k = 1; __k < wgroup_size_; __k <<= 1) {
       auto tmp = (local_id >= __k) ? local_scan_[local_id - __k] : 0;
-      item_id.barrier(sycl_local_fence);
+      sycl::group_barrier(item_id.get_group());
       local_scan_[local_id] += tmp;
-      item_id.barrier(sycl_local_fence);
+      sycl::group_barrier(item_id.get_group());
     }
 
     // flush result into dst
@@ -243,7 +243,7 @@ struct ScanAccumulateKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
 
     if (local_id == 0)
       local_carry_[0] = carry_ptr_[group_id];
-    item_id.barrier(sycl_local_fence);
+    sycl::group_barrier(item_id.get_group());
 
     if (global_id < N_) {
       d_first_[global_id] += local_carry_[0];

--- a/src/comm/SYCLHelpers.h
+++ b/src/comm/SYCLHelpers.h
@@ -21,13 +21,6 @@ static constexpr auto sycl_local_space =
 static constexpr auto sycl_global_space =
     sycl::access::address_space::global_space;
 
-// sycl access fence space
-static constexpr auto sycl_local_fence = sycl::access::fence_space::local_space;
-static constexpr auto sycl_global_fence =
-    sycl::access::fence_space::global_space;
-static constexpr auto sycl_global_and_local_fence =
-    sycl::access::fence_space::global_and_local;
-
 // sycl memory ordering
 static constexpr auto sycl_mem_odr_rlx = sycl::memory_order::relaxed;
 static constexpr auto sycl_mem_odr_acq = sycl::memory_order::acquire;


### PR DESCRIPTION
# Motivation
In https://github.com/intel/torch-xpu-ops/issues/2078, we identified an inaccurate usage of `sycl::nd_item.barrier`.
According to the [CUDA programming guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#synchronization-functions), 
`__syncthreads()` waits until all threads in the thread block have reached this point and all **global** and **shared** memory accesses made by these threads prior to `__syncthreads()` are visible to all threads in the block.
In SYCL terms, `__syncthreads()` mostly closely corresponds to the `sycl::nd_item::barrier(sycl::access::fence_space::global_and_local)` which enforces both **global** and **local** memory consistency. SYCL also provides finer-grained synchronization:

- `sycl::nd_item::barrier(sycl::access::fence_space::local_space)` ensures consistency only for shared local memory, and
- `sycl::nd_item::barrier(sycl::access::fence_space::global_space)` ensures consistency only for global memory.

However, `sycl::nd_item.barrier` is a legacy API from SYCL 1.2.1 and has been **removed** in SYCL 2020, see https://github.com/intel/llvm/issues/12531
In SYCL 2020, synchronization should be performed using `sycl::group_barrier`, which synchronizes all work-items within a work group (or sub-group). As specified in:

- [3.9.4. Work-group data parallel kernels](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_work_group_data_parallel_kernels), and
- [4.17.2.3. group_barrier](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_group_barrier)

`sycl::group_barrier` blocks until all work-items in group `g` have reached this synchronization point, providing the correct and portable replacement for `__syncthreads()` semantics in SYCL 2020.

# Additional Context

- Since `sycl::group_barrier` synchronizes both global and local memory, it enforces wider fence semantics than `nd_item.barrier(local_sace)` and `nd_item.barrier(global_space)`. As a result, some minor overhead is expected due to the stronger memory ordering guarantees, but the overall performance impact should be low.

- This PR should be merged after the PT2.10 branch cut to avoid introducing any unexpected behavior that could block the release.