### PR TITLE
Align with CUDA efficient_attention_backward to throw error

### DIFF
--- a/src/ATen/native/transformers/Attention.cpp
+++ b/src/ATen/native/transformers/Attention.cpp
@@ -520,6 +520,10 @@ _scaled_dot_product_efficient_attention_backward_xpu(
   if (grad_input_mask[2])
     v.requires_grad_(true);
 
+  TORCH_CHECK(
+      !grad_input_mask[3] || attn_bias.defined(),
+      "bias_requires_grad is true but no bias was provided");
+
   std::optional<Tensor> attn_bias_opt;
   Tensor ab;
   if (attn_bias.defined()) {


### PR DESCRIPTION
Fix https://github.com/intel/torch-xpu-ops/issues/3131

When bias_requires_grad is True but bias is not defined, it should throw errors.