### PR TITLE
Skip device_check for hypot op

### DIFF
--- a/yaml/native/native_functions.yaml
+++ b/yaml/native/native_functions.yaml
@@ -4674,7 +4674,7 @@
   python_module: nn
 
 - func: hypot.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
-  device_check: NoCheck # TensorIterator
+  device_check: NoCheck   # TensorIterator
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
@@ -4682,13 +4682,13 @@
   tags: pointwise
 
 - func: hypot(Tensor self, Tensor other) -> Tensor
-  device_check: NoCheck # TensorIterator
+  device_check: NoCheck   # TensorIterator
   structured_delegate: hypot.out
   variants: method, function
   tags: pointwise
 
 - func: hypot_(Tensor(a!) self, Tensor other) -> Tensor(a!)
-  device_check: NoCheck # TensorIterator
+  device_check: NoCheck   # TensorIterator
   structured_delegate: hypot.out
   variants: method
   tags: pointwise


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/2740 and https://github.com/intel/torch-xpu-ops/issues/2634

Other backends have this check disabled. XPU didn't skip device_check which result in fails when hypot is called on 1 XPU input and 1 CPU scalar. This patch aligns XPU with other backends