### PR TITLE
Enable vectorized memory access for fp32/fp16/bf16 dtype cast copies

### DIFF
--- a/src/ATen/native/xpu/sycl/CopyKernel.cpp
+++ b/src/ATen/native/xpu/sycl/CopyKernel.cpp
@@ -146,48 +146,62 @@ void float4_copy_kernel_xpu(TensorIteratorBase& iter) {
   }
 }
 
-// Optimized cast kernel for common fp32/fp16/bf16 conversions.
-// Uses gpu_kernel_nocast with explicit CastScalarFunc to enable vectorized
-// memory access, bypassing the generic LoadWithCast/StoreWithCast path
-// which disables vectorization and uses per-element runtime dtype dispatch.
-bool try_fast_copy_kernel_xpu(TensorIteratorBase& iter) {
+bool isFastCastType(TensorIteratorBase& iter) {
   ScalarType dst_dtype = iter.dtype(0);
   ScalarType src_dtype = iter.dtype(1);
+
   if (dst_dtype == src_dtype) {
     return false;
   }
 
+  if (src_dtype != kFloat && src_dtype != kHalf && src_dtype != kBFloat16) {
+    return false;
+  }
+
+  if (dst_dtype != kFloat && dst_dtype != kHalf && dst_dtype != kBFloat16) {
+    return false;
+  }
+
+  return true;
+}
+
+// Optimized cast kernel for common fp32/fp16/bf16 conversions.
+// Uses gpu_kernel_nocast with explicit CastScalarFunc to enable vectorized
+// memory access, bypassing the generic LoadWithCast/StoreWithCast path
+// which disables vectorization and uses per-element runtime dtype dispatch.
+void fast_copy_kernel_xpu(TensorIteratorBase& iter) {
+  ScalarType dst_dtype = iter.dtype(0);
+  ScalarType src_dtype = iter.dtype(1);
+
   // fp32 <-> fp16
   if (src_dtype == kFloat && dst_dtype == kHalf) {
     gpu_kernel_nocast(iter, CastScalarFunc<float, Half>());
-    return true;
+    return;
   }
   if (src_dtype == kHalf && dst_dtype == kFloat) {
     gpu_kernel_nocast(iter, CastScalarFunc<Half, float>());
-    return true;
+    return;
   }
 
   // fp32 <-> bf16
   if (src_dtype == kFloat && dst_dtype == kBFloat16) {
     gpu_kernel_nocast(iter, CastScalarFunc<float, BFloat16>());
-    return true;
+    return;
   }
   if (src_dtype == kBFloat16 && dst_dtype == kFloat) {
     gpu_kernel_nocast(iter, CastScalarFunc<BFloat16, float>());
-    return true;
+    return;
   }
 
   // fp16 <-> bf16
   if (src_dtype == kHalf && dst_dtype == kBFloat16) {
     gpu_kernel_nocast(iter, CastScalarFunc<Half, BFloat16>());
-    return true;
+    return;
   }
   if (src_dtype == kBFloat16 && dst_dtype == kHalf) {
     gpu_kernel_nocast(iter, CastScalarFunc<BFloat16, Half>());
-    return true;
+    return;
   }
-
-  return false;
 }
 
 void copy_kernel(TensorIteratorBase& iter) {
@@ -200,9 +214,8 @@ void copy_kernel(TensorIteratorBase& iter) {
     float8_copy_kernel_xpu(iter);
   } else if (iter.dtype(0) == kFloat4_e2m1fn_x2) {
     float4_copy_kernel_xpu(iter);
-  } else if (try_fast_copy_kernel_xpu(iter)) {
-    // Handled by optimized vectorized cast path above.
-    return;
+  } else if (isFastCastType(iter)) {
+    fast_copy_kernel_xpu(iter);
   } else {
     AT_DISPATCH_V2(
         dtype,

--- a/src/ATen/native/xpu/sycl/CopyKernel.cpp
+++ b/src/ATen/native/xpu/sycl/CopyKernel.cpp
@@ -35,6 +35,25 @@ struct CastScalarFunc {
   }
 };
 
+// TODO: Remove this work around for Half -0.0
+template <>
+struct CastScalarFunc<Half, float> {
+  float operator()(Half src_val) const {
+    if (src_val.x == 0x8000)
+      return -0.0f;
+    return (float)src_val;
+  }
+};
+
+// TODO: Remove this work around for Half -0.0
+template <>
+struct CastScalarFunc<Half, BFloat16> {
+  BFloat16 operator()(Half src_val) const {
+    Half val = src_val == Half(-0.0) ? Half(0.0) : src_val;
+    return (BFloat16)val;
+  }
+};
+
 // TODO: Avoid using sycl::half to prevent the fp16->fp32->fp8 fusion
 // from incorrectly converting -0.0 to NaN. This temporary fix should
 // be removed once the compiler/driver error is resolved.

--- a/src/ATen/native/xpu/sycl/CopyKernel.cpp
+++ b/src/ATen/native/xpu/sycl/CopyKernel.cpp
@@ -39,8 +39,7 @@ struct CastScalarFunc {
 template <>
 struct CastScalarFunc<Half, float> {
   float operator()(Half src_val) const {
-    Half val = src_val == Half(-0.0) ? Half(0.0) : src_val;
-    return (float)val;
+    return c10::convert<float>(src_val);
   }
 };
 
@@ -48,8 +47,7 @@ struct CastScalarFunc<Half, float> {
 template <>
 struct CastScalarFunc<Half, BFloat16> {
   BFloat16 operator()(Half src_val) const {
-    Half val = src_val == Half(-0.0) ? Half(0.0) : src_val;
-    return (BFloat16)val;
+    return c10::convert<BFloat16>(src_val);
   }
 };
 

--- a/src/ATen/native/xpu/sycl/CopyKernel.cpp
+++ b/src/ATen/native/xpu/sycl/CopyKernel.cpp
@@ -35,17 +35,16 @@ struct CastScalarFunc {
   }
 };
 
-// TODO: Remove this work around for Half -0.0
+// TODO: Remove this workaround for Half -0.0
 template <>
 struct CastScalarFunc<Half, float> {
   float operator()(Half src_val) const {
-    if (src_val.x == 0x8000)
-      return -0.0f;
-    return (float)src_val;
+    Half val = src_val == Half(-0.0) ? Half(0.0) : src_val;
+    return (float)val;
   }
 };
 
-// TODO: Remove this work around for Half -0.0
+// TODO: Remove this workaround for Half -0.0
 template <>
 struct CastScalarFunc<Half, BFloat16> {
   BFloat16 operator()(Half src_val) const {

--- a/src/ATen/native/xpu/sycl/CopyKernel.cpp
+++ b/src/ATen/native/xpu/sycl/CopyKernel.cpp
@@ -146,6 +146,50 @@ void float4_copy_kernel_xpu(TensorIteratorBase& iter) {
   }
 }
 
+// Optimized cast kernel for common fp32/fp16/bf16 conversions.
+// Uses gpu_kernel_nocast with explicit CastScalarFunc to enable vectorized
+// memory access, bypassing the generic LoadWithCast/StoreWithCast path
+// which disables vectorization and uses per-element runtime dtype dispatch.
+bool try_fast_copy_kernel_xpu(TensorIteratorBase& iter) {
+  ScalarType dst_dtype = iter.dtype(0);
+  ScalarType src_dtype = iter.dtype(1);
+  if (dst_dtype == src_dtype) {
+    return false;
+  }
+
+  // fp32 <-> fp16
+  if (src_dtype == kFloat && dst_dtype == kHalf) {
+    gpu_kernel_nocast(iter, CastScalarFunc<float, Half>());
+    return true;
+  }
+  if (src_dtype == kHalf && dst_dtype == kFloat) {
+    gpu_kernel_nocast(iter, CastScalarFunc<Half, float>());
+    return true;
+  }
+
+  // fp32 <-> bf16
+  if (src_dtype == kFloat && dst_dtype == kBFloat16) {
+    gpu_kernel_nocast(iter, CastScalarFunc<float, BFloat16>());
+    return true;
+  }
+  if (src_dtype == kBFloat16 && dst_dtype == kFloat) {
+    gpu_kernel_nocast(iter, CastScalarFunc<BFloat16, float>());
+    return true;
+  }
+
+  // fp16 <-> bf16
+  if (src_dtype == kHalf && dst_dtype == kBFloat16) {
+    gpu_kernel_nocast(iter, CastScalarFunc<Half, BFloat16>());
+    return true;
+  }
+  if (src_dtype == kBFloat16 && dst_dtype == kHalf) {
+    gpu_kernel_nocast(iter, CastScalarFunc<BFloat16, Half>());
+    return true;
+  }
+
+  return false;
+}
+
 void copy_kernel(TensorIteratorBase& iter) {
   ScalarType dtype = iter.common_dtype();
   if (isQIntType(dtype)) {
@@ -156,6 +200,9 @@ void copy_kernel(TensorIteratorBase& iter) {
     float8_copy_kernel_xpu(iter);
   } else if (iter.dtype(0) == kFloat4_e2m1fn_x2) {
     float4_copy_kernel_xpu(iter);
+  } else if (try_fast_copy_kernel_xpu(iter)) {
+    // Handled by optimized vectorized cast path above.
+    return;
   } else {
     AT_DISPATCH_V2(
         dtype,

--- a/src/ATen/native/xpu/sycl/CopyKernel.cpp
+++ b/src/ATen/native/xpu/sycl/CopyKernel.cpp
@@ -164,7 +164,7 @@ void float4_copy_kernel_xpu(TensorIteratorBase& iter) {
   }
 }
 
-bool isFastCastType(TensorIteratorBase& iter) {
+bool isFastCastType(const TensorIteratorBase& iter) {
   ScalarType dst_dtype = iter.dtype(0);
   ScalarType src_dtype = iter.dtype(1);
 


### PR DESCRIPTION
The generic `copy_kernel` path uses `gpu_kernel` which, for cross-dtype copies, detects `needs_dynamic_casting=true` and falls into the `LoadWithCast/StoreWithCast` code path. This path performs per-element runtime dtype dispatch and disables vectorized (wide, aligned) memory loads/stores — resulting in significantly lower memory bandwidth utilization.

This PR intercepts the 6 common fp32/fp16/bf16 cast combinations before reaching the generic path and uses gpu_kernel_nocast with an explicit `CastScalarFunc<in_t, out_t>` whose functor signature matches the tensor dtypes exactly, so `needs_dynamic_casting` evaluates to false and the vectorized kernel launch path is taken.

Covered conversions:

- fp32 ↔ fp16
- fp32 ↔ bf16
- fp16 ↔ bf16