### PR TITLE
Enable view_as_real and view_as_complex for SparseXPU

### DIFF
--- a/yaml/native/native_functions.yaml
+++ b/yaml/native/native_functions.yaml
@@ -1495,11 +1495,13 @@
   variants: function
   dispatch:
     XPU: view_as_real
+    SparseXPU: view_as_real_sparse
 
 - func: view_as_complex(Tensor(a) self) -> Tensor(a)
   variants: function
   dispatch:
     XPU: view_as_complex
+    SparseXPU: view_as_complex_sparse
 
 - func: view_copy(Tensor self, SymInt[] size) -> Tensor
   variants: function


### PR DESCRIPTION
This PR adds `SparseXPU` dispatch for `view_as_real` and `view_as_complex`.
Reusing common implementation `view_as_real_sparse` and `view_as_complex_sparse` to handle sparse tensors.