### PR TITLE
Fix device string format mismatch for XPU InstanceNorm tests

### DIFF
--- a/test/xpu/test_modules_xpu.py
+++ b/test/xpu/test_modules_xpu.py
@@ -174,7 +174,7 @@ def _test_to(self, device, dtype, module_info, training, swap, set_grad):
             # reset
             m.to(dtype=torch.float32)
 
-        prev_device, prev_dtype = device, dtype
+        prev_device, prev_dtype = torch.device(device).type, dtype
         for device_, dtype_ in product(devices, dtypes):
             # if device/dtype do not change, grad.to(device, dtype) is a no-op so
             # swapping will not change ._cdata


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/3116

## Bug description
The _test_to function computes a g_no_swap flag to decide whether gradient _cdata values should remain unchanged (no-op conversion) or differ (actual swap). It does so by comparing prev_device against the current iteration's device. However, prev_device is initialized from the device parameter provided by the test framework, which is a fully-qualified string like 'xpu:0' (with device index), while the iteration devices list contains bare type strings like 'xpu' (without index). The comparison 'xpu' == 'xpu:0' evaluates to False, so on the first iteration g_no_swap is incorrectly False even though the conversion is a no-op. The test then asserts that gradient _cdata values must have changed, but since nothing actually changed, the assert fails.

## The fix
Normalize prev_device to the bare device type string at initialization by wrapping it with torch.device(...).type, so it uses the same format as the devices list entries. This makes the first-iteration comparison correctly evaluate to True.

## Why this bug was not visible before
Before commit 9219f70 (https://github.com/pytorch/pytorch/pull/176573), all InstanceNorm test inputs in common_modules.py used the default affine=False, meaning the modules had zero learnable parameters. When the parameter list is empty, every all(...) assertion in the swap-checking block trivially evaluates to True — the faulty g_no_swap logic was never exercised. The commit added new InstanceNorm test cases with affine=True, giving the module actual weight and bias parameters. With a non-empty parameter list, the gradient _cdata comparisons are finally evaluated for real, exposing the latent device string format mismatch.