### PR TITLE
Allow `nonzero` execution for large inputs

### DIFF
--- a/src/ATen/native/xpu/Nonzero.cpp
+++ b/src/ATen/native/xpu/Nonzero.cpp
@@ -23,11 +23,6 @@ void nonzero_common_checks(
     Tensor& out,
     const std::string& op_name) {
   TORCH_CHECK(
-      self.numel() < std::numeric_limits<int>::max(),
-      op_name,
-      " is not supported for tensors with more than INT_MAX elements, \
-      See https://github.com/pytorch/pytorch/issues/51871");
-  TORCH_CHECK(
       self.device() == out.device(),
       "expected self and out to be on the same device, but got out on ",
       out.device(),

--- a/test/xpu/test_unary_ufuncs_xpu.py
+++ b/test/xpu/test_unary_ufuncs_xpu.py
@@ -54,6 +54,7 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     numpy_to_torch_dtype_dict,
     run_tests,
+    serialTest,
     skipIfNoSciPy,
     slowTest,
     slowTestIf,
@@ -1662,6 +1663,7 @@ class TestUnaryUfuncs(TestCase):
         self.assertEqual(1, len(z))
         self.assertEqual(torch.empty(0, dtype=torch.long), z[0])
 
+    @serialTest()
     @dtypes(torch.int8)
     @largeTensorTest("8GB")
     def test_nonzero_large(self, device, dtype):


### PR DESCRIPTION
The `nonzero` op is disabled for large inputs (number of elements exceeding int32), however the implementation allows handling such large input tensors. This commit removes the `TORCH_CHECK` for large input tensors.

disable_e2e
disable_distributed