### PR TITLE
Add static for kernel_bundle and sycl::kernel to enforce a single globally accessible instance.

### DIFF
--- a/src/comm/DeviceProperties.h
+++ b/src/comm/DeviceProperties.h
@@ -29,10 +29,11 @@ static int64_t syclMaxWorkGroupSize(
   // runtime error. Here is an alternative as a temporary solution to
   // provide an extra hint to SYCL runtime.
   // https://github.com/intel/llvm/issues/15127
-  auto kbundle = ::sycl::get_kernel_bundle<::sycl::bundle_state::executable>(
-      ctx, {dev}, {kid});
+  static auto kbundle =
+      ::sycl::get_kernel_bundle<::sycl::bundle_state::executable>(
+          ctx, {dev}, {kid});
 
-  ::sycl::kernel k = kbundle.get_kernel(kid);
+  static ::sycl::kernel k = kbundle.get_kernel(kid);
   return k.get_info<::sycl::info::kernel_device_specific::work_group_size>(dev);
 }
 


### PR DESCRIPTION
By declaring kernel_bundle and sycl::kernel as static, they are created and initialized only once during the first invocation of syclMaxWorkGroupSize<KernelClass>(). Subsequent calls reuse the existing instances directly, avoiding repeated initialization.