### PR TITLE
[windowsCI] Remove hardcoded MKL pin from CI requirements to avoid conflicts with Torch XPU wheel

### DIFF
--- a/.github/workflows/_windows_ut.yml
+++ b/.github/workflows/_windows_ut.yml
@@ -214,7 +214,7 @@ jobs:
           )
           echo "[INFO] the torch version is %TORCH_WHL%"
           python -m pip install %TORCH_WHL%
-          REM Remove mkl hardcode installation to avoid potential conflicts with torch xpu wheel (PowerShell)
+          REM Remove hardcoded MKL installation to avoid potential conflicts with Torch XPU wheel (PowerShell)
           powershell -Command "(Get-Content '.ci\docker\requirements-ci.txt') | Where-Object { $_ -notmatch 'mkl' } | Set-Content '.ci\docker\requirements-ci.txt'"
           pip install -r .ci\docker\requirements-ci.txt
       - name: Torch Config


### PR DESCRIPTION
Remove the hardcoded MKL installation line from the Windows CI workflow so that the CI does not force-install MKL versions that can conflict with the locally-built Torch XPU wheel.

The change updates the Windows workflow file to remove lines mentioning mkl from the requirements before installing them.

Changed file:
`torch-xpu-ops/.github/workflows/_windows_ut.yml`

**Related PR:**
#3118 
#3245 