### PR TITLE
[SYCLTLA] Support more headdim for FlashAttention fwd/bwd

### DIFF
--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/generate_kernels.py
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/generate_kernels.py
@@ -1,0 +1,133 @@
+# Copyright 2020-2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+"""Generate per-headdim kernel instantiation files for XPU flash attention.
+
+Each file provides explicit template specializations for all dtype x causal
+combinations at a given head dimension. This splits heavy template
+instantiation across compilation units to speed up parallel builds.
+
+Usage:
+    python generate_kernels.py [-o OUTPUT_DIR]
+
+If no output directory is specified, files are written to the script's directory.
+"""
+
+import argparse
+from pathlib import Path
+from typing import Optional
+
+HEAD_DIMENSIONS = [32, 64, 96, 128, 192, 256]
+
+DTYPE_MAP = {
+    "fp16": "cute::half_t",
+    "bf16": "cute::bfloat16_t",
+}
+
+PRELUDE = """\
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Splitting the different head dimensions to different files to speed up
+// compilation. This file is auto-generated. See "generate_kernels.py"
+"""
+
+FWD_TEMPLATE = """\
+{prelude}
+#include <sycltla/mha_fwd_launch.h>
+
+namespace cute {{
+
+{specializations}
+
+}} // namespace cute
+"""
+
+BWD_TEMPLATE = """\
+{prelude}
+#include <sycltla/mha_bwd_launch.h>
+
+namespace cute {{
+
+{specializations}
+
+}} // namespace cute
+"""
+
+FWD_SPECIALIZATION = """\
+template <>
+void run_mha_fwd_<{dtype}, {hdim}, {causal}>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {{
+  run_mha_fwd_hdim{hdim}<{dtype}, {causal}>(queue, params);
+}}"""
+
+BWD_SPECIALIZATION = """\
+template <>
+void run_mha_bwd_<{dtype}, {hdim}, {causal}>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {{
+  run_mha_bwd_hdim{hdim}<{dtype}, {causal}>(queue, params);
+}}"""
+
+
+def generate_specializations(template: str, hdim: int) -> str:
+    specs = []
+    for dtype_cpp in DTYPE_MAP.values():
+        for causal in ["false", "true"]:
+            specs.append(template.format(dtype=dtype_cpp, hdim=hdim, causal=causal))
+    return "\n\n".join(specs)
+
+
+def generate_file(direction: str, hdim: int) -> tuple[str, str]:
+    if direction == "fwd":
+        body = FWD_TEMPLATE.format(
+            prelude=PRELUDE,
+            specializations=generate_specializations(FWD_SPECIALIZATION, hdim),
+        )
+    else:
+        body = BWD_TEMPLATE.format(
+            prelude=PRELUDE,
+            specializations=generate_specializations(BWD_SPECIALIZATION, hdim),
+        )
+    filename = f"mha_{direction}_hdim{hdim}.cpp"
+    return filename, body
+
+
+def main(output_dir: Optional[str]) -> None:
+    if output_dir is None:
+        out = Path(__file__).parent
+    else:
+        out = Path(output_dir)
+
+    for direction in ["fwd", "bwd"]:
+        for hdim in HEAD_DIMENSIONS:
+            filename, content = generate_file(direction, hdim)
+            (out / filename).write_text(content)
+            print(f"  {filename}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Generate per-headdim kernel instantiation files for XPU flash attention",
+    )
+    parser.add_argument(
+        "-o",
+        "--output_dir",
+        required=False,
+        help="Output directory (defaults to script directory)",
+    )
+    args = parser.parse_args()
+    main(args.output_dir)

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.cpp
@@ -8,1177 +8,44 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include <ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h>
-#include <ATen/native/transformers/xpu/flash_attn/sycltla/mha_common.h>
-// batch, numhead_qo,numhead_kv,seqlen_qo,seqlen_kv,headsize_qk,headsize_vo
-using ProblemShapeRegular = cute::tuple<int, int, int, int, int, int, int>;
+#include <sycltla/mha_bwd.h>
+#include <sycltla/mha_common.h>
 
 namespace cute {
 
-template <typename Layout>
-auto convert_layout_2d_layout(Layout layout) {
-  auto l =
-      make_layout(make_layout(get<0>(layout), get<1>(layout)), get<2>(layout));
-  return l;
-}
-
-template <bool Is_even_M, class T>
-void compute_o_dot_do(
-    T& trait,
-    Param<typename T::DType>& param,
-    const int m_block,
-    const int bidb,
-    const int bidh) {
-  // The thread index.
-  constexpr int kBlockM = T::kBlockM;
-  constexpr int kHeadDim = T::kHeadDim;
-  constexpr int kNSGs = T::kNSGs;
-  constexpr int SubgroupSize = T::SubgroupSize;
-  using DType = typename T::DType;
-  using VType = typename T::VType;
-
-  auto sg = compat::get_nd_item<1>().get_sub_group();
-  auto bofst = Boffset(param);
-
-  const index_t o_offset = bofst.o_offset(bidb, bidh, m_block * kBlockM);
-  const index_t do_offset = bofst.do_offset(bidb, bidh, m_block * kBlockM);
-  const index_t dqaccum_offset =
-      bofst.dqaccum_offset(bidb, bidh, m_block * kBlockM);
-  const index_t dpsum_offset = bofst.lse_offset(bidb, bidh, m_block * kBlockM);
-
-  using ShapeO =
-      Shape<std::conditional_t<Is_even_M, Int<kBlockM>, int>, Int<kHeadDim>>;
-  using ShapeP = Shape<std::conditional_t<Is_even_M, Int<kBlockM>, int>>;
-  ShapeO O_shape;
-  ShapeP dP_shape;
-  if constexpr (Is_even_M) {
-    O_shape = make_shape(Int<kBlockM>{}, Int<kHeadDim>{});
-    dP_shape = make_shape(Int<kBlockM>{});
-  } else {
-    O_shape = make_shape(param.tail_m, Int<kHeadDim>{});
-    dP_shape = make_shape(param.tail_m);
-  }
-  auto dQ_shape = make_shape(Int<kBlockM>{}, Int<kHeadDim>{});
-
-  Tensor mdO = make_tensor(
-      make_gmem_ptr(param.do_ptr + do_offset),
-      make_layout(O_shape, make_stride(param.do_r_stride, _1{})));
-  Tensor mO = make_tensor(
-      make_gmem_ptr(param.o_ptr + o_offset),
-      make_layout(O_shape, make_stride(param.o_r_stride, _1{})));
-  Tensor mdQaccum = make_tensor(
-      make_gmem_ptr(param.dqaccum_ptr + dqaccum_offset),
-      make_layout(
-          make_shape(Int<kBlockM>{}, Int<kHeadDim>{}),
-          make_stride(param.head_dim, _1{})));
-  Tensor mdPsum = make_tensor(
-      make_gmem_ptr(param.odo_ptr + dpsum_offset),
-      make_layout(dP_shape, Stride<_1>{}));
-  using ThreadLayout = Layout<
-      Shape<Int<kNSGs>, Int<SubgroupSize>>,
-      Stride<Int<SubgroupSize>, _1>>;
-  using ValueLayout = std::conditional_t<
-      kHeadDim == 96,
-      Layout<Shape<_1, _2>>,
-      std::conditional_t<
-          kHeadDim == 192,
-          Layout<Shape<_1, _4>>,
-          Layout<Shape<_1, Int<kHeadDim / SubgroupSize>>>>>;
-  using OdOType = cutlass::AlignedArray<DType, size(ValueLayout{})>;
-  using OdOAtom = Copy_Atom<UniversalCopy<OdOType>, DType>;
-  using dQType = cutlass::AlignedArray<VType, size(ValueLayout{})>;
-  using dQAtom = Copy_Atom<UniversalCopy<dQType>, VType>;
-
-  auto tileload_odo = make_tiled_copy(OdOAtom{}, ThreadLayout{}, ValueLayout{});
-  auto tileload_dq = make_tiled_copy(dQAtom{}, ThreadLayout{}, ValueLayout{});
-
-  auto thr_load_odo = tileload_odo.get_thread_slice(ThreadIdxX());
-  auto thr_load_dq = tileload_dq.get_thread_slice(ThreadIdxX());
-
-  Tensor thr_tile_do_S = thr_load_odo.partition_S(mdO);
-  Tensor thr_tile_o_S = thr_load_odo.partition_S(mO);
-  Tensor thr_tile_dq_D = thr_load_dq.partition_D(mdQaccum);
-  Tensor rdQ = make_fragment_like(thr_tile_dq_D);
-  Tensor rdO = make_fragment_like<DType>(rdQ);
-  Tensor rO = make_fragment_like<DType>(rdQ);
-  Tensor cO = make_identity_tensor(dQ_shape);
-  Tensor tcO = thr_load_odo.partition_S(cO);
-  Tensor tcO_row = logical_divide(tcO, Shape<_1>{})(make_coord(0, 0), _, 0);
-  Layout rdO_layout = rdO.layout();
-  Tensor rdO_2d = make_tensor(
-      rdO.data(),
-      make_layout(
-          get<1>(rdO_layout),
-          make_layout(get<0>(rdO_layout), get<2>(rdO_layout))));
-  Tensor rO_2d = make_tensor(rO.data(), rdO_2d.layout());
-
-  constexpr int NumValperCol = size<0>(rdO_2d);
-  auto smem = compat::local_mem<VType[kNSGs * SubgroupSize * NumValperCol]>();
-  auto stensor = make_tensor(
-      make_smem_ptr(smem),
-      make_layout(Shape<Int<NumValperCol>, Int<kNSGs>, Int<SubgroupSize>>{}));
-  clear(rdO_2d);
-  clear(rO_2d);
-  if constexpr (Is_even_M) {
-    for (int mi = 0; mi < size<0>(rdO_2d); ++mi) {
-      copy(tileload_odo, thr_tile_do_S(_, mi, _), rdO(_, mi, _));
-      copy(tileload_odo, thr_tile_o_S(_, mi, _), rO(_, mi, _));
-    }
-  } else {
-    for (int mi = 0; mi < size<0>(rdO_2d); ++mi) {
-      if (get<0>(tcO_row(mi)) < param.tail_m) {
-        copy(tileload_odo, thr_tile_do_S(_, mi, _), rdO(_, mi, _));
-        copy(tileload_odo, thr_tile_o_S(_, mi, _), rO(_, mi, _));
-      }
-    }
-  }
-  int sg_group_id = sg.get_group_id();
-  int sg_local_id = sg.get_local_id();
-  CUTLASS_PRAGMA_UNROLL
-  for (int mi = 0; mi < size<0>(rdO_2d); ++mi) {
-    float accum = 0.0f;
-    CUTLASS_PRAGMA_UNROLL
-    for (int ni = 0; ni < size<1>(rdO_2d); ++ni) {
-      accum = accum + (float)rdO_2d(mi, ni) * (float)rO_2d(mi, ni);
-    }
-    stensor(mi, sg_group_id, sg_local_id) = accum;
-  }
-
-  sg.barrier();
-
-  if (sg_local_id == 0) {
-    CUTLASS_PRAGMA_UNROLL
-    for (int mi = 0; mi < NumValperCol; ++mi) {
-      float accum = 0.0f;
-      // reduce within subgroup
-      CUTLASS_PRAGMA_UNROLL
-      for (int ni = 0; ni < SubgroupSize; ++ni) {
-        accum += stensor(mi, sg_group_id, ni);
-      }
-      if constexpr (Is_even_M) {
-        mdPsum(get<0>(tcO_row(mi))) = accum;
-      } else {
-        if (get<0>(tcO_row(mi)) < param.tail_m) {
-          mdPsum(get<0>(tcO_row(mi))) = accum;
-        }
-      }
-    }
-  }
-}
-
-template <class T>
-void mha_dot_do_o(T trait, Param<typename T::DType> param) {
-  // The block index for the M dimension.
-  const int m_block = BlockIdxX();
-  // The block index for the batch.
-  const int bidb = BlockIdxZ();
-  // The block index for the head.
-  const int bidh = BlockIdxY();
-  if (m_block == param.m_block - 1 and param.tail_m > 0) {
-    compute_o_dot_do<false>(trait, param, m_block, bidb, bidh);
-  } else {
-    compute_o_dot_do<true>(trait, param, m_block, bidb, bidh);
-  }
-}
-
-template <
-    typename Engine0,
-    typename Layout0,
-    typename Engine1,
-    typename Layout1>
-CUTLASS_DEVICE void apply_mask_causal(
-    Tensor<Engine0, Layout0>& tensor,
-    Tensor<Engine1, Layout1>& rC,
-    int m_offset,
-    int n_offset,
-    int diagonal_offset = 0) {
-  Tensor rC_2d = make_tensor(rC.data(), convert_layout_2d_layout(rC.layout()));
-  CUTLASS_PRAGMA_UNROLL
-  for (int n = 0; n < size<1>(tensor); ++n) {
-    CUTLASS_PRAGMA_UNROLL
-    for (int m = 0; m < size<0>(tensor); ++m) {
-      int y = m_offset + get<1>(rC_2d(m, n)) + diagonal_offset;
-      int x = n_offset + get<0>(rC_2d(m, n));
-      if (x > y) {
-        tensor(m, n) = -INFINITY;
-      }
-    }
-  }
-  return;
-}
-
-template <typename T, class Trait, class MTensor, class TiledMMA>
-auto create_reg(
-    Trait const& trait,
-    MTensor const& C,
-    TiledMMA const& tiled_mma) {
-  auto local_id = int(compat::get_nd_item<1>().get_local_id(0));
-  auto thr_mma = tiled_mma.get_slice(local_id);
-
-  Tensor cC = make_identity_tensor(C.shape()); // (M,N)
-  auto tile_mnk = tiled_mma.tile_mnk();
-  Tensor gC =
-      local_tile(cC, select<0, 1>(tile_mnk), make_coord(0, 0)); // (BLK_M,BLK_N)
-  auto copy_c = make_block_2d_copy_D(tiled_mma, C);
-  auto thr_copy_c = copy_c.get_slice(local_id);
-  if constexpr (is_same_v<T, float>) {
-    auto r32 = thr_mma.partition_sg_fragment_C(make_identity_tensor(
-        select<0, 1>(tile_mnk))); // allocate C fragment storage
-    return r32;
-  } else {
-    auto r16 = thr_copy_c.partition_sg_fragment_S(gC);
-    return r16;
-  }
-}
-
-template <
-    bool clear_acc,
-    class Trait,
-    class Engine0,
-    class Layout0,
-    class Engine1,
-    class Layout1,
-    class Engine2,
-    class Layout2,
-    class TVLayout2,
-    class TiledMMA>
-void gemm_kernel(
-    Trait& trait,
-    Tensor<Engine0, Layout0> const& A, // (M,K)
-    Tensor<Engine1, Layout1> const& B, // (N,K)
-    SubgroupTensor<Engine2, Layout2, TVLayout2>& acc,
-    TiledMMA const& mma) {
-  // -----
-  // Setup
-  // -----
-
-  /* Get workgroup and local IDs */
-  auto local_id = int(compat::get_nd_item<1>().get_local_id(0));
-
-  /* Create proxy coordinate tensors for each global tensor */
-  Tensor cA = make_identity_tensor(A.shape()); // (M,K)
-  Tensor cB = make_identity_tensor(B.shape()); // (N,K)
-
-  auto tile_mnk = mma.tile_mnk();
-
-  Tensor gA = local_tile(
-      cA, select<0, 2>(tile_mnk), make_coord(0, _)); // (BLK_M,BLK_K,k)
-  Tensor gB = local_tile(
-      cB, select<1, 2>(tile_mnk), make_coord(0, _)); // (BLK_N,BLK_K,k)
-
-  /* Create block 2D TiledCopies */
-  auto copy_a = make_block_2d_copy_A(mma, A);
-  auto copy_b = make_block_2d_copy_B(mma, B);
-
-  /* Slice TiledCopy/TiledMMA operations to thread (work-item) level */
-  auto thr_mma = mma.get_slice(local_id);
-  auto thr_copy_a = copy_a.get_slice(local_id);
-  auto thr_copy_b = copy_b.get_slice(local_id);
-
-  /* Register fragments for MMA */
-  auto tCrA = thr_mma.partition_sg_fragment_A(gA(_, _, 0));
-  auto tCrB = thr_mma.partition_sg_fragment_B(gB(_, _, 0));
-
-  /* Register fragments for copies */
-  auto tArA = thr_copy_a.partition_sg_fragment_D(gA(_, _, 0));
-  auto tBrB = thr_copy_b.partition_sg_fragment_D(gB(_, _, 0));
-
-  /* Partition global tensor (proxies) for copies */
-  Tensor tAgA = thr_copy_a.partition_S(gA);
-  Tensor tBgB = thr_copy_b.partition_S(gB);
-
-  /* Partition C */
-  // Tensor tCrC = partition_fragment_C(mma, select<0,1>(tile_mnk));
-
-  /* Create prefetch TiledCopy instances */
-  auto prefetch_a = make_block_2d_prefetch(copy_a);
-  auto prefetch_b = make_block_2d_prefetch(copy_b);
-
-  auto thr_prefetch_A = prefetch_a.get_slice(local_id);
-  auto thr_prefetch_B = prefetch_b.get_slice(local_id);
-
-  /* Partition global tensor (proxies) for prefetch */
-  auto pAgA = thr_prefetch_A.partition_S(gA);
-  auto pBgB = thr_prefetch_B.partition_S(gB);
-
-  /* Prefetch distance, in units of k tiles */
-  const int prefetch_dist = 3;
-
-  // ------
-  // Kernel
-  // ------
-
-  constexpr int barrier_scope = 2;
-
-  int k_tile_count = ceil_div(shape<1>(A), get<2>(tile_mnk));
-  int k_tile_prefetch = 0;
-  /* Clear the accumulators */
-  if constexpr (clear_acc)
-    clear(acc);
-  /* Warm up loops with prefetch to L1 */
-  int prefetch_warmup =
-      prefetch_dist < k_tile_count ? prefetch_dist : k_tile_count;
-  CUTE_UNROLL
-  for (; k_tile_prefetch < prefetch_warmup; k_tile_prefetch++) {
-    prefetch(prefetch_a, pAgA(_, _, _, k_tile_prefetch));
-    prefetch(prefetch_b, pBgB(_, _, _, k_tile_prefetch));
-  }
-  /* Main loop */
-  for (int k_tile = 0; k_tile < k_tile_count; k_tile++, k_tile_prefetch++) {
-    /* Split barrier keeping threads loosely together */
-    barrier_arrive(barrier_scope);
-
-    /* Copy A/B from global memory (ideally L1 cache) to registers */
-    copy(copy_a, tAgA(_, _, _, k_tile), tArA);
-    copy(copy_b, tBgB(_, _, _, k_tile), tBrB);
-
-    /* Prefetch A/B tiles to L1 */
-    if (k_tile_prefetch < k_tile_count) {
-      prefetch(prefetch_a, pAgA(_, _, _, k_tile_prefetch));
-      prefetch(prefetch_b, pBgB(_, _, _, k_tile_prefetch));
-    }
-
-    /* Shuffle data from copy fragments to MMA fragments */
-    reorder(tArA, tCrA);
-    reorder(tBrB, tCrB);
-
-    /* Accumulate C += A * B */
-    gemm(mma, tCrA, tCrB, acc);
-
-    /* Other half of split barrier */
-    barrier_wait(barrier_scope);
-  }
-}
-
-template <
-    class Trait,
-    class Engine0,
-    class Layout0,
-    class Engine1,
-    class Layout1,
-    class Engine2,
-    class Layout2,
-    class TVLayout2,
-    class TiledMMA>
-void gemm_SdP(
-    Trait& trait,
-    Tensor<Engine0, Layout0> const& A, // (M,K)
-    Tensor<Engine1, Layout1> const& B, // (N,K)
-    SubgroupTensor<Engine2, Layout2, TVLayout2>& rSdP,
-    TiledMMA const& mma) {
-  gemm_kernel<true>(trait, A, B, rSdP, mma);
-}
-
-template <
-    class Trait,
-    class Engine0,
-    class Layout0,
-    class Engine1,
-    class Layout1,
-    class Engine2,
-    class Layout2,
-    class TVLayout2,
-    class TiledMMA>
-void gemm_dKV(
-    Trait& trait,
-    Tensor<Engine0, Layout0> const& A, // (M,K)
-    Tensor<Engine1, Layout1> const& B, // (N,K)
-    SubgroupTensor<Engine2, Layout2, TVLayout2>& rdKV,
-    TiledMMA const& mma) {
-  gemm_kernel<false>(trait, A, B, rdKV, mma);
-}
-
-template <
-    class Trait,
-    class Engine0,
-    class Layout0,
-    class Engine1,
-    class Layout1,
-    class Engine2,
-    class Layout2,
-    class TiledMMA>
-void gemm_dQ(
-    Trait& trait,
-    Tensor<Engine0, Layout0> const& A, // (M,K)
-    Tensor<Engine1, Layout1> const& B, // (N,K)
-    Tensor<Engine2, Layout2>& C, // (M,N)
-    TiledMMA const& mma) {
-  auto local_id = int(compat::get_nd_item<1>().get_local_id(0));
-  auto tile_mnk = mma.tile_mnk();
-  Tensor cC = make_identity_tensor(C.shape()); // (M,N)
-  Tensor gC =
-      local_tile(cC, select<0, 1>(tile_mnk), make_coord(0, 0)); // (BLK_M,BLK_N)
-  auto thr_mma = mma.get_slice(local_id);
-  auto tCrC = thr_mma.partition_sg_fragment_C(make_identity_tensor(
-      select<0, 1>(tile_mnk))); // allocate C fragment storage
-  Tensor tCgC = thr_mma.partition_C(gC);
-  gemm_kernel<true>(trait, A, B, tCrC, mma);
-
-  CUTLASS_PRAGMA_UNROLL
-  for (int i = 0; i < size(tCgC); ++i) {
-    auto [m, n] = tCgC(i);
-    cutlass::atomicAdd(&C(m, n), tCrC(i));
-  }
-}
-
-template <
-    class Trait,
-    class TiledMma,
-    class Engine0,
-    class Layout0,
-    class TVLayout0,
-    class Engine1,
-    class Layout1>
-void mha_copy(
-    Trait& trait,
-    TiledMma& tiled_mma,
-    SubgroupTensor<Engine0, Layout0, TVLayout0>& r,
-    Tensor<Engine1, Layout1>& m,
-    int m_block = 0,
-    int n_block = 0) {
-  auto local_id = int(compat::get_nd_item<1>().get_local_id(0));
-  auto copy_c = make_block_2d_copy_D(tiled_mma, m);
-  auto thr_copy_c = copy_c.get_slice(local_id);
-  auto tile_mnk = tiled_mma.tile_mnk();
-  Tensor cC = make_identity_tensor(m.shape());
-  Tensor gC =
-      local_tile(cC, select<0, 1>(tile_mnk), make_coord(m_block, n_block));
-  Tensor tCgC = thr_copy_c.partition_D(gC);
-  copy(copy_c, r, tCgC);
-}
-
-template <
-    class Trait,
-    class TiledMma,
-    class Engine0,
-    class Layout0,
-    class TVLayout0,
-    class Engine1,
-    class Layout1>
-void mha_reorder_copy(
-    Trait& trait,
-    TiledMma& tiled_mma,
-    SubgroupTensor<Engine0, Layout0, TVLayout0>& r,
-    Tensor<Engine1, Layout1>& m) {
-  auto r16 = create_reg<typename Trait::DType>(trait, m, tiled_mma);
-  reorder(r, r16);
-  mha_copy(trait, tiled_mma, r16, m);
-}
-
-template <bool Is_even_M, class Tensor0, class Tensor1, class Tensor2>
-CUTLASS_DEVICE void load_1colvec(
-    Tensor0& reg,
-    Tensor1& mT,
-    Tensor2& coord_row,
-    int tail_m = 0) {
-  if constexpr (Is_even_M) {
-    CUTLASS_PRAGMA_UNROLL
-    for (int mi = 0; mi < size(reg); ++mi) {
-      reg(mi) = mT(get<0>(coord_row(mi)));
-    }
-  } else {
-    for (int mi = 0; mi < size(reg); ++mi) {
-      int row = get<0>(coord_row(mi));
-      if (row < tail_m) {
-        reg(mi) = mT(row);
-      }
-    }
-  }
-}
-
-template <typename Layout>
-CUTLASS_DEVICE auto convert_layout_acc_layout(Layout acc_layout) {
-  static_assert(decltype(size<0>(acc_layout))::value == 8);
-  static_assert(decltype(rank(acc_layout))::value == 3);
-  auto l = logical_divide(
-      acc_layout, Shape<_1>{}); // ((2, 2), MMA_M, MMA_N, Tile_M, M, N)
-  auto l2 =
-      make_layout(make_layout(get<0, 1>(l), get<1>(l)), make_layout(get<2>(l)));
-  return l2;
-}
-
-template <
-    bool Is_even_M,
-    class Engine0,
-    class Layout0,
-    class Engine1,
-    class Layout1,
-    class Engine2,
-    class Layout2>
-CUTLASS_DEVICE void scale_apply_exp2(
-    Tensor<Engine0, Layout0>& tensor,
-    Tensor<Engine1, Layout1>& max,
-    Tensor<Engine2, Layout2>& rC,
-    const float scale,
-    const int tail_m = 0) {
-  static_assert(Layout0::rank == 2, "Only support 2D Tensor");
-  static_assert(Layout1::rank == 1, "Only support 1D Tensor");
-  Tensor rC_2d = make_tensor(rC.data(), convert_layout_2d_layout(rC.layout()));
-  if constexpr (Is_even_M) {
-    CUTLASS_PRAGMA_UNROLL
-    for (int ni = 0; ni < size<1>(tensor); ++ni) {
-      int n = get<1>(rC_2d(0, ni));
-      const float max_scaled = max(n) == -INFINITY ? 0.f : max(n) * M_LOG2E;
-      CUTLASS_PRAGMA_UNROLL
-      for (int mi = 0; mi < size<0>(tensor); ++mi) {
-        tensor(mi, ni) = exp2f(tensor(mi, ni) * scale - max_scaled);
-      }
-    }
-  } else {
-    CUTLASS_PRAGMA_UNROLL
-    for (int ni = 0; ni < size<1>(tensor); ++ni) {
-      int n = get<1>(rC_2d(0, ni));
-      const float max_scaled =
-          ((n >= tail_m) || (max(n) == -INFINITY)) ? 0.f : max(n) * M_LOG2E;
-      CUTLASS_PRAGMA_UNROLL
-      for (int mi = 0; mi < size<0>(tensor); ++mi) {
-        tensor(mi, ni) = exp2f(tensor(mi, ni) * scale - max_scaled);
-      }
-    }
-  }
-}
-
-template <
-    bool Is_even_M,
-    class Engine0,
-    class Layout0,
-    class Engine1,
-    class Layout1,
-    class Engine2,
-    class Layout2,
-    class Engine3,
-    class Layout3>
-CUTLASS_DEVICE void softmax_backward(
-    Tensor<Engine0, Layout0>& P,
-    Tensor<Engine1, Layout1>& dP_sum,
-    Tensor<Engine2, Layout2>& dP,
-    Tensor<Engine3, Layout3>& rC,
-    const float scale,
-    const int tail_m = 0) {
-  Tensor rC_2d = make_tensor(rC.data(), convert_layout_2d_layout(rC.layout()));
-  if constexpr (Is_even_M) {
-    CUTLASS_PRAGMA_UNROLL
-    for (int ni = 0; ni < size<1>(dP); ++ni) {
-      int n = get<1>(rC_2d(0, ni));
-      const float neg_dpsum_scaled = -(dP_sum(n) * scale);
-      CUTLASS_PRAGMA_UNROLL
-      for (int mi = 0; mi < size<0>(dP); ++mi) {
-        dP(mi, ni) = P(mi, ni) * fmaf(dP(mi, ni), scale, neg_dpsum_scaled);
-      }
-    }
-  } else {
-    CUTLASS_PRAGMA_UNROLL
-    for (int ni = 0; ni < size<1>(dP); ++ni) {
-      int n = get<1>(rC_2d(0, ni));
-      if (n < tail_m) {
-        const float neg_dpsum_scaled = -(dP_sum(n) * scale);
-        CUTLASS_PRAGMA_UNROLL
-        for (int mi = 0; mi < size<0>(dP); ++mi) {
-          dP(mi, ni) = P(mi, ni) * fmaf(dP(mi, ni), scale, neg_dpsum_scaled);
-        }
-      }
-    }
-  }
-}
-
-template <bool Is_even_N, bool Seq_parallel, class Trait>
-void dq_dk_dv_1colblock(
-    Trait& trait,
-    Param<typename Trait::DType>& param,
-    const int bidb,
-    const int bidh,
-    const int bidhkv,
-    const int n_block,
-    const int tail_n = 0) {
-  using T = typename Trait::DType;
-  using V = typename Trait::VType;
-  constexpr int kHeadDim = Trait::kHeadDim;
-  constexpr int kBlockM = Trait::kBlockM;
-  constexpr int kBlockN = Trait::kBlockN;
-  constexpr int kNSGs = Trait::kNSGs;
-  constexpr int SubgroupSize = Trait::SubgroupSize;
-  constexpr bool is_causal = Trait::is_causal;
-  auto local_id = int(compat::get_nd_item<1>().get_local_id(0));
-  auto group = compat::get_nd_item<1>().get_group();
-  auto bofst = Boffset(param);
-
-  const index_t q_offset = bofst.q_offset(bidb, bidh, 0);
-  const index_t k_offset = bofst.k_offset(bidb, bidhkv, n_block * kBlockN);
-  const index_t v_offset = bofst.v_offset(bidb, bidhkv, n_block * kBlockN);
-  const index_t dk_offset = bofst.dk_offset(bidb, bidh, n_block * kBlockN);
-  const index_t dv_offset = bofst.dv_offset(bidb, bidh, n_block * kBlockN);
-  const index_t do_offset = bofst.do_offset(bidb, bidh, 0);
-  const index_t dqaccum_offset = bofst.dqaccum_offset(bidb, bidh, 0);
-  const index_t lse_offset = bofst.lse_offset(bidb, bidh, 0);
-  // buff offset
-  const index_t pb_offset =
-      (bidb * param.num_head_q * param.seq_len_kv_pad * kBlockM +
-       bidh * param.seq_len_kv_pad * kBlockM + n_block * kBlockN * kBlockM) *
-      2;
-  const index_t dsb_offset = pb_offset + kBlockN * kBlockM;
-
-  // 2D_Load requires the width to be 4 bytes aligned. Hence bf16/fp16 needs to
-  // round to even number when processing tail_n.
-  // TODO: Remove this after reorder api supports unaligned load. See
-  // CUTLASS9-460
-  const auto block_n_dim = tail_n == 0 ? Int<kBlockN>{} : ((tail_n + 1) & ~1);
-  auto shapeO = make_shape(kBlockM, Int<kHeadDim>{});
-  auto shapeQtOt = make_shape(Int<kHeadDim>{}, kBlockM);
-  auto shapeSPt = make_shape(Int<kBlockN>{}, kBlockM);
-  auto shapeSP = make_shape(kBlockM, block_n_dim);
-
-  using Shape1 =
-      Shape<std::conditional_t<Is_even_N, Int<kBlockN>, int>, Int<kHeadDim>>;
-  using Shape2 =
-      Shape<Int<kHeadDim>, std::conditional_t<Is_even_N, Int<kBlockN>, int>>;
-  auto shapeQ = make_shape(kBlockM, Int<kHeadDim>{});
-  auto shapedQ = Shape<Int<kBlockM>, Int<kHeadDim>>{};
-  Shape1 shapeKtVt;
-  Shape2 shapeKV;
-  if constexpr (Is_even_N) {
-    shapeKtVt = make_shape(Int<kBlockN>{}, Int<kHeadDim>{});
-    shapeKV = make_shape(Int<kHeadDim>{}, Int<kBlockN>{});
-  } else {
-    shapeKtVt = make_shape(tail_n, Int<kHeadDim>{});
-    shapeKV = make_shape(Int<kHeadDim>{}, tail_n);
-  }
-  Tensor mQ = make_tensor(
-      make_gmem_ptr(param.q_ptr + q_offset),
-      make_layout(shapeQ, make_stride(param.q_r_stride, _1{})));
-  Tensor mKt = make_tensor(
-      make_gmem_ptr(param.k_ptr + k_offset),
-      make_layout(shapeKtVt, make_stride(param.k_r_stride, _1{})));
-  Tensor mdO = make_tensor(
-      make_gmem_ptr(param.do_ptr + do_offset),
-      make_layout(shapeO, make_stride(param.do_r_stride, _1{})));
-  Tensor mVt = make_tensor(
-      make_gmem_ptr(param.v_ptr + v_offset),
-      make_layout(shapeKtVt, make_stride(param.v_r_stride, _1{})));
-  // intermediate buffer
-  Tensor mPt = make_tensor(
-      make_gmem_ptr(param.pb_ptr + pb_offset),
-      make_layout(shapeSPt, make_stride(Int<kBlockM>{}, _1{})));
-  Tensor mdOt = make_tensor(
-      make_gmem_ptr(param.do_ptr + do_offset),
-      make_layout(shapeQtOt, make_stride(_1{}, param.do_r_stride)));
-  Tensor mK = make_tensor(
-      make_gmem_ptr(param.k_ptr + k_offset),
-      make_layout(shapeKV, make_stride(_1{}, param.k_r_stride)));
-  Tensor mdPt = make_tensor(
-      make_gmem_ptr(param.pb_ptr + dsb_offset),
-      make_layout(shapeSPt, make_stride(Int<kBlockM>{}, _1{})));
-  Tensor mQt = make_tensor(
-      make_gmem_ptr(param.q_ptr + q_offset),
-      make_layout(shapeQtOt, make_stride(_1{}, param.q_r_stride)));
-
-  Tensor mLSE = make_tensor(
-      make_gmem_ptr(param.lse_ptr + lse_offset),
-      make_layout(Shape<Int<kBlockM>>{}, Stride<_1>{}));
-  Tensor mdPsum = make_tensor(
-      make_gmem_ptr(param.odo_ptr + lse_offset),
-      make_layout(Shape<Int<kBlockM>>{}, Stride<_1>{}));
-
-  Tensor mdV = make_tensor(
-      make_gmem_ptr(param.dv_ptr + dv_offset),
-      make_layout(shapeKtVt, make_stride(param.dv_r_stride, _1{})));
-  Tensor mdP = make_tensor(
-      make_gmem_ptr(param.pb_ptr + dsb_offset),
-      make_layout(shapeSP, make_stride(_1{}, Int<kBlockM>{})));
-  Tensor mdQaccum = make_tensor(
-      make_gmem_ptr(param.dqaccum_ptr + dqaccum_offset),
-      make_layout(shapedQ, make_stride(param.head_dim, _1{})));
-  Tensor mdK = make_tensor(
-      make_gmem_ptr(param.dk_ptr + dk_offset),
-      make_layout(shapeKtVt, make_stride(param.dk_r_stride, _1{})));
-
-  typename Trait::TiledMmaSdP tiled_mma_sdp;
-  typename Trait::TiledMmadKV tiled_mma_dkv;
-  typename Trait::TiledMmadQ tiled_mma_dq;
-
-  auto thr_mma_sdp = tiled_mma_sdp.get_slice(local_id);
-
-  Tensor caccSt = make_identity_tensor(
-      Shape<Int<kBlockN>, Int<kBlockM>>{}); // same buffer as accSt
-  Tensor taccScSt = thr_mma_sdp.partition_C(caccSt);
-  Tensor taccScS_rt = logical_divide(taccScSt, Shape<_1>{});
-  // static_assert(size<0>(tSrS) * size<1>(tSrS) == size<0>(lse) && "row of acc
-  // and lse not match"); misc
-
-  const int max_m_block = ceil_div(param.seq_len_q, kBlockM);
-  const int tail_m = param.seq_len_q % kBlockM;
-
-  auto rdV = create_reg<V>(trait, mdV, tiled_mma_dkv);
-  auto rdK = create_reg<V>(trait, mdK, tiled_mma_dkv);
-  clear(rdV);
-  clear(rdK);
-  // clear accumulator
-  for (int m_block = 0; m_block < max_m_block; ++m_block) {
-    const bool Is_even_M = not((m_block == max_m_block - 1) and (tail_m != 0));
-    if (not Is_even_M) {
-      // 2D_Load requires the width to be 4 bytes aligned. Hence bf16/fp16 needs
-      // to round to even number when processing tail_n.
-      // TODO: Remove this after reorder api supports unaligned load. See
-      // CUTLASS9-460
-      const int block_m_dim = ((tail_m + 1) & ~1);
-      mQ = make_tensor(
-          make_gmem_ptr(mQ.data()),
-          make_layout(
-              make_shape(tail_m, Int<kHeadDim>{}),
-              make_stride(param.q_r_stride, _1{})));
-      mdO = make_tensor(
-          make_gmem_ptr(mdO.data()),
-          make_layout(
-              make_shape(tail_m, Int<kHeadDim>{}),
-              make_stride(param.do_r_stride, _1{})));
-      mPt = make_tensor(
-          make_gmem_ptr(mPt.data()),
-          make_layout(
-              make_shape(Int<kBlockN>{}, block_m_dim),
-              make_stride(Int<kBlockM>{}, _1{})));
-      mdOt = make_tensor(
-          make_gmem_ptr(mdOt.data()),
-          make_layout(
-              make_shape(Int<kHeadDim>{}, tail_m),
-              make_stride(_1{}, param.do_r_stride)));
-      mdPt = make_tensor(
-          make_gmem_ptr(mdPt.data()),
-          make_layout(
-              make_shape(Int<kBlockN>{}, block_m_dim),
-              make_stride(Int<kBlockM>{}, _1{})));
-      mdP = make_tensor(
-          make_gmem_ptr(mdP.data()),
-          make_layout(
-              make_shape(block_m_dim, block_n_dim),
-              make_stride(_1{}, Int<kBlockM>{})));
-      mdQaccum = make_tensor(
-          make_gmem_ptr(mdQaccum.data()),
-          make_layout(shapedQ, make_stride(param.head_dim, _1{})));
-      mQt = make_tensor(
-          make_gmem_ptr(mQt.data()),
-          make_layout(
-              make_shape(Int<kHeadDim>{}, tail_m),
-              make_stride(_1{}, param.q_r_stride)));
-    }
-    {
-      auto rS = create_reg<V>(trait, mPt, tiled_mma_sdp);
-      // S=QKt
-      gemm_SdP(trait, mKt, mQ, rS, tiled_mma_sdp);
-      Tensor scores =
-          make_tensor(rS.data(), convert_layout_acc_layout(rS.layout()));
-      if constexpr (is_causal) {
-        apply_mask_causal(
-            scores,
-            taccScS_rt,
-            m_block * kBlockM,
-            n_block * kBlockN,
-            param.seq_len_kv - param.seq_len_q);
-      }
-      // P=softmax(S,lse)
-      if (Is_even_M) {
-        scale_apply_exp2<true>(
-            scores, mLSE, taccScS_rt, param.scale_softmax_log2);
-      } else {
-        scale_apply_exp2<false>(
-            scores, mLSE, taccScS_rt, param.scale_softmax_log2, tail_m);
-      }
-      auto rdP = create_reg<V>(trait, mdPt, tiled_mma_sdp);
-      // dP=dO*Vt
-      gemm_SdP(trait, mVt, mdO, rdP, tiled_mma_sdp);
-      Tensor dS = make_tensor(rdP.data(), scores.layout());
-      // dS=P(dP-sum_row(P))*scale
-      if (Is_even_M) {
-        softmax_backward<true>(
-            scores, mdPsum, dS, taccScS_rt, param.scale_softmax);
-      } else {
-        softmax_backward<false>(
-            scores, mdPsum, dS, taccScS_rt, param.scale_softmax, tail_m);
-      }
-      mha_reorder_copy(trait, tiled_mma_sdp, rS, mPt);
-      mha_reorder_copy(
-          trait, tiled_mma_sdp, rdP, mdPt); // copy dP to internal buff
-    }
-    sycl::group_barrier(group);
-    // dV=Pt*dO
-    gemm_dKV(trait, mPt, mdOt, rdV, tiled_mma_dkv);
-    // dK=dPt*Q
-    gemm_dKV(trait, mdPt, mQt, rdK, tiled_mma_dkv);
-    // dQ=dP*K
-    gemm_dQ(trait, mdP, mK, mdQaccum, tiled_mma_dq);
-    // update ptr/atom copy
-    mQ.data() = mQ.data() + int(kBlockM * param.q_r_stride);
-    mdO.data() = mdO.data() + int(kBlockM * param.do_r_stride);
-    mdOt.data() = mdOt.data() + int(kBlockM * param.do_r_stride);
-    mdQaccum.data() = mdQaccum.data() + int(kBlockM * param.head_dim);
-    mQt.data() = mQt.data() + int(kBlockM * param.q_r_stride);
-    mLSE.data() = mLSE.data() + int(kBlockM);
-    mdPsum.data() = mdPsum.data() + int(kBlockM);
-  }
-  mha_reorder_copy(trait, tiled_mma_dkv, rdV, mdV);
-  mha_reorder_copy(trait, tiled_mma_dkv, rdK, mdK);
-}
-
-template <class T>
-void mha_backward_seq(T trait, Param<typename T::DType> param) {
-  const int bidb = BlockIdxZ();
-  const int bidhq = BlockIdxY();
-  const int bidnblk = BlockIdxX();
-  const int bidhkv = bidhq / param.num_qh_per_kvh;
-  for (int n_block = bidnblk; n_block < param.n_block; n_block += GridDimX()) {
-    if (param.tail_n > 0 and n_block == param.n_block - 1)
-      dq_dk_dv_1colblock<false, false>(
-          trait, param, bidb, bidhq, bidhkv, param.n_block - 1, param.tail_n);
-    else
-      dq_dk_dv_1colblock<true, false>(
-          trait, param, bidb, bidhq, bidhkv, n_block);
-  }
-}
-
-template <typename To_type, typename Engine, typename Layout>
-CUTLASS_DEVICE auto convert_type(Tensor<Engine, Layout> const& tensor) {
-  using From_type = typename Engine::value_type;
-  constexpr int numel = decltype(size(tensor))::value;
-  cutlass::NumericArrayConverter<To_type, From_type, numel> convert_op;
-  auto frag =
-      convert_op(*reinterpret_cast<const cutlass::Array<From_type, numel>*>(
-          tensor.data()));
-  return make_tensor(make_rmem_ptr<To_type>(&frag), tensor.layout());
-}
-
-template <class Engine0, class Layout0, class Engine1, class Layout1>
-CUTLASS_DEVICE void convert_type(
-    Tensor<Engine0, Layout0> const& src,
-    Tensor<Engine1, Layout1>& dst) {
-  using From_type = typename Engine0::value_type;
-  using To_type = typename Engine1::value_type;
-  constexpr int numel = decltype(size(src))::value;
-  cutlass::NumericConverter<To_type, From_type> convert_op;
-  CUTLASS_PRAGMA_UNROLL
-  for (int i = 0; i < numel; ++i) {
-    dst(i) = convert_op(src(i));
-  }
-}
-
-template <bool Is_even_M, class T>
-void convert_dq(
-    T& trait,
-    Param<typename T::DType>& param,
-    int m_block,
-    int bidb,
-    int bidh) {
-  constexpr int kBlockM = T::kBlockM;
-  constexpr int kHeadDim = T::kHeadDim;
-  constexpr int kNSGs = T::kNSGs;
-  constexpr int SubgroupSize = T::SubgroupSize;
-  using DType = typename T::DType;
-  using VType = typename T::VType;
-
-  auto bofst = Boffset(param);
-  const index_t dq_offset = bofst.dq_offset(bidb, bidh, m_block * kBlockM);
-  const index_t dqaccum_offset =
-      bofst.dqaccum_offset(bidb, bidh, m_block * kBlockM);
-  using ShapeQ =
-      Shape<std::conditional_t<Is_even_M, Int<kBlockM>, int>, Int<kHeadDim>>;
-  ShapeQ shapeQ;
-  if constexpr (Is_even_M) {
-    shapeQ = make_shape(Int<kBlockM>{}, Int<kHeadDim>{});
-  } else {
-    shapeQ = make_shape(param.tail_m, Int<kHeadDim>{});
-  }
-
-  Tensor mdQaccum = make_tensor(
-      make_gmem_ptr(param.dqaccum_ptr + dqaccum_offset),
-      make_layout(
-          Shape<Int<kBlockM>, Int<kHeadDim>>{},
-          make_stride(param.head_dim, _1{})));
-  Tensor mdQ = make_tensor(
-      make_gmem_ptr(param.dq_ptr + dq_offset),
-      make_layout(shapeQ, make_stride(param.dq_r_stride, _1{})));
-
-  using ThreadLayout = Layout<
-      Shape<Int<kNSGs>, Int<SubgroupSize>>,
-      Stride<Int<SubgroupSize>, _1>>;
-  using ValueLayout = std::conditional_t<
-      kHeadDim == 96,
-      Layout<Shape<_1, _2>>,
-      std::conditional_t<
-          kHeadDim == 192,
-          Layout<Shape<_1, _4>>,
-          Layout<Shape<_1, Int<kHeadDim / SubgroupSize>>>>>;
-
-  using dQaccumType = cutlass::AlignedArray<VType, size(ValueLayout{})>;
-  using dQaccumAtom = Copy_Atom<UniversalCopy<dQaccumType>, VType>;
-  using dQType = cutlass::AlignedArray<DType, size(ValueLayout{})>;
-  using dQAtom = Copy_Atom<UniversalCopy<dQType>, DType>;
-
-  auto tileload_dQaccum =
-      make_tiled_copy(dQaccumAtom{}, ThreadLayout{}, ValueLayout{});
-  auto tilesave_dQ = make_tiled_copy(dQAtom{}, ThreadLayout{}, ValueLayout{});
-
-  auto thr_load_dQaccum = tileload_dQaccum.get_thread_slice(ThreadIdxX());
-  auto thr_save_dQ = tilesave_dQ.get_thread_slice(ThreadIdxX());
-
-  Tensor thr_tile_dQaccum_S = thr_load_dQaccum.partition_S(mdQaccum);
-  Tensor thr_tile_dQ_D = thr_save_dQ.partition_D(mdQ);
-
-  Tensor rdQaccum = make_fragment_like(thr_tile_dQaccum_S);
-
-  copy(tileload_dQaccum, thr_tile_dQaccum_S, rdQaccum);
-  if constexpr (Is_even_M) {
-    Tensor rdQ = convert_type<DType>(rdQaccum);
-    Tensor accQ = make_identity_tensor(shapeQ);
-    Tensor taccQ = thr_save_dQ.partition_D(accQ);
-    Tensor taccQ_rc = logical_divide(taccQ, Shape<_1>{})(0, _, 0);
-    for (int m = 0; m < size<1>(thr_tile_dQ_D); ++m) {
-      int row_m = get<0>(taccQ_rc(m));
-      auto thr_tile_dq = thr_tile_dQ_D(_, m, _);
-      auto r_dq = rdQ(_, m, _);
-      copy(r_dq, thr_tile_dq);
-    }
-  } else {
-    Tensor rdQ = make_tensor_like<DType>(rdQaccum);
-    convert_type(rdQaccum, rdQ);
-    Tensor accQ = make_identity_tensor(shapeQ);
-    Tensor taccQ = thr_save_dQ.partition_D(accQ);
-    Tensor taccQ_rc = logical_divide(taccQ, Shape<_1>{})(0, _, 0);
-    for (int m = 0; m < size<1>(thr_tile_dQ_D); ++m) {
-      int row_m = get<0>(taccQ_rc(m));
-      if (row_m < param.tail_m) {
-        auto thr_tile_dq = thr_tile_dQ_D(_, m, _);
-        auto r_dq = rdQ(_, m, _);
-        copy(r_dq, thr_tile_dq);
-      }
-    }
-  }
-}
-
-template <class T>
-void mhd_convert_dq(T trait, Param<typename T::DType> param) {
-  // The block index for the M dimension.
-  const int m_block = BlockIdxX();
-  // The block index for the batch.
-  const int bidb = BlockIdxZ();
-  // The block index for the head.
-  const int bidh = BlockIdxY();
-  if (param.tail_m > 0 and m_block == param.m_block - 1) {
-    convert_dq<false>(trait, param, m_block, bidb, bidh);
-  } else {
-    convert_dq<true>(trait, param, m_block, bidb, bidh);
-  }
-}
-
-template <class...>
-class MhaDotDoOName;
-
-template <class...>
-class MhaBackwardName;
-
-template <class...>
-class MhdConvertDqName;
-
-template <
-    typename T,
-    int kBlockM,
-    int kBlockN,
-    int kHeadDim,
-    int kNSGs,
-    int AtomLayoutMSdP,
-    int AtomLayoutNdKV,
-    int AtomLayoutMdQ,
-    bool is_causal>
-void run_mha_bwd_specialized(
-    sycl::queue& queue,
-    FLASH_BWD_params& flash_bwd_params) {
-  auto trait = FAKernel<
-      T,
-      kHeadDim,
-      kBlockM,
-      kBlockN,
-      kNSGs,
-      AtomLayoutMSdP,
-      AtomLayoutNdKV,
-      AtomLayoutMdQ,
-      is_causal>{};
-
-  const int BATCH = flash_bwd_params.batch_size;
-  const int NUM_HEAD_Q = flash_bwd_params.num_heads_qo;
-  const int NUM_HEAD_KV = flash_bwd_params.num_heads_kv;
-  const int SEQ_LEN_Q = flash_bwd_params.seqlen_qo;
-  const int SEQ_LEN_KV = flash_bwd_params.seqlen_kv;
-  const int N_BLOCK = ceil_div(SEQ_LEN_KV, kBlockN);
-  const int tail_n = SEQ_LEN_KV % kBlockN;
-  const int M_BLOCK = ceil_div(SEQ_LEN_Q, kBlockM);
-  const int tail_m = SEQ_LEN_Q % kBlockM;
-  auto param = Param<T>(
-      static_cast<const T*>(flash_bwd_params.do_ptr),
-      static_cast<const T*>(flash_bwd_params.o_ptr),
-      static_cast<const T*>(flash_bwd_params.q_ptr),
-      static_cast<const T*>(flash_bwd_params.k_ptr),
-      static_cast<const T*>(flash_bwd_params.v_ptr),
-      static_cast<const float*>(flash_bwd_params.lse_ptr),
-      static_cast<float*>(flash_bwd_params.odo_ptr),
-      static_cast<float*>(flash_bwd_params.dqaccum_ptr),
-      static_cast<T*>(flash_bwd_params.dq_ptr),
-      static_cast<T*>(flash_bwd_params.dk_ptr),
-      static_cast<T*>(flash_bwd_params.dv_ptr),
-      static_cast<T*>(flash_bwd_params.pb_ptr),
-      flash_bwd_params.scale);
-  param.batch = BATCH;
-  param.num_head_q = NUM_HEAD_Q;
-  param.num_head_kv = NUM_HEAD_KV;
-  param.num_qh_per_kvh = NUM_HEAD_Q / NUM_HEAD_KV;
-  param.num_nb_per_blk = std::max(
-      N_BLOCK * NUM_HEAD_Q * BATCH / 1024,
-      1); // 1024 tuneable here, best for pvc
-  param.seq_len_q = SEQ_LEN_Q;
-  param.seq_len_kv = SEQ_LEN_KV;
-  param.head_dim = kHeadDim;
-  param.n_block = N_BLOCK;
-  param.tail_n = tail_n;
-  param.m_block = M_BLOCK;
-  param.tail_m = tail_m;
-  param.seq_len_kv_pad = flash_bwd_params.seqlen_kv_pad;
-  param.seq_len_q_pad = flash_bwd_params.seqlen_qo_pad;
-
-  setup_stride(param, flash_bwd_params);
-
-  auto dimGrid0 =
-      compat::dim3(size(M_BLOCK), size(param.num_head_q), size(param.batch));
-  auto dimBlock0 =
-      compat::dim3(size(kNSGs * trait.SubgroupSize), size(1), size(1));
-  compat::experimental::launch_properties launch_props0{};
-  compat::experimental::kernel_properties kernel_props0{
-      sycl::ext::oneapi::experimental::sub_group_size<trait.SubgroupSize>};
-  compat::experimental::launch_policy policy0{
-      dimGrid0, dimBlock0, launch_props0, kernel_props0};
-  compat::experimental::
-      launch<mha_dot_do_o<decltype(trait)>, MhaDotDoOName<decltype(trait)>>(
-          policy0, queue, trait, param);
-
-  auto dimGrid1 = compat::dim3(
-      size(ceil_div(param.n_block, param.num_nb_per_blk)),
-      size(param.num_head_q),
-      size(param.batch));
-  auto dimBlock1 =
-      compat::dim3(size(kNSGs * trait.SubgroupSize), size(1), size(1));
-  compat::experimental::launch_properties launch_props1{
-      sycl::ext::oneapi::experimental::work_group_scratch_size(
-          trait.smem_size)};
-  compat::experimental::kernel_properties kernel_props1{
-      sycl::ext::oneapi::experimental::sub_group_size<trait.SubgroupSize>};
-  compat::experimental::launch_policy policy1{
-      dimGrid1, dimBlock1, launch_props1, kernel_props1};
-  compat::experimental::launch<
-      mha_backward_seq<decltype(trait)>,
-      MhaBackwardName<decltype(trait)>>(policy1, queue, trait, param);
-
-  auto dimGrid2 =
-      compat::dim3(size(M_BLOCK), size(param.num_head_q), size(param.batch));
-  auto dimBlock2 =
-      compat::dim3(size(kNSGs * trait.SubgroupSize), size(1), size(1));
-  compat::experimental::launch_properties launch_props2{};
-  compat::experimental::kernel_properties kernel_props2{
-      sycl::ext::oneapi::experimental::sub_group_size<trait.SubgroupSize>};
-  compat::experimental::launch_policy policy2{
-      dimGrid2, dimBlock2, launch_props2, kernel_props2};
-  auto event2 = compat::experimental::launch<
-      mhd_convert_dq<decltype(trait)>,
-      MhdConvertDqName<decltype(trait)>>(policy2, queue, trait, param);
-}
-
-template <typename T, int kMPad, int kNPad, bool is_causal>
+// Declared but not defined here -- explicit specializations are provided by
+// the per-headdim compilation units (mha_bwd_hdim*.cpp).
+template <typename T, int Headdim, bool is_causal>
+void run_mha_bwd_(sycl::queue& queue, FLASH_BWD_params& params);
+
+template <typename T, bool is_causal>
 void run_mha_bwd_(sycl::queue& queue, FLASH_BWD_params& params) {
   const int headdim = params.head_size_vo;
-#define RUN_MHA_BWD_SPECIALIZED() \
-  run_mha_bwd_specialized<        \
-      T,                          \
-      kBlockM,                    \
-      kBlockN,                    \
-      kHeadDim,                   \
-      kNSGs,                      \
-      AtomLayoutMSdP,             \
-      AtomLayoutNdKV,             \
-      AtomLayoutMdQ,              \
-      is_causal>(queue, params);
 
-  if (headdim == 64) {
-    constexpr int kBlockM = 64;
-    constexpr int kBlockN = 32;
-    constexpr int kHeadDim = 64;
-    constexpr int kNSGs = 8;
-    constexpr int AtomLayoutMSdP = 4;
-    constexpr int AtomLayoutNdKV = 2;
-    constexpr int AtomLayoutMdQ = 2;
-    static_assert(
-        kBlockM <= kMPad, "kBlockM must be less than or equal to kMPad");
-    static_assert(
-        kBlockN <= kNPad, "kBlockN must be less than or equal to kNPad");
-    RUN_MHA_BWD_SPECIALIZED();
-  } else if (headdim == 96) {
-    constexpr int kBlockM = 64;
-    constexpr int kBlockN = 64;
-    constexpr int kHeadDim = 96;
-    constexpr int kNSGs = 8;
-    constexpr int AtomLayoutMSdP = 2;
-    constexpr int AtomLayoutNdKV = 4;
-    constexpr int AtomLayoutMdQ = 4;
-    static_assert(
-        kBlockM <= kMPad, "kBlockM must be less than or equal to kMPad");
-    static_assert(
-        kBlockN <= kNPad, "kBlockN must be less than or equal to kNPad");
-    RUN_MHA_BWD_SPECIALIZED();
-  } else if (headdim == 128) {
-    constexpr int kBlockM = 128;
-    constexpr int kBlockN = 128;
-    constexpr int kHeadDim = 128;
-    constexpr int kNSGs = 32;
-    constexpr int AtomLayoutMSdP = 4;
-    constexpr int AtomLayoutNdKV = 4;
-    constexpr int AtomLayoutMdQ = 4;
-    static_assert(
-        kBlockM <= kMPad, "kBlockM must be less than or equal to kMPad");
-    static_assert(
-        kBlockN <= kNPad, "kBlockN must be less than or equal to kNPad");
-    RUN_MHA_BWD_SPECIALIZED();
-  } else if (headdim == 192) {
-    constexpr int kBlockM = 64;
-    constexpr int kBlockN = 32;
-    constexpr int kHeadDim = 192;
-    constexpr int kNSGs = 8;
-    constexpr int AtomLayoutMSdP = 4;
-    constexpr int AtomLayoutNdKV = 2;
-    constexpr int AtomLayoutMdQ = 2;
-    static_assert(
-        kBlockM <= kMPad, "kBlockM must be less than or equal to kMPad");
-    static_assert(
-        kBlockN <= kNPad, "kBlockN must be less than or equal to kNPad");
-    RUN_MHA_BWD_SPECIALIZED();
-  } else if (headdim == 256) {
-    constexpr int kBlockM = 64;
-    constexpr int kBlockN = 32;
-    constexpr int kHeadDim = 256;
-    constexpr int kNSGs = 8;
-    constexpr int AtomLayoutMSdP = 4;
-    constexpr int AtomLayoutNdKV = 2;
-    constexpr int AtomLayoutMdQ = 2;
-    static_assert(
-        kBlockM <= kMPad, "kBlockM must be less than or equal to kMPad");
-    static_assert(
-        kBlockN <= kNPad, "kBlockN must be less than or equal to kNPad");
-    RUN_MHA_BWD_SPECIALIZED();
+  if (headdim <= 32) {
+    run_mha_bwd_<T, 32, is_causal>(queue, params);
+  } else if (headdim <= 64) {
+    run_mha_bwd_<T, 64, is_causal>(queue, params);
+  } else if (headdim <= 96) {
+    run_mha_bwd_<T, 96, is_causal>(queue, params);
+  } else if (headdim <= 128) {
+    run_mha_bwd_<T, 128, is_causal>(queue, params);
+  } else if (headdim <= 192) {
+    run_mha_bwd_<T, 192, is_causal>(queue, params);
+  } else if (headdim <= 256) {
+    run_mha_bwd_<T, 256, is_causal>(queue, params);
   } else {
     TORCH_CHECK(
         false,
-        "FlashAttentionBackwardXPU: unsupported head dimension: ",
+        "FlashAttentionBackwardXPU only support headdim up to 256, got ",
         headdim);
   }
-#undef RUN_MHA_BWD_SPECIALIZED
 }
 
-template <int kMPad, int kNPad>
 void run_mha_bwd(sycl::queue& queue, FLASH_BWD_params& params) {
   FP16_SWITCH(params.is_fp16, [&] {
     BOOL_SWITCH(params.is_causal, IS_CAUSAL, [&] {
-      run_mha_bwd_<elem_type, kMPad, kNPad, IS_CAUSAL>(queue, params);
+      run_mha_bwd_<elem_type, IS_CAUSAL>(queue, params);
     });
   });
 }
@@ -1290,6 +157,29 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> flash_attention_backward_sycltla(
       logsumexp.is_contiguous(),
       "FlashAttentionBackwardXPU: logsumexp must be contiguous in [batch_size, numhead_qo, seqlen_qo]");
 
+  const int headsize_padded = round_up_headdim(headsize_qk);
+  const bool needs_headsize_pad = headsize_padded > headsize_qk;
+
+  at::Tensor q_padded = query;
+  at::Tensor k_padded = key;
+  at::Tensor v_padded = value;
+  at::Tensor out_padded = out;
+  at::Tensor grad_out_padded = contiguous_grad_out;
+  if (needs_headsize_pad) {
+    int pad = headsize_padded - headsize_qk;
+    q_padded = at::constant_pad_nd(query, {0, pad}, 0);
+    k_padded = at::constant_pad_nd(key, {0, pad}, 0);
+    v_padded = at::constant_pad_nd(value, {0, pad}, 0);
+    out_padded = at::constant_pad_nd(out, {0, pad}, 0);
+    grad_out_padded = at::constant_pad_nd(contiguous_grad_out, {0, pad}, 0);
+  }
+
+  at::Tensor q_aligned = ensure_alignment_for_sdpa(q_padded);
+  at::Tensor k_aligned = ensure_alignment_for_sdpa(k_padded);
+  at::Tensor v_aligned = ensure_alignment_for_sdpa(v_padded);
+  at::Tensor out_aligned = ensure_alignment_for_sdpa(out_padded);
+  at::Tensor grad_out_aligned = ensure_alignment_for_sdpa(grad_out_padded);
+
   auto sycl_queue = at::xpu::getCurrentXPUStream().queue();
   auto device_architecture =
       sycl_queue.get_device()
@@ -1310,34 +200,44 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> flash_attention_backward_sycltla(
         "XPU device architecture does not support flash attention backward. Supported architectures are: intel_gpu_pvc, intel_gpu_pvc_vg, intel_gpu_bmg_g21, intel_gpu_bmg_g31.");
   }
 
+  auto opts = query.options();
+
   auto grad_query = at::empty_like(query);
   auto grad_key = at::empty_like(key);
   auto grad_value = at::empty_like(value);
 
-  auto opts = query.options();
+  // Allocate padded buffers for the kernel when headsize padding is needed.
+  auto grad_query_padded = needs_headsize_pad
+      ? at::empty({batch_size, numhead_qo, seqlen_qo, headsize_padded}, opts)
+      : grad_query;
+  auto grad_key_padded = needs_headsize_pad
+      ? at::empty({batch_size, numhead_kv, seqlen_kv, headsize_padded}, opts)
+      : grad_key;
+  auto grad_value_padded = needs_headsize_pad
+      ? at::empty({batch_size, numhead_kv, seqlen_kv, headsize_padded}, opts)
+      : grad_value;
 
+  const bool is_gqa = (numhead_kv != numhead_qo);
   at::Tensor grad_key_expanded, grad_value_expanded;
-  if (numhead_kv != numhead_qo) { // MQA / GQA
+  if (is_gqa) {
     grad_key_expanded =
-        at::empty({batch_size, numhead_qo, seqlen_kv, headsize_qk}, opts);
+        at::empty({batch_size, numhead_qo, seqlen_kv, headsize_padded}, opts);
     grad_value_expanded =
-        at::empty({batch_size, numhead_qo, seqlen_kv, headsize_vo}, opts);
+        at::empty({batch_size, numhead_qo, seqlen_kv, headsize_padded}, opts);
   } else {
-    grad_key_expanded = grad_key;
-    grad_value_expanded = grad_value;
+    grad_key_expanded = grad_key_padded;
+    grad_value_expanded = grad_value_padded;
   }
 
-  constexpr int kMPad = 128;
-  constexpr int kNPad = 128;
-  int seqlen_qo_pad = (seqlen_qo + kMPad - 1) / kMPad * kMPad;
-  int seqlen_kv_pad = (seqlen_kv + kNPad - 1) / kNPad * kNPad;
+  int seqlen_qo_pad = (seqlen_qo + kBwdMPad - 1) / kBwdMPad * kBwdMPad;
+  int seqlen_kv_pad = (seqlen_kv + kBwdNPad - 1) / kBwdNPad * kBwdNPad;
   auto tensor_odo =
       at::empty({batch_size, numhead_qo, seqlen_qo}, opts.dtype(at::kFloat));
   auto tensor_dqaccum = at::zeros(
-      {batch_size, numhead_qo, seqlen_qo_pad, headsize_qk},
+      {batch_size, numhead_qo, seqlen_qo_pad, headsize_padded},
       opts.dtype(at::kFloat));
   auto tensor_pbuff =
-      at::empty({batch_size, numhead_qo, seqlen_kv_pad, 2 * kMPad}, opts);
+      at::empty({batch_size, numhead_qo, seqlen_kv_pad, 2 * kBwdMPad}, opts);
 
   FLASH_BWD_params params;
   set_params_dgrad(
@@ -1347,17 +247,17 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> flash_attention_backward_sycltla(
       numhead_kv,
       seqlen_qo,
       seqlen_kv,
-      headsize_qk,
-      headsize_vo,
+      headsize_padded,
+      headsize_padded,
       seqlen_qo_pad,
       seqlen_kv_pad,
-      query,
-      key,
-      value,
-      out,
-      contiguous_grad_out,
+      q_aligned,
+      k_aligned,
+      v_aligned,
+      out_aligned,
+      grad_out_aligned,
       logsumexp,
-      grad_query,
+      grad_query_padded,
       grad_key_expanded,
       grad_value_expanded,
       tensor_odo,
@@ -1366,29 +266,67 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> flash_attention_backward_sycltla(
       scale,
       is_causal);
 
-  cute::run_mha_bwd<kMPad, kNPad>(sycl_queue, params);
+  cute::run_mha_bwd(sycl_queue, params);
 
-  if (numhead_kv != numhead_qo) {
-    at::sum_out(
-        grad_key,
-        at::reshape(
-            grad_key_expanded,
-            {batch_size,
-             numhead_kv,
-             numhead_qo / numhead_kv,
-             seqlen_kv,
-             headsize_qk}),
-        {2});
-    at::sum_out(
-        grad_value,
-        at::reshape(
-            grad_value_expanded,
-            {batch_size,
-             numhead_kv,
-             numhead_qo / numhead_kv,
-             seqlen_kv,
-             headsize_vo}),
-        {2});
+  if (is_gqa) {
+    if (needs_headsize_pad) {
+      auto grad_key_reduced =
+          at::empty({batch_size, numhead_kv, seqlen_kv, headsize_padded}, opts);
+      auto grad_value_reduced =
+          at::empty({batch_size, numhead_kv, seqlen_kv, headsize_padded}, opts);
+      at::sum_out(
+          grad_key_reduced,
+          at::reshape(
+              grad_key_expanded,
+              {batch_size,
+               numhead_kv,
+               numhead_qo / numhead_kv,
+               seqlen_kv,
+               headsize_padded}),
+          {2});
+      at::sum_out(
+          grad_value_reduced,
+          at::reshape(
+              grad_value_expanded,
+              {batch_size,
+               numhead_kv,
+               numhead_qo / numhead_kv,
+               seqlen_kv,
+               headsize_padded}),
+          {2});
+      grad_key_padded = grad_key_reduced;
+      grad_value_padded = grad_value_reduced;
+    } else {
+      at::sum_out(
+          grad_key,
+          at::reshape(
+              grad_key_expanded,
+              {batch_size,
+               numhead_kv,
+               numhead_qo / numhead_kv,
+               seqlen_kv,
+               headsize_padded}),
+          {2});
+      at::sum_out(
+          grad_value,
+          at::reshape(
+              grad_value_expanded,
+              {batch_size,
+               numhead_kv,
+               numhead_qo / numhead_kv,
+               seqlen_kv,
+               headsize_padded}),
+          {2});
+    }
+  }
+
+  if (needs_headsize_pad) {
+    grad_query.copy_(
+        grad_query_padded.slice(/*dim=*/3, /*start=*/0, /*end=*/headsize_qk));
+    grad_key.copy_(
+        grad_key_padded.slice(/*dim=*/3, /*start=*/0, /*end=*/headsize_qk));
+    grad_value.copy_(
+        grad_value_padded.slice(/*dim=*/3, /*start=*/0, /*end=*/headsize_vo));
   }
 
   return std::make_tuple(

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_hdim128.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_hdim128.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Splitting the different head dimensions to different files to speed up
+// compilation. This file is auto-generated. See "generate_kernels.py"
+
+#include <sycltla/mha_bwd_launch.h>
+
+namespace cute {
+
+template <>
+void run_mha_bwd_<cute::half_t, 128, false>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim128<cute::half_t, false>(queue, params);
+}
+
+template <>
+void run_mha_bwd_<cute::half_t, 128, true>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim128<cute::half_t, true>(queue, params);
+}
+
+template <>
+void run_mha_bwd_<cute::bfloat16_t, 128, false>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim128<cute::bfloat16_t, false>(queue, params);
+}
+
+template <>
+void run_mha_bwd_<cute::bfloat16_t, 128, true>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim128<cute::bfloat16_t, true>(queue, params);
+}
+
+} // namespace cute

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_hdim192.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_hdim192.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Splitting the different head dimensions to different files to speed up
+// compilation. This file is auto-generated. See "generate_kernels.py"
+
+#include <sycltla/mha_bwd_launch.h>
+
+namespace cute {
+
+template <>
+void run_mha_bwd_<cute::half_t, 192, false>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim192<cute::half_t, false>(queue, params);
+}
+
+template <>
+void run_mha_bwd_<cute::half_t, 192, true>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim192<cute::half_t, true>(queue, params);
+}
+
+template <>
+void run_mha_bwd_<cute::bfloat16_t, 192, false>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim192<cute::bfloat16_t, false>(queue, params);
+}
+
+template <>
+void run_mha_bwd_<cute::bfloat16_t, 192, true>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim192<cute::bfloat16_t, true>(queue, params);
+}
+
+} // namespace cute

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_hdim256.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_hdim256.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Splitting the different head dimensions to different files to speed up
+// compilation. This file is auto-generated. See "generate_kernels.py"
+
+#include <sycltla/mha_bwd_launch.h>
+
+namespace cute {
+
+template <>
+void run_mha_bwd_<cute::half_t, 256, false>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim256<cute::half_t, false>(queue, params);
+}
+
+template <>
+void run_mha_bwd_<cute::half_t, 256, true>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim256<cute::half_t, true>(queue, params);
+}
+
+template <>
+void run_mha_bwd_<cute::bfloat16_t, 256, false>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim256<cute::bfloat16_t, false>(queue, params);
+}
+
+template <>
+void run_mha_bwd_<cute::bfloat16_t, 256, true>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim256<cute::bfloat16_t, true>(queue, params);
+}
+
+} // namespace cute

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_hdim32.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_hdim32.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Splitting the different head dimensions to different files to speed up
+// compilation. This file is auto-generated. See "generate_kernels.py"
+
+#include <sycltla/mha_bwd_launch.h>
+
+namespace cute {
+
+template <>
+void run_mha_bwd_<cute::half_t, 32, false>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim32<cute::half_t, false>(queue, params);
+}
+
+template <>
+void run_mha_bwd_<cute::half_t, 32, true>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim32<cute::half_t, true>(queue, params);
+}
+
+template <>
+void run_mha_bwd_<cute::bfloat16_t, 32, false>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim32<cute::bfloat16_t, false>(queue, params);
+}
+
+template <>
+void run_mha_bwd_<cute::bfloat16_t, 32, true>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim32<cute::bfloat16_t, true>(queue, params);
+}
+
+} // namespace cute

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_hdim64.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_hdim64.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Splitting the different head dimensions to different files to speed up
+// compilation. This file is auto-generated. See "generate_kernels.py"
+
+#include <sycltla/mha_bwd_launch.h>
+
+namespace cute {
+
+template <>
+void run_mha_bwd_<cute::half_t, 64, false>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim64<cute::half_t, false>(queue, params);
+}
+
+template <>
+void run_mha_bwd_<cute::half_t, 64, true>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim64<cute::half_t, true>(queue, params);
+}
+
+template <>
+void run_mha_bwd_<cute::bfloat16_t, 64, false>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim64<cute::bfloat16_t, false>(queue, params);
+}
+
+template <>
+void run_mha_bwd_<cute::bfloat16_t, 64, true>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim64<cute::bfloat16_t, true>(queue, params);
+}
+
+} // namespace cute

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_hdim96.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_hdim96.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Splitting the different head dimensions to different files to speed up
+// compilation. This file is auto-generated. See "generate_kernels.py"
+
+#include <sycltla/mha_bwd_launch.h>
+
+namespace cute {
+
+template <>
+void run_mha_bwd_<cute::half_t, 96, false>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim96<cute::half_t, false>(queue, params);
+}
+
+template <>
+void run_mha_bwd_<cute::half_t, 96, true>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim96<cute::half_t, true>(queue, params);
+}
+
+template <>
+void run_mha_bwd_<cute::bfloat16_t, 96, false>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim96<cute::bfloat16_t, false>(queue, params);
+}
+
+template <>
+void run_mha_bwd_<cute::bfloat16_t, 96, true>(
+    sycl::queue& queue,
+    FLASH_BWD_params& params) {
+  run_mha_bwd_hdim96<cute::bfloat16_t, true>(queue, params);
+}
+
+} // namespace cute

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
@@ -1,0 +1,1132 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Splitting the different head dimensions to different files to speed up
+// compilation. This file contains the template definitions shared by all
+// per-headdim backward compilation units.
+
+#pragma once
+
+#include <ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h>
+#include <ATen/native/transformers/xpu/flash_attn/sycltla/mha_common.h>
+
+// batch, numhead_qo,numhead_kv,seqlen_qo,seqlen_kv,headsize_qk,headsize_vo
+using ProblemShapeRegular = cute::tuple<int, int, int, int, int, int, int>;
+
+namespace cute {
+
+// Primary template declaration -- explicit specializations are provided by
+// the per-headdim compilation units (mha_bwd_hdim*.cpp).
+template <typename T, int Headdim, bool is_causal>
+void run_mha_bwd_(sycl::queue& queue, FLASH_BWD_params& params);
+
+template <typename Layout>
+auto convert_layout_2d_layout(Layout layout) {
+  auto l =
+      make_layout(make_layout(get<0>(layout), get<1>(layout)), get<2>(layout));
+  return l;
+}
+
+template <bool Is_even_M, class T>
+void compute_o_dot_do(
+    T& trait,
+    Param<typename T::DType>& param,
+    const int m_block,
+    const int bidb,
+    const int bidh) {
+  constexpr int kBlockM = T::kBlockM;
+  constexpr int kHeadDim = T::kHeadDim;
+  constexpr int kNSGs = T::kNSGs;
+  constexpr int SubgroupSize = T::SubgroupSize;
+  using DType = typename T::DType;
+  using VType = typename T::VType;
+
+  auto sg = compat::get_nd_item<1>().get_sub_group();
+  auto bofst = Boffset(param);
+
+  const index_t o_offset = bofst.o_offset(bidb, bidh, m_block * kBlockM);
+  const index_t do_offset = bofst.do_offset(bidb, bidh, m_block * kBlockM);
+  const index_t dqaccum_offset =
+      bofst.dqaccum_offset(bidb, bidh, m_block * kBlockM);
+  const index_t dpsum_offset = bofst.lse_offset(bidb, bidh, m_block * kBlockM);
+
+  using ShapeO =
+      Shape<std::conditional_t<Is_even_M, Int<kBlockM>, int>, Int<kHeadDim>>;
+  using ShapeP = Shape<std::conditional_t<Is_even_M, Int<kBlockM>, int>>;
+  ShapeO O_shape;
+  ShapeP dP_shape;
+  if constexpr (Is_even_M) {
+    O_shape = make_shape(Int<kBlockM>{}, Int<kHeadDim>{});
+    dP_shape = make_shape(Int<kBlockM>{});
+  } else {
+    O_shape = make_shape(param.tail_m, Int<kHeadDim>{});
+    dP_shape = make_shape(param.tail_m);
+  }
+  auto dQ_shape = make_shape(Int<kBlockM>{}, Int<kHeadDim>{});
+
+  Tensor mdO = make_tensor(
+      make_gmem_ptr(param.do_ptr + do_offset),
+      make_layout(O_shape, make_stride(param.do_r_stride, _1{})));
+  Tensor mO = make_tensor(
+      make_gmem_ptr(param.o_ptr + o_offset),
+      make_layout(O_shape, make_stride(param.o_r_stride, _1{})));
+  Tensor mdQaccum = make_tensor(
+      make_gmem_ptr(param.dqaccum_ptr + dqaccum_offset),
+      make_layout(
+          make_shape(Int<kBlockM>{}, Int<kHeadDim>{}),
+          make_stride(param.head_dim, _1{})));
+  Tensor mdPsum = make_tensor(
+      make_gmem_ptr(param.odo_ptr + dpsum_offset),
+      make_layout(dP_shape, Stride<_1>{}));
+  using ThreadLayout = Layout<
+      Shape<Int<kNSGs>, Int<SubgroupSize>>,
+      Stride<Int<SubgroupSize>, _1>>;
+  using ValueLayout = std::conditional_t<
+      kHeadDim == 96,
+      Layout<Shape<_1, _2>>,
+      std::conditional_t<
+          kHeadDim == 192,
+          Layout<Shape<_1, _4>>,
+          Layout<Shape<_1, Int<kHeadDim / SubgroupSize>>>>>;
+  using OdOType = cutlass::AlignedArray<DType, size(ValueLayout{})>;
+  using OdOAtom = Copy_Atom<UniversalCopy<OdOType>, DType>;
+  using dQType = cutlass::AlignedArray<VType, size(ValueLayout{})>;
+  using dQAtom = Copy_Atom<UniversalCopy<dQType>, VType>;
+
+  auto tileload_odo = make_tiled_copy(OdOAtom{}, ThreadLayout{}, ValueLayout{});
+  auto tileload_dq = make_tiled_copy(dQAtom{}, ThreadLayout{}, ValueLayout{});
+
+  auto thr_load_odo = tileload_odo.get_thread_slice(ThreadIdxX());
+  auto thr_load_dq = tileload_dq.get_thread_slice(ThreadIdxX());
+
+  Tensor thr_tile_do_S = thr_load_odo.partition_S(mdO);
+  Tensor thr_tile_o_S = thr_load_odo.partition_S(mO);
+  Tensor thr_tile_dq_D = thr_load_dq.partition_D(mdQaccum);
+  Tensor rdQ = make_fragment_like(thr_tile_dq_D);
+  Tensor rdO = make_fragment_like<DType>(rdQ);
+  Tensor rO = make_fragment_like<DType>(rdQ);
+  Tensor cO = make_identity_tensor(dQ_shape);
+  Tensor tcO = thr_load_odo.partition_S(cO);
+  Tensor tcO_row = logical_divide(tcO, Shape<_1>{})(make_coord(0, 0), _, 0);
+  Layout rdO_layout = rdO.layout();
+  Tensor rdO_2d = make_tensor(
+      rdO.data(),
+      make_layout(
+          get<1>(rdO_layout),
+          make_layout(get<0>(rdO_layout), get<2>(rdO_layout))));
+  Tensor rO_2d = make_tensor(rO.data(), rdO_2d.layout());
+
+  constexpr int NumValperCol = size<0>(rdO_2d);
+  auto smem = compat::local_mem<VType[kNSGs * SubgroupSize * NumValperCol]>();
+  auto stensor = make_tensor(
+      make_smem_ptr(smem),
+      make_layout(Shape<Int<NumValperCol>, Int<kNSGs>, Int<SubgroupSize>>{}));
+  clear(rdO_2d);
+  clear(rO_2d);
+  if constexpr (Is_even_M) {
+    for (int mi = 0; mi < size<0>(rdO_2d); ++mi) {
+      copy(tileload_odo, thr_tile_do_S(_, mi, _), rdO(_, mi, _));
+      copy(tileload_odo, thr_tile_o_S(_, mi, _), rO(_, mi, _));
+    }
+  } else {
+    for (int mi = 0; mi < size<0>(rdO_2d); ++mi) {
+      if (get<0>(tcO_row(mi)) < param.tail_m) {
+        copy(tileload_odo, thr_tile_do_S(_, mi, _), rdO(_, mi, _));
+        copy(tileload_odo, thr_tile_o_S(_, mi, _), rO(_, mi, _));
+      }
+    }
+  }
+  int sg_group_id = sg.get_group_id();
+  int sg_local_id = sg.get_local_id();
+  CUTLASS_PRAGMA_UNROLL
+  for (int mi = 0; mi < size<0>(rdO_2d); ++mi) {
+    float accum = 0.0f;
+    CUTLASS_PRAGMA_UNROLL
+    for (int ni = 0; ni < size<1>(rdO_2d); ++ni) {
+      accum = accum + (float)rdO_2d(mi, ni) * (float)rO_2d(mi, ni);
+    }
+    stensor(mi, sg_group_id, sg_local_id) = accum;
+  }
+
+  sg.barrier();
+
+  if (sg_local_id == 0) {
+    CUTLASS_PRAGMA_UNROLL
+    for (int mi = 0; mi < NumValperCol; ++mi) {
+      float accum = 0.0f;
+      CUTLASS_PRAGMA_UNROLL
+      for (int ni = 0; ni < SubgroupSize; ++ni) {
+        accum += stensor(mi, sg_group_id, ni);
+      }
+      if constexpr (Is_even_M) {
+        mdPsum(get<0>(tcO_row(mi))) = accum;
+      } else {
+        if (get<0>(tcO_row(mi)) < param.tail_m) {
+          mdPsum(get<0>(tcO_row(mi))) = accum;
+        }
+      }
+    }
+  }
+}
+
+template <class T>
+void mha_dot_do_o(T trait, Param<typename T::DType> param) {
+  const int m_block = BlockIdxX();
+  const int bidb = BlockIdxZ();
+  const int bidh = BlockIdxY();
+  if (m_block == param.m_block - 1 and param.tail_m > 0) {
+    compute_o_dot_do<false>(trait, param, m_block, bidb, bidh);
+  } else {
+    compute_o_dot_do<true>(trait, param, m_block, bidb, bidh);
+  }
+}
+
+template <
+    typename Engine0,
+    typename Layout0,
+    typename Engine1,
+    typename Layout1>
+CUTLASS_DEVICE void apply_mask_causal(
+    Tensor<Engine0, Layout0>& tensor,
+    Tensor<Engine1, Layout1>& rC,
+    int m_offset,
+    int n_offset,
+    int diagonal_offset = 0) {
+  Tensor rC_2d = make_tensor(rC.data(), convert_layout_2d_layout(rC.layout()));
+  CUTLASS_PRAGMA_UNROLL
+  for (int n = 0; n < size<1>(tensor); ++n) {
+    CUTLASS_PRAGMA_UNROLL
+    for (int m = 0; m < size<0>(tensor); ++m) {
+      int y = m_offset + get<1>(rC_2d(m, n)) + diagonal_offset;
+      int x = n_offset + get<0>(rC_2d(m, n));
+      if (x > y) {
+        tensor(m, n) = -INFINITY;
+      }
+    }
+  }
+  return;
+}
+
+template <typename T, class Trait, class MTensor, class TiledMMA>
+auto create_reg(
+    Trait const& trait,
+    MTensor const& C,
+    TiledMMA const& tiled_mma) {
+  auto local_id = int(compat::get_nd_item<1>().get_local_id(0));
+  auto thr_mma = tiled_mma.get_slice(local_id);
+
+  Tensor cC = make_identity_tensor(C.shape());
+  auto tile_mnk = tiled_mma.tile_mnk();
+  Tensor gC = local_tile(cC, select<0, 1>(tile_mnk), make_coord(0, 0));
+  auto copy_c = make_block_2d_copy_D(tiled_mma, C);
+  auto thr_copy_c = copy_c.get_slice(local_id);
+  if constexpr (is_same_v<T, float>) {
+    auto r32 = thr_mma.partition_sg_fragment_C(
+        make_identity_tensor(select<0, 1>(tile_mnk)));
+    return r32;
+  } else {
+    auto r16 = thr_copy_c.partition_sg_fragment_S(gC);
+    return r16;
+  }
+}
+
+template <
+    bool clear_acc,
+    class Trait,
+    class Engine0,
+    class Layout0,
+    class Engine1,
+    class Layout1,
+    class Engine2,
+    class Layout2,
+    class TVLayout2,
+    class TiledMMA>
+void gemm_kernel(
+    Trait& trait,
+    Tensor<Engine0, Layout0> const& A,
+    Tensor<Engine1, Layout1> const& B,
+    SubgroupTensor<Engine2, Layout2, TVLayout2>& acc,
+    TiledMMA const& mma) {
+  auto local_id = int(compat::get_nd_item<1>().get_local_id(0));
+
+  Tensor cA = make_identity_tensor(A.shape());
+  Tensor cB = make_identity_tensor(B.shape());
+
+  auto tile_mnk = mma.tile_mnk();
+
+  Tensor gA = local_tile(cA, select<0, 2>(tile_mnk), make_coord(0, _));
+  Tensor gB = local_tile(cB, select<1, 2>(tile_mnk), make_coord(0, _));
+
+  auto copy_a = make_block_2d_copy_A(mma, A);
+  auto copy_b = make_block_2d_copy_B(mma, B);
+
+  auto thr_mma = mma.get_slice(local_id);
+  auto thr_copy_a = copy_a.get_slice(local_id);
+  auto thr_copy_b = copy_b.get_slice(local_id);
+
+  auto tCrA = thr_mma.partition_sg_fragment_A(gA(_, _, 0));
+  auto tCrB = thr_mma.partition_sg_fragment_B(gB(_, _, 0));
+
+  auto tArA = thr_copy_a.partition_sg_fragment_D(gA(_, _, 0));
+  auto tBrB = thr_copy_b.partition_sg_fragment_D(gB(_, _, 0));
+
+  Tensor tAgA = thr_copy_a.partition_S(gA);
+  Tensor tBgB = thr_copy_b.partition_S(gB);
+
+  auto prefetch_a = make_block_2d_prefetch(copy_a);
+  auto prefetch_b = make_block_2d_prefetch(copy_b);
+
+  auto thr_prefetch_A = prefetch_a.get_slice(local_id);
+  auto thr_prefetch_B = prefetch_b.get_slice(local_id);
+
+  auto pAgA = thr_prefetch_A.partition_S(gA);
+  auto pBgB = thr_prefetch_B.partition_S(gB);
+
+  const int prefetch_dist = 3;
+
+  constexpr int barrier_scope = 2;
+
+  int k_tile_count = ceil_div(shape<1>(A), get<2>(tile_mnk));
+  int k_tile_prefetch = 0;
+  if constexpr (clear_acc)
+    clear(acc);
+  int prefetch_warmup =
+      prefetch_dist < k_tile_count ? prefetch_dist : k_tile_count;
+  CUTE_UNROLL
+  for (; k_tile_prefetch < prefetch_warmup; k_tile_prefetch++) {
+    prefetch(prefetch_a, pAgA(_, _, _, k_tile_prefetch));
+    prefetch(prefetch_b, pBgB(_, _, _, k_tile_prefetch));
+  }
+  for (int k_tile = 0; k_tile < k_tile_count; k_tile++, k_tile_prefetch++) {
+    barrier_arrive(barrier_scope);
+
+    copy(copy_a, tAgA(_, _, _, k_tile), tArA);
+    copy(copy_b, tBgB(_, _, _, k_tile), tBrB);
+
+    if (k_tile_prefetch < k_tile_count) {
+      prefetch(prefetch_a, pAgA(_, _, _, k_tile_prefetch));
+      prefetch(prefetch_b, pBgB(_, _, _, k_tile_prefetch));
+    }
+
+    reorder(tArA, tCrA);
+    reorder(tBrB, tCrB);
+
+    gemm(mma, tCrA, tCrB, acc);
+
+    barrier_wait(barrier_scope);
+  }
+}
+
+template <
+    class Trait,
+    class Engine0,
+    class Layout0,
+    class Engine1,
+    class Layout1,
+    class Engine2,
+    class Layout2,
+    class TVLayout2,
+    class TiledMMA>
+void gemm_SdP(
+    Trait& trait,
+    Tensor<Engine0, Layout0> const& A,
+    Tensor<Engine1, Layout1> const& B,
+    SubgroupTensor<Engine2, Layout2, TVLayout2>& rSdP,
+    TiledMMA const& mma) {
+  gemm_kernel<true>(trait, A, B, rSdP, mma);
+}
+
+template <
+    class Trait,
+    class Engine0,
+    class Layout0,
+    class Engine1,
+    class Layout1,
+    class Engine2,
+    class Layout2,
+    class TVLayout2,
+    class TiledMMA>
+void gemm_dKV(
+    Trait& trait,
+    Tensor<Engine0, Layout0> const& A,
+    Tensor<Engine1, Layout1> const& B,
+    SubgroupTensor<Engine2, Layout2, TVLayout2>& rdKV,
+    TiledMMA const& mma) {
+  gemm_kernel<false>(trait, A, B, rdKV, mma);
+}
+
+template <
+    class Trait,
+    class Engine0,
+    class Layout0,
+    class Engine1,
+    class Layout1,
+    class Engine2,
+    class Layout2,
+    class TiledMMA>
+void gemm_dQ(
+    Trait& trait,
+    Tensor<Engine0, Layout0> const& A,
+    Tensor<Engine1, Layout1> const& B,
+    Tensor<Engine2, Layout2>& C,
+    TiledMMA const& mma) {
+  auto local_id = int(compat::get_nd_item<1>().get_local_id(0));
+  auto tile_mnk = mma.tile_mnk();
+  Tensor cC = make_identity_tensor(C.shape());
+  Tensor gC = local_tile(cC, select<0, 1>(tile_mnk), make_coord(0, 0));
+  auto thr_mma = mma.get_slice(local_id);
+  auto tCrC = thr_mma.partition_sg_fragment_C(
+      make_identity_tensor(select<0, 1>(tile_mnk)));
+  Tensor tCgC = thr_mma.partition_C(gC);
+  gemm_kernel<true>(trait, A, B, tCrC, mma);
+
+  CUTLASS_PRAGMA_UNROLL
+  for (int i = 0; i < size(tCgC); ++i) {
+    auto [m, n] = tCgC(i);
+    cutlass::atomicAdd(&C(m, n), tCrC(i));
+  }
+}
+
+template <
+    class Trait,
+    class TiledMma,
+    class Engine0,
+    class Layout0,
+    class TVLayout0,
+    class Engine1,
+    class Layout1>
+void mha_copy(
+    Trait& trait,
+    TiledMma& tiled_mma,
+    SubgroupTensor<Engine0, Layout0, TVLayout0>& r,
+    Tensor<Engine1, Layout1>& m,
+    int m_block = 0,
+    int n_block = 0) {
+  auto local_id = int(compat::get_nd_item<1>().get_local_id(0));
+  auto copy_c = make_block_2d_copy_D(tiled_mma, m);
+  auto thr_copy_c = copy_c.get_slice(local_id);
+  auto tile_mnk = tiled_mma.tile_mnk();
+  Tensor cC = make_identity_tensor(m.shape());
+  Tensor gC =
+      local_tile(cC, select<0, 1>(tile_mnk), make_coord(m_block, n_block));
+  Tensor tCgC = thr_copy_c.partition_D(gC);
+  copy(copy_c, r, tCgC);
+}
+
+template <
+    class Trait,
+    class TiledMma,
+    class Engine0,
+    class Layout0,
+    class TVLayout0,
+    class Engine1,
+    class Layout1>
+void mha_reorder_copy(
+    Trait& trait,
+    TiledMma& tiled_mma,
+    SubgroupTensor<Engine0, Layout0, TVLayout0>& r,
+    Tensor<Engine1, Layout1>& m) {
+  auto r16 = create_reg<typename Trait::DType>(trait, m, tiled_mma);
+  reorder(r, r16);
+  mha_copy(trait, tiled_mma, r16, m);
+}
+
+template <bool Is_even_M, class Tensor0, class Tensor1, class Tensor2>
+CUTLASS_DEVICE void load_1colvec(
+    Tensor0& reg,
+    Tensor1& mT,
+    Tensor2& coord_row,
+    int tail_m = 0) {
+  if constexpr (Is_even_M) {
+    CUTLASS_PRAGMA_UNROLL
+    for (int mi = 0; mi < size(reg); ++mi) {
+      reg(mi) = mT(get<0>(coord_row(mi)));
+    }
+  } else {
+    for (int mi = 0; mi < size(reg); ++mi) {
+      int row = get<0>(coord_row(mi));
+      if (row < tail_m) {
+        reg(mi) = mT(row);
+      }
+    }
+  }
+}
+
+template <typename Layout>
+CUTLASS_DEVICE auto convert_layout_acc_layout(Layout acc_layout) {
+  static_assert(decltype(size<0>(acc_layout))::value == 8);
+  static_assert(decltype(rank(acc_layout))::value == 3);
+  auto l = logical_divide(acc_layout, Shape<_1>{});
+  auto l2 =
+      make_layout(make_layout(get<0, 1>(l), get<1>(l)), make_layout(get<2>(l)));
+  return l2;
+}
+
+template <
+    bool Is_even_M,
+    class Engine0,
+    class Layout0,
+    class Engine1,
+    class Layout1,
+    class Engine2,
+    class Layout2>
+CUTLASS_DEVICE void scale_apply_exp2(
+    Tensor<Engine0, Layout0>& tensor,
+    Tensor<Engine1, Layout1>& max,
+    Tensor<Engine2, Layout2>& rC,
+    const float scale,
+    const int tail_m = 0) {
+  static_assert(Layout0::rank == 2, "Only support 2D Tensor");
+  static_assert(Layout1::rank == 1, "Only support 1D Tensor");
+  Tensor rC_2d = make_tensor(rC.data(), convert_layout_2d_layout(rC.layout()));
+  if constexpr (Is_even_M) {
+    CUTLASS_PRAGMA_UNROLL
+    for (int ni = 0; ni < size<1>(tensor); ++ni) {
+      int n = get<1>(rC_2d(0, ni));
+      const float max_scaled = max(n) == -INFINITY ? 0.f : max(n) * M_LOG2E;
+      CUTLASS_PRAGMA_UNROLL
+      for (int mi = 0; mi < size<0>(tensor); ++mi) {
+        tensor(mi, ni) = exp2f(tensor(mi, ni) * scale - max_scaled);
+      }
+    }
+  } else {
+    CUTLASS_PRAGMA_UNROLL
+    for (int ni = 0; ni < size<1>(tensor); ++ni) {
+      int n = get<1>(rC_2d(0, ni));
+      const float max_scaled =
+          ((n >= tail_m) || (max(n) == -INFINITY)) ? 0.f : max(n) * M_LOG2E;
+      CUTLASS_PRAGMA_UNROLL
+      for (int mi = 0; mi < size<0>(tensor); ++mi) {
+        tensor(mi, ni) = exp2f(tensor(mi, ni) * scale - max_scaled);
+      }
+    }
+  }
+}
+
+template <
+    bool Is_even_M,
+    class Engine0,
+    class Layout0,
+    class Engine1,
+    class Layout1,
+    class Engine2,
+    class Layout2,
+    class Engine3,
+    class Layout3>
+CUTLASS_DEVICE void softmax_backward(
+    Tensor<Engine0, Layout0>& P,
+    Tensor<Engine1, Layout1>& dP_sum,
+    Tensor<Engine2, Layout2>& dP,
+    Tensor<Engine3, Layout3>& rC,
+    const float scale,
+    const int tail_m = 0) {
+  Tensor rC_2d = make_tensor(rC.data(), convert_layout_2d_layout(rC.layout()));
+  if constexpr (Is_even_M) {
+    CUTLASS_PRAGMA_UNROLL
+    for (int ni = 0; ni < size<1>(dP); ++ni) {
+      int n = get<1>(rC_2d(0, ni));
+      const float neg_dpsum_scaled = -(dP_sum(n) * scale);
+      CUTLASS_PRAGMA_UNROLL
+      for (int mi = 0; mi < size<0>(dP); ++mi) {
+        dP(mi, ni) = P(mi, ni) * fmaf(dP(mi, ni), scale, neg_dpsum_scaled);
+      }
+    }
+  } else {
+    CUTLASS_PRAGMA_UNROLL
+    for (int ni = 0; ni < size<1>(dP); ++ni) {
+      int n = get<1>(rC_2d(0, ni));
+      if (n < tail_m) {
+        const float neg_dpsum_scaled = -(dP_sum(n) * scale);
+        CUTLASS_PRAGMA_UNROLL
+        for (int mi = 0; mi < size<0>(dP); ++mi) {
+          dP(mi, ni) = P(mi, ni) * fmaf(dP(mi, ni), scale, neg_dpsum_scaled);
+        }
+      }
+    }
+  }
+}
+
+template <bool Is_even_N, bool Seq_parallel, class Trait>
+void dq_dk_dv_1colblock(
+    Trait& trait,
+    Param<typename Trait::DType>& param,
+    const int bidb,
+    const int bidh,
+    const int bidhkv,
+    const int n_block,
+    const int tail_n = 0) {
+  using T = typename Trait::DType;
+  using V = typename Trait::VType;
+  constexpr int kHeadDim = Trait::kHeadDim;
+  constexpr int kBlockM = Trait::kBlockM;
+  constexpr int kBlockN = Trait::kBlockN;
+  constexpr int kNSGs = Trait::kNSGs;
+  constexpr int SubgroupSize = Trait::SubgroupSize;
+  constexpr bool is_causal = Trait::is_causal;
+  auto local_id = int(compat::get_nd_item<1>().get_local_id(0));
+  auto group = compat::get_nd_item<1>().get_group();
+  auto bofst = Boffset(param);
+
+  const index_t q_offset = bofst.q_offset(bidb, bidh, 0);
+  const index_t k_offset = bofst.k_offset(bidb, bidhkv, n_block * kBlockN);
+  const index_t v_offset = bofst.v_offset(bidb, bidhkv, n_block * kBlockN);
+  const index_t dk_offset = bofst.dk_offset(bidb, bidh, n_block * kBlockN);
+  const index_t dv_offset = bofst.dv_offset(bidb, bidh, n_block * kBlockN);
+  const index_t do_offset = bofst.do_offset(bidb, bidh, 0);
+  const index_t dqaccum_offset = bofst.dqaccum_offset(bidb, bidh, 0);
+  const index_t lse_offset = bofst.lse_offset(bidb, bidh, 0);
+  const index_t pb_offset =
+      (bidb * param.num_head_q * param.seq_len_kv_pad * kBlockM +
+       bidh * param.seq_len_kv_pad * kBlockM + n_block * kBlockN * kBlockM) *
+      2;
+  const index_t dsb_offset = pb_offset + kBlockN * kBlockM;
+
+  const auto block_n_dim = tail_n == 0 ? Int<kBlockN>{} : ((tail_n + 1) & ~1);
+  auto shapeO = make_shape(kBlockM, Int<kHeadDim>{});
+  auto shapeQtOt = make_shape(Int<kHeadDim>{}, kBlockM);
+  auto shapeSPt = make_shape(Int<kBlockN>{}, kBlockM);
+  auto shapeSP = make_shape(kBlockM, block_n_dim);
+
+  using Shape1 =
+      Shape<std::conditional_t<Is_even_N, Int<kBlockN>, int>, Int<kHeadDim>>;
+  using Shape2 =
+      Shape<Int<kHeadDim>, std::conditional_t<Is_even_N, Int<kBlockN>, int>>;
+  auto shapeQ = make_shape(kBlockM, Int<kHeadDim>{});
+  auto shapedQ = Shape<Int<kBlockM>, Int<kHeadDim>>{};
+  Shape1 shapeKtVt;
+  Shape2 shapeKV;
+  if constexpr (Is_even_N) {
+    shapeKtVt = make_shape(Int<kBlockN>{}, Int<kHeadDim>{});
+    shapeKV = make_shape(Int<kHeadDim>{}, Int<kBlockN>{});
+  } else {
+    shapeKtVt = make_shape(tail_n, Int<kHeadDim>{});
+    shapeKV = make_shape(Int<kHeadDim>{}, tail_n);
+  }
+  Tensor mQ = make_tensor(
+      make_gmem_ptr(param.q_ptr + q_offset),
+      make_layout(shapeQ, make_stride(param.q_r_stride, _1{})));
+  Tensor mKt = make_tensor(
+      make_gmem_ptr(param.k_ptr + k_offset),
+      make_layout(shapeKtVt, make_stride(param.k_r_stride, _1{})));
+  Tensor mdO = make_tensor(
+      make_gmem_ptr(param.do_ptr + do_offset),
+      make_layout(shapeO, make_stride(param.do_r_stride, _1{})));
+  Tensor mVt = make_tensor(
+      make_gmem_ptr(param.v_ptr + v_offset),
+      make_layout(shapeKtVt, make_stride(param.v_r_stride, _1{})));
+  Tensor mPt = make_tensor(
+      make_gmem_ptr(param.pb_ptr + pb_offset),
+      make_layout(shapeSPt, make_stride(Int<kBlockM>{}, _1{})));
+  Tensor mdOt = make_tensor(
+      make_gmem_ptr(param.do_ptr + do_offset),
+      make_layout(shapeQtOt, make_stride(_1{}, param.do_r_stride)));
+  Tensor mK = make_tensor(
+      make_gmem_ptr(param.k_ptr + k_offset),
+      make_layout(shapeKV, make_stride(_1{}, param.k_r_stride)));
+  Tensor mdPt = make_tensor(
+      make_gmem_ptr(param.pb_ptr + dsb_offset),
+      make_layout(shapeSPt, make_stride(Int<kBlockM>{}, _1{})));
+  Tensor mQt = make_tensor(
+      make_gmem_ptr(param.q_ptr + q_offset),
+      make_layout(shapeQtOt, make_stride(_1{}, param.q_r_stride)));
+
+  Tensor mLSE = make_tensor(
+      make_gmem_ptr(param.lse_ptr + lse_offset),
+      make_layout(Shape<Int<kBlockM>>{}, Stride<_1>{}));
+  Tensor mdPsum = make_tensor(
+      make_gmem_ptr(param.odo_ptr + lse_offset),
+      make_layout(Shape<Int<kBlockM>>{}, Stride<_1>{}));
+
+  Tensor mdV = make_tensor(
+      make_gmem_ptr(param.dv_ptr + dv_offset),
+      make_layout(shapeKtVt, make_stride(param.dv_r_stride, _1{})));
+  Tensor mdP = make_tensor(
+      make_gmem_ptr(param.pb_ptr + dsb_offset),
+      make_layout(shapeSP, make_stride(_1{}, Int<kBlockM>{})));
+  Tensor mdQaccum = make_tensor(
+      make_gmem_ptr(param.dqaccum_ptr + dqaccum_offset),
+      make_layout(shapedQ, make_stride(param.head_dim, _1{})));
+  Tensor mdK = make_tensor(
+      make_gmem_ptr(param.dk_ptr + dk_offset),
+      make_layout(shapeKtVt, make_stride(param.dk_r_stride, _1{})));
+
+  typename Trait::TiledMmaSdP tiled_mma_sdp;
+  typename Trait::TiledMmadKV tiled_mma_dkv;
+  typename Trait::TiledMmadQ tiled_mma_dq;
+
+  auto thr_mma_sdp = tiled_mma_sdp.get_slice(local_id);
+
+  Tensor caccSt = make_identity_tensor(Shape<Int<kBlockN>, Int<kBlockM>>{});
+  Tensor taccScSt = thr_mma_sdp.partition_C(caccSt);
+  Tensor taccScS_rt = logical_divide(taccScSt, Shape<_1>{});
+
+  const int max_m_block = ceil_div(param.seq_len_q, kBlockM);
+  const int tail_m = param.seq_len_q % kBlockM;
+
+  auto rdV = create_reg<V>(trait, mdV, tiled_mma_dkv);
+  auto rdK = create_reg<V>(trait, mdK, tiled_mma_dkv);
+  clear(rdV);
+  clear(rdK);
+  for (int m_block = 0; m_block < max_m_block; ++m_block) {
+    const bool Is_even_M = not((m_block == max_m_block - 1) and (tail_m != 0));
+    if (not Is_even_M) {
+      const int block_m_dim = ((tail_m + 1) & ~1);
+      mQ = make_tensor(
+          make_gmem_ptr(mQ.data()),
+          make_layout(
+              make_shape(tail_m, Int<kHeadDim>{}),
+              make_stride(param.q_r_stride, _1{})));
+      mdO = make_tensor(
+          make_gmem_ptr(mdO.data()),
+          make_layout(
+              make_shape(tail_m, Int<kHeadDim>{}),
+              make_stride(param.do_r_stride, _1{})));
+      mPt = make_tensor(
+          make_gmem_ptr(mPt.data()),
+          make_layout(
+              make_shape(Int<kBlockN>{}, block_m_dim),
+              make_stride(Int<kBlockM>{}, _1{})));
+      mdOt = make_tensor(
+          make_gmem_ptr(mdOt.data()),
+          make_layout(
+              make_shape(Int<kHeadDim>{}, tail_m),
+              make_stride(_1{}, param.do_r_stride)));
+      mdPt = make_tensor(
+          make_gmem_ptr(mdPt.data()),
+          make_layout(
+              make_shape(Int<kBlockN>{}, block_m_dim),
+              make_stride(Int<kBlockM>{}, _1{})));
+      mdP = make_tensor(
+          make_gmem_ptr(mdP.data()),
+          make_layout(
+              make_shape(block_m_dim, block_n_dim),
+              make_stride(_1{}, Int<kBlockM>{})));
+      mdQaccum = make_tensor(
+          make_gmem_ptr(mdQaccum.data()),
+          make_layout(shapedQ, make_stride(param.head_dim, _1{})));
+      mQt = make_tensor(
+          make_gmem_ptr(mQt.data()),
+          make_layout(
+              make_shape(Int<kHeadDim>{}, tail_m),
+              make_stride(_1{}, param.q_r_stride)));
+    }
+    {
+      auto rS = create_reg<V>(trait, mPt, tiled_mma_sdp);
+      gemm_SdP(trait, mKt, mQ, rS, tiled_mma_sdp);
+      Tensor scores =
+          make_tensor(rS.data(), convert_layout_acc_layout(rS.layout()));
+      if constexpr (is_causal) {
+        apply_mask_causal(
+            scores,
+            taccScS_rt,
+            m_block * kBlockM,
+            n_block * kBlockN,
+            param.seq_len_kv - param.seq_len_q);
+      }
+      if (Is_even_M) {
+        scale_apply_exp2<true>(
+            scores, mLSE, taccScS_rt, param.scale_softmax_log2);
+      } else {
+        scale_apply_exp2<false>(
+            scores, mLSE, taccScS_rt, param.scale_softmax_log2, tail_m);
+      }
+      auto rdP = create_reg<V>(trait, mdPt, tiled_mma_sdp);
+      gemm_SdP(trait, mVt, mdO, rdP, tiled_mma_sdp);
+      Tensor dS = make_tensor(rdP.data(), scores.layout());
+      if (Is_even_M) {
+        softmax_backward<true>(
+            scores, mdPsum, dS, taccScS_rt, param.scale_softmax);
+      } else {
+        softmax_backward<false>(
+            scores, mdPsum, dS, taccScS_rt, param.scale_softmax, tail_m);
+      }
+      mha_reorder_copy(trait, tiled_mma_sdp, rS, mPt);
+      mha_reorder_copy(trait, tiled_mma_sdp, rdP, mdPt);
+    }
+    sycl::group_barrier(group);
+    gemm_dKV(trait, mPt, mdOt, rdV, tiled_mma_dkv);
+    gemm_dKV(trait, mdPt, mQt, rdK, tiled_mma_dkv);
+    gemm_dQ(trait, mdP, mK, mdQaccum, tiled_mma_dq);
+    mQ.data() = mQ.data() + int(kBlockM * param.q_r_stride);
+    mdO.data() = mdO.data() + int(kBlockM * param.do_r_stride);
+    mdOt.data() = mdOt.data() + int(kBlockM * param.do_r_stride);
+    mdQaccum.data() = mdQaccum.data() + int(kBlockM * param.head_dim);
+    mQt.data() = mQt.data() + int(kBlockM * param.q_r_stride);
+    mLSE.data() = mLSE.data() + int(kBlockM);
+    mdPsum.data() = mdPsum.data() + int(kBlockM);
+  }
+  mha_reorder_copy(trait, tiled_mma_dkv, rdV, mdV);
+  mha_reorder_copy(trait, tiled_mma_dkv, rdK, mdK);
+}
+
+template <class T>
+void mha_backward_seq(T trait, Param<typename T::DType> param) {
+  const int bidb = BlockIdxZ();
+  const int bidhq = BlockIdxY();
+  const int bidnblk = BlockIdxX();
+  const int bidhkv = bidhq / param.num_qh_per_kvh;
+  for (int n_block = bidnblk; n_block < param.n_block; n_block += GridDimX()) {
+    if (param.tail_n > 0 and n_block == param.n_block - 1)
+      dq_dk_dv_1colblock<false, false>(
+          trait, param, bidb, bidhq, bidhkv, param.n_block - 1, param.tail_n);
+    else
+      dq_dk_dv_1colblock<true, false>(
+          trait, param, bidb, bidhq, bidhkv, n_block);
+  }
+}
+
+template <typename To_type, typename Engine, typename Layout>
+CUTLASS_DEVICE auto convert_type(Tensor<Engine, Layout> const& tensor) {
+  using From_type = typename Engine::value_type;
+  constexpr int numel = decltype(size(tensor))::value;
+  cutlass::NumericArrayConverter<To_type, From_type, numel> convert_op;
+  auto frag =
+      convert_op(*reinterpret_cast<const cutlass::Array<From_type, numel>*>(
+          tensor.data()));
+  return make_tensor(make_rmem_ptr<To_type>(&frag), tensor.layout());
+}
+
+template <class Engine0, class Layout0, class Engine1, class Layout1>
+CUTLASS_DEVICE void convert_type(
+    Tensor<Engine0, Layout0> const& src,
+    Tensor<Engine1, Layout1>& dst) {
+  using From_type = typename Engine0::value_type;
+  using To_type = typename Engine1::value_type;
+  constexpr int numel = decltype(size(src))::value;
+  cutlass::NumericConverter<To_type, From_type> convert_op;
+  CUTLASS_PRAGMA_UNROLL
+  for (int i = 0; i < numel; ++i) {
+    dst(i) = convert_op(src(i));
+  }
+}
+
+template <bool Is_even_M, class T>
+void convert_dq(
+    T& trait,
+    Param<typename T::DType>& param,
+    int m_block,
+    int bidb,
+    int bidh) {
+  constexpr int kBlockM = T::kBlockM;
+  constexpr int kHeadDim = T::kHeadDim;
+  constexpr int kNSGs = T::kNSGs;
+  constexpr int SubgroupSize = T::SubgroupSize;
+  using DType = typename T::DType;
+  using VType = typename T::VType;
+
+  auto bofst = Boffset(param);
+  const index_t dq_offset = bofst.dq_offset(bidb, bidh, m_block * kBlockM);
+  const index_t dqaccum_offset =
+      bofst.dqaccum_offset(bidb, bidh, m_block * kBlockM);
+  using ShapeQ =
+      Shape<std::conditional_t<Is_even_M, Int<kBlockM>, int>, Int<kHeadDim>>;
+  ShapeQ shapeQ;
+  if constexpr (Is_even_M) {
+    shapeQ = make_shape(Int<kBlockM>{}, Int<kHeadDim>{});
+  } else {
+    shapeQ = make_shape(param.tail_m, Int<kHeadDim>{});
+  }
+
+  Tensor mdQaccum = make_tensor(
+      make_gmem_ptr(param.dqaccum_ptr + dqaccum_offset),
+      make_layout(
+          Shape<Int<kBlockM>, Int<kHeadDim>>{},
+          make_stride(param.head_dim, _1{})));
+  Tensor mdQ = make_tensor(
+      make_gmem_ptr(param.dq_ptr + dq_offset),
+      make_layout(shapeQ, make_stride(param.dq_r_stride, _1{})));
+
+  using ThreadLayout = Layout<
+      Shape<Int<kNSGs>, Int<SubgroupSize>>,
+      Stride<Int<SubgroupSize>, _1>>;
+  using ValueLayout = std::conditional_t<
+      kHeadDim == 96,
+      Layout<Shape<_1, _2>>,
+      std::conditional_t<
+          kHeadDim == 192,
+          Layout<Shape<_1, _4>>,
+          Layout<Shape<_1, Int<kHeadDim / SubgroupSize>>>>>;
+
+  using dQaccumType = cutlass::AlignedArray<VType, size(ValueLayout{})>;
+  using dQaccumAtom = Copy_Atom<UniversalCopy<dQaccumType>, VType>;
+  using dQType = cutlass::AlignedArray<DType, size(ValueLayout{})>;
+  using dQAtom = Copy_Atom<UniversalCopy<dQType>, DType>;
+
+  auto tileload_dQaccum =
+      make_tiled_copy(dQaccumAtom{}, ThreadLayout{}, ValueLayout{});
+  auto tilesave_dQ = make_tiled_copy(dQAtom{}, ThreadLayout{}, ValueLayout{});
+
+  auto thr_load_dQaccum = tileload_dQaccum.get_thread_slice(ThreadIdxX());
+  auto thr_save_dQ = tilesave_dQ.get_thread_slice(ThreadIdxX());
+
+  Tensor thr_tile_dQaccum_S = thr_load_dQaccum.partition_S(mdQaccum);
+  Tensor thr_tile_dQ_D = thr_save_dQ.partition_D(mdQ);
+
+  Tensor rdQaccum = make_fragment_like(thr_tile_dQaccum_S);
+
+  copy(tileload_dQaccum, thr_tile_dQaccum_S, rdQaccum);
+  if constexpr (Is_even_M) {
+    Tensor rdQ = convert_type<DType>(rdQaccum);
+    Tensor accQ = make_identity_tensor(shapeQ);
+    Tensor taccQ = thr_save_dQ.partition_D(accQ);
+    Tensor taccQ_rc = logical_divide(taccQ, Shape<_1>{})(0, _, 0);
+    for (int m = 0; m < size<1>(thr_tile_dQ_D); ++m) {
+      int row_m = get<0>(taccQ_rc(m));
+      auto thr_tile_dq = thr_tile_dQ_D(_, m, _);
+      auto r_dq = rdQ(_, m, _);
+      copy(r_dq, thr_tile_dq);
+    }
+  } else {
+    Tensor rdQ = make_tensor_like<DType>(rdQaccum);
+    convert_type(rdQaccum, rdQ);
+    Tensor accQ = make_identity_tensor(shapeQ);
+    Tensor taccQ = thr_save_dQ.partition_D(accQ);
+    Tensor taccQ_rc = logical_divide(taccQ, Shape<_1>{})(0, _, 0);
+    for (int m = 0; m < size<1>(thr_tile_dQ_D); ++m) {
+      int row_m = get<0>(taccQ_rc(m));
+      if (row_m < param.tail_m) {
+        auto thr_tile_dq = thr_tile_dQ_D(_, m, _);
+        auto r_dq = rdQ(_, m, _);
+        copy(r_dq, thr_tile_dq);
+      }
+    }
+  }
+}
+
+template <class T>
+void mhd_convert_dq(T trait, Param<typename T::DType> param) {
+  const int m_block = BlockIdxX();
+  const int bidb = BlockIdxZ();
+  const int bidh = BlockIdxY();
+  if (param.tail_m > 0 and m_block == param.m_block - 1) {
+    convert_dq<false>(trait, param, m_block, bidb, bidh);
+  } else {
+    convert_dq<true>(trait, param, m_block, bidb, bidh);
+  }
+}
+
+template <class...>
+class MhaDotDoOName;
+
+template <class...>
+class MhaBackwardName;
+
+template <class...>
+class MhdConvertDqName;
+
+template <
+    typename T,
+    int kBlockM,
+    int kBlockN,
+    int kHeadDim,
+    int kNSGs,
+    int AtomLayoutMSdP,
+    int AtomLayoutNdKV,
+    int AtomLayoutMdQ,
+    bool is_causal>
+void run_mha_bwd_specialized(
+    sycl::queue& queue,
+    FLASH_BWD_params& flash_bwd_params) {
+  auto trait = FAKernel<
+      T,
+      kHeadDim,
+      kBlockM,
+      kBlockN,
+      kNSGs,
+      AtomLayoutMSdP,
+      AtomLayoutNdKV,
+      AtomLayoutMdQ,
+      is_causal>{};
+
+  const int BATCH = flash_bwd_params.batch_size;
+  const int NUM_HEAD_Q = flash_bwd_params.num_heads_qo;
+  const int NUM_HEAD_KV = flash_bwd_params.num_heads_kv;
+  const int SEQ_LEN_Q = flash_bwd_params.seqlen_qo;
+  const int SEQ_LEN_KV = flash_bwd_params.seqlen_kv;
+  const int N_BLOCK = ceil_div(SEQ_LEN_KV, kBlockN);
+  const int tail_n = SEQ_LEN_KV % kBlockN;
+  const int M_BLOCK = ceil_div(SEQ_LEN_Q, kBlockM);
+  const int tail_m = SEQ_LEN_Q % kBlockM;
+  auto param = Param<T>(
+      static_cast<const T*>(flash_bwd_params.do_ptr),
+      static_cast<const T*>(flash_bwd_params.o_ptr),
+      static_cast<const T*>(flash_bwd_params.q_ptr),
+      static_cast<const T*>(flash_bwd_params.k_ptr),
+      static_cast<const T*>(flash_bwd_params.v_ptr),
+      static_cast<const float*>(flash_bwd_params.lse_ptr),
+      static_cast<float*>(flash_bwd_params.odo_ptr),
+      static_cast<float*>(flash_bwd_params.dqaccum_ptr),
+      static_cast<T*>(flash_bwd_params.dq_ptr),
+      static_cast<T*>(flash_bwd_params.dk_ptr),
+      static_cast<T*>(flash_bwd_params.dv_ptr),
+      static_cast<T*>(flash_bwd_params.pb_ptr),
+      flash_bwd_params.scale);
+  param.batch = BATCH;
+  param.num_head_q = NUM_HEAD_Q;
+  param.num_head_kv = NUM_HEAD_KV;
+  param.num_qh_per_kvh = NUM_HEAD_Q / NUM_HEAD_KV;
+  param.num_nb_per_blk = std::max(N_BLOCK * NUM_HEAD_Q * BATCH / 1024, 1);
+  param.seq_len_q = SEQ_LEN_Q;
+  param.seq_len_kv = SEQ_LEN_KV;
+  param.head_dim = kHeadDim;
+  param.n_block = N_BLOCK;
+  param.tail_n = tail_n;
+  param.m_block = M_BLOCK;
+  param.tail_m = tail_m;
+  param.seq_len_kv_pad = flash_bwd_params.seqlen_kv_pad;
+  param.seq_len_q_pad = flash_bwd_params.seqlen_qo_pad;
+
+  setup_stride(param, flash_bwd_params);
+
+  auto dimGrid0 =
+      compat::dim3(size(M_BLOCK), size(param.num_head_q), size(param.batch));
+  auto dimBlock0 =
+      compat::dim3(size(kNSGs * trait.SubgroupSize), size(1), size(1));
+  compat::experimental::launch_properties launch_props0{};
+  compat::experimental::kernel_properties kernel_props0{
+      sycl::ext::oneapi::experimental::sub_group_size<trait.SubgroupSize>};
+  compat::experimental::launch_policy policy0{
+      dimGrid0, dimBlock0, launch_props0, kernel_props0};
+  compat::experimental::
+      launch<mha_dot_do_o<decltype(trait)>, MhaDotDoOName<decltype(trait)>>(
+          policy0, queue, trait, param);
+
+  auto dimGrid1 = compat::dim3(
+      size(ceil_div(param.n_block, param.num_nb_per_blk)),
+      size(param.num_head_q),
+      size(param.batch));
+  auto dimBlock1 =
+      compat::dim3(size(kNSGs * trait.SubgroupSize), size(1), size(1));
+  compat::experimental::launch_properties launch_props1{
+      sycl::ext::oneapi::experimental::work_group_scratch_size(
+          trait.smem_size)};
+  compat::experimental::kernel_properties kernel_props1{
+      sycl::ext::oneapi::experimental::sub_group_size<trait.SubgroupSize>};
+  compat::experimental::launch_policy policy1{
+      dimGrid1, dimBlock1, launch_props1, kernel_props1};
+  compat::experimental::launch<
+      mha_backward_seq<decltype(trait)>,
+      MhaBackwardName<decltype(trait)>>(policy1, queue, trait, param);
+
+  auto dimGrid2 =
+      compat::dim3(size(M_BLOCK), size(param.num_head_q), size(param.batch));
+  auto dimBlock2 =
+      compat::dim3(size(kNSGs * trait.SubgroupSize), size(1), size(1));
+  compat::experimental::launch_properties launch_props2{};
+  compat::experimental::kernel_properties kernel_props2{
+      sycl::ext::oneapi::experimental::sub_group_size<trait.SubgroupSize>};
+  compat::experimental::launch_policy policy2{
+      dimGrid2, dimBlock2, launch_props2, kernel_props2};
+  auto event2 = compat::experimental::launch<
+      mhd_convert_dq<decltype(trait)>,
+      MhdConvertDqName<decltype(trait)>>(policy2, queue, trait, param);
+}
+
+// Per-headdim backward dispatch functions.
+
+#define RUN_MHA_BWD_SPECIALIZED() \
+  run_mha_bwd_specialized<        \
+      T,                          \
+      kBlockM,                    \
+      kBlockN,                    \
+      kHeadDim,                   \
+      kNSGs,                      \
+      AtomLayoutMSdP,             \
+      AtomLayoutNdKV,             \
+      AtomLayoutMdQ,              \
+      is_causal>(queue, params)
+
+template <typename T, bool is_causal>
+void run_mha_bwd_hdim32(sycl::queue& queue, FLASH_BWD_params& params) {
+  constexpr int kBlockM = 64;
+  constexpr int kBlockN = 32;
+  constexpr int kHeadDim = 32;
+  constexpr int kNSGs = 4;
+  constexpr int AtomLayoutMSdP = 2;
+  constexpr int AtomLayoutNdKV = 2;
+  constexpr int AtomLayoutMdQ = 2;
+  static_assert(kBlockM <= kBwdMPad, "kBlockM must be <= kBwdMPad");
+  static_assert(kBlockN <= kBwdNPad, "kBlockN must be <= kBwdNPad");
+  RUN_MHA_BWD_SPECIALIZED();
+}
+
+template <typename T, bool is_causal>
+void run_mha_bwd_hdim64(sycl::queue& queue, FLASH_BWD_params& params) {
+  constexpr int kBlockM = 64;
+  constexpr int kBlockN = 32;
+  constexpr int kHeadDim = 64;
+  constexpr int kNSGs = 8;
+  constexpr int AtomLayoutMSdP = 4;
+  constexpr int AtomLayoutNdKV = 2;
+  constexpr int AtomLayoutMdQ = 2;
+  static_assert(kBlockM <= kBwdMPad, "kBlockM must be <= kBwdMPad");
+  static_assert(kBlockN <= kBwdNPad, "kBlockN must be <= kBwdNPad");
+  RUN_MHA_BWD_SPECIALIZED();
+}
+
+template <typename T, bool is_causal>
+void run_mha_bwd_hdim96(sycl::queue& queue, FLASH_BWD_params& params) {
+  constexpr int kBlockM = 64;
+  constexpr int kBlockN = 64;
+  constexpr int kHeadDim = 96;
+  constexpr int kNSGs = 8;
+  constexpr int AtomLayoutMSdP = 2;
+  constexpr int AtomLayoutNdKV = 4;
+  constexpr int AtomLayoutMdQ = 4;
+  static_assert(kBlockM <= kBwdMPad, "kBlockM must be <= kBwdMPad");
+  static_assert(kBlockN <= kBwdNPad, "kBlockN must be <= kBwdNPad");
+  RUN_MHA_BWD_SPECIALIZED();
+}
+
+template <typename T, bool is_causal>
+void run_mha_bwd_hdim128(sycl::queue& queue, FLASH_BWD_params& params) {
+  constexpr int kBlockM = 128;
+  constexpr int kBlockN = 128;
+  constexpr int kHeadDim = 128;
+  constexpr int kNSGs = 32;
+  constexpr int AtomLayoutMSdP = 4;
+  constexpr int AtomLayoutNdKV = 4;
+  constexpr int AtomLayoutMdQ = 4;
+  static_assert(kBlockM <= kBwdMPad, "kBlockM must be <= kBwdMPad");
+  static_assert(kBlockN <= kBwdNPad, "kBlockN must be <= kBwdNPad");
+  RUN_MHA_BWD_SPECIALIZED();
+}
+
+template <typename T, bool is_causal>
+void run_mha_bwd_hdim192(sycl::queue& queue, FLASH_BWD_params& params) {
+  constexpr int kBlockM = 64;
+  constexpr int kBlockN = 32;
+  constexpr int kHeadDim = 192;
+  constexpr int kNSGs = 8;
+  constexpr int AtomLayoutMSdP = 4;
+  constexpr int AtomLayoutNdKV = 2;
+  constexpr int AtomLayoutMdQ = 2;
+  static_assert(kBlockM <= kBwdMPad, "kBlockM must be <= kBwdMPad");
+  static_assert(kBlockN <= kBwdNPad, "kBlockN must be <= kBwdNPad");
+  RUN_MHA_BWD_SPECIALIZED();
+}
+
+template <typename T, bool is_causal>
+void run_mha_bwd_hdim256(sycl::queue& queue, FLASH_BWD_params& params) {
+  constexpr int kBlockM = 64;
+  constexpr int kBlockN = 32;
+  constexpr int kHeadDim = 256;
+  constexpr int kNSGs = 8;
+  constexpr int AtomLayoutMSdP = 4;
+  constexpr int AtomLayoutNdKV = 2;
+  constexpr int AtomLayoutMdQ = 2;
+  static_assert(kBlockM <= kBwdMPad, "kBlockM must be <= kBwdMPad");
+  static_assert(kBlockN <= kBwdNPad, "kBlockN must be <= kBwdNPad");
+  RUN_MHA_BWD_SPECIALIZED();
+}
+
+#undef RUN_MHA_BWD_SPECIALIZED
+
+} // namespace cute

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_common.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_common.h
@@ -137,7 +137,7 @@ struct FLASH_BWD_params : public FLASH_FWD_params {
   index_t dv_row_stride;
 };
 
-void set_params_fprop(
+inline void set_params_fprop(
     FLASH_FWD_params& params,
     // sizes
     const int batch_size,
@@ -198,7 +198,7 @@ void set_params_fprop(
   params.scale = scale;
 }
 
-void set_params_dgrad(
+inline void set_params_dgrad(
     FLASH_BWD_params& params,
     // sizes
     const int batch_size,
@@ -268,4 +268,70 @@ void set_params_dgrad(
   params.dq_row_stride = dq.stride(2);
   params.dk_row_stride = dk.stride(2);
   params.dv_row_stride = dv.stride(2);
+}
+
+// Backward kernel padding constants.
+constexpr int kBwdMPad = 128;
+constexpr int kBwdNPad = 128;
+
+// block 2D restrictions:
+//
+//   1. Base address: per-subgroup base pointer must be cache-line aligned
+//      (64 bytes).
+//   2. Memory Width: >= 64 bytes and a multiple of 4 bytes.
+//   3. Memory Height: > 0.
+//   4. Memory Pitch: >= Memory Width and a multiple of 16 bytes.
+//   5. Block Width: must be a multiple of 4 bytes.
+//   6. Coordinate X: must be a multiple of 4 bytes.
+//   7. Out-of-bounds: loads return zero for OOB elements; stores and prefetches
+//      silently ignore OOB elements.
+//
+// See: https://github.khronos.org/SPIRV-Registry/extensions/INTEL/
+//      SPV_INTEL_2d_block_io.html#_restrictions
+
+static bool is_64_bytes_aligned(const at::Tensor& t) {
+  return reinterpret_cast<uintptr_t>(t.data_ptr()) % 64 == 0;
+}
+
+// Ensure tensor satisfies block 2D load 64-byte base address alignment
+// requirement. Tries contiguous() first (may reuse storage), falls back to
+// clone() which always allocates fresh aligned memory.
+static at::Tensor ensure_alignment_for_sdpa(const at::Tensor& t) {
+  if (is_64_bytes_aligned(t)) {
+    return t;
+  }
+  at::Tensor out = t.contiguous();
+  if (!is_64_bytes_aligned(out)) {
+    out = out.clone();
+  }
+  return out;
+}
+
+// The kernel is dispatched by Headdim template parameter (32, 64, 96, ...),
+// and its tile sizes are chosen accordingly. Pad headsize to the matching
+// Headdim so that:
+//   1. Tensor dimensions are consistent with the kernel's tile sizes.
+//   2. Memory Width >= 64 bytes.
+//   3. Memory Pitch >= Memory Width. Without
+//      padding, a headdim smaller than the kernel's Headdim would have
+//      Pitch (= real headdim * elem_size) < Width (= Headdim * elem_size).
+inline int round_up_headdim(int d) {
+  if (d <= 32)
+    return 32;
+  if (d <= 64)
+    return 64;
+  if (d <= 96)
+    return 96;
+  if (d <= 128)
+    return 128;
+  if (d <= 192)
+    return 192;
+  if (d <= 256)
+    return 256;
+  TORCH_CHECK(
+      false,
+      "FlashAttentionXPU: head dimension ",
+      d,
+      " exceeds maximum supported (256)");
+  return -1;
 }

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.cpp
@@ -40,313 +40,34 @@
 #include <sycltla/mha_common.h>
 #include <sycltla/mha_fwd.h>
 
-// batch, numhead_qo,numhead_kv,seqlen_qo,seqlen_kv,headsize_qk,headsize_vo
-using ProblemShapeRegular = cute::tuple<int, int, int, int, int, int, int>;
-
 namespace cute {
 
-template <class...>
-class MhaName;
-
-template <class FMHAPrefillKernel, bool isVarLen>
-struct FA2Runner {
-  using ElementQ = typename FMHAPrefillKernel::ElementQ;
-  using ElementK = typename FMHAPrefillKernel::ElementK;
-  using ElementV = typename FMHAPrefillKernel::ElementV;
-  using ElementO = typename FMHAPrefillKernel::ElementO;
-
-  using ProblemShapeType = cutlass::fmha::kernel::FMHAProblemShape<isVarLen>;
-
-  //
-  // Methods
-  //
-
-  // Note that the GemmUniversalAdapter currently doesn't support flash
-  // attention, which is why this secondary `run` function is required to launch
-  // the kernel.
-  void run(sycl::queue& queue, typename FMHAPrefillKernel::Params params) {
-    namespace syclex = sycl::ext::oneapi::experimental;
-    namespace intelex = sycl::ext::intel::experimental;
-
-    dim3 const block = FMHAPrefillKernel::get_block_shape();
-    dim3 const grid = FMHAPrefillKernel::get_grid_shape(params);
-
-    // configure smem size and carveout
-    int smem_size = FMHAPrefillKernel::SharedStorageSize;
-
-    const auto sycl_block = compat::dim3(block.x, block.y, block.z);
-    const auto sycl_grid = compat::dim3(grid.x, grid.y, grid.z);
-
-    // Launch parameters depend on whether SYCL compiler supports work-group
-    // scratch memory extension
-    compat::experimental::launch_properties launch_props{
-        syclex::work_group_scratch_size(smem_size),
-    };
-    compat::experimental::kernel_properties kernel_props{
-        syclex::sub_group_size<cute::intel::sg_size>, intelex::grf_size<256>};
-    compat::experimental::launch_policy policy{
-        sycl_grid, sycl_block, launch_props, kernel_props};
-    compat::experimental::launch<
-        cutlass::device_kernel<FMHAPrefillKernel>,
-        MhaName<FMHAPrefillKernel>>(policy, queue, params);
-  }
-
-  void run(
-      sycl::queue& queue,
-      FLASH_FWD_params& params,
-      const cutlass::KernelHardwareInfo& hw_info) {
-    int batch = params.batch_size;
-    int num_heads_qo = params.num_heads_qo;
-    int num_heads_kv = params.num_heads_kv;
-    int seq_len_qo = params.seqlen_qo;
-    int seq_len_kv = params.seqlen_kv;
-    int head_size_qk = params.head_size_qk;
-    int head_size_vo = params.head_size_vo;
-
-    ProblemShapeType shape;
-    shape.batch = batch;
-    shape.num_heads_q = num_heads_qo;
-    shape.num_heads_kv = num_heads_kv;
-    shape.seq_len_qo = seq_len_qo;
-    shape.seq_len_kv = seq_len_kv;
-    shape.head_size_qk = head_size_qk;
-    shape.head_size_vo = head_size_vo;
-
-    const ElementQ* q_ptr = static_cast<const ElementQ*>(params.q_ptr);
-    const ElementK* k_ptr = static_cast<const ElementK*>(params.k_ptr);
-    const ElementV* v_ptr = static_cast<const ElementV*>(params.v_ptr);
-    ElementO* o_ptr = static_cast<ElementO*>(params.o_ptr);
-    float* lse_ptr = static_cast<float*>(params.lse_ptr);
-    float softmax_scale = params.scale;
-
-    typename FMHAPrefillKernel::Arguments arguments{
-        {
-            shape,
-            q_ptr,
-            params.q_batch_stride,
-            params.q_head_stride,
-            params.q_row_stride,
-            k_ptr,
-            params.k_batch_stride,
-            params.k_head_stride,
-            params.k_row_stride,
-            v_ptr,
-            params.v_batch_stride,
-            params.v_head_stride,
-            params.v_row_stride,
-            o_ptr,
-            params.o_batch_stride,
-            params.o_head_stride,
-            params.o_row_stride,
-            lse_ptr,
-        },
-        {softmax_scale},
-        {},
-        hw_info};
-
-    // Define device-global scratch memory
-    size_t workspace_size = FMHAPrefillKernel::get_workspace_size(arguments);
-    at::Tensor workspace_tensor = at::empty(
-        {static_cast<int64_t>(workspace_size)},
-        at::device(at::kXPU).dtype(at::kByte));
-
-    if (!FMHAPrefillKernel::can_implement(arguments)) {
-      TORCH_CHECK(
-          false,
-          "Invalid Problem Size",
-          batch,
-          "x",
-          num_heads_qo,
-          "x",
-          seq_len_qo,
-          "x",
-          seq_len_kv,
-          "x",
-          head_size_qk,
-          "x",
-          head_size_vo);
-      return;
-    }
-
-    // Initialize the workspace
-    CUTLASS_CHECK(FMHAPrefillKernel::initialize_workspace(
-        arguments, workspace_tensor.data_ptr()));
-
-    // Convert host-side arguments to device-side arguments to be passed to the
-    // kernel
-    auto kernel_params = FMHAPrefillKernel::to_underlying_arguments(
-        arguments, workspace_tensor.data_ptr());
-
-    // Launch a SYCL kernel using scratch/shared memory
-    run(queue, kernel_params);
-  }
-};
-
-template <
-    typename T,
-    bool IS_CAUSAL,
-    typename TileShapeQK,
-    typename TileShapePV,
-    typename TileShapeOutPut,
-    typename SubgroupLayoutQK,
-    int PipelineStages,
-    bool isVarLen = false>
-void run_mha_fwd_(sycl::queue& queue, FLASH_FWD_params& params) {
-  using ElementQ = T;
-  using ElementK = T;
-  using ElementV = T;
-  using ElementO = T;
-  using StrideQ = Stride<int64_t, _1, int64_t, int64_t>;
-  using StrideK = Stride<int64_t, _1, int64_t, int64_t>;
-  using StrideV = Stride<_1, int64_t, int64_t, int64_t>;
-  using StrideO = Stride<int64_t, _1, int64_t, int64_t>;
-  auto make_dummy_tensor = [&](auto val, auto stride) {
-    return make_tensor(
-        make_gmem_ptr(static_cast<decltype(val)*>(nullptr)),
-        make_layout(repeat<rank_v<decltype(stride)>>(1), stride));
-  };
-  auto make_const_dummy_tensor = [&](auto val, auto stride) {
-    return make_tensor(
-        make_gmem_ptr(static_cast<const decltype(val)*>(nullptr)),
-        make_layout(repeat<rank_v<decltype(stride)>>(1), stride));
-  };
-  using TensorQ = decltype(make_const_dummy_tensor(ElementQ{}, StrideQ{}));
-  using TensorK = decltype(make_const_dummy_tensor(ElementK{}, StrideK{}));
-  using TensorV = decltype(make_const_dummy_tensor(ElementV{}, StrideV{}));
-  using TensorO = decltype(make_dummy_tensor(ElementO{}, StrideO{}));
-
-  static constexpr int SGTileQ =
-      get<0>(shape_div(TileShapeQK{}, shape(SubgroupLayoutQK{})))();
-  static_assert(SGTileQ <= 16, "Subgroup tile in Q dimension must be <= 16");
-  using MMAOperation = XE_DPAS_TT<cute::gcd(SGTileQ, 8), float, T>;
-  using SubgroupLayoutPV =
-      decltype(cutlass::fmha::collective::get_sg_layout_pv(SubgroupLayoutQK{}));
-  using TiledMMAQK = typename TiledMMAHelper<
-      MMA_Atom<MMAOperation>,
-      Layout<TileShapeQK>,
-      SubgroupLayoutQK>::TiledMMA;
-  using TiledMMAPV = typename TiledMMAHelper<
-      MMA_Atom<MMAOperation>,
-      Layout<TileShapePV>,
-      SubgroupLayoutPV>::TiledMMA;
-  static_assert(
-      get<0>(TileShapeOutPut{}) == get<0>(TileShapePV{}),
-      "Output tile and P*V tile have different sizes in Q dimension");
-  constexpr int VTiles = get<1>(TileShapeOutPut{}) / get<1>(TileShapePV{});
-
-  cutlass::KernelHardwareInfo hw_info;
-
-  // Mainloop
-  using MainloopDispatchPolicy = cutlass::fmha::XeDefault<PipelineStages>;
-  using CollectiveMainloop = cutlass::fmha::collective::FMHAFwdMainloop<
-      MainloopDispatchPolicy,
-      IS_CAUSAL,
-      TiledMMAQK,
-      TiledMMAPV,
-      VTiles,
-      TensorQ,
-      TensorK,
-      TensorV>;
-
-  // Epilogue
-  using CollectiveEpilogue = cutlass::fmha::collective::
-      FMHAFwdEpilogue<CollectiveMainloop, TileShapeOutPut, TensorO>;
-
-  using Scheduler = cutlass::fmha::kernel::XeFMHAIndividualTileScheduler;
-  using ProblemShapeType = cutlass::fmha::kernel::FMHAProblemShape<isVarLen>;
-  using FMHAPrefillKernel = cutlass::fmha::kernel::XeFMHAFwdKernel<
-      ProblemShapeType,
-      CollectiveMainloop,
-      CollectiveEpilogue,
-      Scheduler>;
-
-  FA2Runner<FMHAPrefillKernel, isVarLen> runner;
-  runner.run(queue, params, hw_info);
-}
+// Declared but not defined here -- explicit specializations are provided by
+// the per-headdim compilation units (mha_fwd_hdim*.cpp).
+template <typename T, int Headdim, bool IS_CAUSAL>
+void run_mha_fwd_(sycl::queue& queue, FLASH_FWD_params& params);
 
 template <typename T, bool IS_CAUSAL>
 void run_mha_fwd_(sycl::queue& queue, FLASH_FWD_params& params) {
   const int headdim = params.head_size_vo;
 
-#define run_mha_fwd_specialized( \
-    TileShapeQK_,                \
-    TileShapePV_,                \
-    TileShapeOutPut_,            \
-    SubgroupLayoutQK_,           \
-    PipelineStages_)             \
-  run_mha_fwd_<                  \
-      T,                         \
-      IS_CAUSAL,                 \
-      TileShapeQK_,              \
-      TileShapePV_,              \
-      TileShapeOutPut_,          \
-      SubgroupLayoutQK_,         \
-      PipelineStages_>(queue, params);
-
-  constexpr int PipelineStages = 2;
-  if (headdim == 64) {
-    int64_t batch_size = params.batch_size;
-    int64_t num_heads_qo = params.num_heads_qo;
-    int64_t seqlen_qo = params.seqlen_qo;
-    if (batch_size * num_heads_qo * seqlen_qo <= 8192) {
-      using TileShapeQK = Shape<_64, _64, _32>;
-      using TileShapePV = Shape<_64, _32, _64>;
-      using TileShapeOutPut = Shape<_64, _64>;
-      using SubgroupLayoutQK = Layout<Shape<_16, _1, _1>>;
-      run_mha_fwd_specialized(
-          TileShapeQK,
-          TileShapePV,
-          TileShapeOutPut,
-          SubgroupLayoutQK,
-          PipelineStages);
-    } else {
-      using TileShapeQK = Shape<_128, _64, _32>;
-      using TileShapePV = Shape<_128, _32, _64>;
-      using TileShapeOutPut = Shape<_128, _64>;
-      using SubgroupLayoutQK = Layout<Shape<_8, _1, _1>>;
-      run_mha_fwd_specialized(
-          TileShapeQK,
-          TileShapePV,
-          TileShapeOutPut,
-          SubgroupLayoutQK,
-          PipelineStages);
-    }
-  } else if (headdim == 96) {
-    using TileShapeQK = Shape<_128, _64, _32>;
-    using TileShapePV = Shape<_128, _32, _64>;
-    using TileShapeOutPut = Shape<_128, _96>;
-    using SubgroupLayoutQK = Layout<Shape<_8, _1, _1>>;
-    run_mha_fwd_specialized(
-        TileShapeQK,
-        TileShapePV,
-        TileShapeOutPut,
-        SubgroupLayoutQK,
-        PipelineStages);
-  } else if (headdim == 128) {
-    using TileShapeQK = Shape<_128, _32, _32>;
-    using TileShapePV = Shape<_128, _32, _32>;
-    using TileShapeOutPut = Shape<_128, _128>;
-    using SubgroupLayoutQK = Layout<Shape<_8, _1, _1>>;
-    run_mha_fwd_specialized(
-        TileShapeQK,
-        TileShapePV,
-        TileShapeOutPut,
-        SubgroupLayoutQK,
-        PipelineStages);
-  } else if (headdim == 192) {
-    using TileShapeQK = Shape<_256, _64, _32>;
-    using TileShapePV = Shape<_256, _32, _64>;
-    using TileShapeOutPut = Shape<_256, _192>;
-    using SubgroupLayoutQK = Layout<Shape<_32, _1, _1>>;
-    run_mha_fwd_specialized(
-        TileShapeQK,
-        TileShapePV,
-        TileShapeOutPut,
-        SubgroupLayoutQK,
-        PipelineStages);
+  if (headdim <= 32) {
+    run_mha_fwd_<T, 32, IS_CAUSAL>(queue, params);
+  } else if (headdim <= 64) {
+    run_mha_fwd_<T, 64, IS_CAUSAL>(queue, params);
+  } else if (headdim <= 96) {
+    run_mha_fwd_<T, 96, IS_CAUSAL>(queue, params);
+  } else if (headdim <= 128) {
+    run_mha_fwd_<T, 128, IS_CAUSAL>(queue, params);
+  } else if (headdim <= 192) {
+    run_mha_fwd_<T, 192, IS_CAUSAL>(queue, params);
+  } else if (headdim <= 256) {
+    run_mha_fwd_<T, 256, IS_CAUSAL>(queue, params);
   } else {
     TORCH_CHECK(
-        false, "FlashAttentionForwardXPU only support headdim 64,96,128,192");
+        false,
+        "FlashAttentionForwardXPU only support headdim up to 256, got ",
+        headdim);
   }
 }
 
@@ -429,19 +150,44 @@ flash_attention_forward_sycltla(
   TORCH_CHECK(
       value.stride(-1) == 1,
       "FlashAttentionForwardXPU: input tensor must have contiguous last dimension");
+  TORCH_CHECK(
+      headsize_vo == headsize_qk,
+      "FlashAttentionForwardXPU only support headsize_qk equal to headsize_vo");
+
+  const int headsize_padded = round_up_headdim(headsize_qk);
+  const bool needs_headsize_pad = headsize_padded > headsize_qk;
+
+  at::Tensor q_padded = query;
+  at::Tensor k_padded = key;
+  at::Tensor v_padded = value;
+  if (needs_headsize_pad) {
+    int pad = headsize_padded - headsize_qk;
+    q_padded = at::constant_pad_nd(query, {0, pad}, 0);
+    k_padded = at::constant_pad_nd(key, {0, pad}, 0);
+    v_padded = at::constant_pad_nd(value, {0, pad}, 0);
+  }
 
   auto opts = query.options();
   at::Tensor out = at::empty_like(query);
+
+  at::Tensor out_padded = needs_headsize_pad
+      ? at::empty({batch_size, numhead_qo, seqlen_qo, headsize_padded}, opts)
+      : out;
 
   if (seqlen_qo > seqlen_kv && is_causal) {
     // When seqlen_qo is greater than seqlen_kv and is_causal(lower_right causal
     // mask) is true, some output positions will skip computation for better
     // performance.
-    out.zero_();
+    out_padded.zero_();
   }
 
   at::Tensor logsumexp =
       at::empty({batch_size, numhead_qo, seqlen_qo}, opts.dtype(at::kFloat));
+
+  // Base pointers must be 64-byte aligned for block 2D load
+  at::Tensor q_aligned = ensure_alignment_for_sdpa(q_padded);
+  at::Tensor k_aligned = ensure_alignment_for_sdpa(k_padded);
+  at::Tensor v_aligned = ensure_alignment_for_sdpa(v_padded);
 
   auto sycl_queue = at::xpu::getCurrentXPUStream().queue();
   auto device_architecture =
@@ -471,19 +217,23 @@ flash_attention_forward_sycltla(
       numhead_kv,
       seqlen_qo,
       seqlen_kv,
-      headsize_qk,
-      headsize_vo,
+      headsize_padded,
+      headsize_padded,
       0, // unused seqlen_qo_pad
       0, // unused seqlen_kv_pad
-      query,
-      key,
-      value,
-      out,
+      q_aligned,
+      k_aligned,
+      v_aligned,
+      out_padded,
       logsumexp,
       scale,
       is_causal);
 
   cute::run_mha_fwd(sycl_queue, params);
+
+  if (needs_headsize_pad) {
+    out.copy_(out_padded.slice(/*dim=*/3, /*start=*/0, /*end=*/headsize_qk));
+  }
 
   return std::tuple<
       at::Tensor,

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd_hdim128.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd_hdim128.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Splitting the different head dimensions to different files to speed up
+// compilation. This file is auto-generated. See "generate_kernels.py"
+
+#include <sycltla/mha_fwd_launch.h>
+
+namespace cute {
+
+template <>
+void run_mha_fwd_<cute::half_t, 128, false>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim128<cute::half_t, false>(queue, params);
+}
+
+template <>
+void run_mha_fwd_<cute::half_t, 128, true>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim128<cute::half_t, true>(queue, params);
+}
+
+template <>
+void run_mha_fwd_<cute::bfloat16_t, 128, false>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim128<cute::bfloat16_t, false>(queue, params);
+}
+
+template <>
+void run_mha_fwd_<cute::bfloat16_t, 128, true>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim128<cute::bfloat16_t, true>(queue, params);
+}
+
+} // namespace cute

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd_hdim192.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd_hdim192.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Splitting the different head dimensions to different files to speed up
+// compilation. This file is auto-generated. See "generate_kernels.py"
+
+#include <sycltla/mha_fwd_launch.h>
+
+namespace cute {
+
+template <>
+void run_mha_fwd_<cute::half_t, 192, false>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim192<cute::half_t, false>(queue, params);
+}
+
+template <>
+void run_mha_fwd_<cute::half_t, 192, true>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim192<cute::half_t, true>(queue, params);
+}
+
+template <>
+void run_mha_fwd_<cute::bfloat16_t, 192, false>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim192<cute::bfloat16_t, false>(queue, params);
+}
+
+template <>
+void run_mha_fwd_<cute::bfloat16_t, 192, true>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim192<cute::bfloat16_t, true>(queue, params);
+}
+
+} // namespace cute

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd_hdim256.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd_hdim256.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Splitting the different head dimensions to different files to speed up
+// compilation. This file is auto-generated. See "generate_kernels.py"
+
+#include <sycltla/mha_fwd_launch.h>
+
+namespace cute {
+
+template <>
+void run_mha_fwd_<cute::half_t, 256, false>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim256<cute::half_t, false>(queue, params);
+}
+
+template <>
+void run_mha_fwd_<cute::half_t, 256, true>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim256<cute::half_t, true>(queue, params);
+}
+
+template <>
+void run_mha_fwd_<cute::bfloat16_t, 256, false>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim256<cute::bfloat16_t, false>(queue, params);
+}
+
+template <>
+void run_mha_fwd_<cute::bfloat16_t, 256, true>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim256<cute::bfloat16_t, true>(queue, params);
+}
+
+} // namespace cute

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd_hdim32.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd_hdim32.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Splitting the different head dimensions to different files to speed up
+// compilation. This file is auto-generated. See "generate_kernels.py"
+
+#include <sycltla/mha_fwd_launch.h>
+
+namespace cute {
+
+template <>
+void run_mha_fwd_<cute::half_t, 32, false>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim32<cute::half_t, false>(queue, params);
+}
+
+template <>
+void run_mha_fwd_<cute::half_t, 32, true>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim32<cute::half_t, true>(queue, params);
+}
+
+template <>
+void run_mha_fwd_<cute::bfloat16_t, 32, false>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim32<cute::bfloat16_t, false>(queue, params);
+}
+
+template <>
+void run_mha_fwd_<cute::bfloat16_t, 32, true>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim32<cute::bfloat16_t, true>(queue, params);
+}
+
+} // namespace cute

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd_hdim64.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd_hdim64.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Splitting the different head dimensions to different files to speed up
+// compilation. This file is auto-generated. See "generate_kernels.py"
+
+#include <sycltla/mha_fwd_launch.h>
+
+namespace cute {
+
+template <>
+void run_mha_fwd_<cute::half_t, 64, false>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim64<cute::half_t, false>(queue, params);
+}
+
+template <>
+void run_mha_fwd_<cute::half_t, 64, true>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim64<cute::half_t, true>(queue, params);
+}
+
+template <>
+void run_mha_fwd_<cute::bfloat16_t, 64, false>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim64<cute::bfloat16_t, false>(queue, params);
+}
+
+template <>
+void run_mha_fwd_<cute::bfloat16_t, 64, true>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim64<cute::bfloat16_t, true>(queue, params);
+}
+
+} // namespace cute

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd_hdim96.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd_hdim96.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Splitting the different head dimensions to different files to speed up
+// compilation. This file is auto-generated. See "generate_kernels.py"
+
+#include <sycltla/mha_fwd_launch.h>
+
+namespace cute {
+
+template <>
+void run_mha_fwd_<cute::half_t, 96, false>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim96<cute::half_t, false>(queue, params);
+}
+
+template <>
+void run_mha_fwd_<cute::half_t, 96, true>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim96<cute::half_t, true>(queue, params);
+}
+
+template <>
+void run_mha_fwd_<cute::bfloat16_t, 96, false>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim96<cute::bfloat16_t, false>(queue, params);
+}
+
+template <>
+void run_mha_fwd_<cute::bfloat16_t, 96, true>(
+    sycl::queue& queue,
+    FLASH_FWD_params& params) {
+  run_mha_fwd_hdim96<cute::bfloat16_t, true>(queue, params);
+}
+
+} // namespace cute

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd_launch.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd_launch.h
@@ -1,0 +1,390 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Copyright (c) 2024 - 2025 Codeplay Software Ltd. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Splitting the different head dimensions to different files to speed up
+// compilation. This file contains the template definitions shared by all
+// per-headdim forward compilation units.
+
+#pragma once
+
+#include <sycltla/mha_common.h>
+#include <sycltla/mha_fwd.h>
+
+// batch, numhead_qo,numhead_kv,seqlen_qo,seqlen_kv,headsize_qk,headsize_vo
+using ProblemShapeRegular = cute::tuple<int, int, int, int, int, int, int>;
+
+namespace cute {
+
+template <class...>
+class MhaName;
+
+template <class FMHAPrefillKernel, bool isVarLen>
+struct FA2Runner {
+  using ElementQ = typename FMHAPrefillKernel::ElementQ;
+  using ElementK = typename FMHAPrefillKernel::ElementK;
+  using ElementV = typename FMHAPrefillKernel::ElementV;
+  using ElementO = typename FMHAPrefillKernel::ElementO;
+
+  using ProblemShapeType = cutlass::fmha::kernel::FMHAProblemShape<isVarLen>;
+
+  void run(sycl::queue& queue, typename FMHAPrefillKernel::Params params) {
+    namespace syclex = sycl::ext::oneapi::experimental;
+    namespace intelex = sycl::ext::intel::experimental;
+
+    dim3 const block = FMHAPrefillKernel::get_block_shape();
+    dim3 const grid = FMHAPrefillKernel::get_grid_shape(params);
+
+    int smem_size = FMHAPrefillKernel::SharedStorageSize;
+
+    const auto sycl_block = compat::dim3(block.x, block.y, block.z);
+    const auto sycl_grid = compat::dim3(grid.x, grid.y, grid.z);
+
+    compat::experimental::launch_properties launch_props{
+        syclex::work_group_scratch_size(smem_size),
+    };
+    compat::experimental::kernel_properties kernel_props{
+        syclex::sub_group_size<cute::intel::sg_size>, intelex::grf_size<256>};
+    compat::experimental::launch_policy policy{
+        sycl_grid, sycl_block, launch_props, kernel_props};
+    compat::experimental::launch<
+        cutlass::device_kernel<FMHAPrefillKernel>,
+        MhaName<FMHAPrefillKernel>>(policy, queue, params);
+  }
+
+  void run(
+      sycl::queue& queue,
+      FLASH_FWD_params& params,
+      const cutlass::KernelHardwareInfo& hw_info) {
+    int batch = params.batch_size;
+    int num_heads_qo = params.num_heads_qo;
+    int num_heads_kv = params.num_heads_kv;
+    int seq_len_qo = params.seqlen_qo;
+    int seq_len_kv = params.seqlen_kv;
+    int head_size_qk = params.head_size_qk;
+    int head_size_vo = params.head_size_vo;
+
+    ProblemShapeType shape;
+    shape.batch = batch;
+    shape.num_heads_q = num_heads_qo;
+    shape.num_heads_kv = num_heads_kv;
+    shape.seq_len_qo = seq_len_qo;
+    shape.seq_len_kv = seq_len_kv;
+    shape.head_size_qk = head_size_qk;
+    shape.head_size_vo = head_size_vo;
+
+    const ElementQ* q_ptr = static_cast<const ElementQ*>(params.q_ptr);
+    const ElementK* k_ptr = static_cast<const ElementK*>(params.k_ptr);
+    const ElementV* v_ptr = static_cast<const ElementV*>(params.v_ptr);
+    ElementO* o_ptr = static_cast<ElementO*>(params.o_ptr);
+    float* lse_ptr = static_cast<float*>(params.lse_ptr);
+    float softmax_scale = params.scale;
+
+    typename FMHAPrefillKernel::Arguments arguments{
+        {
+            shape,
+            q_ptr,
+            params.q_batch_stride,
+            params.q_head_stride,
+            params.q_row_stride,
+            k_ptr,
+            params.k_batch_stride,
+            params.k_head_stride,
+            params.k_row_stride,
+            v_ptr,
+            params.v_batch_stride,
+            params.v_head_stride,
+            params.v_row_stride,
+            o_ptr,
+            params.o_batch_stride,
+            params.o_head_stride,
+            params.o_row_stride,
+            lse_ptr,
+        },
+        {softmax_scale},
+        {},
+        hw_info};
+
+    size_t workspace_size = FMHAPrefillKernel::get_workspace_size(arguments);
+    at::Tensor workspace_tensor = at::empty(
+        {static_cast<int64_t>(workspace_size)},
+        at::device(at::kXPU).dtype(at::kByte));
+
+    if (!FMHAPrefillKernel::can_implement(arguments)) {
+      TORCH_CHECK(
+          false,
+          "Invalid Problem Size",
+          batch,
+          "x",
+          num_heads_qo,
+          "x",
+          seq_len_qo,
+          "x",
+          seq_len_kv,
+          "x",
+          head_size_qk,
+          "x",
+          head_size_vo);
+      return;
+    }
+
+    CUTLASS_CHECK(FMHAPrefillKernel::initialize_workspace(
+        arguments, workspace_tensor.data_ptr()));
+
+    auto kernel_params = FMHAPrefillKernel::to_underlying_arguments(
+        arguments, workspace_tensor.data_ptr());
+
+    run(queue, kernel_params);
+  }
+};
+
+template <
+    typename T,
+    bool IS_CAUSAL,
+    typename TileShapeQK,
+    typename TileShapePV,
+    typename TileShapeOutPut,
+    typename SubgroupLayoutQK,
+    int PipelineStages,
+    bool isVarLen = false>
+void run_mha_fwd_impl(sycl::queue& queue, FLASH_FWD_params& params) {
+  using ElementQ = T;
+  using ElementK = T;
+  using ElementV = T;
+  using ElementO = T;
+  using StrideQ = Stride<int64_t, _1, int64_t, int64_t>;
+  using StrideK = Stride<int64_t, _1, int64_t, int64_t>;
+  using StrideV = Stride<_1, int64_t, int64_t, int64_t>;
+  using StrideO = Stride<int64_t, _1, int64_t, int64_t>;
+  auto make_dummy_tensor = [&](auto val, auto stride) {
+    return make_tensor(
+        make_gmem_ptr(static_cast<decltype(val)*>(nullptr)),
+        make_layout(repeat<rank_v<decltype(stride)>>(1), stride));
+  };
+  auto make_const_dummy_tensor = [&](auto val, auto stride) {
+    return make_tensor(
+        make_gmem_ptr(static_cast<const decltype(val)*>(nullptr)),
+        make_layout(repeat<rank_v<decltype(stride)>>(1), stride));
+  };
+  using TensorQ = decltype(make_const_dummy_tensor(ElementQ{}, StrideQ{}));
+  using TensorK = decltype(make_const_dummy_tensor(ElementK{}, StrideK{}));
+  using TensorV = decltype(make_const_dummy_tensor(ElementV{}, StrideV{}));
+  using TensorO = decltype(make_dummy_tensor(ElementO{}, StrideO{}));
+
+  static constexpr int SGTileQ =
+      get<0>(shape_div(TileShapeQK{}, shape(SubgroupLayoutQK{})))();
+  static_assert(SGTileQ <= 16, "Subgroup tile in Q dimension must be <= 16");
+  using MMAOperation = XE_DPAS_TT<cute::gcd(SGTileQ, 8), float, T>;
+  using SubgroupLayoutPV =
+      decltype(cutlass::fmha::collective::get_sg_layout_pv(SubgroupLayoutQK{}));
+  using TiledMMAQK = typename TiledMMAHelper<
+      MMA_Atom<MMAOperation>,
+      Layout<TileShapeQK>,
+      SubgroupLayoutQK>::TiledMMA;
+  using TiledMMAPV = typename TiledMMAHelper<
+      MMA_Atom<MMAOperation>,
+      Layout<TileShapePV>,
+      SubgroupLayoutPV>::TiledMMA;
+  static_assert(
+      get<0>(TileShapeOutPut{}) == get<0>(TileShapePV{}),
+      "Output tile and P*V tile have different sizes in Q dimension");
+  constexpr int VTiles = get<1>(TileShapeOutPut{}) / get<1>(TileShapePV{});
+
+  cutlass::KernelHardwareInfo hw_info;
+
+  using MainloopDispatchPolicy = cutlass::fmha::XeDefault<PipelineStages>;
+  using CollectiveMainloop = cutlass::fmha::collective::FMHAFwdMainloop<
+      MainloopDispatchPolicy,
+      IS_CAUSAL,
+      TiledMMAQK,
+      TiledMMAPV,
+      VTiles,
+      TensorQ,
+      TensorK,
+      TensorV>;
+
+  using CollectiveEpilogue = cutlass::fmha::collective::
+      FMHAFwdEpilogue<CollectiveMainloop, TileShapeOutPut, TensorO>;
+
+  using Scheduler = cutlass::fmha::kernel::XeFMHAIndividualTileScheduler;
+  using ProblemShapeType = cutlass::fmha::kernel::FMHAProblemShape<isVarLen>;
+  using FMHAPrefillKernel = cutlass::fmha::kernel::XeFMHAFwdKernel<
+      ProblemShapeType,
+      CollectiveMainloop,
+      CollectiveEpilogue,
+      Scheduler>;
+
+  FA2Runner<FMHAPrefillKernel, isVarLen> runner;
+  runner.run(queue, params, hw_info);
+}
+
+// Convenience macro for invoking run_mha_fwd_impl with tile shape parameters
+#define run_mha_fwd_specialized( \
+    TileShapeQK_,                \
+    TileShapePV_,                \
+    TileShapeOutPut_,            \
+    SubgroupLayoutQK_,           \
+    PipelineStages_)             \
+  run_mha_fwd_impl<              \
+      T,                         \
+      IS_CAUSAL,                 \
+      TileShapeQK_,              \
+      TileShapePV_,              \
+      TileShapeOutPut_,          \
+      SubgroupLayoutQK_,         \
+      PipelineStages_>(queue, params)
+
+// Per-headdim dispatch functions.
+// The template functions below are implementation details used by the
+// per-headdim .cpp files. The non-template entry points declared after
+// them are what mha_fwd.cpp calls for runtime headdim dispatch.
+
+template <typename T, bool IS_CAUSAL>
+void run_mha_fwd_hdim32(sycl::queue& queue, FLASH_FWD_params& params) {
+  constexpr int PipelineStages = 2;
+  using TileShapeQK = Shape<_128, _64, _32>;
+  using TileShapePV = Shape<_128, _32, _64>;
+  using TileShapeOutPut = Shape<_128, _32>;
+  using SubgroupLayoutQK = Layout<Shape<_8, _1, _1>>;
+  run_mha_fwd_specialized(
+      TileShapeQK,
+      TileShapePV,
+      TileShapeOutPut,
+      SubgroupLayoutQK,
+      PipelineStages);
+}
+
+template <typename T, bool IS_CAUSAL>
+void run_mha_fwd_hdim64(sycl::queue& queue, FLASH_FWD_params& params) {
+  constexpr int PipelineStages = 2;
+  int64_t batch_size = params.batch_size;
+  int64_t num_heads_qo = params.num_heads_qo;
+  int64_t seqlen_qo = params.seqlen_qo;
+  if (batch_size * num_heads_qo * seqlen_qo <= 8192) {
+    using TileShapeQK = Shape<_64, _64, _32>;
+    using TileShapePV = Shape<_64, _32, _64>;
+    using TileShapeOutPut = Shape<_64, _64>;
+    using SubgroupLayoutQK = Layout<Shape<_16, _1, _1>>;
+    run_mha_fwd_specialized(
+        TileShapeQK,
+        TileShapePV,
+        TileShapeOutPut,
+        SubgroupLayoutQK,
+        PipelineStages);
+  } else {
+    using TileShapeQK = Shape<_128, _64, _32>;
+    using TileShapePV = Shape<_128, _32, _64>;
+    using TileShapeOutPut = Shape<_128, _64>;
+    using SubgroupLayoutQK = Layout<Shape<_8, _1, _1>>;
+    run_mha_fwd_specialized(
+        TileShapeQK,
+        TileShapePV,
+        TileShapeOutPut,
+        SubgroupLayoutQK,
+        PipelineStages);
+  }
+}
+
+template <typename T, bool IS_CAUSAL>
+void run_mha_fwd_hdim96(sycl::queue& queue, FLASH_FWD_params& params) {
+  constexpr int PipelineStages = 2;
+  using TileShapeQK = Shape<_128, _64, _32>;
+  using TileShapePV = Shape<_128, _32, _64>;
+  using TileShapeOutPut = Shape<_128, _96>;
+  using SubgroupLayoutQK = Layout<Shape<_8, _1, _1>>;
+  run_mha_fwd_specialized(
+      TileShapeQK,
+      TileShapePV,
+      TileShapeOutPut,
+      SubgroupLayoutQK,
+      PipelineStages);
+}
+
+template <typename T, bool IS_CAUSAL>
+void run_mha_fwd_hdim128(sycl::queue& queue, FLASH_FWD_params& params) {
+  constexpr int PipelineStages = 2;
+  using TileShapeQK = Shape<_128, _32, _32>;
+  using TileShapePV = Shape<_128, _32, _32>;
+  using TileShapeOutPut = Shape<_128, _128>;
+  using SubgroupLayoutQK = Layout<Shape<_8, _1, _1>>;
+  run_mha_fwd_specialized(
+      TileShapeQK,
+      TileShapePV,
+      TileShapeOutPut,
+      SubgroupLayoutQK,
+      PipelineStages);
+}
+
+template <typename T, bool IS_CAUSAL>
+void run_mha_fwd_hdim192(sycl::queue& queue, FLASH_FWD_params& params) {
+  constexpr int PipelineStages = 2;
+  using TileShapeQK = Shape<_256, _64, _32>;
+  using TileShapePV = Shape<_256, _32, _64>;
+  using TileShapeOutPut = Shape<_256, _192>;
+  using SubgroupLayoutQK = Layout<Shape<_32, _1, _1>>;
+  run_mha_fwd_specialized(
+      TileShapeQK,
+      TileShapePV,
+      TileShapeOutPut,
+      SubgroupLayoutQK,
+      PipelineStages);
+}
+
+template <typename T, bool IS_CAUSAL>
+void run_mha_fwd_hdim256(sycl::queue& queue, FLASH_FWD_params& params) {
+  constexpr int PipelineStages = 2;
+  using TileShapeQK = Shape<_256, _64, _32>;
+  using TileShapePV = Shape<_256, _32, _64>;
+  using TileShapeOutPut = Shape<_256, _256>;
+  using SubgroupLayoutQK = Layout<Shape<_32, _1, _1>>;
+  run_mha_fwd_specialized(
+      TileShapeQK,
+      TileShapePV,
+      TileShapeOutPut,
+      SubgroupLayoutQK,
+      PipelineStages);
+}
+
+// Primary template declaration -- explicit specializations are provided by
+// the per-headdim compilation units (mha_fwd_hdim*.cpp).
+template <typename T, int Headdim, bool IS_CAUSAL>
+void run_mha_fwd_(sycl::queue& queue, FLASH_FWD_params& params);
+
+#undef run_mha_fwd_specialized
+
+} // namespace cute

--- a/src/BuildOnLinux.cmake
+++ b/src/BuildOnLinux.cmake
@@ -72,24 +72,20 @@ if(USE_SYCLTLA)
   set_build_flags()
   replace_cmake_build_flags()
 
-  foreach(sycl_src ${ATen_XPU_SYCLTLA_SRCS})
-    get_filename_component(name ${sycl_src} NAME_WLE REALPATH)
-    set(sycl_lib torch-xpu-ops-sycltla-${name})
-    sycl_add_library(
-      ${sycl_lib}
-      SHARED
-      SYCL_SOURCES ${sycl_src})
-    target_link_libraries(torch_xpu_ops PUBLIC ${sycl_lib})
-    list(APPEND TORCH_XPU_OPS_LIBRARIES ${sycl_lib})
+  set(sycl_lib torch-xpu-ops-sycltla)
+  sycl_add_library(
+    ${sycl_lib}
+    SHARED
+    SYCL_SOURCES ${ATen_XPU_SYCLTLA_SRCS})
+  target_link_libraries(torch_xpu_ops PUBLIC ${sycl_lib})
+  list(APPEND TORCH_XPU_OPS_LIBRARIES ${sycl_lib})
 
-    # Decouple with PyTorch cmake definition.
-    install(TARGETS ${sycl_lib} DESTINATION "${TORCH_INSTALL_LIB_DIR}")
+  install(TARGETS ${sycl_lib} DESTINATION "${TORCH_INSTALL_LIB_DIR}")
 
-    # Set Compile options for sycltla kernels
-    target_compile_definitions(${sycl_lib} PRIVATE ${SYCLTLA_COMPILE_DEFINITIONS})
-    target_include_directories(${sycl_lib} PRIVATE ${SYCLTLA_INCLUDE_DIRS})
-    target_include_directories(${sycl_lib} PRIVATE ${ATen_XPU_FLASH_ATTN_DIRS})
-  endforeach()
+  # Set Compile options for sycltla kernels
+  target_compile_definitions(${sycl_lib} PRIVATE ${SYCLTLA_COMPILE_DEFINITIONS})
+  target_include_directories(${sycl_lib} PRIVATE ${SYCLTLA_INCLUDE_DIRS})
+  target_include_directories(${sycl_lib} PRIVATE ${ATen_XPU_FLASH_ATTN_DIRS})
 
   set(REPLACE_FLAGS_FOR_SYCLTLA FALSE)
   set_build_flags()


### PR DESCRIPTION
Fix https://github.com/intel/torch-xpu-ops/issues/3141

This PR 
1.support tileshape for headdim32/headdim256 in kernel. Just for functionality. No tune performance yet.
2.support all headdim <= 256 input tensor by padding tensor. 
3.split the `mha_fwd.cpp/mha_bwd.cpp` to several `xxx_hdimxxx.cpp` files to specialize templates in different cpp files instead of in single file, to accelerate compilation time. Aligned with Tridao.