### PR TITLE
Revert "Bump version and unskip compiler warnings (#2583)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ if(NOT WIN32)
   endif()
 endif()
 
-project(torch-xpu-ops VERSION 2.11.0 LANGUAGES C CXX)
+project(torch-xpu-ops VERSION 2.10.0 LANGUAGES C CXX)
 
 set(TORCH_XPU_OPS_FOUND FALSE)
 

--- a/src/ATen/native/quantized/sycl/QuantizedMaxPool2d.cpp
+++ b/src/ATen/native/quantized/sycl/QuantizedMaxPool2d.cpp
@@ -8,6 +8,12 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/AccumulateType.h>
 #include <ATen/native/Pool.h>
 #include <ATen/native/utils/ParamUtils.h>
@@ -324,3 +330,6 @@ Tensor quantized_max_pool2d_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/AdaptiveAveragePooling3dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/AdaptiveAveragePooling3dKernels.cpp
@@ -7,6 +7,12 @@
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  */
+
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/NumericUtils.h>
@@ -685,3 +691,6 @@ void adaptive_avg_pool3d_backward_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/AdaptiveMaxPooling2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/AdaptiveMaxPooling2dKernels.cpp
@@ -8,6 +8,12 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/ATen.h>
 #include <ATen/NumericUtils.h>
 #include <ATen/native/AdaptivePooling.h>
@@ -390,3 +396,6 @@ void adaptive_max_pool2d_backward_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/AdaptiveMaxPooling3dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/AdaptiveMaxPooling3dKernels.cpp
@@ -8,6 +8,12 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/ATen.h>
 #include <ATen/NumericUtils.h>
 #include <ATen/native/AdaptivePooling.h>
@@ -587,3 +593,6 @@ void adaptive_max_pool3d_backward_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/AveragePool3dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/AveragePool3dKernels.cpp
@@ -12,6 +12,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/ceil_div.h>
@@ -980,3 +986,5 @@ void avg_pool3d_backward_kernel(
 }
 
 } // namespace at::native::xpu
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop

--- a/src/ATen/native/xpu/sycl/DeformConv2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/DeformConv2dKernels.cpp
@@ -72,6 +72,11 @@
  *  https://github.com/open-mmlab/mmdetection/blob/master/mmdet/ops/dcn/src/deform_conv_cuda.cpp
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
 #include <ATen/ceil_div.h>
 #include <ATen/native/xpu/sycl/Atomics.h>
 #include <ATen/native/xpu/sycl/DistributionTemplates.h>
@@ -1492,3 +1497,6 @@ deform_conv2d_backward_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/DilatedMaxPool2d.cpp
+++ b/src/ATen/native/xpu/sycl/DilatedMaxPool2d.cpp
@@ -12,6 +12,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/native/Pool.h>
@@ -1419,3 +1425,5 @@ void max_pool2d_with_indices_backward_kernel(
 
 } // namespace at::native::xpu
 #undef LAUNCH_MAXPOOL_CHANNEL_LAST_VEC
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/DilatedMaxPool3d.cpp
+++ b/src/ATen/native/xpu/sycl/DilatedMaxPool3d.cpp
@@ -12,6 +12,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/ATen.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/ceil_div.h>
@@ -795,3 +801,6 @@ void max_pool3d_with_indices_backward_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
+++ b/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
@@ -8,6 +8,12 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <comm/xpu_aten.h>
@@ -966,3 +972,6 @@ Tensor _embedding_bag_per_sample_weights_backward_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/FractionalMaxPool2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/FractionalMaxPool2dKernels.cpp
@@ -8,6 +8,12 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/ATen.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/NativeFunctions.h>
@@ -290,3 +296,6 @@ void fractional_max_pool2d_backward_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop

--- a/src/ATen/native/xpu/sycl/FractionalMaxPool3dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/FractionalMaxPool3dKernels.cpp
@@ -8,6 +8,12 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/ATen.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/NativeFunctions.h>
@@ -323,3 +329,6 @@ void fractional_max_pool3d_backward_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop

--- a/src/ATen/native/xpu/sycl/GridSampler.cpp
+++ b/src/ATen/native/xpu/sycl/GridSampler.cpp
@@ -12,6 +12,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/OpMathType.h>
 #include <ATen/native/CanUse32BitIndexMath.h>
 #include <ATen/native/GridSamplerUtils.h>
@@ -1806,3 +1812,6 @@ void grid_sampler_3d_backward_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/HistogramddKernels.cpp
+++ b/src/ATen/native/xpu/sycl/HistogramddKernels.cpp
@@ -12,6 +12,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
 #include <ATen/native/xpu/sycl/Atomics.h>
@@ -543,3 +549,6 @@ void histogram_select_outer_bin_edges_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/Indexing.cpp
+++ b/src/ATen/native/xpu/sycl/Indexing.cpp
@@ -8,6 +8,12 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/MemoryOverlap.h>
@@ -2180,3 +2186,6 @@ Tensor index_select_sparse_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/LossCTCKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LossCTCKernels.cpp
@@ -20,6 +20,12 @@
  * Graves et al call the probabilities y, we use log_probs (also calling them inputs)
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/ATen.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/xpu/sycl/Atomics.h>
@@ -1295,3 +1301,6 @@ Tensor ctc_loss_backward_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/LossNLL2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LossNLL2dKernels.cpp
@@ -7,6 +7,12 @@
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  */
+
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
 #include <ATen/ATen.h>
 #include <ATen/core/TensorAccessor.h>
 #include <ATen/native/CanUse32BitIndexMath.h>
