### PR TITLE
Fix incorrect stride handling in adaptive_avg_pool3d

### DIFF
--- a/src/ATen/native/xpu/sycl/AdaptiveAveragePooling3dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/AdaptiveAveragePooling3dKernels.cpp
@@ -53,12 +53,13 @@ struct AdaptiveAvgPool3dKernelFunctor {
     ot = o_plane % osizeT_;
     int d = o_plane / osizeT_;
 
+    // Decompose d into batch and channel indices
+    int batch_idx = d / sizeD_;
+    int channel_idx = d % sizeD_;
+
     int istartT = start_index(ot, osizeT_, isizeT_);
     int iendT = end_index(ot, osizeT_, isizeT_);
     int kT = iendT - istartT;
-
-    const scalar_t* input_dt =
-        input_data_ + d * istrideD_ + istartT * istrideT_;
 
     scalar_t* output_dt = output_data_ + o_plane * osizeH_ * osizeW_;
 
@@ -73,9 +74,6 @@ struct AdaptiveAvgPool3dKernelFunctor {
         int iendW = end_index(ow, osizeW_, isizeW_);
         int kW = iendW - istartW;
 
-        // Compute the average pooling from corresponding input pixels
-        const scalar_t* ptr_input =
-            input_dt + istartH * istrideH_ + istartW * istrideW_;
         scalar_t* ptr_output = output_dt + oh * osizeW_ + ow;
         accscalar_t sum = static_cast<accscalar_t>(0);
 
@@ -83,11 +81,13 @@ struct AdaptiveAvgPool3dKernelFunctor {
         for (it = 0; it < kT; ++it) {
           for (ih = 0; ih < kH; ++ih) {
             for (iw = 0; iw < kW; ++iw) {
-              scalar_t val = ptr_input[ih * istrideH_ + iw * istrideW_];
+              int64_t input_offset = batch_idx * istrideB_ +
+                  channel_idx * istrideD_ + (istartT + it) * istrideT_ +
+                  (istartH + ih) * istrideH_ + (istartW + iw) * istrideW_;
+              scalar_t val = input_data_[input_offset];
               sum += static_cast<accscalar_t>(val);
             }
           }
-          ptr_input += istrideT_; // next input frame
         }
         // Update output
         const accscalar_t divide_factor =
@@ -106,6 +106,8 @@ struct AdaptiveAvgPool3dKernelFunctor {
       int osizeT,
       int osizeH,
       int osizeW,
+      int64_t sizeD,
+      int64_t istrideB,
       int64_t istrideD,
       int64_t istrideT,
       int64_t istrideH,
@@ -119,6 +121,8 @@ struct AdaptiveAvgPool3dKernelFunctor {
         osizeT_(osizeT),
         osizeH_(osizeH),
         osizeW_(osizeW),
+        sizeD_(sizeD),
+        istrideB_(istrideB),
         istrideD_(istrideD),
         istrideT_(istrideT),
         istrideH_(istrideH),
@@ -134,6 +138,8 @@ struct AdaptiveAvgPool3dKernelFunctor {
   int osizeT_;
   int osizeH_;
   int osizeW_;
+  int64_t sizeD_;
+  int64_t istrideB_;
   int64_t istrideD_;
   int64_t istrideT_;
   int64_t istrideH_;
@@ -152,6 +158,8 @@ void adaptive_avg_pool3d_template(
     int osizeT,
     int osizeH,
     int osizeW,
+    int64_t sizeD,
+    int64_t istrideB,
     int64_t istrideD,
     int64_t istrideT,
     int64_t istrideH,
@@ -171,6 +179,8 @@ void adaptive_avg_pool3d_template(
         osizeT,
         osizeH,
         osizeW,
+        sizeD,
+        istrideB,
         istrideD,
         istrideT,
         istrideH,
@@ -223,7 +233,7 @@ void adaptive_avg_pool3d_kernel(
   int64_t osizeW = output_size[2];
 
   int64_t sizeD, isizeT, isizeH, isizeW;
-  int64_t istrideD, istrideT, istrideH, istrideW;
+  int64_t istrideB, istrideD, istrideT, istrideH, istrideW;
   int64_t totalZ;
 
   const Tensor& input = input_.ndimension() == 4 ? input_ : input_.contiguous();
@@ -234,6 +244,7 @@ void adaptive_avg_pool3d_kernel(
     isizeH = input.size(2);
     isizeW = input.size(3);
 
+    istrideB = 0;
     istrideD = input.stride(0);
     istrideT = input.stride(1);
     istrideH = input.stride(2);
@@ -249,6 +260,7 @@ void adaptive_avg_pool3d_kernel(
     isizeH = input.size(3);
     isizeW = input.size(4);
 
+    istrideB = input.stride(0);
     istrideD = input.stride(1);
     istrideT = input.stride(2);
     istrideH = input.stride(3);
@@ -279,6 +291,8 @@ void adaptive_avg_pool3d_kernel(
             osizeT,
             osizeH,
             osizeW,
+            sizeD,
+            istrideB,
             istrideD,
             istrideT,
             istrideH,


### PR DESCRIPTION
To solve #2555.
This PR allows 3D adaptive average pooling kernel to decompose the input index `d` into separate `batch_idx` and `channel_idx` variables, which correctly handles the strides of batch and channel dimensions during pooling.