### PR TITLE
[xpu][feature] Add fused Dual GEMM SiLU-Mul kernel (sycl-tla)

### DIFF
--- a/src/ATen/CMakeLists.txt
+++ b/src/ATen/CMakeLists.txt
@@ -8,9 +8,9 @@
 
 # ATen XPU sources
 
-file(GLOB xpu_native_cpp "native/xpu/*.cpp" "native/sparse/*.cpp" "native/sparse/xpu/*.cpp" "native/nested/*.cpp" "native/nested/xpu/*.cpp" "native/transformers/*.cpp" "native/quantized/*.cpp" "native/transformers/xpu/flash_attn/*.cpp")
+file(GLOB xpu_native_cpp "native/xpu/*.cpp" "native/sparse/*.cpp" "native/sparse/xpu/*.cpp" "native/nested/*.cpp" "native/nested/xpu/*.cpp" "native/transformers/*.cpp" "native/quantized/*.cpp" "native/transformers/xpu/flash_attn/*.cpp" "native/transformers/xpu/dual_gemm/*.cpp")
 file(GLOB xpu_sycl "native/xpu/sycl/*.cpp" "native/sparse/xpu/sycl/*.cpp" "native/nested/xpu/sycl/*.cpp" "native/transformers/sycl/*.cpp" "native/quantized/sycl/*.cpp")
-file(GLOB xpu_sycltla "native/transformers/xpu/flash_attn/sycltla/*.cpp")
+file(GLOB xpu_sycltla "native/transformers/xpu/flash_attn/sycltla/*.cpp" "native/transformers/xpu/dual_gemm/sycltla/*.cpp")
 
 if(USE_ONEMKL_XPU)
   file(GLOB xpu_mkl "native/xpu/mkl/*.cpp")

--- a/src/ATen/native/transformers/xpu/dual_gemm/dual_gemm_api.cpp
+++ b/src/ATen/native/transformers/xpu/dual_gemm/dual_gemm_api.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include <ATen/native/transformers/xpu/dual_gemm/dual_gemm_api.h>
+
+#ifdef USE_SYCLTLA
+#include <ATen/xpu/XPUContext.h>
+
+namespace sycltla {
+// Forward declaration of the sycltla implementation
+// (dual_gemm/sycltla/dual_gemm.cpp)
+at::Tensor dual_gemm_silu_mul_impl(
+    sycl::queue& queue,
+    const at::Tensor& x,
+    const at::Tensor& w1,
+    const at::Tensor& w3);
+} // namespace sycltla
+#endif // USE_SYCLTLA
+
+namespace sycltla {
+
+bool is_dual_gemm_available() {
+#ifndef USE_SYCLTLA
+  return false;
+#else
+  return true;
+#endif
+}
+
+at::Tensor dual_gemm_silu_mul(
+    const at::Tensor& x,
+    const at::Tensor& w1,
+    const at::Tensor& w3) {
+#ifndef USE_SYCLTLA
+  TORCH_CHECK(
+      false,
+      "dual_gemm_silu_mul: Torch XPU was not compiled with SYCLTLA support.");
+  return at::Tensor();
+#else
+  TORCH_CHECK(x.is_xpu(), "dual_gemm_silu_mul: x must be on XPU");
+  TORCH_CHECK(w1.is_xpu(), "dual_gemm_silu_mul: w1 must be on XPU");
+  TORCH_CHECK(w3.is_xpu(), "dual_gemm_silu_mul: w3 must be on XPU");
+
+  TORCH_CHECK(
+      x.dtype() == at::kBFloat16,
+      "dual_gemm_silu_mul: only bfloat16 is currently supported, got ",
+      x.dtype());
+  TORCH_CHECK(
+      w1.dtype() == at::kBFloat16 && w3.dtype() == at::kBFloat16,
+      "dual_gemm_silu_mul: w1 and w3 must be bfloat16");
+
+  TORCH_CHECK(x.dim() == 2, "dual_gemm_silu_mul: x must be 2-D [M, K]");
+  TORCH_CHECK(w1.dim() == 2, "dual_gemm_silu_mul: w1 must be 2-D [N, K]");
+  TORCH_CHECK(w3.dim() == 2, "dual_gemm_silu_mul: w3 must be 2-D [N, K]");
+
+  TORCH_CHECK(x.is_contiguous(), "dual_gemm_silu_mul: x must be contiguous");
+  TORCH_CHECK(w1.is_contiguous(), "dual_gemm_silu_mul: w1 must be contiguous");
+  TORCH_CHECK(w3.is_contiguous(), "dual_gemm_silu_mul: w3 must be contiguous");
+
+  const int64_t K = x.size(1);
+  TORCH_CHECK(
+      w1.size(1) == K && w3.size(1) == K,
+      "dual_gemm_silu_mul: x, w1, w3 must share the same K dimension");
+  TORCH_CHECK(
+      w1.size(0) == w3.size(0),
+      "dual_gemm_silu_mul: w1 and w3 must have the same N dimension");
+
+  // The sycl-tla DualGemm kernel expects B matrices in [K, N] row-major
+  // (i.e. already transposed relative to the [N, K] weight layout).
+  // Transpose w1 and w3 so the kernel computes x @ w1.T correctly.
+  at::Tensor w1_t = w1.t().contiguous();
+  at::Tensor w3_t = w3.t().contiguous();
+
+  auto sycl_queue = at::xpu::getCurrentXPUStream().queue();
+  return sycltla::dual_gemm_silu_mul_impl(sycl_queue, x, w1_t, w3_t);
+#endif
+}
+
+} // namespace sycltla

