### PR TITLE
[SYCLTLA] rebase FA2 bwd to latest version

### DIFF
--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.cpp
@@ -401,7 +401,7 @@ void gemm_dQ(
     Trait& trait,
     Tensor<Engine0, Layout0> const& A, // (M,K)
     Tensor<Engine1, Layout1> const& B, // (N,K)
-    Tensor<Engine2, Layout2> const& C, // (M,N)
+    Tensor<Engine2, Layout2>& C, // (M,N)
     TiledMMA const& mma) {
   auto local_id = int(compat::get_nd_item<1>().get_local_id(0));
   auto tile_mnk = mma.tile_mnk();
@@ -529,7 +529,7 @@ CUTLASS_DEVICE void scale_apply_exp2(
     for (int ni = 0; ni < size<1>(tensor); ++ni) {
       int n = get<1>(rC_2d(0, ni));
       const float max_scaled =
-          ((max(n) == -INFINITY) or (n >= tail_m)) ? 0.f : max(n) * M_LOG2E;
+          ((n >= tail_m) || (max(n) == -INFINITY)) ? 0.f : max(n) * M_LOG2E;
       CUTLASS_PRAGMA_UNROLL
       for (int mi = 0; mi < size<0>(tensor); ++mi) {
         tensor(mi, ni) = exp2f(tensor(mi, ni) * scale - max_scaled);

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
@@ -101,14 +101,14 @@ struct Param {
         k_ptr(k),
         v_ptr(v),
         lse_ptr(lse),
+        scale_softmax(softmax_scale),
+        scale_softmax_log2(softmax_scale * M_LOG2E),
         odo_ptr(odo),
         dqaccum_ptr(dqaccum),
         dq_ptr(dq),
         dk_ptr(dk),
         dv_ptr(dv),
-        pb_ptr(pb),
-        scale_softmax(softmax_scale),
-        scale_softmax_log2(softmax_scale * M_LOG2E) {}
+        pb_ptr(pb) {}
   // read only
   const T* do_ptr;
   const T* o_ptr;


### PR DESCRIPTION
Current, SYCLTLA based FA2 backward kernel are based on SYCLTLA legacy api which is going to deprecate. This PR swich to new cute api. The code is from https://github.com/intel/sycl-tla/pull/546  latest commit 94c6fe4fcee01f47522b2df0f31fcf4c80410b81

This change can pass SDPA related UTs and have ~200% performance improvement on PVC.