### PR TITLE
Enable INCLUDE code lint check in CI

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -42,6 +42,7 @@ init_command = [
 code = 'CLANGFORMAT'
 include_patterns = [
     'src/**/*.h',
+    'src/**/*.hpp',
     'src/**/*.cpp',
 ]
 init_command = [
@@ -330,11 +331,9 @@ command = [
 [[linter]]
 code = 'INCLUDE'
 include_patterns = [
-    'src/comm/**',
-    'src/Aten/**',
-    'src/Aten/**/**',
-    'src/Aten/**/**/**',
-    'src/Aten/**/**/**/**',
+    'src/**/*.h',
+    'src/**/*.hpp',
+    'src/**/*.cpp',
 ]
 command = [
     'python3',

--- a/src/ATen/native/quantized/QuantizedMaxPool2d.cpp
+++ b/src/ATen/native/quantized/QuantizedMaxPool2d.cpp
@@ -12,9 +12,9 @@
 #include <ATen/native/Pool.h>
 #include <ATen/native/quantized/sycl/QuantizedMaxPool2d.h>
 #include <ATen/native/utils/ParamUtils.h>
+#include <c10/core/ScalarType.h>
 #include <comm/RegisterUtils.h>
 #include <torch/library.h>
-#include "c10/core/ScalarType.h"
 
 namespace at {
 namespace native {

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_flash_attn_sdpa_fwd_epilogue.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_flash_attn_sdpa_fwd_epilogue.h
@@ -10,13 +10,13 @@
 
 #pragma once
 
+#include <cutlass/cutlass.h>
+#include <cutlass/detail/layout.hpp>
+#include <cutlass/epilogue/collective/collective_epilogue.hpp>
+#include <cutlass/epilogue/collective/detail.hpp>
+#include <cutlass/epilogue/dispatch_policy.hpp>
+#include <flash_attention_v2/collective/fmha_fusion.hpp>
 #include <sycl/sycl.hpp>
-#include "cutlass/cutlass.h"
-#include "cutlass/detail/layout.hpp"
-#include "cutlass/epilogue/collective/collective_epilogue.hpp"
-#include "cutlass/epilogue/collective/detail.hpp"
-#include "cutlass/epilogue/dispatch_policy.hpp"
-#include "flash_attention_v2/collective/fmha_fusion.hpp"
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 namespace cutlass {

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_flash_attn_sdpa_fwd_mma.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_flash_attn_sdpa_fwd_mma.h
@@ -10,14 +10,14 @@
 
 #pragma once
 
-#include "cutlass/cutlass.h"
-#include "cutlass/fp8_to_fp16.h"
-#include "cutlass/gemm/dispatch_policy.hpp"
+#include <cutlass/cutlass.h>
+#include <cutlass/fp8_to_fp16.h>
+#include <cutlass/gemm/dispatch_policy.hpp>
 
-#include "cute/algorithm/functional.hpp"
-#include "cute/algorithm/gemm.hpp"
-#include "cute/atom/mma_atom.hpp"
-#include "flash_attention_v2/collective/fmha_fusion.hpp"
+#include <cute/algorithm/functional.hpp>
+#include <cute/algorithm/gemm.hpp>
+#include <cute/atom/mma_atom.hpp>
+#include <flash_attention_v2/collective/fmha_fusion.hpp>
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_flash_attn_sdpa_fwd_softmax_epilogue.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_flash_attn_sdpa_fwd_softmax_epilogue.h
@@ -10,12 +10,12 @@
 
 #pragma once
 
+#include <cutlass/cutlass.h>
+#include <cutlass/detail/layout.hpp>
+#include <cutlass/epilogue/collective/collective_epilogue.hpp>
+#include <cutlass/epilogue/collective/detail.hpp>
+#include <cutlass/epilogue/dispatch_policy.hpp>
 #include <sycl/sycl.hpp>
-#include "cutlass/cutlass.h"
-#include "cutlass/detail/layout.hpp"
-#include "cutlass/epilogue/collective/collective_epilogue.hpp"
-#include "cutlass/epilogue/collective/detail.hpp"
-#include "cutlass/epilogue/dispatch_policy.hpp"
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/kernel/tile_scheduler_sdpa_fwd.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/kernel/tile_scheduler_sdpa_fwd.h
@@ -10,9 +10,9 @@
 
 #pragma once
 
-#include "cutlass/cutlass.h"
-#include "cutlass/fast_math.h"
-#include "cutlass/kernel_hardware_info.h"
+#include <cutlass/cutlass.h>
+#include <cutlass/fast_math.h>
+#include <cutlass/kernel_hardware_info.h>
 
 namespace cutlass::flash_attention {
 

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/kernel/xe_sdpa_fwd.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/kernel/xe_sdpa_fwd.h
@@ -10,12 +10,12 @@
 
 #pragma once
 
-#include "cutlass/cutlass.h"
-#include "cutlass/gemm/dispatch_policy.hpp"
-#include "cutlass/gemm/gemm.h"
-#include "cutlass/kernel_hardware_info.hpp"
+#include <cutlass/cutlass.h>
+#include <cutlass/gemm/dispatch_policy.hpp>
+#include <cutlass/gemm/gemm.h>
+#include <cutlass/kernel_hardware_info.hpp>
 
-#include "../collective/xe_flash_attn_sdpa_fwd_mma.h"
+#include <sycltla/collective/xe_flash_attn_sdpa_fwd_mma.h>
 
 namespace cutlass::flash_attention::kernel {
 

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
@@ -13,7 +13,7 @@
 #include <cute/util/compat.hpp>
 #include <cutlass/numeric_conversion.h>
 #include <sycl/sycl.hpp>
-#include "mha_common.h"
+#include <sycltla/mha_common.h>
 
 namespace cute {
 template <

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.cpp
@@ -37,8 +37,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "mha_fwd.h"
-#include "mha_common.h"
+#include <sycltla/mha_common.h>
+#include <sycltla/mha_fwd.h>
 
 // batch, numhead_qo,numhead_kv,seqlen_qo,seqlen_kv,headsize_qk,headsize_vo
 using ProblemShapeRegular = cute::tuple<int, int, int, int, int, int, int>;

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.h
@@ -15,9 +15,9 @@
 #include <cutlass/util/packed_stride.hpp>
 #include <sycl/sycl.hpp>
 
-#include "collective/xe_flash_attn_sdpa_fwd_epilogue.h"
-#include "collective/xe_flash_attn_sdpa_fwd_mma.h"
-#include "collective/xe_flash_attn_sdpa_fwd_softmax_epilogue.h"
-#include "flash_attention_v2/collective/fmha_fusion.hpp"
-#include "kernel/tile_scheduler_sdpa_fwd.h"
-#include "kernel/xe_sdpa_fwd.h"
+#include <flash_attention_v2/collective/fmha_fusion.hpp>
+#include <sycltla/collective/xe_flash_attn_sdpa_fwd_epilogue.h>
+#include <sycltla/collective/xe_flash_attn_sdpa_fwd_mma.h>
+#include <sycltla/collective/xe_flash_attn_sdpa_fwd_softmax_epilogue.h>
+#include <sycltla/kernel/tile_scheduler_sdpa_fwd.h>
+#include <sycltla/kernel/xe_sdpa_fwd.h>

--- a/src/ATen/native/xpu/ReflectionPad.cpp
+++ b/src/ATen/native/xpu/ReflectionPad.cpp
@@ -14,6 +14,7 @@
 #include <ATen/native/Padding.h>
 #include <ATen/native/xpu/sycl/ReflectionPadKernels.h>
 
+#include <ATen/TensorMeta.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/reflection_pad1d_backward_native.h>
 #include <ATen/ops/reflection_pad1d_native.h>
@@ -22,7 +23,6 @@
 #include <ATen/ops/reflection_pad3d_backward_native.h>
 #include <ATen/ops/reflection_pad3d_native.h>
 #include <ATen/ops/zeros_like.h>
-#include "ATen/TensorMeta.h"
 
 namespace at {
 namespace native {

--- a/src/ATen/native/xpu/UpSampleLinear1d.cpp
+++ b/src/ATen/native/xpu/UpSampleLinear1d.cpp
@@ -12,8 +12,8 @@
 #include <ATen/native/xpu/UpSample.h>
 #include <ATen/native/xpu/sycl/UpSampleLinear1dKernels.h>
 
+#include <ATen/core/ATen_fwd.h>
 #include <comm/RegisterUtils.h>
-#include "ATen/core/ATen_fwd.h"
 
 #include <ATen/ops/upsample_linear1d_backward_native.h>
 #include <ATen/ops/upsample_linear1d_native.h>

--- a/src/ATen/native/xpu/sycl/UpSampleLinear1dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleLinear1dKernels.cpp
@@ -16,13 +16,13 @@
 
 #include <ATen/ATen.h>
 #include <ATen/AccumulateType.h>
+#include <ATen/Context.h>
 #include <ATen/Dispatch.h>
 #include <ATen/TensorUtils.h>
+#include <ATen/core/TensorBase.h>
 #include <ATen/native/xpu/UpSample.h>
 #include <ATen/native/xpu/sycl/Atomics.h>
 #include <comm/SYCLContext.h>
-#include "ATen/Context.h"
-#include "ATen/core/TensorBase.h"
 
 #include <ATen/native/xpu/sycl/UpSampleLinear1dKernels.h>
 

--- a/src/ATen/native/xpu/sycl/WeightNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/WeightNormKernels.cpp
@@ -12,10 +12,10 @@
 #include <ATen/core/Array.h>
 #include <ATen/native/xpu/sycl/BatchKernel.h>
 #include <ATen/native/xpu/sycl/Reduce.h>
+#include <comm/Runtime.h>
 #include <comm/SYCLContext.h>
 #include <comm/TensorInfo.h>
 #include <comm/TensorOptions.h>
-#include "comm/Runtime.h"
 
 #include <ATen/native/xpu/sycl/WeightNormKernels.h>
 

--- a/src/BuildOnLinux.cmake
+++ b/src/BuildOnLinux.cmake
@@ -88,6 +88,7 @@ if(USE_SYCLTLA)
     # Set Compile options for sycltla kernels
     target_compile_definitions(${sycl_lib} PRIVATE ${SYCLTLA_COMPILE_DEFINITIONS})
     target_include_directories(${sycl_lib} PRIVATE ${SYCLTLA_INCLUDE_DIRS})
+    target_include_directories(${sycl_lib} PRIVATE ${ATen_XPU_FLASH_ATTN_DIRS})
   endforeach()
 
   set(REPLACE_FLAGS_FOR_SYCLTLA FALSE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,10 @@ set(ATen_XPU_SYCLTLA_SRCS)
 set(ATen_XPU_XCCL_SRCS)
 
 set(ATen_XPU_INCLUDE_DIRS ${TORCH_XPU_OPS_ROOT}/src CACHE STRING "ATen XPU Include directory")
+set(ATen_XPU_FLASH_ATTN_DIRS
+  ${TORCH_XPU_OPS_ROOT}/src/ATen/native/transformers/xpu/flash_attn
+  CACHE STRING "ATen XPU Flash Attention directory"
+)
 
 add_subdirectory(ATen)
 if(USE_C10D_XCCL)


### PR DESCRIPTION
# Motivation
This PR aims to format the code and enable the **INCLUDE** lint check in our CI. Similar to CLANGFORMAT, INCLUDE check was never enabled correctly in our CI.
This PR also fixes the INCLUDE lint failures.