--- a/src/ATen/native/transformers/xpu/dual_gemm/dual_gemm_api.h
+++ b/src/ATen/native/transformers/xpu/dual_gemm/dual_gemm_api.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#pragma once
+
+#include <ATen/ATen.h>
+
+namespace sycltla {
+
+// Returns true if the sycltla dual_gemm kernel is compiled in.
+bool is_dual_gemm_available();
+
+/**
+ * Fused dual GEMM with SiLU-Mul epilogue.
+ *
+ * Computes:  out = silu(x @ w1.T) * (x @ w3.T)
+ *
+ * This fuses two GEMM operations that share the same A matrix (x) into a
+ * single kernel, loading x from HBM only once.
+ *
+ * @param x      Input tensor of shape [M, K], contiguous, bf16 or fp16.
+ * @param w1     Weight matrix of shape [N, K], contiguous, same dtype as x.
+ * @param w3     Weight matrix of shape [N, K], contiguous, same dtype as x.
+ * @return       Output tensor of shape [M, N], same dtype as x.
+ */
+at::Tensor dual_gemm_silu_mul(
+    const at::Tensor& x,
+    const at::Tensor& w1,
+    const at::Tensor& w3);
+
+} // namespace sycltla

--- a/src/ATen/native/transformers/xpu/dual_gemm/sycltla/dual_gemm.cpp
+++ b/src/ATen/native/transformers/xpu/dual_gemm/sycltla/dual_gemm.cpp
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/*
+ * Fused Dual GEMM with SiLU-Mul epilogue for XPU (Intel GPU / PVC).
+ *
+ * Computes: out = silu(x @ w1.T) * (x @ w3.T)
+ *
+ * Uses the sycl-tla (CUTLASS SYCL port, v0.6+) DualGemm kernel which loads
+ * the shared A matrix (x) from HBM only once, saving one full matrix read
+ * compared to two separate GEMM calls.
+ *
+ * Tile configuration: 128×128×64 with WarpLayout 8×4×1 (32 subgroups).
+ * This is the only tile shape compatible with sycl-tla's DualGemm MMA/copy
+ * atom constraints (make_fragment_layout requires specific alignment between
+ * GmemTiledCopy block shapes and MMA atom fragment sizes).
+ *
+ * NOTE: For LLaMA inference shapes (small M, large N), the fused kernel is
+ * slower than eager (oneDNN) due to M-dimension padding overhead.  The FX
+ * fusion pass (xpu_dual_gemm.py) includes shape guards to skip fusion in
+ * those cases.  The fused kernel is beneficial when M is large enough to
+ * fill the 128-row tiles efficiently (roughly M >= 512 for square-ish shapes).
+ */
+
+// dual_gemm_common.h is in the parent directory (dual_gemm/).
+// The build system adds that directory to the include path.
+#include <sycltla/dual_gemm_common.h>
+
+// gemm_universal_adapter.h must come first: it includes gemm_universal.hpp
+// which in turn includes tile_scheduler.hpp (defines PersistentScheduler and
+// detail::TileSchedulerSelector).  xe_dual_gemm.hpp depends on these but does
+// not include tile_scheduler.hpp itself.
+#include "cutlass/epilogue/fusion/xe_callbacks.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+
+#include <cute/tensor.hpp>
+#include <cute/util/compat.hpp>
+#include <cutlass/numeric_conversion.h>
+#include <cutlass/util/packed_stride.hpp>
+#include <sycl/sycl.hpp>
+
+#include <dual_gemm/collective/xe_dual_gemm_epilogue.hpp>
+#include <dual_gemm/collective/xe_dual_gemm_epilogue_elementwise_activation.hpp>
+#include <dual_gemm/kernel/xe_dual_gemm.hpp>
+#include <dual_gemm/thread/xe_binary_elem_wise_op.hpp>
+
+using namespace cute;
+
+// ---------------------------------------------------------------------------
+// Type aliases – BF16 input / BF16 output, float accumulator
+// ---------------------------------------------------------------------------
+
+using ElementInputAB = bfloat16_t;
+using ElementOutput = bfloat16_t;
+using ElementAcc = float;
+using ElementCompute = float;
+
+using LayoutA = cutlass::layout::RowMajor;
+using LayoutB = cutlass::layout::RowMajor; // weights are [N, K], row-major
+using LayoutC = cutlass::layout::RowMajor;
+using LayoutD = cutlass::layout::RowMajor;
+
+using GmemTiledCopyA = XE_2D_U16x16x32_LD_N;
+using GmemTiledCopyB = XE_2D_U16x32x32_LD_V;
+
+using TileShape = Shape<_128, _128, _64>;
+
+using TiledMma = typename TiledMMAHelper<
+    MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
+    Layout<TileShape>,
+    Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>>::TiledMMA;
+
+constexpr int PipelineStages = 2;
+using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelXeXMX16<PipelineStages>;
+using EpilogueDispatchPolicy = cutlass::epilogue::IntelXeXMX16;
+
+// Epilogue 0: Identity (no activation) – we'll apply activation in the fused
+// ElemAct epilogue that writes the final output.  We still need to write the
+// intermediate D0/D1 so the ElemAct epilogue can read them.
+//
+// Actually with DualGemmElemActEpilogue the intermediate outputs are kept in
+// registers / SLM – we don't need to write them to global memory.  Setting
+// WriteEpilogueOutput = false keeps them in-registers.
+constexpr bool WriteEpilogueOutput0 = false;
+constexpr bool WriteEpilogueOutput1 = false;
+
+using EpilogueOp0 = cutlass::epilogue::fusion::LinCombEltAct<
+    cutlass::epilogue::thread::Identity,
+    ElementOutput,
+    ElementCompute,
+    ElementAcc,
+    ElementAcc,
+    cutlass::FloatRoundStyle::round_to_nearest>;
+
+using EpilogueOp1 = cutlass::epilogue::fusion::LinCombEltAct<
+    cutlass::epilogue::thread::Identity,
+    ElementOutput,
+    ElementCompute,
+    ElementAcc,
+    ElementAcc,
+    cutlass::FloatRoundStyle::round_to_nearest>;
+
+using FusionCallBacks0 = cutlass::epilogue::fusion::FusionCallbacks<
+    EpilogueDispatchPolicy,
+    EpilogueOp0,
+    TileShape,
+    decltype(tile_shape(TiledMma()))>;
+
+using FusionCallBacks1 = cutlass::epilogue::fusion::FusionCallbacks<
+    EpilogueDispatchPolicy,
+    EpilogueOp1,
+    TileShape,
+    decltype(tile_shape(TiledMma()))>;
+
+// ElementC must equal the mainloop ElementAccumulator (float) due to the
+// static_assert in xe_dual_gemm.hpp.  The C bias is never actually loaded
+// (ptr_C = nullptr, beta = 0), but the type must still be consistent.
+// XE_2D_U32x8x16_LD_N handles 32-bit (float) loads; XE_2D_U16x8x16_ST_N
+// handles 16-bit (bfloat16) stores for D.
+// WriteEpilogueOutput = false means D0/D1 are never written to global memory;
+// they stay in registers for the ElemAct epilogue.
+using CollectiveEpilogue0 = cutlass::epilogue::collective::DualGemmEpilogue<
+    EpilogueDispatchPolicy,
+    TileShape,
+    ElementAcc, // ElementC = float (= ElementAccumulator, required by mainloop)
+    cutlass::gemm::TagToStrideC_t<LayoutC>,
+    ElementOutput, // ElementD = bfloat16_t
+    cutlass::gemm::TagToStrideC_t<LayoutD>,
+    FusionCallBacks0,
+    XE_2D_U32x8x16_LD_N, // 32-bit load for float C
+    XE_2D_U16x8x16_ST_N, // 16-bit store for bf16 D (unused since
+                         // WriteOutput=false)
+    WriteEpilogueOutput0>;
+
+using CollectiveEpilogue1 = cutlass::epilogue::collective::DualGemmEpilogue<
+    EpilogueDispatchPolicy,
+    TileShape,
+    ElementAcc, // ElementC = float
+    cutlass::gemm::TagToStrideC_t<LayoutC>,
+    ElementOutput, // ElementD = bfloat16_t
+    cutlass::gemm::TagToStrideC_t<LayoutD>,
+    FusionCallBacks1,
+    XE_2D_U32x8x16_LD_N,
+    XE_2D_U16x8x16_ST_N,
+    WriteEpilogueOutput1>;
+
+// Fused element-wise epilogue: silu(D0) * D1 → D2
+using EpilogueOutputOp2 = cutlass::epilogue::thread::FusedElementWiseOpDualGemm<
+    ElementOutput,
+    cutlass::epilogue::thread::SiLu,
+    cutlass::epilogue::thread::Identity,
+    cutlass::multiplies,
+    ElementAcc,
+    ElementAcc>;
+
+using CollectiveEpilogueActivation =
+    cutlass::epilogue::collective::DualGemmElemActEpilogue<
+        EpilogueDispatchPolicy,
+        TileShape,
+        void,
+        cutlass::gemm::TagToStrideC_t<LayoutC>,
+        ElementOutput,
+        cutlass::gemm::TagToStrideC_t<LayoutD>,
+        void,
+        XE_2D_U16x8x16_ST_N,
+        EpilogueOutputOp2>;
+
+using CollectiveMainloop = cutlass::gemm::collective::DualGemmMma<
+    GEMMDispatchPolicy,
+    TileShape,
+    ElementInputAB,
+    cutlass::gemm::TagToStrideA_t<LayoutA>,
+    ElementInputAB,
+    cutlass::gemm::TagToStrideB_t<LayoutB>,
+    TiledMma,
+    GmemTiledCopyA,
+    GmemTiledCopyB>;
+
+using GemmKernel = cutlass::gemm::kernel::DualGemm<
+    Shape<int, int, int, int>,
+    CollectiveMainloop,
+    CollectiveEpilogue0,
+    CollectiveEpilogue1,
+    CollectiveEpilogueActivation>;
+
+// ---------------------------------------------------------------------------
+// Kernel launcher – mirrors the pattern used in mha_fwd.cpp
+// ---------------------------------------------------------------------------
+
+// Anonymous name tag for kernel caching (analogous to MhaName in mha_fwd.cpp)
+namespace cute {
+template <class...>
+class DualGemmName;
+} // namespace cute
+
+static cutlass::Status launch_dual_gemm_kernel(
+    sycl::queue& queue,
+    typename GemmKernel::Params params) {
+  dim3 const block = GemmKernel::get_block_shape();
+  dim3 const grid = GemmKernel::get_grid_shape(params);
+  int smem_size = GemmKernel::SharedStorageSize;
+
+  const auto sycl_block = compat::dim3(block.x, block.y, block.z);
+  const auto sycl_grid = compat::dim3(grid.x, grid.y, grid.z);
+
+#if !defined(SYCL_EXT_ONEAPI_WORK_GROUP_SCRATCH_MEMORY)
+  using namespace compat::experimental;
+  auto event = launch<
+      cutlass::device_kernel<GemmKernel>,
+      cute::DualGemmName<GemmKernel>>(
+      launch_policy{
+          sycl_grid,
+          sycl_block,
+          local_mem_size{static_cast<std::size_t>(smem_size)},
+          kernel_properties{sycl_exp::sub_group_size<
+              GemmKernel::DispatchPolicy::SubgroupSize>}},
+      queue,
+      params);
+#else
+  compat::experimental::launch_properties launch_props{
+      sycl::ext::oneapi::experimental::work_group_scratch_size(smem_size),
+  };
+  compat::experimental::kernel_properties kernel_props{
+      sycl::ext::oneapi::experimental::sub_group_size<
+          GemmKernel::DispatchPolicy::SubgroupSize>};
+  compat::experimental::launch_policy policy{
+      sycl_grid, sycl_block, launch_props, kernel_props};
+  auto event = compat::experimental::launch<
+      cutlass::device_kernel<GemmKernel>,
+      cute::DualGemmName<GemmKernel>>(policy, queue, params);
+#endif
+  (void)event;
+  return cutlass::Status::kSuccess;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+namespace sycltla {
+
+at::Tensor dual_gemm_silu_mul_impl(
+    sycl::queue& queue,
+    const at::Tensor& x,
+    const at::Tensor& w1,
+    const at::Tensor& w3) {
+  // Dimensions: x [M, K], w1 [K, N], w3 [K, N]  (already transposed by caller)
+  const int M = static_cast<int>(x.size(0));
+  const int K = static_cast<int>(x.size(1));
+  const int N = static_cast<int>(w1.size(1)); // w1 is [K, N]
+  const int L = 1; // no batch
+
+  using StrideA = typename GemmKernel::StrideA;
+  using StrideB = typename GemmKernel::StrideB;
+  using StrideD = typename GemmKernel::StrideD;
+
+  StrideA stride_A =
+      cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(M, K, L));
+  StrideB stride_B =
+      cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(N, K, L));
+  StrideD stride_D =
+      cutlass::make_cute_packed_stride(StrideD{}, cute::make_shape(M, N, L));
+
+  // No C matrix – set alpha=1, beta=0
+  using EpilogueArguments0 = typename GemmKernel::EpilogueArguments0;
+  using EpilogueArguments1 = typename GemmKernel::EpilogueArguments1;
+
+  // C pointers set to nullptr because beta=0 and we skip the C load.
+  // We also skip writing D0/D1 (WriteEpilogueOutput = false) so nullptr is
+  // safe.
+  EpilogueArguments0 epilogue0{
+      {1.f, 0.f}, nullptr, stride_D, nullptr, stride_D};
+  EpilogueArguments1 epilogue1{
+      {1.f, 0.f}, nullptr, stride_D, nullptr, stride_D};
+
+  // Output tensor for silu(x@w1.T) * (x@w3.T)
+  at::Tensor out = at::empty({M, N}, x.options());
+
+  typename GemmKernel::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      {M, N, K, L},
+      {static_cast<const ElementInputAB*>(x.data_ptr()),
+       stride_A,
+       static_cast<const ElementInputAB*>(w1.data_ptr()),
+       stride_B,
+       static_cast<const ElementInputAB*>(w3.data_ptr()),
+       stride_B},
+      epilogue0,
+      epilogue1,
+      {static_cast<ElementOutput*>(out.data_ptr()), stride_D},
+      cutlass::KernelHardwareInfo{}};
+
+  // Workspace
+  size_t workspace_size = GemmKernel::get_workspace_size(arguments);
+  at::Tensor workspace;
+  void* workspace_ptr = nullptr;
+  if (workspace_size > 0) {
+    workspace = at::empty(
+        {static_cast<int64_t>(workspace_size)},
+        at::device(at::kXPU).dtype(at::kByte));
+    workspace_ptr = workspace.data_ptr();
+  }
+
+  TORCH_CHECK(
+      GemmKernel::can_implement(arguments),
+      "dual_gemm_silu_mul: invalid problem size M=",
+      M,
+      " N=",
+      N,
+      " K=",
+      K);
+
+  CUTLASS_CHECK(GemmKernel::initialize_workspace(arguments, workspace_ptr));
+
+  auto params = GemmKernel::to_underlying_arguments(arguments, workspace_ptr);
+  CUTLASS_CHECK(launch_dual_gemm_kernel(queue, params));
+
+  return out;
+}
+
+} // namespace sycltla

