### PR TITLE
Add tests that fails also on cuda to skip common list

### DIFF
--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -34,6 +34,9 @@ skip_dict = {
         # AssertionError:
         # Not equal to tolerance rtol=1e-06, atol=1e-06
         "test_forward_per_channel_xpu",
+        # AssertionError:
+        # Not equal to tolerance rtol=1e-06, atol=1e-06
+        "test_forward_per_tensor_xpu",
         # AssertionError: False is not true : Expected kernel forward function to have results match the reference forward function
         "test_learnable_forward_per_channel_cpu_xpu",
     ),


### PR DESCRIPTION
Tests from issue #2188 test_add_scalar_relu_xpu, test_cat_nhwc_xpu, test_forward_per_channel_xpu, test_forward_per_tensor_xpu, test_learnable_forward_per_channel_cpu_xpu fails also on cuda in pytorch CI: https://github.com/pytorch/pytorch/actions/workflows/quantization-periodic.yml