### PR TITLE
Refine XPU coverage for matmul_mv float32 large-shape path

### DIFF
--- a/test/xpu/test_linalg_xpu.py
+++ b/test/xpu/test_linalg_xpu.py
@@ -107,7 +107,7 @@ def matmul_45724(self, device):
 
 @dtypes(torch.float)
 def matmul_mv_xpu(self, device, dtype):
-    n = 50_000
+    n = 32_769
     A = torch.ones(n, n, dtype=dtype, device=device)
     B = torch.randn(n, dtype=dtype, device=device)
     C = torch.matmul(A, B)


### PR DESCRIPTION
Fixes:
https://github.com/intel/torch-xpu-ops/issues/1973
test_matmul_mv_xpu_float32

This PR refines XPU test coverage for the matmul_mv float32 large-shape scenario by enabling stable execution in the XPU test suite while keeping upstream [test_linalg](vscode-file://vscode-app/c:/Users/gplutopx/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) coverage intact.