### PR TITLE
Use the correct toAccumulateType

### DIFF
--- a/src/ATen/native/xpu/BatchNorm.cpp
+++ b/src/ATen/native/xpu/BatchNorm.cpp
@@ -94,7 +94,7 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_xpu(
   auto output = at::empty_like(input);
   int64_t n_input = input.size(1);
   auto options =
-      input.options().dtype(at::toAccumulateType(input.scalar_type(), true));
+      input.options().dtype(at::toAccumulateType(input.scalar_type(), kXPU));
   auto save_mean = at::empty({n_input}, options);
   auto save_invstd = at::empty({n_input}, options);
 
@@ -258,7 +258,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> _batch_norm_with_update_xpu(
   auto output = at::empty_like(input);
   int64_t n_input = input.size(1);
   auto options =
-      input.options().dtype(at::toAccumulateType(input.scalar_type(), true));
+      input.options().dtype(at::toAccumulateType(input.scalar_type(), kXPU));
   auto save_mean = at::empty({n_input}, options);
   auto save_invstd = at::empty({n_input}, options);
 

--- a/src/ATen/native/xpu/LayerNorm.cpp
+++ b/src/ATen/native/xpu/LayerNorm.cpp
@@ -69,7 +69,7 @@ namespace native {
       std::nullopt /* pin_memory */,
       LEGACY_CONTIGUOUS_MEMORY_FORMAT);
 
-  auto acc_type = at::toAccumulateType(input.scalar_type(), true);
+  auto acc_type = at::toAccumulateType(input.scalar_type(), kXPU);
 
   Tensor mean = at::empty({M}, X->options().dtype(acc_type));
   Tensor rstd = at::empty({M}, X->options().dtype(acc_type));

--- a/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
@@ -996,7 +996,7 @@ std::tuple<Tensor, Tensor> batch_norm_stats_kernel(
     const Tensor& self,
     double epsilon) {
   auto options =
-      self.options().dtype(at::toAccumulateType(self.scalar_type(), true));
+      self.options().dtype(at::toAccumulateType(self.scalar_type(), kXPU));
   auto n_channels = self.size(1);
   auto save_mean = at::empty({n_channels}, options);
   auto save_invstd = at::empty({n_channels}, options);
@@ -3889,7 +3889,7 @@ std::tuple<Tensor, Tensor> batch_norm_update_stats_kernel(
       self.sizes());
 
   auto options =
-      self.options().dtype(at::toAccumulateType(self.scalar_type(), true));
+      self.options().dtype(at::toAccumulateType(self.scalar_type(), kXPU));
 
   auto save_mean = at::empty({n_input}, options);
   auto save_var = at::empty({n_input}, options);
@@ -5018,7 +5018,7 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_kernel(
         });
   }
 
-  const auto acc_type = at::toAccumulateType(input.scalar_type(), true);
+  const auto acc_type = at::toAccumulateType(input.scalar_type(), kXPU);
   Tensor mean;
   TORCH_INTERNAL_ASSERT(
       save_mean->defined(), "save_mean should always be defined\n");


### PR DESCRIPTION
# Motivation
`toAccumulateType` has two signatures:
1. [`TORCH_API c10::ScalarType toAccumulateType(c10::ScalarType type, c10::DeviceType device)`](
https://github.com/pytorch/pytorch/blob/468ef3d2591612c54b91d474c4b6986b432fd6a2/aten/src/ATen/AccumulateType.h#L168-L170)
2. [`TORCH_API c10::ScalarType toAccumulateType(c10::ScalarType type, bool is_cuda);`](https://github.com/pytorch/pytorch/blob/468ef3d2591612c54b91d474c4b6986b432fd6a2/aten/src/ATen/AccumulateType.h#L171)

Obviously, we should use option 1 instead of option 2.