### PR TITLE
[CI]Fix summary issue

### DIFF
--- a/.github/scripts/check-ut.py
+++ b/.github/scripts/check-ut.py
@@ -42,13 +42,20 @@ error_types = [
     "NotImplementedError",
 ]
 
+def _normalize_text(value):
+    if not value:
+        return ''
+    return ' '.join(str(value).split())
+
 def get_classname(case):
-    return ' '.join(case.classname.split()) if hasattr(case, 'classname') else case.get('classname', '')
+    if isinstance(case, dict):
+        return _normalize_text(case.get('classname', ''))
+    return _normalize_text(getattr(case, 'classname', ''))
 
 def get_name(case):
     if isinstance(case, dict):
-        return case.get('name', '')
-    return ' '.join(case.name.split())
+        return _normalize_text(case.get('name', ''))
+    return _normalize_text(getattr(case, 'name', ''))
 
 def get_category_from_case(case):
     if isinstance(case, dict):
@@ -105,7 +112,13 @@ def get_message(case):
                 indent_level = 0
                 break
 
-    return " ; ".join(error_messages) if error_messages else f"{case.result[0].message.splitlines()[0]}"
+    if error_messages:
+        return " ; ".join(error_messages)
+
+    message = getattr(case.result[0], 'message', '') or ''
+    if message:
+        return message.splitlines()[0]
+    return ""
 
 def print_md_row(row, print_header=False, failure_list=None):
     if print_header:


### PR DESCRIPTION
```
2026-03-30T16:56:12.6944738Z + python ./.github/scripts/check-ut.py -n op_ut -i /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.complex_tensor.test_complex_tensor_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.export.test_export_opinfo_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.export.test_hop_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.functorch.test_aotdispatch_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.functorch.test_control_flow_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.functorch.test_eager_transforms_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.functorch.test_ops_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.functorch.test_vmap_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.nn.test_convolution_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.nn.test_dropout_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.nn.test_embedding_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.nn.test_init_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.nn.test_lazy_modules_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.nn.test_load_state_dict_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.nn.test_module_hooks_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.nn.test_multihead_attention_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.nn.test_packed_sequence_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.nn.test_parametrization_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.nn.test_pooling_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.nn.test_pruning_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.profiler.test_memory_profiler.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.quantization.core.test_quantized_op_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.quantization.core.test_quantized_tensor_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.quantization.core.test_workflow_module_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.quantization.core.test_workflow_ops_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test.xpu.dynamo.test_ctx_manager_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_autocast_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_autograd_fallback_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_autograd_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_comparison_utils_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_complex_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_content_store_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_cpp_api_parity_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_dataloader_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_decomp_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_distributions_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_dynamic_shapes_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_expanded_weights_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_fake_tensor_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_indexing_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_masked_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_maskedtensor_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_matmul_cuda_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_modules_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_namedtensor_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_native_functions_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_native_mha_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_nestedtensor_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_nn_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_ops_fwd_gradients_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_ops_gradients_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_optim_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_reductions_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_scatter_gather_ops_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_schema_check.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_segment_reductions_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_shape_ops_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_sort_and_select_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_sparse_csr_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_sparse_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_spectral_ops_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_tensor_creation_ops_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_transformers_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_type_promotion_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_unary_ufuncs_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_all.test_view_ops_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_skip.test_binary_ufuncs_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_skip.test_foreach_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_skip.test_linalg_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_skip.test_meta_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_skip.test_ops_xpu.xml /home/jenkins/actions-runner/_work/torch-xpu-ops/torch-xpu-ops/ut_log/op_ut_with_skip.test_torch_xpu.xml
2026-03-30T16:56:15.5879229Z Traceback (most recent call last):
2026-03-30T16:56:15.5879734Z   File "/__w/torch-xpu-ops/torch-xpu-ops/./.github/scripts/check-ut.py", line 387, in <module>
2026-03-30T16:56:15.5880313Z     main()
2026-03-30T16:56:15.5880599Z   File "/__w/torch-xpu-ops/torch-xpu-ops/./.github/scripts/check-ut.py", line 381, in main
2026-03-30T16:56:15.5880907Z     generate_passed_log()
2026-03-30T16:56:15.5881242Z   File "/__w/torch-xpu-ops/torch-xpu-ops/./.github/scripts/check-ut.py", line 312, in generate_passed_log
2026-03-30T16:56:15.5881580Z     class_name = get_classname(case)
2026-03-30T16:56:15.5881901Z   File "/__w/torch-xpu-ops/torch-xpu-ops/./.github/scripts/check-ut.py", line 46, in get_classname
2026-03-30T16:56:15.5882336Z     return ' '.join(case.classname.split()) if hasattr(case, 'classname') else case.get('classname', '')
2026-03-30T16:56:15.5882716Z AttributeError: 'NoneType' object has no attribute 'split'
```