### PR TITLE
Migrate trigonometric and related math functions from std:: to sycl:: namespace

### DIFF
--- a/src/ATen/native/xpu/sycl/ActivationMishKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ActivationMishKernels.cpp
@@ -27,7 +27,7 @@ struct MishFunctor {
   scalar_t operator()(scalar_t x) const {
     using opmath_t = at::opmath_type<scalar_t>;
     const opmath_t x_acc = static_cast<opmath_t>(x);
-    return x_acc * std::tanh(std::log1p(std::exp(x_acc)));
+    return x_acc * sycl::tanh(std::log1p(std::exp(x_acc)));
   }
 };
 
@@ -47,7 +47,7 @@ struct MishBackwardFunctor {
     const opmath_t dy_acc = static_cast<opmath_t>(dy);
     const opmath_t x_acc = static_cast<opmath_t>(x);
     const opmath_t s_acc = opmath_t(1) / (opmath_t(1) + std::exp(-x_acc));
-    const opmath_t t_acc = std::tanh(std::log1p(std::exp(x_acc)));
+    const opmath_t t_acc = sycl::tanh(std::log1p(std::exp(x_acc)));
     return dy_acc * (t_acc + x_acc * s_acc * (opmath_t(1) - t_acc * t_acc));
   }
 };

--- a/src/ATen/native/xpu/sycl/BinaryGeometricKernels.cpp
+++ b/src/ATen/native/xpu/sycl/BinaryGeometricKernels.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <ATen/Dispatch.h>
+#include <ATen/OpMathType.h>
 #include <ATen/native/TensorIterator.h>
 #include <comm/xpu_aten.h>
 
