### PR TITLE
Remove unused variable

### DIFF
--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_mainloop.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_mainloop.h
@@ -326,7 +326,6 @@ struct FMHAFwdMainloop<
       if (check_remainder_k && K == blk_k1 - 1) {
         CUTLASS_PRAGMA_UNROLL
         for (int i = 0; i < tSrS.size(); ++i) {
-          int row_idx = get<0>(cS_thread(i));
           int col_idx = get<1>(cS_thread(i));
           if (col_idx >= seq_len_kv) {
             tSrS(i) = ElementS(-INFINITY);


### PR DESCRIPTION
This pull request makes a minor change to the `FMHAFwdMainloop` structure in `xe_fmha_fwd_mainloop.h` by removing the unused `row_idx` variable from a loop, simplifying the code and improving clarity.

- Code cleanup:
  * Removed the unused `row_idx` variable from the loop in `FMHAFwdMainloop` to reduce unnecessary code.