@@ -539,3 +545,6 @@ void nll_loss2d_backward_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/MultinomialKernel.cpp
+++ b/src/ATen/native/xpu/sycl/MultinomialKernel.cpp
@@ -8,6 +8,12 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/AccumulateType.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/native/xpu/sycl/Atomics.h>
@@ -547,3 +553,5 @@ void multinomial_kernel(
 }
 
 } // namespace at::native::xpu
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/PsRoiAlignKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PsRoiAlignKernels.cpp
@@ -12,6 +12,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
 #include <ATen/ceil_div.h>
 #include <ATen/native/xpu/sycl/Atomics.h>
 #include <ATen/native/xpu/sycl/KernelUtils.h>
@@ -498,3 +503,6 @@ Tensor ps_roi_align_backward_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/PsRoiPoolKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PsRoiPoolKernels.cpp
@@ -12,6 +12,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
 #include <ATen/ceil_div.h>
 #include <ATen/native/xpu/sycl/Atomics.h>
 #include <ATen/native/xpu/sycl/KernelUtils.h>
@@ -326,3 +331,6 @@ Tensor ps_roi_pool_backward_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/ReflectionPadKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ReflectionPadKernels.cpp
@@ -8,6 +8,12 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/Dispatch.h>
 #include <ATen/ceil_div.h>
 #include <ATen/native/IndexingUtils.h>
@@ -878,3 +884,6 @@ void reflection_pad3d_backward_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/ReplicationPaddingKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ReplicationPaddingKernels.cpp
@@ -8,6 +8,12 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/ATen.h>
 #include <ATen/Context.h>
 #include <ATen/Dispatch.h>
@@ -770,3 +776,6 @@ void replication_pad3d_backward_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/RoiAlignKernels.cpp
+++ b/src/ATen/native/xpu/sycl/RoiAlignKernels.cpp
@@ -12,6 +12,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
 #include <ATen/ceil_div.h>
 #include <ATen/native/xpu/sycl/Atomics.h>
 #include <ATen/native/xpu/sycl/KernelUtils.h>
@@ -561,3 +566,6 @@ Tensor roi_align_backward_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/RoiPoolKernels.cpp
+++ b/src/ATen/native/xpu/sycl/RoiPoolKernels.cpp
@@ -12,6 +12,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
 #include <ATen/ceil_div.h>
 #include <ATen/native/xpu/sycl/Atomics.h>
 #include <ATen/native/xpu/sycl/KernelUtils.h>
@@ -309,3 +314,6 @@ Tensor roi_pool_backward_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/ScatterGatherKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ScatterGatherKernels.cpp
@@ -8,6 +8,12 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/Dispatch.h>
 #include <ATen/MemoryOverlap.h>
 #include <ATen/ceil_div.h>
@@ -854,3 +860,6 @@ void scatter_scalar_reduce_kernel(
 } // namespace xpu
 } // namespace native
 } // namespace at
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/Sorting.cpp
+++ b/src/ATen/native/xpu/sycl/Sorting.cpp
@@ -8,6 +8,12 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/Dispatch.h>
 #include <ATen/MemoryOverlap.h>
 #include <ATen/NumericUtils.h>
@@ -548,3 +554,6 @@ void launch_kthvalue_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/SummaryOpsKernels.cpp
+++ b/src/ATen/native/xpu/sycl/SummaryOpsKernels.cpp
@@ -8,6 +8,12 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/AccumulateType.h>
 #include <ATen/native/xpu/sycl/Atomics.h>
 #include <comm/Runtime.h>
@@ -325,3 +331,6 @@ Tensor bincount_kernel(
   });
 }
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/UpSampleBicubic2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleBicubic2dKernels.cpp
@@ -8,6 +8,12 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/TensorUtils.h>
@@ -336,3 +342,6 @@ void upsample_bicubic2d_backward_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/UpSampleBilinear2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleBilinear2dKernels.cpp
@@ -8,6 +8,12 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/TensorUtils.h>
@@ -1698,3 +1704,6 @@ void _upsample_bicubic2d_aa_backward_out_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/UpSampleLinear1dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleLinear1dKernels.cpp
@@ -8,6 +8,12 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/ATen.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
@@ -217,3 +223,6 @@ void upsample_linear1d_backward_kernel(
       });
 }
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop

--- a/src/ATen/native/xpu/sycl/UpSampleNearest3dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleNearest3dKernels.cpp
@@ -8,6 +8,11 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/TensorUtils.h>
@@ -439,3 +444,6 @@ void upsample_nearest3d_backward_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop

--- a/src/ATen/native/xpu/sycl/UpSampleTrilinear3dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleTrilinear3dKernels.cpp
@@ -8,6 +8,12 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#pragma clang diagnostic push
+#pragma GCC diagnostic push
+// Avoid SYCL compiler return-type error
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/TensorUtils.h>
@@ -431,3 +437,6 @@ void upsample_trilinear3d_backward_out_kernel(
 }
 
 } // namespace at::native::xpu
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop


### PR DESCRIPTION
This reverts commit b40f2c13d259cd1f4ffcac719b8ba0f1c1d72546.
PyTorch CI still retains building PyTorch XPU with oneAPI 2025.2. #2583 introduced Werror in Pytorch CI XPU build when using compiler 2025.2.
disable_win