### PR TITLE
Use sycl::fma in addcmul and foreach pointwise ops for FMA parity with CUDA

### DIFF
--- a/src/ATen/native/xpu/sycl/DeviceAddCmulCdiv.h
+++ b/src/ATen/native/xpu/sycl/DeviceAddCmulCdiv.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#pragma once
+
+#include <sycl/sycl.hpp>
+#include <functional>
+#include <type_traits>
+
+namespace at::native::xpu {
+
+// Trait to detect multiply-like functors (std::multiplies<T> for any T).
+// This enables the FMA fast-path for any instantiation of std::multiplies,
+// not just std::multiplies<opmath_t>.
+template <typename Op>
+struct is_multiply_op : std::false_type {};
+
+template <typename T>
+struct is_multiply_op<std::multiplies<T>> : std::true_type {};
+
+template <typename Op>
+inline constexpr bool is_multiply_op_v = is_multiply_op<Op>::value;
+
+// Computes input + alpha * op(tensor1, tensor2).
+// Uses sycl::fma for real floating-point types to ensure consistent
+// FMA behavior matching CUDA's pointwise_op_impl.
+template <typename opmath_t, typename Op>
+inline opmath_t pointwise_op_impl(
+    opmath_t input,
+    opmath_t tensor1,
+    opmath_t tensor2,
+    opmath_t alpha,
+    Op op) {
+  if (alpha == opmath_t(1)) {
+    if constexpr (is_multiply_op_v<Op> && std::is_floating_point_v<opmath_t>) {
+      return sycl::fma(tensor1, tensor2, input);
+    } else {
+      return input + op(tensor1, tensor2);
+    }
+  }
+  if constexpr (std::is_floating_point_v<opmath_t>) {
+    return sycl::fma(alpha, op(tensor1, tensor2), input);
+  } else {
+    return input + alpha * op(tensor1, tensor2);
+  }
+}
+
+} // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/ForeachFunctors.h
+++ b/src/ATen/native/xpu/sycl/ForeachFunctors.h
@@ -12,10 +12,12 @@
 #include <ATen/OpMathType.h>
 #include <ATen/native/ForeachUtils.h>
 
