### PR TITLE
[XPU] Align complex pow(exp==2.0) fastpath with CUDA

### DIFF
--- a/src/ATen/native/xpu/sycl/PowKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PowKernels.cpp
@@ -123,7 +123,7 @@ struct PowChalfTensorScalarFunctor {
   scalar_t operator()(scalar_t base) const {
     return std::pow(opmath_t{base}, exp_);
   }
-  PowChalfTensogitrScalarFunctor(opmath_t exp) : exp_(exp) {}
+  PowChalfTensorScalarFunctor(opmath_t exp) : exp_(exp) {}
 
  private:
   opmath_t exp_;


### PR DESCRIPTION
Fixes: https://github.com/intel/torch-xpu-ops/issues/1973

CUDA has a fastpath for complex scalar exp == 2.0 (PowImplUnaryFunctor1).
XPU was missing this optimization, leading to different behavior for extremal values (Inf/NaN).

This aligns XPU with CUDA semantics.

Fixed tests:
- test_pow_cuda_complex_extremal_passing_xpu_complex128
- test_pow_cuda_complex_extremal_passing_xpu_complex64