### PR TITLE
Add weight dtype validation to fix CI issue

### DIFF
--- a/src/ATen/native/xpu/sycl/LossNLLKernel.cpp
+++ b/src/ATen/native/xpu/sycl/LossNLLKernel.cpp
@@ -406,6 +406,15 @@ void nll_loss_forward_kernel(
 
   auto weight_ = weight.defined() ? weight.contiguous() : weight;
 
+  if (weight_.defined()) {
+    TORCH_CHECK(
+        input.scalar_type() == weight_.scalar_type(),
+        "expected scalar type ",
+        input.scalar_type(),
+        " but found ",
+        weight_.scalar_type());
+  }
+
   if (reduction == at::Reduction::None && n_dims == 2) {
     at::native::resize_output(output, {batch_size});
     total_weight.zero_();


### PR DESCRIPTION
# Motivation
https://github.com/pytorch/pytorch/pull/172018 adds weight dtype validation to CUDA and MPS, then introduces CI issue that we have skipped in https://github.com/pytorch/pytorch/issues/173335.
This PR aims to add weight dtype to XPU so that it resolves https://github.com/pytorch/pytorch/issues/173335