--- a/src/ATen/native/transformers/xpu/dual_gemm/sycltla/dual_gemm_common.h
+++ b/src/ATen/native/transformers/xpu/dual_gemm/sycltla/dual_gemm_common.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#pragma once
+#include <cassert>
+
+#include <ATen/xpu/XPUContext.h>
+
+#include <ATen/native/transformers/xpu/dual_gemm/dual_gemm_api.h>
+
+/**
+ * Panic wrapper for unwinding CUTLASS errors
+ */
+#define CUTLASS_CHECK(status)                                             \
+  {                                                                       \
+    cutlass::Status error = status;                                       \
+    if (error != cutlass::Status::kSuccess) {                             \
+      std::cerr << "Got cutlass error: " << cutlassGetStatusString(error) \
+                << " at: " << __LINE__ << std::endl;                      \
+      exit(EXIT_FAILURE);                                                 \
+    }                                                                     \
+  }
+
+#define CHECK_DEVICE(x) TORCH_CHECK(x.is_xpu(), #x " must be on XPU")

--- a/src/ATen/native/xpu/DualGemmOps.cpp
+++ b/src/ATen/native/xpu/DualGemmOps.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/*
+ * Custom XPU operator registrations.
+ *
+ * Registers ops in the `xpu_ops` namespace so they can be called from Python
+ * as torch.ops.xpu_ops.<name>.
+ */
+
+#include <ATen/native/transformers/xpu/dual_gemm/dual_gemm_api.h>
+#include <torch/library.h>
+
+namespace at::native::xpu {
+
+// ---------------------------------------------------------------------------
+// dual_gemm_silu_mul
+//
+// Fused kernel: out = silu(x @ w1.T) * (x @ w3.T)
+// x  : [M, K] bfloat16 XPU tensor
+// w1 : [N, K] bfloat16 XPU tensor
+// w3 : [N, K] bfloat16 XPU tensor
+// out: [M, N] bfloat16 XPU tensor
+// ---------------------------------------------------------------------------
+at::Tensor dual_gemm_silu_mul(
+    const at::Tensor& x,
+    const at::Tensor& w1,
+    const at::Tensor& w3) {
+  return sycltla::dual_gemm_silu_mul(x, w1, w3);
+}
+
+// Abstract (meta) implementation: infers output shape/dtype without executing
+// the real kernel.  Required for torch.compile / FakeTensor propagation.
+at::Tensor dual_gemm_silu_mul_meta(
+    const at::Tensor& x,
+    const at::Tensor& w1,
+    const at::Tensor& w3) {
+  // Output is [M, N] with the same dtype and device as x.
+  const int64_t M = x.size(0);
+  const int64_t N = w1.size(0);
+  return at::empty({M, N}, x.options());
+}
+
+} // namespace at::native::xpu
+
+// Register schema only (no default implementation).
+TORCH_LIBRARY(xpu_ops, m) {
+  m.def("dual_gemm_silu_mul(Tensor x, Tensor w1, Tensor w3) -> Tensor");
+}
+
+// Register the XPU kernel for the XPU dispatch key.
+TORCH_LIBRARY_IMPL(xpu_ops, XPU, m) {
+  m.impl("dual_gemm_silu_mul", TORCH_FN(at::native::xpu::dual_gemm_silu_mul));
+}
+
+// Register the abstract/meta implementation for FakeTensor / shape inference.
+TORCH_LIBRARY_IMPL(xpu_ops, Meta, m) {
+  m.impl(
+      "dual_gemm_silu_mul", TORCH_FN(at::native::xpu::dual_gemm_silu_mul_meta));
+}

