### PR TITLE
Make linalg.svd CPU fallback warning not break the test test_cond_errors_and_warnings.

### DIFF
--- a/test/xpu/test_linalg_xpu.py
+++ b/test/xpu/test_linalg_xpu.py
@@ -513,7 +513,7 @@ def pinv_errors_and_warnings(self, device, dtype):
     with warnings.catch_warnings(record=True) as w:
         warnings.filterwarnings(
             "ignore",
-            message=r".*Aten Op fallback from XPU to CPU happened.*",
+            message=r".*Aten Op fallback from XPU to CPU happends.*",
             category=UserWarning,
         )
         torch.linalg.pinv(a, out=out)
@@ -594,7 +594,7 @@ def cond_errors_and_warnings(self, device, dtype):
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings(
                 "ignore",
-                message=r".*Aten Op fallback from XPU to CPU happened.*",
+                message=r".*Aten Op fallback from XPU to CPU happends.*",
                 category=UserWarning,
             )
             # Trigger warning

--- a/test/xpu/test_linalg_xpu.py
+++ b/test/xpu/test_linalg_xpu.py
@@ -513,7 +513,7 @@ def pinv_errors_and_warnings(self, device, dtype):
     with warnings.catch_warnings(record=True) as w:
         warnings.filterwarnings(
             "ignore",
-            message=r".*Aten Op fallback from XPU to CPU happends.*",
+            message=r".*Aten Op fallback from XPU to CPU happened.*",
             category=UserWarning,
         )
         torch.linalg.pinv(a, out=out)
@@ -594,7 +594,7 @@ def cond_errors_and_warnings(self, device, dtype):
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings(
                 "ignore",
-                message=r".*Aten Op fallback from XPU to CPU happends.*",
+                message=r".*Aten Op fallback from XPU to CPU happened.*",
                 category=UserWarning,
             )
             # Trigger warning

--- a/test/xpu/test_linalg_xpu.py
+++ b/test/xpu/test_linalg_xpu.py
@@ -18,6 +18,7 @@ import math
 import unittest
 import warnings
 from functools import partial
+from math import inf
 
 import torch
 from torch.testing import make_tensor
@@ -565,6 +566,84 @@ def pinv_errors_and_warnings(self, device, dtype):
         torch.linalg.pinv(a, rtol=rtol)
 
 
