### PR TITLE
Handle complex squared in `pow` kernel

### DIFF
--- a/src/ATen/native/xpu/sycl/PowKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PowKernels.cpp
@@ -242,6 +242,10 @@ void pow_tensor_scalar_kernel(
       return;
     }
     AT_DISPATCH_COMPLEX_TYPES(iter.common_dtype(), "pow_xpu", [&]() {
+      if (exp_scalar.equal(2.0)) {
+        gpu_kernel(iter, PowImplUnaryFunctor1<scalar_t>());
+        return;
+      }
       const auto exp = exp_scalar.to<scalar_t>();
       gpu_kernel(iter, PowScalarTensorFunctor2<scalar_t>(exp));
     });


### PR DESCRIPTION
If the base is a complex dtype and the exponent is a scalar, the `pow` kernel calls the `PowScalarTensorFunctor2`, which in turn calls the `pow_` implementation. However, if the exponent `exp = 2`, rather than calling the pow implementation, one should compute the result directly: `result = base * base`. This commit aligns `pow`'s XPU behaviour with the CUDA implementation [1].

[1] https://github.com/pytorch/pytorch/blob/1265fb75baf7bbcc84ec9ac9b1839876dbe23806/aten/src/ATen/native/cuda/PowKernel.cu#L188
