### PR TITLE
Fallback fused RMS normalization fwd/bwd to CPU for functionality

### DIFF
--- a/src/ATen/native/xpu/XPUFallback.template
+++ b/src/ATen/native/xpu/XPUFallback.template
@@ -193,6 +193,8 @@ TORCH_LIBRARY_IMPL(aten, XPU, m) {
     "dot",
     "_efficient_attention_forward",
     "_flash_attention_forward",
+    "_fused_rms_norm",
+    "_fused_rms_norm_backward",
     "geqrf",
     "geqrf.a",
     "hash_tensor.out",


### PR DESCRIPTION
Fallback _fused_rms_norm and _fused_rms_norm_backward to CPU for XPU backend.