### PR TITLE
Align error message with upstream pytorch

### DIFF
--- a/src/ATen/native/xpu/sycl/MultiMarginLossKernels.cpp
+++ b/src/ATen/native/xpu/sycl/MultiMarginLossKernels.cpp
@@ -44,10 +44,14 @@ void multi_margin_loss_shape_check(
 
   TORCH_CHECK(
       target.dim() <= 1 && target.numel() == nframe,
-      "inconsistent target size, expected ",
+      "multi_margin_loss: target tensor should be 1-D with size equal to "
+      "the number of input samples (batch size). Expected target size [",
       nframe,
-      " but got ",
-      target.sizes());
+      "], but got ",
+      target.sizes(),
+      ". Input has shape ",
+      input.sizes(),
+      ".");
   if (weight && weight->defined()) {
     TORCH_CHECK(
         weight->dim() <= 1 && weight->numel() == dim,


### PR DESCRIPTION
Fix: https://github.com/pytorch/pytorch/issues/175718

```
FAILED CONSISTENTLY: test/test_modules.py::TestModuleXPU::test_errors_nn_MultiMarginLoss_xpu_float32
FAILED CONSISTENTLY: test/test_modules.py::TestModuleXPU::test_errors_nn_MultiMarginLoss_xpu_float64
```
The root cause is that the error message has changed by:
https://github.com/pytorch/pytorch/pull/174072 