### PR TITLE
Skip `test_upsamplingBiLinear2d_consistency_interp_size_bug` on XPU

### DIFF
--- a/test/xpu/test_nn_xpu.py
+++ b/test/xpu/test_nn_xpu.py
@@ -13561,9 +13561,11 @@ class TestNNDeviceType(NNTestCase):
         self, device, memory_format, align_corners, input_size, output_size
     ):
         # Non-regression test for https://github.com/pytorch/pytorch/pull/101403
-
-        if torch.device(device).type in ("cuda", "xpu"):
-            raise SkipTest("CUDA implementation is not yet supporting uint8")
+        dev_type = torch.device(device).type
+        if dev_type in ("cuda", "xpu"):
+            raise SkipTest(
+                f"{dev_type.upper()} implementation is not yet supporting uint8"
+            )
 
         mode = "bilinear"
         input_ui8 = torch.randint(


### PR DESCRIPTION
This pull request makes a minor update to the test suite for PyTorch's neural network module on XPU devices. The change ensures that the test for bilinear upsampling skips both CUDA and XPU devices when uint8 is not supported, improving test consistency for device-specific limitations.
Fix https://github.com/intel/torch-xpu-ops/issues/2833