### PR TITLE
Use `int64_t` for `outer_size` in softmax

### DIFF
--- a/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
+++ b/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
@@ -674,7 +674,7 @@ void softmax_forward_kernel(
     const inscalar_t* in_data,
     outscalar_t* out_data,
     int dim_size,
-    int outer_size) {
+    int64_t outer_size) {
   using vec_t = at::native::memory::aligned_vector<inscalar_t, vec_size>;
   constexpr int align_bytes = alignof(vec_t);
   using KernelClass = SoftmaxForwardKernelFunctor<
@@ -1334,7 +1334,7 @@ void softmax_backward_kernel(
     const outscalar_t* output,
     const outscalar_t* gradOutput,
     int dim_size,
-    int outer_size) {
+    int64_t outer_size) {
   using vec_t = at::native::memory::aligned_vector<outscalar_t, vec_size>;
   constexpr int align_bytes = alignof(vec_t);
   using KernelClass = SoftmaxBackwardKernelFunctor<


### PR DESCRIPTION
Tests from [1] fail due to integer overflow in softmax kernels. The `outer_size` is computed as an int64 but later is passed to functions which expect an `int`, which causes an implicit cast and value overflow, resulting in the following exception:
`RuntimeError: Non-uniform work-groups are not supported by the target device`. This commit changes the `outer_size` type from `int` to `int64_t`.

[1] https://github.com/pytorch/pytorch/blob/a1560557626275cb66bda37251faabacc5ae3435/test/test_nn.py#L11064


Fixes tests `test_warp_softmax_64bit_indexing_xpu_float{32,16}` from https://github.com/intel/torch-xpu-ops/issues/2280 

disable_e2e
disable_distribute