### PR TITLE
addcmul | Early exit if inputs are on different devices (CPU and XPU)

### DIFF
--- a/src/ATen/native/xpu/sycl/PointwiseOpsKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PointwiseOpsKernels.cpp
@@ -47,18 +47,16 @@ struct AddcmulComplexFunctor {
 
 void addcmul_kernel(TensorIteratorBase& iter, const Scalar& value) {
   TORCH_CHECK(
-    !iter.is_cpu_scalar(1),
-    "CPU Scalar support for self argument is not supported when "
-    "calling addcmul on XPU tensors."
-  );
+      !iter.is_cpu_scalar(1),
+      "CPU Scalar support for self argument is not supported when "
+      "calling addcmul on XPU tensors.");
 
   TORCH_CHECK(
-    !iter.is_cpu_scalar(2),
-    "CPU Scalar support for tensor1 argument is not supported when "
-    "calling addcmul on XPU tensors. "
-    "However, CPU Scalar support for tensor2 is supported, "
-    "please swap your tensor1 and tensor2 terms."
-  );
+      !iter.is_cpu_scalar(2),
+      "CPU Scalar support for tensor1 argument is not supported when "
+      "calling addcmul on XPU tensors. "
+      "However, CPU Scalar support for tensor2 is supported, "
+      "please swap your tensor1 and tensor2 terms.");
 
   auto dtype = iter.common_dtype();
   if (at::isComplexType(dtype)) {


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/2515

This patch introduces early exit with user-friendly error message. Without this TORCH_CHECK, the functionality doesn't work anyway, but the error message is generic

```Python
RuntimeError: iter.device(arg).is_xpu() INTERNAL ASSERT FAILED
```
from kernel.