### PR TITLE
Fix work-group size for reduction kernel when total work-item count < sub-group size

### DIFF
--- a/src/ATen/native/xpu/sycl/Reduce.h
+++ b/src/ATen/native/xpu/sycl/Reduce.h
@@ -269,7 +269,7 @@ struct ReduceConfig {
     num_items = group_width * group_height;
 
     if (num_items < max_sg_sz) {
-      // Hardware always allocates full sub-group regradless of work-group size.
+      // Hardware always allocates full sub-group regardless of work-group size.
       // Enforce group_width to align with sub-group size.
       group_width = max_sg_sz;
       // Ensure num_items <= max_num_items


### PR DESCRIPTION
Fix regression introduced by #2477.
Since `group_width` is always aligned with the hardware's sub-group size (`max_sg_sz`) when the total number of items is less than the sub-group size, this PR is to adjust `group_height` to ensure the total number of items does not exceed `max_num_items`.