### PR TITLE
Decompose dot_xpu_mkl into mul and sum in non oneMKL path

### DIFF
--- a/src/ATen/native/xpu/Blas.cpp
+++ b/src/ATen/native/xpu/Blas.cpp
@@ -450,9 +450,6 @@ Tensor dot_xpu(const Tensor& self, const Tensor& other) {
   }
 
 #if defined(USE_ONEMKL_XPU)
-  if (self.scalar_type() == at::ScalarType::Long) {
-    return at::mul(self, other).sum();
-  }
   return at::native::xpu::dot_xpu_mkl(self, other);
 #else
   return at::mul(self, other).sum();

--- a/test/xpu/xpu_test_utils.py
+++ b/test/xpu/xpu_test_utils.py
@@ -334,9 +334,6 @@ _ops_without_cuda_support = [
 ]
 
 _ops_dtype_different_cuda_support = {
-    "dot": {"forward": {torch.int64}},
-    "inner": {"forward": {torch.int64}},
-    "vdot": {"forward": {torch.int64}},
     "histc": {"forward": {torch.bfloat16, torch.float16}},
     "stft": {"forward": {torch.float16}, "backward": {torch.float16}},
 }


### PR DESCRIPTION
If oneMKL is not available, replace CPU fallback with `dot` to `mul`+`sum` decomposition to avoid unnecessary data copies between devices.
