### PR TITLE
Port test_torch_binomial_dtype_errors upstream test

### DIFF
--- a/test/xpu/test_distributions_xpu.py
+++ b/test/xpu/test_distributions_xpu.py
@@ -155,6 +155,7 @@ def _test_poisson_gpu_sample(self):
             failure_rate=1e-3,
         )
 
+
 def _test_torch_binomial_dtype_errors(self):
     dtypes = [torch.int, torch.long, torch.short]
     devices = ["cpu", "xpu"]
@@ -179,6 +180,7 @@ def _test_torch_binomial_dtype_errors(self):
                 "binomial only supports floating-point dtypes for prob.*",
             ):
                 torch.binomial(total_count, total_prob)
+
 
 TestDistributions.test_beta_underflow_gpu = _test_beta_underflow_gpu
 TestDistributions.test_zero_excluded_binomial = _test_zero_excluded_binomial

--- a/test/xpu/test_distributions_xpu.py
+++ b/test/xpu/test_distributions_xpu.py
@@ -155,12 +155,37 @@ def _test_poisson_gpu_sample(self):
             failure_rate=1e-3,
         )
 
+def _test_torch_binomial_dtype_errors(self):
+    dtypes = [torch.int, torch.long, torch.short]
+    devices = ["cpu", "xpu"]
+
+    for device in devices:
+        for count_dtype in dtypes:
+            total_count = torch.tensor([10, 10], dtype=count_dtype, device=device)
+            total_prob = torch.tensor([0.5, 0.5], dtype=torch.float, device=device)
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "binomial only supports floating-point dtypes for count.*",
+            ):
+                torch.binomial(total_count, total_prob)
+
+        for prob_dtype in dtypes:
+            total_count = torch.tensor([10, 10], dtype=torch.float, device=device)
+            total_prob = torch.tensor([0.5, 0.5], dtype=prob_dtype, device=device)
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "binomial only supports floating-point dtypes for prob.*",
+            ):
+                torch.binomial(total_count, total_prob)
 
 TestDistributions.test_beta_underflow_gpu = _test_beta_underflow_gpu
 TestDistributions.test_zero_excluded_binomial = _test_zero_excluded_binomial
 TestDistributions.test_gamma_gpu_sample = _test_gamma_gpu_sample
 TestDistributions.test_gamma_gpu_shape = _test_gamma_gpu_shape
 TestDistributions.test_poisson_gpu_sample = _test_poisson_gpu_sample
+TestDistributions.test_torch_binomial_dtype_errors = _test_torch_binomial_dtype_errors
 instantiate_device_type_tests(
     TestDistributions, globals(), only_for="xpu", allow_xpu=True
 )


### PR DESCRIPTION
Fixes: https://github.com/intel/torch-xpu-ops/issues/3242

Port upstream UT into torch-xpu-ops. Without modification upstream test tries to run on `CUDA` backend that raises `Torch not compiled with CUDA enabled`. After replacing `CUDA` with `XPU` test passes, as binomial checks were added in https://github.com/intel/torch-xpu-ops/pull/3276