### PR TITLE
Remove stale ConvTranspose3d complex half parity xfail

### DIFF
--- a/test/xpu/xpu_test_utils.py
+++ b/test/xpu/xpu_test_utils.py
@@ -353,6 +353,7 @@ _cuda_xfail_xpu_pass = [
     ("_refs.mul", "test_python_ref"),
     ("_refs.mul", "test_python_ref_torch_fallback"),
     ("nn.AvgPool2d", "test_memory_format"),
+    ("nn.ConvTranspose3d", "test_cpu_gpu_parity"),
     ("narrow_copy", "test_meta_outplace"),
     ("narrow_copy", "test_dispatch_meta_outplace"),
     ("narrow_copy", "test_dispatch_symbolic_meta_outplace"),


### PR DESCRIPTION
Fixes:
https://github.com/intel/torch-xpu-ops/issues/3030

This PR removes the stale inherited expected failure for ConvTranspose3d complex half CPU/GPU parity on XPU. The test now passes with the corresponding PyTorch change: https://github.com/pytorch/pytorch/pull/179713
