### PR TITLE
Add test case for _refs.true_divide to _cuda_xfail_xpu_pass

### DIFF
--- a/test/xpu/xpu_test_utils.py
+++ b/test/xpu/xpu_test_utils.py
@@ -368,6 +368,7 @@ _cuda_xfail_xpu_pass = [
         "_refs.true_div",
         "test_python_ref_torch_fallback",
     ),
+    ("_refs.true_divide", "test_python_ref_torch_fallback"),
     ("argsort", "test_non_standard_bool_values"),
     ("sort", "test_non_standard_bool_values"),
 ]


### PR DESCRIPTION
Resolves https://github.com/intel/torch-xpu-ops/issues/2307 and adds support for test_python_ref_torch_fallback__refs_true_divide_xpu_complex32, which was introduced in https://github.com/intel/torch-xpu-ops/commit/ac208893d17216548e1822c4dc2175918b156ca6. The test case, previously marked xfail for CUDA, would pass on XPU, resulting in a false negative (unexpected success). This PR adds an exception so it can execute successfully on XPU.