+@dtypes(*floating_and_complex_types())
+@precisionOverride({torch.float32: 1e-3})
+def cond_errors_and_warnings(self, device, dtype):
+    norm_types = [1, -1, 2, -2, inf, -inf, "fro", "nuc", None]
+
+    # cond expects the input to be at least 2-dimensional
+    a = torch.ones(3, dtype=dtype, device=device)
+    for p in norm_types:
+        with self.assertRaisesRegex(RuntimeError, r"at least 2 dimensions"):
+            torch.linalg.cond(a, p)
+
+    # for some norm types cond expects the input to be square
+    a = torch.ones(3, 2, dtype=dtype, device=device)
+    norm_types = [1, -1, inf, -inf, "fro", "nuc"]
+    for p in norm_types:
+        with self.assertRaisesRegex(
+            RuntimeError, r"must be batches of square matrices"
+        ):
+            torch.linalg.cond(a, p)
+
+    # if non-empty out tensor with wrong shape is passed a warning is given
+    a = torch.ones((2, 2), dtype=dtype, device=device)
+    for p in ["fro", 2]:
+        real_dtype = a.real.dtype if dtype.is_complex else dtype
+        out = torch.empty(a.shape, dtype=real_dtype, device=device)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings(
+                "ignore",
+                message=r".*Aten Op fallback from XPU to CPU happends.*",
+                category=UserWarning,
+            )
+            # Trigger warning
+            torch.linalg.cond(a, p, out=out)
+            # Check warning occurs
+            self.assertEqual(len(w), 1)
+            self.assertTrue(
+                "An output with one or more elements was resized" in str(w[-1].message)
+            )
+
+    # dtypes should be safely castable
+    out = torch.empty(0, dtype=torch.int, device=device)
+    for p in ["fro", 2]:
+        with self.assertRaisesRegex(RuntimeError, "but got result with dtype Int"):
+            torch.linalg.cond(a, p, out=out)
+
+    # device should match
+    if torch.xpu.is_available():
+        wrong_device = "cpu" if self.device_type != "cpu" else "xpu"
+        out = torch.empty(0, dtype=dtype, device=wrong_device)
+        for p in ["fro", 2]:
+            with self.assertRaisesRegex(
+                RuntimeError, "tensors to be on the same device"
+            ):
+                torch.linalg.cond(a, p, out=out)
+
+    # for batched input if at least one matrix in the batch is not invertible,
+    # we can't get the result for all other (possibly) invertible matrices in the batch without an explicit for loop.
+    # this should change when at::inverse works with silent errors
+    # NumPy works fine in this case because it's possible to silence the error and get the inverse matrix results
+    # possibly filled with NANs
+    batch_dim = 3
+    a = torch.eye(3, 3, dtype=dtype, device=device)
+    a = a.reshape((1, 3, 3))
+    a = a.repeat(batch_dim, 1, 1)
+    a[1, -1, -1] = 0  # now a[1] is singular
+    for p in [1, -1, inf, -inf, "fro", "nuc"]:
+        result = torch.linalg.cond(a, p)
+        self.assertEqual(result[1], float("inf"))
+
+    # check invalid norm type
+    a = torch.ones(3, 3, dtype=dtype, device=device)
+    for p in ["wrong_norm", 5]:
+        with self.assertRaisesRegex(
+            RuntimeError, f"linalg.cond got an invalid norm type: {p}"
+        ):
+            torch.linalg.cond(a, p)
+
+
 # Skip Float8_e4m3fnuz rowwise scaled GEMM on XPU: oneDNN lacks FNUZ support.
 # Note: the primary CUDA test is already limited to ROCm (onlyCUDA + skipCUDAIfNotRocm),
 # so this XPU variant is intentionally skipped for the same unsupported dtype.
@@ -591,6 +670,7 @@ TestLinalg.test_ck_blas_library = ck_blas_library
 TestLinalg.test_addmm_relu_tunableop_rocm = addmm_relu_tunableop_rocm
 TestLinalg.test_pinv_errors_and_warnings = pinv_errors_and_warnings
 TestLinalg.test_rotating_buffer_tunableop = rotating_buffer_tunableop
+TestLinalg.test_cond_errors_and_warnings = cond_errors_and_warnings
 TestLinalg._tunableop_ctx = __tunableop_ctx
 
 TestLinalg._default_dtype_check_enabled = True


### PR DESCRIPTION
Fix for: #3344 

## Summary

This PR fixes a flaky XPU linalg test by adding an XPU-specific override for `test_cond_errors_and_warnings`.
The same approach was already used and merged in #3034 

## Problem

`TestLinalgXPU.test_cond_errors_and_warnings_xpu_float64` intermittently fails because the test expects exactly one warning (`out` resize warning), but on XPU an additional warning may appear:

- `Aten Op fallback from XPU to CPU happened...`

This extra warning is emitted when `torch.linalg.cond(..., p=2)` goes through the SVD path and falls back to CPU on XPU. Since fallback warnings can be one-time/process-order dependent, the warning count is not stable, which makes the test flaky.

## What changed

In `test/xpu/test_linalg_xpu.py`, this PR:

- Adds an XPU override: `cond_errors_and_warnings`
- Mirrors the upstream `test_cond_errors_and_warnings` logic
- Filters the known XPU fallback warning inside the warning-capture block

## Why this approach

The same approach was already used and merged in #3034 
This keeps the behavioral assertions intact while removing noise from a backend-specific, non-functional warning that makes the warning-count assertion nondeterministic.
