### PR TITLE
Fix linter errors and adjust code to linter requirements.

### DIFF
--- a/test/xpu/functorch/test_ops_xpu.py
+++ b/test/xpu/functorch/test_ops_xpu.py
@@ -927,12 +927,6 @@ class TestOperators(TestCase):
             tol1("masked.cumprod", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
             tol1("cumprod", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
             tol1("linalg.vander", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
-            tol2(
-                "index_reduce",
-                "prod",
-                {torch.float32: tol(atol=5e-05, rtol=5e-05)},
-                device_type="xpu",
-            ),
         ),
     )
     def test_vjpvjp(self, device, dtype, op):


### PR DESCRIPTION
This change is not functional, only fixing linter errors regarding coding style.

The problem is that between running the whole CI on my last commit [LAST COMMIT](https://github.com/intel/torch-xpu-ops/commit/0fd825adcb6090e06989e192e4718785060df905) and merging it, there must have been change in the linter requirements and settings, so it now detects things it hasn't so far.
