### PR TITLE
Using `2^(y * log2(x))` instead of `pow` achieves higher precision

### DIFF
--- a/src/ATen/native/xpu/sycl/PowKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PowKernels.cpp
@@ -17,12 +17,6 @@
 #include <ATen/native/xpu/sycl/UnaryKernels.h>
 
 #include <ATen/native/xpu/sycl/PowKernels.h>
-#if __has_include(<sycl/ext/intel/math.hpp>)
-#include <sycl/ext/intel/math.hpp>
-#define TORCH_XPU_HAS_INTEL_MATH 1
-#else
-#define TORCH_XPU_HAS_INTEL_MATH 0
-#endif
 
 namespace at {
 namespace native {
@@ -46,12 +40,8 @@ static inline Base_type pow_(Base_type base, Exp_type exp) {
     using base_opmath_t = at::opmath_type<Base_type>;
     using exp_opmath_t = at::opmath_type<Exp_type>;
     using opmath_t = std::common_type_t<base_opmath_t, exp_opmath_t>;
-#if defined(__SYCL_DEVICE_ONLY__) && TORCH_XPU_HAS_INTEL_MATH
-    return static_cast<Base_type>(sycl::ext::intel::math::ha::exp2(
-        static_cast<opmath_t>(exp) * sycl::log2(static_cast<opmath_t>(base))));
-#else
-    return std::pow(base, exp);
-#endif
+    return static_cast<Base_type>(std::exp2(
+        static_cast<opmath_t>(exp) * std::log2(static_cast<opmath_t>(base))));
   }
 }
 


### PR DESCRIPTION
According to driver team comments "because GPUs usually don't support x^y natively, but only 2^y—so it must be calculated with 2^(y*log2( x ))." And sglang team also report RotaryEmbedding accuracy gap caused by `pow`, Add exp implement here.