### PR TITLE
Parse torch.device to drop card-ID suffix in comparison

### DIFF
--- a/test/xpu/test_nn_xpu.py
+++ b/test/xpu/test_nn_xpu.py
@@ -15006,7 +15006,7 @@ class TestNNDeviceType(NNTestCase):
             # (Issue is filed at https://github.com/pytorch/pytorch/issues/21875)
             mw[0][0] = 5
             self.assertTrue(mw[0][0].device.type == "cpu")
-            self.assertTrue(mw._base[0][0].device.type == device)
+            self.assertTrue(mw._base[0][0].device.type == torch.device(device).type)
 
         try:
             torch.__future__.set_overwrite_module_params_on_conversion(True)


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/2931

Regression was introduced when porting the test. Upstream has explicit `device.type == "cuda"` and after port it checks `device.type == device`. `device` from pytest parameter was `xpu:0`, leading to `xpu != xpu:0` comparison