@@ -23,7 +24,8 @@ namespace xpu {
 template <typename scalar_t>
 struct Atan2Functor {
   scalar_t operator()(scalar_t a, scalar_t b) const {
-    return std::atan2(a, b);
+    using opmath_t = at::opmath_type<scalar_t>;
+    return sycl::atan2(static_cast<opmath_t>(a), static_cast<opmath_t>(b));
   }
 };
 
@@ -39,7 +41,8 @@ void atan2_kernel(TensorIteratorBase& iter) {
 template <typename scalar_t>
 struct HypotFunctor {
   scalar_t operator()(scalar_t a, scalar_t b) const {
-    return std::hypot(a, b);
+    using opmath_t = at::opmath_type<scalar_t>;
+    return sycl::hypot(static_cast<opmath_t>(a), static_cast<opmath_t>(b));
   }
 };
 

--- a/src/ATen/native/xpu/sycl/ComplexKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ComplexKernels.cpp
@@ -36,7 +36,7 @@ void complex_kernel(TensorIterator& iter) {
 template <typename scalar_t>
 struct PolarFunctor {
   c10::complex<scalar_t> operator()(scalar_t a, scalar_t b) const {
-    return c10::complex<scalar_t>(a * std::cos(b), a * std::sin(b));
+    return c10::complex<scalar_t>(a * sycl::cos(b), a * sycl::sin(b));
   }
 };
 

--- a/src/ATen/native/xpu/sycl/RNNKernels.cpp
+++ b/src/ATen/native/xpu/sycl/RNNKernels.cpp
@@ -167,11 +167,11 @@ struct LstmCellForwardFunctor {
 
       ig = sigmoid(H2F(iig) + H2F(hig) + H2F(b1i) + H2F(b2i));
       fg = sigmoid(H2F(ifg) + H2F(hfg) + H2F(b1f) + H2F(b2f));
-      cg = std::tanh(H2F(icg) + H2F(hcg) + H2F(b1c) + H2F(b2c));
+      cg = sycl::tanh(H2F(icg) + H2F(hcg) + H2F(b1c) + H2F(b2c));
       og = sigmoid(H2F(iog) + H2F(hog) + H2F(b1o) + H2F(b2o));
 
       f_cy = (fg * H2F(cx)) + (ig * cg);
-      f_hy = og * std::tanh(f_cy);
+      f_hy = og * sycl::tanh(f_cy);
 
       *hy = F2H(f_hy);
       *cy = F2H(f_cy);
@@ -258,7 +258,7 @@ struct LstmCellBackwardFunctor {
           ? H2F(DEVICE_LINEAR_GET(gradoutputcell_, linearIndex))
           : 0.f;
 
-      accscalar_t gcx = std::tanh(H2F(cy));
+      accscalar_t gcx = sycl::tanh(H2F(cy));
 
       accscalar_t gog = go * gcx;
       gcx = go * H2F(og) * (1 - gcx * gcx) + goc;
@@ -366,7 +366,7 @@ struct GruCellForwardFunctor {
       ig = sigmoid<accscalar_t>(H2F(ii) + H2F(hi) + H2F(b1i) + H2F(b2i));
 
       ng = H2F(in) + H2F(b1n) + rg * (H2F(hn) + H2F(b2n));
-      ng = std::tanh(ng);
+      ng = sycl::tanh(ng);
       *hy = F2H(ng + ig * (H2F(hx) - ng));
 
       // SAVE FOR BACKWARDS

--- a/src/ATen/native/xpu/sycl/UnaryGeometricAcosKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricAcosKernel.cpp
@@ -9,16 +9,21 @@
  */
 
 #include <ATen/Dispatch.h>
+#include <ATen/OpMathType.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/xpu/sycl/Loops.h>
 
 #include <ATen/native/xpu/sycl/UnaryGeometricAcosKernel.h>
 
 namespace at::native::xpu {
-template <typename scalar_t, typename acc_t = scalar_t>
+template <typename scalar_t, typename acc_t = at::opmath_type<scalar_t>>
 struct AcosFunctor {
   scalar_t operator()(scalar_t a) const {
-    return std::acos(static_cast<acc_t>(a));
+    if constexpr (c10::is_complex<acc_t>::value) {
+      return std::acos(static_cast<acc_t>(a));
+    } else {
+      return sycl::acos(static_cast<acc_t>(a));
+    }
   }
 };
 

--- a/src/ATen/native/xpu/sycl/UnaryGeometricAcoshKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricAcoshKernel.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <ATen/Dispatch.h>
+#include <ATen/OpMathType.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/xpu/sycl/Loops.h>
 
@@ -16,10 +17,14 @@
 
 namespace at::native::xpu {
 
-template <typename scalar_t, typename acc_t = scalar_t>
+template <typename scalar_t, typename acc_t = at::opmath_type<scalar_t>>
 struct AcoshFunctor {
   scalar_t operator()(scalar_t a) const {
-    return std::acosh(static_cast<acc_t>(a));
+    if constexpr (c10::is_complex<acc_t>::value) {
+      return std::acosh(static_cast<acc_t>(a));
+    } else {
+      return sycl::acosh(static_cast<acc_t>(a));
+    }
   }
 };
 

--- a/src/ATen/native/xpu/sycl/UnaryGeometricAsinKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricAsinKernel.cpp
@@ -28,7 +28,8 @@ struct AsinComplexFunctor {
 template <typename scalar_t>
 struct AsinFunctor {
   scalar_t operator()(const scalar_t a) const {
-    return std::asin(a);
+    using opmath_t = at::opmath_type<scalar_t>;
+    return sycl::asin(static_cast<opmath_t>(a));
   }
 };
 

--- a/src/ATen/native/xpu/sycl/UnaryGeometricAsinhKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricAsinhKernel.cpp
@@ -28,7 +28,8 @@ struct AsinhComplexFunctor {
 template <typename scalar_t>
 struct AsinhFunctor {
   scalar_t operator()(const scalar_t a) const {
-    return std::asinh(a);
+    using opmath_t = at::opmath_type<scalar_t>;
+    return sycl::asinh(static_cast<opmath_t>(a));
   }
 };
 

--- a/src/ATen/native/xpu/sycl/UnaryGeometricAtanKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricAtanKernel.cpp
@@ -28,7 +28,12 @@ struct AtanComplexFunctor {
 template <typename scalar_t>
 struct AtanFunctor {
   scalar_t operator()(const scalar_t a) const {
-    return std::atan(a);
+    if constexpr (c10::is_complex<scalar_t>::value) {
+      return std::atan(a);
+    } else {
+      using opmath_t = at::opmath_type<scalar_t>;
+      return sycl::atan(static_cast<opmath_t>(a));
+    }
   }
 };
 

--- a/src/ATen/native/xpu/sycl/UnaryGeometricAtanhKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricAtanhKernel.cpp
@@ -28,7 +28,12 @@ struct AtanhComplexFunctor {
 template <typename scalar_t>
 struct AtanhFunctor {
   scalar_t operator()(const scalar_t a) const {
-    return std::atanh(a);
+    if constexpr (c10::is_complex<scalar_t>::value) {
+      return std::atanh(a);
+    } else {
+      using opmath_t = at::opmath_type<scalar_t>;
+      return sycl::atanh(static_cast<opmath_t>(a));
+    }
   }
 };
 

--- a/src/ATen/native/xpu/sycl/UnaryGeometricCosKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricCosKernel.cpp
@@ -22,7 +22,12 @@ namespace at::native::xpu {
 template <typename scalar_t>
 struct CosFunctor {
   scalar_t operator()(const scalar_t a) const {
-    return std::cos(a);
+    if constexpr (c10::is_complex<scalar_t>::value) {
+      return std::cos(a);
+    } else {
+      using opmath_t = at::opmath_type<scalar_t>;
+      return sycl::cos(static_cast<opmath_t>(a));
+    }
   }
 };
 

--- a/src/ATen/native/xpu/sycl/UnaryGeometricCoshKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricCoshKernel.cpp
@@ -28,7 +28,8 @@ struct CoshComplexFunctor {
 template <typename scalar_t>
 struct CoshFunctor {
   scalar_t operator()(scalar_t a) const {
-    return std::cosh(a);
+    using opmath_t = at::opmath_type<scalar_t>;
+    return sycl::cosh(static_cast<opmath_t>(a));
   }
 };
 

--- a/src/ATen/native/xpu/sycl/UnaryGeometricSinKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricSinKernel.cpp
@@ -22,7 +22,12 @@ namespace at::native::xpu {
 template <typename scalar_t>
 struct SinFunctor {
   scalar_t operator()(const scalar_t a) const {
-    return std::sin(a);
+    if constexpr (c10::is_complex<scalar_t>::value) {
+      return std::sin(a);
+    } else {
+      using opmath_t = at::opmath_type<scalar_t>;
+      return sycl::sin(static_cast<opmath_t>(a));
+    }
   }
 };
 

--- a/src/ATen/native/xpu/sycl/UnaryGeometricSinhKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricSinhKernel.cpp
@@ -28,7 +28,8 @@ struct SinhComplexFunctor {
 template <typename scalar_t>
 struct SinhFunctor {
   scalar_t operator()(scalar_t a) const {
-    return std::sinh(a);
+    using opmath_t = at::opmath_type<scalar_t>;
+    return sycl::sinh(static_cast<opmath_t>(a));
   }
 };
 

--- a/src/ATen/native/xpu/sycl/UnaryGeometricTanKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricTanKernel.cpp
@@ -28,7 +28,8 @@ struct TanComplexFunctor {
 template <typename scalar_t>
 struct TanFunctor {
   scalar_t operator()(scalar_t a) const {
-    return std::tan(a);
+    using opmath_t = at::opmath_type<scalar_t>;
+    return sycl::tan(static_cast<opmath_t>(a));
   }
 };
 

--- a/src/ATen/native/xpu/sycl/UnaryGeometricTanhKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricTanhKernel.cpp
@@ -23,7 +23,11 @@ template <typename scalar_t>
 struct TanhFunctor {
   scalar_t operator()(scalar_t a) const {
     using opmath_t = at::opmath_type<scalar_t>;
-    return std::tanh(static_cast<opmath_t>(a));
+    if constexpr (c10::is_complex<opmath_t>::value) {
+      return std::tanh(static_cast<opmath_t>(a));
+    } else {
+      return sycl::tanh(static_cast<opmath_t>(a));
+    }
   }
 };
 

--- a/src/ATen/native/xpu/sycl/UnarySpecialOpsKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UnarySpecialOpsKernels.cpp
@@ -323,7 +323,11 @@ struct SincFunctor {
     } else {
       using opmath_t = at::opmath_type<scalar_t>;
       opmath_t product = c10::detail::pi<opmath_t>() * opmath_t{a};
-      return static_cast<scalar_t>(std::sin(product) / product);
+      if constexpr (c10::is_complex<opmath_t>::value) {
+        return static_cast<scalar_t>(std::sin(product) / product);
+      } else {
+        return static_cast<scalar_t>(sycl::sin(product) / product);
+      }
     }
   }
 };


### PR DESCRIPTION
> **Note**: This PR was authored with the assistance of AI (Claude).

## Summary

Migrate 17 kernel files to use `sycl::` math functions instead of `std::` for trigonometric and related operations. This is part of the broader effort to align XPU kernels with SYCL-native math builtins (#3266).

### Functions migrated
- **Unary trig**: sin, cos, tan, asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh
- **Binary geometric**: atan2, hypot
- **Other**: sinc, polar, mish (tanh inside), RNN tanh

### Key implementation details

1. **`opmath_type` cast to avoid Half/BFloat16 ambiguity**: `sycl::func(static_cast<opmath_t>(a))` where `opmath_t = at::opmath_type<scalar_t>`. This resolves ambiguity when `c10::Half`/`c10::BFloat16` can implicitly convert to both `float` and `sycl::half`.

2. **`if constexpr` for complex types**: SYCL math functions do not support `c10::complex<T>`. For functors dispatched with both real and complex types, we use:
   ```cpp
   if constexpr (c10::is_complex<scalar_t>::value) {
     return std::func(a);  // complex path unchanged
   } else {
     using opmath_t = at::opmath_type<scalar_t>;
     return sycl::func(static_cast<opmath_t>(a));
   }
   ```

3. **Files with separate ComplexFunctor**: Where complex dispatch uses a separate functor (e.g., AsinComplexFunctor), the plain functor is real-only and is directly migrated to `sycl::` without `if constexpr`.

### Not changed (intentionally)
- All `ComplexFunctor` variants (AsinComplex, AtanComplex, etc.) -- remain `std::`
- `ForeachUnaryKernels.cpp` STD_FUNCTOR macro -- separate PR scope
- Files where arguments are already safe types (mish uses `opmath_t`, RNN uses `H2F()` macro, sinc uses `opmath_t product`) -- only changed `std::` to `sycl::` prefix

### Testing
- **Accuracy**: All 17 ops pass across float16, bfloat16, float32, float64, complex64, complex128
- **Performance** (N=1M, PVC, before to after):
  - No regressions (>5% threshold)
  - Overall: +0.6% (within measurement noise, ~26us per op dominated by launch overhead)
  - One improvement: cosh bfloat16 -28% (baseline had a one-off spike)

```
        Op       dtype      before       after        diff      change
       sin     float16      26.7 us      27.0 us      +0.3 us     +1.1%
       sin     float32      26.4 us      26.7 us      +0.3 us     +1.1%
       cos     float16      26.1 us      26.6 us      +0.5 us     +1.9%
       cos     float32      26.1 us      26.6 us      +0.5 us     +1.9%
      tanh     float32      27.1 us      26.7 us      -0.4 us     -1.5%
      tanh     float64      31.0 us      31.0 us      +0.0 us     +0.0%
      cosh    bfloat16      37.1 us      26.7 us     -10.4 us    -28.0%
      mish     float64      39.6 us      39.6 us      +0.0 us     +0.0%
     polar     float32      27.2 us      27.7 us      +0.5 us     +1.8%
```
(Selected rows shown; all ops within +/-2.3% except cosh bf16 improvement)

Part of #3266