### PR TITLE
Increase tolerance for conv3d related functorch tests due to non-deterministic oneDNN behavior.

### DIFF
--- a/test/xpu/functorch/test_ops_xpu.py
+++ b/test/xpu/functorch/test_ops_xpu.py
@@ -524,6 +524,11 @@ class TestOperators(TestCase):
                 {torch.float32: tol(atol=3e-05, rtol=4e-06)},
                 device_type="cpu",
             ),
+            tol1(
+                "nn.functional.conv3d",
+                {torch.float32: tol(atol=5e-04, rtol=5e-04)},
+                device_type="xpu",
+            ),
         ),
     )
     def test_grad(self, device, dtype, op):
@@ -819,6 +824,11 @@ class TestOperators(TestCase):
             tol1("linalg.multi_dot", {torch.float32: tol(atol=1e-04, rtol=1e-04)}),
             tol1("svd_lowrank", {torch.float32: tol(atol=1e-04, rtol=1e-04)}),
             tol1("pca_lowrank", {torch.float32: tol(atol=1e-04, rtol=1e-04)}),
+            tol1(
+                "nn.functional.conv3d",
+                {torch.float32: tol(atol=5e-04, rtol=5e-04)},
+                device_type="xpu",
+            ),
         ),
     )
     def test_vjp(self, device, dtype, op):
@@ -1859,6 +1869,11 @@ class TestOperators(TestCase):
             ),
             tol2(
                 "linalg.pinv", "hermitian", {torch.float32: tol(atol=5e-03, rtol=5e-03)}
+            ),
+            tol1(
+                "nn.functional.conv3d",
+                {torch.float32: tol(atol=5e-04, rtol=5e-04)},
+                device_type="xpu",
             ),
         ),
     )


### PR DESCRIPTION
Is part of the solution for #2238 

This PR fixes 3 test cases:
> op_ut,third_party.torch-xpu-ops.test.xpu.functorch.test_ops_xpu.TestOperatorsXPU,test_vjp_nn_functional_conv3d_xpu_float32
op_ut,third_party.torch-xpu-ops.test.xpu.functorch.test_ops_xpu.TestOperatorsXPU,test_grad_nn_functional_conv3d_xpu_float32
op_ut,third_party.torch-xpu-ops.test.xpu.functorch.test_ops_xpu.TestOperatorsXPU,test_jvpvjp_nn_functional_conv3d_xpu_float32

### Root cause

Mentioned tests compare the functorch features with reference computation.
They take different code paths, but all use the oneDNN kernel for conv3d computation.
The problem is that oneDNN convolution kernels are not deterministic, so consecutive launches of the same kernel with same input values can create different results.
As conv3d is prone to accumulation precision loss, it is expected that the results are produced with precision around `1e-5` for single pass. When propagated, the precision loss can be bigger (double gradient).

If conv3d was deterministic, then we would have identical results, but it isn't, as we compare the XPU computation to different path XPU computation, not to CPU results.
The confirmation of this hypothesis was achieved by enforcing the deterministic oneDNN convolution behavior.
For tests I changed the fragment [CODE FRAGMENT](https://github.com/BBBela/pytorch/blob/bc3016d9d44d51abbd4456d572517455a843d68b/aten/src/ATen/native/mkldnn/xpu/detail/Conv.cpp#L207-L212):
```cpp
#if ONEDNN_SUPPORT_DETERMINISTIC
  if (at::globalContext().deterministicAlgorithms() ||
      at::globalContext().deterministicMkldnn()) {
    pattr.set_deterministic(true);
  }
#endif
```

to

```cpp
#if ONEDNN_SUPPORT_DETERMINISTIC
  pattr.set_deterministic(true);
#endif
```

thus enforcing determinism.

With those changes, the results were identical. That proved me that it is not some bug issue, but the result of non-deterministic results for the same input values.

### Solutions

So the first solution would be to make the oneDNN convolution kernel deterministic, but that can affect performance - due to [DOCUMENTATION](https://www.intel.com/content/www/us/en/docs/onednn/developer-guide-reference/2024-1/primitive-attributes-deterministic.html)
The second solution, which I propose, is to make the tolerances less strict.