### PR TITLE
Support call oneccl all2all directly

### DIFF
--- a/src/xccl/xccl.cpp
+++ b/src/xccl/xccl.cpp
@@ -424,13 +424,13 @@ void onecclAllToAll(
     xcclComm_t& comm,
     ccl::stream& xcclStream,
     at::xpu::XPUStream& stream) {
-
-  auto [isUniform, uniformCount] = checkUniformAllToAll(
-      sendcounts, senddispls, recvcounts, recvdispls, numranks);
   if (isCCLV2EnabledCached()) {
     auto xcclDataType = getXcclDataTypeV2(dataType, false);
     int numranks = 0;
     onecclCommCount(comm.onecclComm, &numranks);
+
+    auto [isUniform, uniformCount] = checkUniformAllToAll(
+        sendcounts, senddispls, recvcounts, recvdispls, numranks);
 
     if (isUniform) {
       // Use native onecclAllToAll for uniform case
@@ -470,6 +470,9 @@ void onecclAllToAll(
   } else {
     auto xcclDataType = getXcclDataTypeV1(dataType, false);
     int numranks = comm.cclComm->size();
+
+    auto [isUniform, uniformCount] = checkUniformAllToAll(
+        sendcounts, senddispls, recvcounts, recvdispls, numranks);
 
     if (isUniform) {
       // Use native ccl::alltoall for uniform case


### PR DESCRIPTION
This PR introduces a direct call path when oneCCL supports `onecclAllToAll`. XCCL currently provides three variants of **all-to-all**:

1. **Tensor-list all-to-all**, i.e. `ProcessGroupXCCL::alltoall`.
   It assumes the input and output tensor lists have the same length. The current implementation uses grouped send/recv, aligning with CUDA.

2. **`ProcessGroupXCCL::alltoall_base` with empty `outputSplitSizes` / `inputSplitSizes`**, i.e. equal partitioning, corresponding to the standard all-to-all semantics.
   When oneCCL directly supports all-to-all, it calls the oneCCL all-to-all API; otherwise, it falls back to grouped send/recv, aligning with CUDA.

3. **`ProcessGroupXCCL::alltoall_base` with non-empty `outputSplitSizes` / `inputSplitSizes`**, i.e. uneven partitioning, corresponding to all-to-all-v semantics.
   oneCCL does not provide this API, so it is implemented using grouped send/recv.

disable_e2e
disable_ut