### PR TITLE
Skip `test_sync_warning` on XPU

### DIFF
--- a/test/xpu/test_torch_xpu.py
+++ b/test/xpu/test_torch_xpu.py
@@ -61,6 +61,7 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     largeTensorTest,
     onlyCPU,
+    onlyCUDA,
     onlyXPU,
     PYTORCH_CUDA_MEMCHECK,
     skipMeta,
@@ -2504,7 +2505,7 @@ else:
         result = original.scatter(0, null_index, null_arr)
         self.assertEqual(result, original, atol=0, rtol=0)
 
-    @onlyXPU
+    @onlyCUDA
     @skipIfTorchInductor("FIXME")
     def test_sync_warning(self, device):
         def _sync_raises_helper(f, level):


### PR DESCRIPTION
On XPU, there is no direct equivalent of CUDA's `sync_debug_mode`, whereas the `test_sync_warning` test utilizes this mechanism. Hence, this commit changes the test's `onlyXPU` dectorator back to `onlyCUDA`.

disable_distributed
disable_e2e