### PR TITLE
Add scaleout workaround for premulsum in reduce scatter and all reduce

### DIFF
--- a/src/xccl/ProcessGroupXCCL.cpp
+++ b/src/xccl/ProcessGroupXCCL.cpp
@@ -81,7 +81,6 @@ ReduceOp applyPreMulSumIfNeeded(
   return newOp;
 }
 
-
 int64_t checkTensorOnSameDevice(const std::vector<at::Tensor>& tensors) {
   TORCH_CHECK_WITH(
       ValueError, tensors.size() != 0, "Tensor list must be nonempty");


### PR DESCRIPTION
Most recent versions of oneCCL do not support PreMul_Sum for more than a single node. This is causing crashes in torchtitan and other scaling cases (https://github.com/pytorch/torchtitan/pull/2332)

This PR provides a workaround which replaces PreMul_Sum with an in-place multiplication and changes the collective op to Sum for AllReduce and ReduceScatter implemenations.

Tests have been proposed in #2690 but there is no current infra to test scale-out cases. I've run the following test on two nodes, two ranks on each node:
```bash
export WORLD_SIZE=4
export MASTER_ADDR=$(head -n 1 ${PBS_NODEFILE})
export MASTER_PORT=29501
mpiexec --pmi=pmix --no-vni --np 4 --ppn 2 -l --line-buffer python test_premul_sum_ops.py
```

<details>
  <summary>test_premul_sum_ops.py</summary>

```python
import torch
import torch.distributed as dist
import torch.distributed as c10d

def init_distributed():
    """Initialize distributed environment"""
    if not dist.is_available():
        raise RuntimeError("Distributed package not available")
    
    if not c10d.is_xccl_available():
        raise RuntimeError("XCCL backend not available")
    
    # Initialize process group with XCCL backend
    dist.init_process_group(backend="xccl")
    
    rank = dist.get_rank()
    world_size = dist.get_world_size()
    
    # Set XPU device
    torch.xpu.set_device(rank % torch.xpu.device_count())
    device = f"xpu:{rank % torch.xpu.device_count()}"
    
    return rank, world_size, device

def test_allreduce_premul_sum(rank, world_size, device):
    """Test allreduce with premul sum"""
    print(f"Rank {rank}: Testing allreduce with premul sum")
    
    factor = 3.0
    tensor = torch.tensor([rank + 1.0], device=device)
    print(f"Rank {rank}: Input tensor: {tensor.item()}")
    
    # Test with premul sum
    opts = c10d.AllreduceOptions()
    opts.reduceOp = c10d._make_nccl_premul_sum(factor)
    
    work = dist.all_reduce(tensor, op=opts.reduceOp)
    work.wait() if hasattr(work, 'wait') else None
    
    expected = factor * (world_size * (world_size + 1) / 2)
    print(f"Rank {rank}: Allreduce result: {tensor.item()}, expected: {expected}")
    
    return tensor

def test_reduce_scatter_premul_sum(rank, world_size, device):
    """Test reduce_scatter with premul sum"""
    print(f"Rank {rank}: Testing reduce_scatter with premul sum")
    
    factor = 2.0
    
    # Create input tensors for reduce_scatter
    input_list = []
    for i in range(world_size):
        input_list.append(torch.tensor([rank + i + 1.0], device=device))
    
    print(f"Rank {rank}: Input list: {[t.item() for t in input_list]}")
    
    # Output tensor
    output = torch.zeros(1, device=device)
    
    # Perform reduce_scatter with premul sum
    opts = c10d.ReduceScatterOptions()
    opts.reduceOp = c10d._make_nccl_premul_sum(factor)
    
    work = dist.reduce_scatter(output, input_list, op=opts.reduceOp)
    work.wait() if hasattr(work, 'wait') else None
    
    # Calculate expected result
    # Each rank contributes (rank + rank + 1), sum across all ranks, then multiply by factor
    sum_contributions = sum(r + rank + 1 for r in range(world_size))
    expected = factor * sum_contributions
    
    print(f"Rank {rank}: Reduce_scatter result: {output.item()}, expected: {expected}")
    
    return output

def main():
    try:
        rank, world_size, device = init_distributed()

        print(f"Rank {rank}/{world_size} on device {device}")

        # Test all operations
        print("\n" + "="*50)
        test_allreduce_premul_sum(rank, world_size, device)

        print("\n" + "="*50) 
        test_reduce_scatter_premul_sum(rank, world_size, device)

        # Barrier to ensure all processes complete
        dist.barrier()

        if rank == 0:
            print("\nAll tests completed successfully!")
            
    except Exception as e:
        print(f"Rank {rank if 'rank' in locals() else '?'}: Error: {e}")
        raise
    finally:
        if dist.is_initialized():
            dist.destroy_process_group()

if __name__ == "__main__":
    main()
```
</details>