### PR TITLE
Align dtype between mvec and avec in test_addmv

### DIFF
--- a/test/xpu/test_sparse_csr_xpu.py
+++ b/test/xpu/test_sparse_csr_xpu.py
@@ -2531,7 +2531,7 @@ class TestSparseCSR(TestCase):
         mat[mat.real < 0] = 0
         sparse_mat = mat.to_sparse_csr()
         mvec = torch.randn((mat.size(1),), dtype=dtype, device=device)
-        avec = torch.randn((mat.size(0),), dtype=torch.float64, device=device)
+        avec = torch.randn((mat.size(0),), dtype=dtype, device=device)
         ref_output = torch.addmv(avec, mat, mvec)
         output = torch.addmv(avec, sparse_mat, mvec)
         self.assertEqual(ref_output, output)


### PR DESCRIPTION
Part of the https://github.com/intel/torch-xpu-ops/issues/2897 issue. Dtype aligned for torch.addmv according to change in pytorch: https://github.com/pytorch/pytorch/pull/165777