### PR TITLE
Fix E2E model setup

### DIFF
--- a/.github/actions/linux-testenv/action.yml
+++ b/.github/actions/linux-testenv/action.yml
@@ -130,6 +130,14 @@ runs:
           cd benchmark
           git checkout ${TORCHBENCH_COMMIT_ID}
           sed -i 's/^ *pynvml.*//' requirements.txt
+          # Work around legacy deps (e.g. visdom) that still import
+          # pkg_resources during build on newer Python toolchains.
+          CONSTRAINT_FILE=/tmp/pip-constraints.txt
+          echo 'setuptools<81' > ${CONSTRAINT_FILE}
+          export PIP_CONSTRAINT=${CONSTRAINT_FILE}
+          export PIP_NO_BUILD_ISOLATION=1
+          pip install -U "pip" "setuptools<81" "wheel"
+          # Follow with standard installation path
           pip install -r requirements.txt
           if [ "${{ github.event_name }}" == "pull_request" ];then
             while read line; do


### PR DESCRIPTION
Currently, some models fail (e.g., `pytorch_CycleGAN_and_pix2pix`) due to `ModuleNotFoundError: No module named 'pkg_resources'`. This is a known-issue in setuptools on Python 3.12. We need to pin the setuptools version and disable build isolation. This commit introduces the mentioned changes.

disable_ut
disable_distributed