### PR TITLE
[CI] Fix filename display issue in summary

### DIFF
--- a/.github/scripts/check-ut.py
+++ b/.github/scripts/check-ut.py
@@ -263,7 +263,8 @@ def process_xml_file(xml_file):
     try:
         xml = JUnitXml.fromfile(xml_file)
         parts = os.path.basename(xml_file).rsplit('.', 2)
-        ut = parts[0]
+        parts[0] = re.sub(r'\.{2,}', '.', parts[0])
+        ut = parts[0] + "." + parts[1]
         parts_category = os.path.basename(xml_file).split('.')[0]
         category = determine_category(parts_category)
 


### PR DESCRIPTION
The file name in CI does not display well now

<img width="1258" height="558" alt="image" src="https://github.com/user-attachments/assets/ed44f3ff-740b-4706-98dc-30d77b5e1b51" />

<img width="1365" height="567" alt="image" src="https://github.com/user-attachments/assets/c83381ac-4d30-432f-a881-1500d80f345f" />



disable_build
disable_e2e