### PR TITLE
Add large tensor tests marker for zeros and ones creation

### DIFF
--- a/test/xpu/test_tensor_creation_ops_xpu.py
+++ b/test/xpu/test_tensor_creation_ops_xpu.py
@@ -4386,10 +4386,18 @@ class TestLikeTensorCreation(TestCase):
         )
 
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
+    @largeTensorTest(
+        lambda self, device, dtype: (2**31 - 1)
+        * torch.tensor([], dtype=dtype).element_size()
+    )
     def test_zeros_large(self, device, dtype):
         output = torch.zeros(2**31 - 1, device=device, dtype=dtype)
 
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
+    @largeTensorTest(
+        lambda self, device, dtype: (2**31 - 1)
+        * torch.tensor([], dtype=dtype).element_size()
+    )
     def test_ones_large(self, device, dtype):
         output = torch.ones(2**31 - 1, device=device, dtype=dtype)
 


### PR DESCRIPTION
The test tries to allocate 2^31 - 1 elements of complex128 (16 bytes each) = ~32 GiB, exceeding the XPU capacity. The fix is to skip dtypes that would exceed device memory. Since complex128 is 16 bytes and complex64 is 8 bytes, the large dtypes push past the limit. The test now correctly skips instead of failing with OOM. The fix adds @largeTensorTest with a callable that computes the exact memory needed ((2^31 - 1) * element_size) per dtype. On environments with memory <32GB, complex128 (16 bytes/element → 32 GiB) is skipped, while smaller dtypes that fit in memory will still run.