--- a/src/BuildOnLinux.cmake
+++ b/src/BuildOnLinux.cmake
@@ -89,6 +89,7 @@ if(USE_SYCLTLA)
     target_compile_definitions(${sycl_lib} PRIVATE ${SYCLTLA_COMPILE_DEFINITIONS})
     target_include_directories(${sycl_lib} PRIVATE ${SYCLTLA_INCLUDE_DIRS})
     target_include_directories(${sycl_lib} PRIVATE ${ATen_XPU_FLASH_ATTN_DIRS})
+    target_include_directories(${sycl_lib} PRIVATE ${ATen_XPU_DUAL_GEMM_DIRS})
   endforeach()
 
   set(REPLACE_FLAGS_FOR_SYCLTLA FALSE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,10 @@ set(ATen_XPU_FLASH_ATTN_DIRS
   ${TORCH_XPU_OPS_ROOT}/src/ATen/native/transformers/xpu/flash_attn
   CACHE STRING "ATen XPU Flash Attention directory"
 )
+set(ATen_XPU_DUAL_GEMM_DIRS
+  ${TORCH_XPU_OPS_ROOT}/src/ATen/native/transformers/xpu/dual_gemm
+  CACHE STRING "ATen XPU Dual GEMM directory"
+)
 
 add_subdirectory(ATen)
 if(USE_C10D_XCCL)


### PR DESCRIPTION
## Summary

Implements `xpu_ops::dual_gemm_silu_mul`, a fused kernel computing:
```
out = silu(x @ w1.T) * (x @ w3.T)
```
using the sycl-tla (CUTLASS SYCL) DualGemm primitive on Intel XPU (PVC).

The kernel loads the shared A matrix (`x`) from HBM only once, saving one full matrix read vs two separate GEMM+epilogue launches.

## New files

- `dual_gemm_api.h / .cpp`: public C++ API — validates inputs, transposes `w1`/`w3` to `[K, N]` row-major before calling the sycl-tla kernel
- `sycltla/dual_gemm_common.h`: sycl-tla header includes and type aliases
- `sycltla/dual_gemm.cpp`: CUTLASS kernel instantiation (BF16 in/out, float accumulator, TileShape 128×128×64, PVC XMX16)
- `DualGemmOps.cpp`: `TORCH_LIBRARY` schema + `TORCH_LIBRARY_IMPL` for `XPU` dispatch key and `Meta` dispatch key (required for `torch.compile` / FakeTensor shape propagation)

## CMake changes

- `ATen/CMakeLists.txt`: glob `dual_gemm/*.cpp` and `dual_gemm/sycltla/*.cpp`
- `CMakeLists.txt`: add `ATen_XPU_DUAL_GEMM_DIRS` cmake variable
- `BuildOnLinux.cmake`: add `ATen_XPU_DUAL_GEMM_DIRS` to sycltla include paths

## Known issues / follow-up

The kernel currently underperforms oneDNN/oneMKL eager on LLaMA-style shapes (small M, large N=14336). The hardcoded `TileShape = Shape<_128, _128, _64>` is not well-suited for small-M rectangular problems. Follow-up work needed to tune tile sizes or add a shape guard in the Inductor FX pass.

## Testing

Tested with `test_dual_gemm.py` (correctness + Inductor fusion trigger) and `bench_dual_gemm.py` (performance) on Intel Data Center GPU Max 1550.
