### PR TITLE
[CI] Use secret PAT for the final merge step

### DIFF
--- a/.github/workflows/auto_merge_by_comment.yml
+++ b/.github/workflows/auto_merge_by_comment.yml
@@ -160,6 +160,7 @@ jobs:
         env:
           FORCE_MERGE: ${{ startsWith(github.event.comment.body, '/merge -f') }}
         with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
           script: |
             const prNumber = ${{ steps.prinfo.outputs.pr_number }};
             const forceMerge = process.env.FORCE_MERGE === 'true';


### PR DESCRIPTION
Updates the auto-merge workflow to authenticate the merge script step using a repository secret PAT instead of the default workflow token.

disable_all