### PR TITLE
[#2811] Increase timeout for test_quick_core_backward

### DIFF
--- a/test/xpu/test_decomp_xpu.py
+++ b/test/xpu/test_decomp_xpu.py
@@ -16,6 +16,7 @@ import unittest
 from collections import defaultdict
 from functools import partial
 
+import pytest
 import torch._inductor.decomposition
 import torch.autograd
 from torch import Tensor
@@ -591,6 +592,7 @@ class TestDecomp(TestCase):
     @skipIfCrossRef
     @suppress_warnings
     @ops(_decomp_test_ops_core_autograd, allowed_dtypes=(torch.float64,))
+    @pytest.mark.timeout(2160)
     def test_quick_core_backward(self, device, dtype, op):
         test_keys = [
             (torch.device(device).type, dtype, op.name),


### PR DESCRIPTION
Part of the https://github.com/intel/torch-xpu-ops/issues/2811. The test_decomp_xpu.py::TestDecompXPU::test_quick_core_backward__unsafe_masked_index_put_accumulate_xpu_float64 test fails because of the timeout. By increasing timeout the test can finished with success. The same test on CUDA is listed in slow_test.json:
`"test_quick_core_backward__unsafe_masked_index_put_accumulate_cuda_float64 (__main__.TestDecompCUDA)": 1446.0608520507812,` and is running in separate workflow `slow.yml`