+#include <ATen/native/xpu/sycl/DeviceAddCmulCdiv.h>
 #include <ATen/native/xpu/sycl/MultiTensorApply.h>
 #include <ATen/native/xpu/sycl/Pow.h>
 
 namespace at::native::xpu {
+
 namespace {
 
 inline void increment_version(TensorList tensors) {
@@ -253,11 +255,12 @@ struct PointwiseOpScalarFunctor {
         load_store(r_args[2], args[2], 0, i_start);
 #pragma unroll
         for (int ii = 0; ii < kILP; ii++) {
-          r_args[0][ii] = static_cast<T>(
-              static_cast<opmath_t>(r_args[0][ii]) +
-              scalar *
-                  op(static_cast<opmath_t>(r_args[1][ii]),
-                     static_cast<opmath_t>(r_args[2][ii])));
+          r_args[0][ii] = static_cast<T>(pointwise_op_impl<opmath_t>(
+              static_cast<opmath_t>(r_args[0][ii]),
+              static_cast<opmath_t>(r_args[1][ii]),
+              static_cast<opmath_t>(r_args[2][ii]),
+              scalar,
+              op));
         }
         load_store(args[res_arg_index], r_args[0], i_start, 0);
       }
@@ -268,11 +271,12 @@ struct PointwiseOpScalarFunctor {
             r_args, args, i_start, chunk_size, n, item_idx, item_range);
 #pragma unroll
         for (int ii = 0; ii < kILP; ii++) {
-          r_args[0][ii] = static_cast<T>(
-              static_cast<opmath_t>(r_args[0][ii]) +
-              scalar *
-                  op(static_cast<opmath_t>(r_args[1][ii]),
-                     static_cast<opmath_t>(r_args[2][ii])));
+          r_args[0][ii] = static_cast<T>(pointwise_op_impl<opmath_t>(
+              static_cast<opmath_t>(r_args[0][ii]),
+              static_cast<opmath_t>(r_args[1][ii]),
+              static_cast<opmath_t>(r_args[2][ii]),
+              scalar,
+              op));
         }
         store_args(
             args[res_arg_index],
@@ -319,11 +323,12 @@ struct PointwiseOpScalarListFunctor {
         load_store(r_args[2], args[2], 0, i_start);
 #pragma unroll
         for (int ii = 0; ii < kILP; ii++) {
-          r_args[0][ii] = static_cast<T>(
-              static_cast<opmath_t>(r_args[0][ii]) +
-              scalar *
-                  op(static_cast<opmath_t>(r_args[1][ii]),
-                     static_cast<opmath_t>(r_args[2][ii])));
+          r_args[0][ii] = static_cast<T>(pointwise_op_impl<opmath_t>(
+              static_cast<opmath_t>(r_args[0][ii]),
+              static_cast<opmath_t>(r_args[1][ii]),
+              static_cast<opmath_t>(r_args[2][ii]),
+              scalar,
+              op));
         }
         load_store(args[res_arg_index], r_args[0], i_start, 0);
       }
@@ -334,11 +339,12 @@ struct PointwiseOpScalarListFunctor {
             r_args, args, i_start, chunk_size, n, item_idx, item_range);
 #pragma unroll
         for (int ii = 0; ii < kILP; ii++) {
-          r_args[0][ii] = static_cast<T>(
-              static_cast<opmath_t>(r_args[0][ii]) +
-              scalar *
-                  op(static_cast<opmath_t>(r_args[1][ii]),
-                     static_cast<opmath_t>(r_args[2][ii])));
+          r_args[0][ii] = static_cast<T>(pointwise_op_impl<opmath_t>(
+              static_cast<opmath_t>(r_args[0][ii]),
+              static_cast<opmath_t>(r_args[1][ii]),
+              static_cast<opmath_t>(r_args[2][ii]),
+              scalar,
+              op));
         }
         store_args(
             args[res_arg_index],

--- a/src/ATen/native/xpu/sycl/PointwiseOpsKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PointwiseOpsKernels.cpp
@@ -13,8 +13,8 @@
 #include <ATen/native/TensorIterator.h>
 #include <comm/xpu_aten.h>
 
+#include <ATen/native/xpu/sycl/DeviceAddCmulCdiv.h>
 #include <ATen/native/xpu/sycl/Loops.h>
-
 #include <ATen/native/xpu/sycl/PointwiseOpsKernels.h>
 
 namespace at::native::xpu {
@@ -23,8 +23,11 @@ template <typename scalar_t>
 struct AddcmulFunctor {
   using accscalar_t = at::acc_type_device<scalar_t, kXPU>;
   scalar_t operator()(scalar_t a, scalar_t b, scalar_t c) const {
-    return static_cast<accscalar_t>(a) +
-        alpha_ * static_cast<accscalar_t>(b) * static_cast<accscalar_t>(c);
+    auto input = static_cast<accscalar_t>(a);
+    auto t1 = static_cast<accscalar_t>(b);
+    auto t2 = static_cast<accscalar_t>(c);
+    return static_cast<scalar_t>(pointwise_op_impl(
+        input, t1, t2, alpha_, std::multiplies<accscalar_t>{}));
   }
 
   AddcmulFunctor(accscalar_t alpha) : alpha_(alpha) {}


### PR DESCRIPTION
- [x] Extract `pointwise_op_impl` helper into a shared `DeviceAddCmulCdiv.h` header
- [x] Update `ForeachFunctors.h` to include the shared header instead of defining `pointwise_op_impl` directly
- [x] Update `PointwiseOpsKernels.cpp` to use the shared helper in `AddcmulFunctor`, removing duplicated FMA logic and unused `#include <functional>` / `#include <type_traits>`

Fixes: https://github.com/intel/torch-xpu-ops/issues/2759