### PR TITLE
build: define Dropout and FusedSgdKernels sycl kernels in named namespaces

### DIFF
--- a/src/ATen/native/xpu/sycl/Dropout.cpp
+++ b/src/ATen/native/xpu/sycl/Dropout.cpp
@@ -25,11 +25,7 @@
 
 #include <ATen/native/xpu/sycl/DropoutKernels.h>
 
-namespace at {
-namespace native {
-namespace xpu {
-
-namespace {
+namespace at::native::xpu {
 
 using namespace at::native;
 using namespace at::xpu::detail;
@@ -378,8 +374,6 @@ inline void launcher(
       });
 }
 
-} // namespace
-
 template <typename mask_t>
 std::tuple<Tensor, Tensor> dropout(
     XPUGeneratorImpl* gen,
@@ -487,6 +481,4 @@ Tensor masked_scale_kernel(
   return dropout_backward<uint8_t>(self, mask, scale);
 }
 
-} // namespace xpu
-} // namespace native
-} // namespace at
+} // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/FusedSgdKernels.cpp
+++ b/src/ATen/native/xpu/sycl/FusedSgdKernels.cpp
@@ -19,8 +19,6 @@
 
 namespace at::native::xpu {
 
-namespace {
-
 template <typename scalar_t, int depth>
 void sgd_math(
     scalar_t r_args[depth][kILP],
@@ -166,8 +164,6 @@ struct FusedSgdMathFunctor {
     }
   }
 };
-
-} // namespace
 
 void fused_sgd_kernel(
     at::TensorList params,


### PR DESCRIPTION
If SYCL kernel object type is declared in the anonymous namespace, then we get a warning building with host compiler. This commit fixes the issue in Dropout and FusedSgdKernels.

```
warning: ‘visibility’ attribute ignored [-Wattributes]
```

CC: @EikanWang @guangyey 