### PR TITLE
Fix factor calculation for double

### DIFF
--- a/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
@@ -471,8 +471,7 @@ struct BatchNormCollectStatisticsKernelFunctor
       stat_accscalar_t o_avg = sycl::permute_group_by_xor(sg, avg, i);
       int o_n = sycl::permute_group_by_xor(sg, n, i);
       stat_accscalar_t factor = static_cast<stat_accscalar_t>(1.0) /
-          fmax(static_cast<stat_accscalar_t>(1.0),
-               static_cast<stat_accscalar_t>(n + o_n));
+          static_cast<stat_accscalar_t>(std::max(1, n + o_n));
       var_n += sycl::permute_group_by_xor(sg, var_n, i) +
           (avg - o_avg) * (avg - o_avg) * n * o_n * factor;
       avg = (n * avg + o_n * o_avg) * factor;
@@ -504,8 +503,7 @@ struct BatchNormCollectStatisticsKernelFunctor
       stat_accscalar_t o_avg = sycl::permute_group_by_xor(sg, avg, i);
       int o_n = sycl::permute_group_by_xor(sg, n, i);
       stat_accscalar_t factor = static_cast<stat_accscalar_t>(1.0) /
-          fmax(static_cast<stat_accscalar_t>(1.0),
-               static_cast<stat_accscalar_t>(n + o_n));
+          static_cast<stat_accscalar_t>(std::max(1, n + o_n));
       var_n += sycl::permute_group_by_xor(sg, var_n, i) +
           (avg - o_avg) * (avg - o_avg) * n * o_n * factor;
       avg = (n * avg + o_n * o_avg) * factor;


### PR DESCRIPTION
Fixes: #2781 

Improve `factor` calculation for double datatypes.

Previously `factor` was always calculated with float precision and then upcasted to double. This leads to small differences in `var` and `mean` (double->float precision error).

With this fix we are calculating `factor` with `stat_accscalar_t` precision retaining behavior for float and lower precision computations and achieving proper accuracy for double datatype.