### PR TITLE
Skip `test_upsamplingBiMode2d_consistency` on XPU

### DIFF
--- a/test/xpu/test_nn_xpu.py
+++ b/test/xpu/test_nn_xpu.py
@@ -13470,8 +13470,11 @@ class TestNNDeviceType(NNTestCase):
         batch_size,
     ):
         # Check output value consistency between resized_input_uint8 and resized input_float
-        if torch.device(device).type == "cuda":
-            raise SkipTest("CUDA implementation is not yet supporting uint8")
+        dev_type = torch.device(device).type
+        if dev_type in ("cuda", "xpu"):
+            raise SkipTest(
+                f"{dev_type.upper()} implementation is not yet supporting uint8"
+            )
 
         torch.manual_seed(0)
 


### PR DESCRIPTION
The bilinear and bicubic upsample kernels are not implemented for `ScalarType::Byte` (`torch.uint8`) on XPU. The same is true for CUDA. This commit updates the `test_upsamplingBiMode2d_consistency` test to be skipped both on CUDA and XPU devices.

Should fix:
- https://github.com/intel/torch-xpu-ops/issues/2830
- https://github.com/intel/torch-xpu-ops/issues/2831
- https://github.com/intel/torch-xpu-ops/issues/2832
- https://github.com/intel/torch-xpu-ops/issues/2833