### PR TITLE
Add skip for test_dummy_mha_with_nt() from test_nestedtensor_xpu.py

### DIFF
--- a/test/xpu/test_nestedtensor_xpu.py
+++ b/test/xpu/test_nestedtensor_xpu.py
@@ -56,6 +56,7 @@ from torch.testing._internal.common_device_type import (
     skipCUDAIf,
     skipCUDAIfRocm,
     skipMeta,
+    skipXPUIf,
 )
 from torch.testing._internal.common_dtype import floating_types_and_half
 from torch.testing._internal.common_utils import (
@@ -7394,6 +7395,7 @@ torch.cuda.synchronize()
     @skipIfTorchDynamo("compiles internally")
     @unittest.skipIf(IS_WINDOWS, reason="Windows not yet supported for torch.compile")
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
+    @skipXPUIf(True, "XPU does not support NestedTensor for SDPA operations.")
     @parametrize("use_legacy_api", [True, False])
     @skipCPUIf(True, "SPDA Math NT fallback causes failure: see issue #133644")
     @unittest.skipIf(


### PR DESCRIPTION
Fixes #2426 

disable_all
disable_build
disable_e2e

## Reasoning

Two test cases from mentioned issue were failing:
> test_nestedtensor_xpu.TestNestedTensorSubclassXPU,test_dummy_mha_with_nt_use_legacy_api_False_xpu
> test_nestedtensor_xpu.TestNestedTensorSubclassXPU,test_dummy_mha_with_nt_use_legacy_api_True_xpu

They are failing because XPU does not support Nested Tensors for SDPA operations and the internal check returns RuntimeError that there is no available backend for scaled_dot_product_attention.

As I talked with @LuFinch - we do not plan in near future (or maybe at all) to support Nested Tensors for SDPA operations as it is experimental API and stock PyTorch is now moving to use `varlen_attention`, which will be supported by XPU. Also Nested Tensor for SDPA operations is not a commonly used API.

## Introduced changes

The change is very small - simply adding `@skipXPUIf` decorator to the failing test.