### PR TITLE
Remove deprecated expectedFailurePropagateRealTensors decorator from FakeTensorOperatorInvariants test

### DIFF
--- a/test/xpu/test_fake_tensor_xpu.py
+++ b/test/xpu/test_fake_tensor_xpu.py
@@ -1722,8 +1722,6 @@ class FakeTensorOperatorInvariants(TestCase):
 
         self.assertEqual(mode.count, 0)
 
-    # PropagateRealTensors installs weakrefs
-    @expectedFailurePropagateRealTensors
     @unittest.skipIf(not RUN_GPU, "requires cuda or xpu")
     def test_module_to(self):
         def _check_device(sd, device_type):


### PR DESCRIPTION
Depends on https://github.com/pytorch/pytorch/pull/178584
Fixes https://github.com/intel/torch-xpu-ops/issues/2712 together with the corresponding change to PyTorch

### Summary

Fixes `RuntimeError: Cannot swap t2 because it has weakref associated with it` in `FakeTensorOperatorInvariants.test_module_to` when running on XPU. The error occurs when calling `Module.to()` under `FakeTensorMode` because `swap_tensors` fails due to weakrefs held on the applied parameter tensor.

The upstream fix is tracked in https://github.com/pytorch/pytorch/pull/171856.

### Changes

- Updated `test/xpu/test_fake_tensor_xpu.py` to align with the upstream PyTorch test changes that make `test_module_to` and related FakeTensor tests device-generic (supporting both CUDA and XPU).