### PR TITLE
Add subgroup topk kernel for XPU (part1 of #3369)

### DIFF
--- a/src/ATen/native/xpu/sycl/TensorTopKKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorTopKKernel.cpp
@@ -16,6 +16,7 @@
 #include <ATen/native/xpu/sycl/SortingKernels.h>
 
 #include <ATen/native/xpu/sycl/TensorTopKKernel.h>
+#include <ATen/native/xpu/sycl/TensorTopKSbtopkKernel.h>
 
 namespace at {
 namespace native {
@@ -113,17 +114,26 @@ void topk_kernel(
         const scalar_t* self_ptr = self_.const_data_ptr<scalar_t>();
         scalar_t* values_ptr = values_.data_ptr<scalar_t>();
         int64_t* indices_ptr = indices_.data_ptr<int64_t>();
-        segmented_group_select_pairs<scalar_t, int64_t>(
-            self_ptr,
-            values_ptr,
-            nullptr,
-            (int64_t*)indices_ptr,
-            nsegments,
-            nelements,
-            k,
-            largest);
 
-        if (sorted) {
+        SbtopkResult sbtopk_result = sbtopk_try_launch(
+            self_, nsegments, nelements, k, largest, values_, indices_);
+        if (sbtopk_result == SbtopkResult::FAILED) {
+          segmented_group_select_pairs<scalar_t, int64_t>(
+              self_ptr,
+              values_ptr,
+              nullptr,
+              (int64_t*)indices_ptr,
+              nsegments,
+              nelements,
+              k,
+              largest);
+        }
+
+        // Only sort if the user asked for sorted output AND sbtopk did not
+        // already produce a sorted result. The subgroup topk kernel returns
+        // SORTED; the single workgroup kernel and the original radix select
+        // return UNSORTED (or FAILED).
+        if (sorted && sbtopk_result != SbtopkResult::SORTED) {
           segmented_sort_pairs<scalar_t, int64_t>(
               values_ptr,
               values_ptr,

--- a/src/ATen/native/xpu/sycl/TensorTopKKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorTopKKernel.cpp
@@ -129,10 +129,9 @@ void topk_kernel(
               largest);
         }
 
-        // Only sort if the user asked for sorted output AND sbtopk did not
-        // already produce a sorted result. The subgroup topk kernel returns
-        // SORTED; the single workgroup kernel and the original radix select
-        // return UNSORTED (or FAILED).
+        // Only sort if the user asked for sorted output AND the optimized
+        // kernel did not already produce a sorted result. The subgroup topk
+        // kernel returns SORTED; the original kernel returns FAILED.
         if (sorted && sbtopk_result != SbtopkResult::SORTED) {
           segmented_sort_pairs<scalar_t, int64_t>(
               values_ptr,

--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
@@ -368,30 +368,66 @@ static void sbtopk_launch_kernel(
     int64_t sliceSize,
     int k,
     bool largest) {
-  constexpr int K = 16;
-  // Dispatch on (largest, IndexT) at the outermost level:
-  //   - largest: so tight insert/merge loops have no runtime direction branch
-  //   - IndexT: int32 when total elements fit (common), int64 otherwise.
-  //     Mirrors CUDA's canUse32BitIndexMath. int32 avoids 64-bit
-  //     arithmetic and reduces register pressure.
-  if (numSlices * sliceSize <= std::numeric_limits<int>::max()) {
-    int numSlices32 = static_cast<int>(numSlices);
-    if (largest) {
-      sbtopk_launch_vec_dispatch<scalar_t, K, true, int>(
-          input, topK, indices, numSlices32, sliceSize, k);
-    } else {
-      sbtopk_launch_vec_dispatch<scalar_t, K, false, int>(
-          input, topK, indices, numSlices32, sliceSize, k);
-    }
-  } else {
-    if (largest) {
-      sbtopk_launch_vec_dispatch<scalar_t, K, true, int64_t>(
-          input, topK, indices, numSlices, sliceSize, k);
-    } else {
-      sbtopk_launch_vec_dispatch<scalar_t, K, false, int64_t>(
-          input, topK, indices, numSlices, sliceSize, k);
-    }
+  // Dispatch on (K, Largest, IndexT).
+  // K: smallest power-of-two >= k.  Smaller K means fewer unrolled
+  //    iterations in insert/merge, less register pressure, zero spills.
+  //    K=1 is a valid special case (top-1 = max/min element).
+  // Largest: compile-time direction eliminates per-element branches.
+  // IndexT: int32 when total elements fit (common), int64 otherwise.
+
+  // Select K: round up k to next power of two, clamped to [1, 16].
+  int K_sel;
+  if (k <= 1)
+    K_sel = 1;
+  else if (k <= 2)
+    K_sel = 2;
+  else if (k <= 4)
+    K_sel = 4;
+  else if (k <= 8)
+    K_sel = 8;
+  else
+    K_sel = 16;
+
+#define SBTOPK_DISPATCH_K(K_VAL, LARGEST, INDEX_T, NUM_SLICES)   \
+  sbtopk_launch_vec_dispatch<scalar_t, K_VAL, LARGEST, INDEX_T>( \
+      input, topK, indices, NUM_SLICES, sliceSize, k)
+
+#define SBTOPK_DISPATCH_LARGEST(K_VAL, INDEX_T, NUM_SLICES) \
+  if (largest) {                                            \
+    SBTOPK_DISPATCH_K(K_VAL, true, INDEX_T, NUM_SLICES);    \
+  } else {                                                  \
+    SBTOPK_DISPATCH_K(K_VAL, false, INDEX_T, NUM_SLICES);   \
   }
+
+#define SBTOPK_DISPATCH_INDEX(K_VAL)                              \
+  if (numSlices * sliceSize <= std::numeric_limits<int>::max()) { \
+    int numSlices32 = static_cast<int>(numSlices);                \
+    SBTOPK_DISPATCH_LARGEST(K_VAL, int, numSlices32);             \
+  } else {                                                        \
+    SBTOPK_DISPATCH_LARGEST(K_VAL, int64_t, numSlices);           \
+  }
+
+  switch (K_sel) {
+    case 1:
+      SBTOPK_DISPATCH_INDEX(1);
+      break;
+    case 2:
+      SBTOPK_DISPATCH_INDEX(2);
+      break;
+    case 4:
+      SBTOPK_DISPATCH_INDEX(4);
+      break;
+    case 8:
+      SBTOPK_DISPATCH_INDEX(8);
+      break;
+    default:
+      SBTOPK_DISPATCH_INDEX(16);
+      break;
+  }
+
+#undef SBTOPK_DISPATCH_INDEX
+#undef SBTOPK_DISPATCH_LARGEST
+#undef SBTOPK_DISPATCH_K
 }
 
 // ================================================================

--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
@@ -22,6 +22,7 @@
 #include <ATen/native/xpu/sycl/TensorTopKSbtopkKernel.h>
 #include <comm/DeviceProperties.h>
 #include <sycl/ext/intel/experimental/grf_size_properties.hpp>
+#include <cstdint>
 #include <limits>
 
 namespace at {
@@ -76,11 +77,18 @@ struct SubgroupTopKFunctor {
     bool inserted = false;
 #pragma unroll
     for (int i = K - 1; i >= 0; --i) {
+      // When count < K the buffer is partially filled: positions [0, count)
+      // hold real values while [count, K) still contain sentinels.
+      // Guard "i <= count" ensures we only stop at position i when
+      // top_vals[i-1] is a real entry.  Without this guard, an input
+      // value equal to the sentinel (e.g. all -inf for largest=true)
+      // would always stop at position K-1, overwriting it repeatedly
+      // instead of filling lower positions.
       bool stop;
       if constexpr (Largest) {
-        stop = (i == 0) || !(val > top_vals[i - 1]);
+        stop = (i == 0) || (i <= count && !(val > top_vals[i - 1]));
       } else {
-        stop = (i == 0) || !(val < top_vals[i - 1]);
+        stop = (i == 0) || (i <= count && !(val < top_vals[i - 1]));
       }
       if (!inserted && stop) {
         top_vals[i] = val;
@@ -209,7 +217,7 @@ struct SubgroupTopKFunctor {
     int64_t base;
     for (base = sg_lid * VEC_SIZE; base + VEC_SIZE <= sliceSize_;
          base += stride) {
-      scalar_t src[VEC_SIZE];
+      alignas(alignof(LoadT)) scalar_t src[VEC_SIZE];
       *reinterpret_cast<LoadT*>(&src) =
           *reinterpret_cast<const LoadT*>(&inputSlice[base]);
 #pragma unroll
@@ -327,13 +335,22 @@ static void sbtopk_launch_vec_dispatch(
   //   1. SG_SIZE * VEC_SIZE <= sliceSize  (all threads get at
   //      least one full vector)
   //   2. sliceSize % VEC_SIZE == 0        (slice boundaries are aligned)
-  if (MAX_VEC >= 8 && sliceSize % 8 == 0 && SG_SIZE * 8 <= sliceSize) {
+  //   3. input pointer is aligned to sizeof(scalar_t) * VEC_SIZE
+  //      (usually guaranteed by PyTorch allocators, but a non-zero
+  //      storage offset can break alignment)
+  auto input_align = reinterpret_cast<uintptr_t>(input);
+  if (MAX_VEC >= 8 && sliceSize % 8 == 0 && SG_SIZE * 8 <= sliceSize &&
+      input_align % (sizeof(scalar_t) * 8) == 0) {
     sbtopk_launch_impl<scalar_t, K, 8, Largest, IndexT>(
         input, topK, indices, numSlices, sliceSize, k);
-  } else if (MAX_VEC >= 4 && sliceSize % 4 == 0 && SG_SIZE * 4 <= sliceSize) {
+  } else if (
+      MAX_VEC >= 4 && sliceSize % 4 == 0 && SG_SIZE * 4 <= sliceSize &&
+      input_align % (sizeof(scalar_t) * 4) == 0) {
     sbtopk_launch_impl<scalar_t, K, 4, Largest, IndexT>(
         input, topK, indices, numSlices, sliceSize, k);
-  } else if (sliceSize % 2 == 0 && SG_SIZE * 2 <= sliceSize) {
+  } else if (
+      sliceSize % 2 == 0 && SG_SIZE * 2 <= sliceSize &&
+      input_align % (sizeof(scalar_t) * 2) == 0) {
     sbtopk_launch_impl<scalar_t, K, 2, Largest, IndexT>(
         input, topK, indices, numSlices, sliceSize, k);
   } else {

--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
@@ -12,7 +12,7 @@
  *            to combine 32 per-lane buffers into one global top-k.
  *   Phase 3: Lane 0 writes k results. Output is already sorted.
  *
- * Dispatch: k <= 16 and enough segments (large batch) and dim >= 1024
+ * Dispatch: k <= 16 and enough segments (large batch) and dim >= 32
  *           routes to subgroup top-k; otherwise falls back to original.
  */
 
@@ -397,8 +397,8 @@ static void sbtopk_launch_kernel(
 // ================================================================
 // Dispatch: subgroup top-k vs original
 //
-//   - dim < 1024: original (kernel launch overhead dominates)
-//   - dim >= 1024, large batch, k <= 16: subgroup top-k
+//   - dim < 32: original (need at least SG_SIZE elements)
+//   - dim >= 32, large batch, k <= 16: subgroup top-k
 // ================================================================
 SbtopkResult sbtopk_try_launch(
     const at::Tensor& self,
@@ -408,8 +408,8 @@ SbtopkResult sbtopk_try_launch(
     bool largest,
     const at::Tensor& values,
     const at::Tensor& indices) {
-  // Not beneficial for small dim
-  if (nelements < 1024) {
+  // Subgroup kernel needs at least SG_SIZE (32) elements per slice
+  if (nelements < 32) {
     return SbtopkResult::FAILED;
   }
 

--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
@@ -5,22 +5,25 @@
  * Zero SLM, zero barriers.
  *
  * Algorithm:
- *   Phase 1: Each lane scans dim/32 elements, maintains a sorted top-k
+ *   Phase 1: Each lane scans nelements/32 elements, maintains a sorted top-k
  *            buffer via insertion sort (fully unrolled, no branches on
  *            direction thanks to compile-time Largest template param).
  *   Phase 2: 5 levels of pairwise bitonic merge via sub-group shuffles
  *            to combine 32 per-lane buffers into one global top-k.
  *   Phase 3: Lane 0 writes k results. Output is already sorted.
  *
- * Dispatch: k <= 16 and enough segments (large batch) and dim >= 32
+ * Dispatch: k <= 16 and enough segments (large batch) and nelements >= 32
  *           routes to subgroup top-k; otherwise falls back to original.
  */
 
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
+#include <ATen/ceil_div.h>
 #include <ATen/native/xpu/sycl/MemoryAccessUtils.h>
 #include <ATen/native/xpu/sycl/TensorTopKSbtopkKernel.h>
+#include <c10/util/llvmMathExtras.h>
 #include <comm/DeviceProperties.h>
+#include <comm/SYCLHelpers.h>
 #include <sycl/ext/intel/experimental/grf_size_properties.hpp>
 #include <cstdint>
 #include <limits>
@@ -33,6 +36,11 @@ namespace syclex = sycl::ext::oneapi::experimental;
 namespace intelex = sycl::ext::intel::experimental;
 
 static constexpr int SG_SIZE = 32;
+// Number of pairwise merge levels in Phase 2 = log2(SG_SIZE).
+static constexpr int SG_MERGE_LEVELS = 5;
+static_assert(
+    (1 << SG_MERGE_LEVELS) == SG_SIZE,
+    "SG_MERGE_LEVELS must equal log2(SG_SIZE)");
 
 // ================================================================
 // SubgroupTopKFunctor
@@ -41,10 +49,9 @@ static constexpr int SG_SIZE = 32;
 // VEC_SIZE: vectorized load width
 // Largest: compile-time direction flag. Eliminates per-element branches
 //          on largest_ that otherwise pessimize the tight insert/merge loops.
-// IndexT: int32 when total elements (nsegments * nelements) <= INT_MAX
-//         (common case), int64_t otherwise.  Mirrors CUDA's
-//         canUse32BitIndexMath.  int32 avoids 64-bit arithmetic on slice
-//         indices and element indices, reducing register pressure.
+// IndexT: int32 when numSlices <= INT_MAX (common case), int64_t
+//         otherwise.  int32 avoids 64-bit arithmetic on slice indices,
+//         reducing register pressure.
 // ================================================================
 template <
     typename scalar_t,
@@ -242,9 +249,9 @@ struct SubgroupTopKFunctor {
         count++;
     }
 
-    // ---- Phase 2: sub-group bitonic merge (5 levels for sg_size=32) ----
+    // ---- Phase 2: sub-group bitonic merge ----
 #pragma unroll
-    for (int d = 0; d < 5; ++d) {
+    for (int d = 0; d < SG_MERGE_LEVELS; ++d) {
       int partner = sg_lid ^ (1 << d);
 
       scalar_t partner_vals[K];
@@ -302,20 +309,19 @@ static void sbtopk_launch_impl(
     int k) {
   constexpr int WG_SIZE = 256; // 8 sub-groups per work-group
   constexpr int SGS_PER_WG = WG_SIZE / SG_SIZE;
-  auto num_wgs =
-      (static_cast<int64_t>(numSlices) + SGS_PER_WG - 1) / SGS_PER_WG;
+  auto num_wgs = at::ceil_div(
+      static_cast<int64_t>(numSlices), static_cast<int64_t>(SGS_PER_WG));
 
   SubgroupTopKFunctor<scalar_t, K, VEC_SIZE, Largest, IndexT> functor(
       input, topK, indices, numSlices, sliceSize, k);
 
-  auto q = at::xpu::getCurrentSYCLQueue();
-  q.submit([&](sycl::handler& cgh) {
-    cgh.parallel_for(
-        sycl::nd_range<1>(num_wgs * WG_SIZE, WG_SIZE),
-        syclex::properties{
-            syclex::sub_group_size<SG_SIZE>, intelex::grf_size<128>},
-        functor);
-  });
+  sycl_kernel_submit(
+      num_wgs * WG_SIZE,
+      WG_SIZE,
+      at::xpu::getCurrentSYCLQueue(),
+      syclex::properties{
+          syclex::sub_group_size<SG_SIZE>, intelex::grf_size<128>},
+      functor);
 }
 
 // Vec-size dispatch: picks the largest VEC_SIZE compatible with
@@ -339,18 +345,18 @@ static void sbtopk_launch_vec_dispatch(
   //      (usually guaranteed by PyTorch allocators, but a non-zero
   //      storage offset can break alignment)
   auto input_align = reinterpret_cast<uintptr_t>(input);
-  if (MAX_VEC >= 8 && sliceSize % 8 == 0 && SG_SIZE * 8 <= sliceSize &&
-      input_align % (sizeof(scalar_t) * 8) == 0) {
+  auto can_use_vec = [&](int vec) {
+    return MAX_VEC >= vec && sliceSize % vec == 0 &&
+        SG_SIZE * vec <= sliceSize &&
+        input_align % (sizeof(scalar_t) * vec) == 0;
+  };
+  if (can_use_vec(8)) {
     sbtopk_launch_impl<scalar_t, K, 8, Largest, IndexT>(
         input, topK, indices, numSlices, sliceSize, k);
-  } else if (
-      MAX_VEC >= 4 && sliceSize % 4 == 0 && SG_SIZE * 4 <= sliceSize &&
-      input_align % (sizeof(scalar_t) * 4) == 0) {
+  } else if (can_use_vec(4)) {
     sbtopk_launch_impl<scalar_t, K, 4, Largest, IndexT>(
         input, topK, indices, numSlices, sliceSize, k);
-  } else if (
-      sliceSize % 2 == 0 && SG_SIZE * 2 <= sliceSize &&
-      input_align % (sizeof(scalar_t) * 2) == 0) {
+  } else if (can_use_vec(2)) {
     sbtopk_launch_impl<scalar_t, K, 2, Largest, IndexT>(
         input, topK, indices, numSlices, sliceSize, k);
   } else {
@@ -373,20 +379,11 @@ static void sbtopk_launch_kernel(
   //    iterations in insert/merge, less register pressure, zero spills.
   //    K=1 is a valid special case (top-1 = max/min element).
   // Largest: compile-time direction eliminates per-element branches.
-  // IndexT: int32 when total elements fit (common), int64 otherwise.
+  // IndexT: int32 when numSlices fits (common), int64 otherwise.
 
   // Select K: round up k to next power of two, clamped to [1, 16].
-  int K_sel;
-  if (k <= 1)
-    K_sel = 1;
-  else if (k <= 2)
-    K_sel = 2;
-  else if (k <= 4)
-    K_sel = 4;
-  else if (k <= 8)
-    K_sel = 8;
-  else
-    K_sel = 16;
+  int K_sel = std::min<int>(
+      static_cast<int>(c10::llvm::PowerOf2Ceil(static_cast<uint64_t>(k))), 16);
 
 #define SBTOPK_DISPATCH_K(K_VAL, LARGEST, INDEX_T, NUM_SLICES)   \
   sbtopk_launch_vec_dispatch<scalar_t, K_VAL, LARGEST, INDEX_T>( \
@@ -399,15 +396,12 @@ static void sbtopk_launch_kernel(
     SBTOPK_DISPATCH_K(K_VAL, false, INDEX_T, NUM_SLICES);   \
   }
 
-#define SBTOPK_DISPATCH_INDEX(K_VAL)                                           \
-  if (numSlices <= std::numeric_limits<int>::max() &&                          \
-      sliceSize <= std::numeric_limits<int>::max() &&                          \
-      numSlices <=                                                             \
-          std::numeric_limits<int>::max() / (sliceSize > 0 ? sliceSize : 1)) { \
-    int numSlices32 = static_cast<int>(numSlices);                             \
-    SBTOPK_DISPATCH_LARGEST(K_VAL, int, numSlices32);                          \
-  } else {                                                                     \
-    SBTOPK_DISPATCH_LARGEST(K_VAL, int64_t, numSlices);                        \
+#define SBTOPK_DISPATCH_INDEX(K_VAL)                    \
+  if (numSlices <= std::numeric_limits<int>::max()) {   \
+    int numSlices32 = static_cast<int>(numSlices);      \
+    SBTOPK_DISPATCH_LARGEST(K_VAL, int, numSlices32);   \
+  } else {                                              \
+    SBTOPK_DISPATCH_LARGEST(K_VAL, int64_t, numSlices); \
   }
 
   switch (K_sel) {

--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
@@ -18,11 +18,11 @@
 
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
-#include <limits>
-#include <sycl/ext/intel/experimental/grf_size_properties.hpp>
 #include <ATen/native/xpu/sycl/MemoryAccessUtils.h>
-#include <comm/DeviceProperties.h>
 #include <ATen/native/xpu/sycl/TensorTopKSbtopkKernel.h>
+#include <comm/DeviceProperties.h>
+#include <sycl/ext/intel/experimental/grf_size_properties.hpp>
+#include <limits>
 
 namespace at {
 namespace native {
@@ -40,32 +40,38 @@ static constexpr int SG_SIZE = 32;
 // VEC_SIZE: vectorized load width
 // Largest: compile-time direction flag. Eliminates per-element branches
 //          on largest_ that otherwise pessimize the tight insert/merge loops.
-// IndexT: int32 for nsegments <= INT_MAX (common), int64_t for huge batch.
-//         Mirrors CUDA's canUse32BitIndexMath dispatch. Only numSlices_ and
-//         the slice variable need IndexT; sliceSize_ and k_ stay int because
-//         nelements is already checked <= INT_MAX.
+// IndexT: int32 when total elements (nsegments * nelements) <= INT_MAX
+//         (common case), int64_t otherwise.  Mirrors CUDA's
+//         canUse32BitIndexMath.  int32 avoids 64-bit arithmetic on slice
+//         indices and element indices, reducing register pressure.
 // ================================================================
-template <typename scalar_t, int K, int VEC_SIZE, bool Largest, typename IndexT = int>
+template <
+    typename scalar_t,
+    int K,
+    int VEC_SIZE,
+    bool Largest,
+    typename IndexT = int>
 struct SubgroupTopKFunctor {
-
   // Insert val into a K-sorted buffer. For Largest=true the buffer is sorted
   // descending (top_vals[0] is max); for Largest=false it is sorted ascending
   // (top_vals[0] is min). The comparator `better(a, b)` means "a should sit
   // above b in the buffer" — i.e. strictly greater for largest, strictly less
   // for smallest.
   //
-  // idx is the element position within a slice (0..sliceSize-1), always int
-  // because sliceSize <= INT_MAX. IndexT is only for the slice count.
-  //
   // Fully unrolled, no early break — SIMD-friendly.
   inline void insert(
-      scalar_t* top_vals, int* top_idx, int count,
-      scalar_t val, int idx) const {
+      scalar_t* top_vals,
+      IndexT* top_idx,
+      int count,
+      scalar_t val,
+      IndexT idx) const {
     // Threshold is at the bottom of the buffer (top_vals[K-1]).
     if constexpr (Largest) {
-      if (count >= K && !(val > top_vals[K - 1])) return;
+      if (count >= K && !(val > top_vals[K - 1]))
+        return;
     } else {
-      if (count >= K && !(val < top_vals[K - 1])) return;
+      if (count >= K && !(val < top_vals[K - 1]))
+        return;
     }
     bool inserted = false;
 #pragma unroll
@@ -91,13 +97,15 @@ struct SubgroupTopKFunctor {
   // Step 1: A[i] = better(A[i], B[K-1-i]) — produces bitonic sequence.
   // Step 2: bitonic sort restores the sorted-by-better order on A.
   inline void bitonic_merge(
-      scalar_t* A, int* A_idx,
-      const scalar_t* B, const int* B_idx) const {
+      scalar_t* A,
+      IndexT* A_idx,
+      const scalar_t* B,
+      const IndexT* B_idx) const {
     // Step 1: compare with reversed partner
 #pragma unroll
     for (int i = 0; i < K; ++i) {
       scalar_t bv = B[K - 1 - i];
-      int bi = B_idx[K - 1 - i];
+      IndexT bi = B_idx[K - 1 - i];
       bool take;
       if constexpr (Largest) {
         take = bv > A[i];
@@ -109,7 +117,27 @@ struct SubgroupTopKFunctor {
         A_idx[i] = bi;
       }
     }
-    // Step 2: bitonic sort in the "better" direction
+    // Step 2: bitonic sort — standard bitonic merge network.
+    //
+    // After step 1, A[0..K-1] is bitonic (first decreasing then increasing,
+    // or vice versa).  At stride = K/2 we compare A[i] with A[i + K/2]
+    // for i in [0, K/2) and swap so the "better" value goes to the low
+    // half.  This guarantees:
+    //   (a) every element in A[0..K/2-1] >= every element in A[K/2..K-1],
+    //   (b) each half is itself bitonic (splitting a bitonic sequence at
+    //       the midpoint with min/max produces two bitonic subsequences).
+    // Recurse with stride K/4, K/8, ..., 1 and each sub-piece halves
+    // again, until every piece has length 1 — the array is sorted.
+    //
+    // j = i ^ stride pairs each element with its partner at distance
+    // `stride`.  The guard j > i ensures each pair is processed once.
+    //
+    // Example for K = 16:
+    //   stride 8: (0,8) (1,9) (2,10) ... (7,15)   — 8 pairs
+    //   stride 4: (0,4) (1,5) (2,6) (3,7)          — two groups of 4
+    //             (8,12) (9,13) (10,14) (11,15)
+    //   stride 2: (0,2) (1,3) (4,6) (5,7) ...      — four groups of 2
+    //   stride 1: (0,1) (2,3) (4,5) ... (14,15)    — 8 adjacent pairs
 #pragma unroll
     for (int stride = K / 2; stride >= 1; stride >>= 1) {
 #pragma unroll
@@ -122,31 +150,37 @@ struct SubgroupTopKFunctor {
           swap = (j > i) && (A[i] > A[j]);
         }
         if (swap) {
-          scalar_t tv = A[i]; A[i] = A[j]; A[j] = tv;
-          int ti = A_idx[i]; A_idx[i] = A_idx[j]; A_idx[j] = ti;
+          scalar_t tv = A[i];
+          A[i] = A[j];
+          A[j] = tv;
+          IndexT ti = A_idx[i];
+          A_idx[i] = A_idx[j];
+          A_idx[j] = ti;
         }
       }
     }
   }
 
-  [[sycl::reqd_sub_group_size(32)]]
   void operator()(sycl::nd_item<1> item) const {
     sycl::sub_group sg = item.get_sub_group();
     int sg_lid = sg.get_local_linear_id();
 
     // Each sub-group handles one slice
     int sgs_per_wg = item.get_local_range(0) / SG_SIZE;
-    IndexT slice = static_cast<IndexT>(item.get_group_linear_id()) * sgs_per_wg
-                   + sg.get_group_linear_id();
-    if (slice >= numSlices_) return;
+    IndexT slice =
+        static_cast<IndexT>(item.get_group_linear_id()) * sgs_per_wg +
+        sg.get_group_linear_id();
+    if (slice >= numSlices_)
+      return;
 
-    const scalar_t* inputSlice = inputData_ + static_cast<int64_t>(slice) * sliceSize_;
+    const scalar_t* inputSlice =
+        inputData_ + static_cast<int64_t>(slice) * sliceSize_;
     scalar_t* topKSlice = topKData_ + static_cast<int64_t>(slice) * k_;
     int64_t* indicesSlice = indicesData_ + static_cast<int64_t>(slice) * k_;
 
     // Initialize sorted top-K buffer
     scalar_t top_vals[K];
-    int top_idx_local[K];
+    IndexT top_idx_local[K];
     scalar_t init_val;
     if constexpr (Largest) {
       if constexpr (std::numeric_limits<scalar_t>::has_infinity) {
@@ -172,22 +206,32 @@ struct SubgroupTopKFunctor {
     using LoadT = memory::aligned_vector<scalar_t, VEC_SIZE>;
     int stride = SG_SIZE * VEC_SIZE;
 
-    int base;
-    for (base = sg_lid * VEC_SIZE; base + VEC_SIZE <= sliceSize_; base += stride) {
+    int64_t base;
+    for (base = sg_lid * VEC_SIZE; base + VEC_SIZE <= sliceSize_;
+         base += stride) {
       scalar_t src[VEC_SIZE];
       *reinterpret_cast<LoadT*>(&src) =
           *reinterpret_cast<const LoadT*>(&inputSlice[base]);
 #pragma unroll
       for (int v = 0; v < VEC_SIZE; ++v) {
-        insert(top_vals, top_idx_local, count, src[v], base + v);
-        if (count < K) count++;
+        insert(
+            top_vals,
+            top_idx_local,
+            count,
+            src[v],
+            static_cast<IndexT>(base + v));
+        if (count < K)
+          count++;
       }
     }
     // Scalar tail
-    for (int idx = base; idx < sliceSize_ && idx < base + VEC_SIZE; ++idx) {
+    for (IndexT idx = static_cast<IndexT>(base);
+         idx < sliceSize_ && idx < base + VEC_SIZE;
+         ++idx) {
       scalar_t val = inputSlice[idx];
       insert(top_vals, top_idx_local, count, val, idx);
-      if (count < K) count++;
+      if (count < K)
+        count++;
     }
 
     // ---- Phase 2: sub-group bitonic merge (5 levels for sg_size=32) ----
@@ -196,7 +240,7 @@ struct SubgroupTopKFunctor {
       int partner = sg_lid ^ (1 << d);
 
       scalar_t partner_vals[K];
-      int partner_idx[K];
+      IndexT partner_idx[K];
 #pragma unroll
       for (int i = 0; i < K; ++i) {
         partner_vals[i] = sycl::select_from_group(sg, top_vals[i], partner);
@@ -220,7 +264,7 @@ struct SubgroupTopKFunctor {
       scalar_t* topKData,
       int64_t* indicesData,
       IndexT numSlices,
-      int sliceSize,
+      int64_t sliceSize,
       int k)
       : inputData_(inputData),
         topKData_(topKData),
@@ -233,7 +277,7 @@ struct SubgroupTopKFunctor {
   scalar_t* topKData_;
   int64_t* indicesData_;
   IndexT numSlices_;
-  int sliceSize_;
+  int64_t sliceSize_;
   int k_;
 };
 
@@ -246,11 +290,12 @@ static void sbtopk_launch_impl(
     scalar_t* topK,
     int64_t* indices,
     IndexT numSlices,
-    int sliceSize,
+    int64_t sliceSize,
     int k) {
   constexpr int WG_SIZE = 256; // 8 sub-groups per work-group
   constexpr int SGS_PER_WG = WG_SIZE / SG_SIZE;
-  auto num_wgs = (static_cast<int64_t>(numSlices) + SGS_PER_WG - 1) / SGS_PER_WG;
+  auto num_wgs =
+      (static_cast<int64_t>(numSlices) + SGS_PER_WG - 1) / SGS_PER_WG;
 
   SubgroupTopKFunctor<scalar_t, K, VEC_SIZE, Largest, IndexT> functor(
       input, topK, indices, numSlices, sliceSize, k);
@@ -260,35 +305,40 @@ static void sbtopk_launch_impl(
     cgh.parallel_for(
         sycl::nd_range<1>(num_wgs * WG_SIZE, WG_SIZE),
         syclex::properties{
-            syclex::sub_group_size<SG_SIZE>,
-            intelex::grf_size<128>},
+            syclex::sub_group_size<SG_SIZE>, intelex::grf_size<128>},
         functor);
   });
 }
 
-// Vec-size dispatch: picks the largest VEC_SIZE compatible with (dtype, sliceSize).
+// Vec-size dispatch: picks the largest VEC_SIZE compatible with
+// (dtype, sliceSize).
 template <typename scalar_t, int K, bool Largest, typename IndexT>
 static void sbtopk_launch_vec_dispatch(
     const scalar_t* input,
     scalar_t* topK,
     int64_t* indices,
     IndexT numSlices,
-    int sliceSize,
+    int64_t sliceSize,
     int k) {
   // Max VEC_SIZE for this dtype
   constexpr int MAX_VEC = sizeof(scalar_t) <= 2 ? 8 : 4;
 
   // Pick largest VEC_SIZE such that:
-  //   1. SG_SIZE * VEC_SIZE <= sliceSize  (all threads get at least one full vector)
+  //   1. SG_SIZE * VEC_SIZE <= sliceSize  (all threads get at
+  //      least one full vector)
   //   2. sliceSize % VEC_SIZE == 0        (slice boundaries are aligned)
   if (MAX_VEC >= 8 && sliceSize % 8 == 0 && SG_SIZE * 8 <= sliceSize) {
-    sbtopk_launch_impl<scalar_t, K, 8, Largest, IndexT>(input, topK, indices, numSlices, sliceSize, k);
+    sbtopk_launch_impl<scalar_t, K, 8, Largest, IndexT>(
+        input, topK, indices, numSlices, sliceSize, k);
   } else if (MAX_VEC >= 4 && sliceSize % 4 == 0 && SG_SIZE * 4 <= sliceSize) {
-    sbtopk_launch_impl<scalar_t, K, 4, Largest, IndexT>(input, topK, indices, numSlices, sliceSize, k);
+    sbtopk_launch_impl<scalar_t, K, 4, Largest, IndexT>(
+        input, topK, indices, numSlices, sliceSize, k);
   } else if (sliceSize % 2 == 0 && SG_SIZE * 2 <= sliceSize) {
-    sbtopk_launch_impl<scalar_t, K, 2, Largest, IndexT>(input, topK, indices, numSlices, sliceSize, k);
+    sbtopk_launch_impl<scalar_t, K, 2, Largest, IndexT>(
+        input, topK, indices, numSlices, sliceSize, k);
   } else {
-    sbtopk_launch_impl<scalar_t, K, 1, Largest, IndexT>(input, topK, indices, numSlices, sliceSize, k);
+    sbtopk_launch_impl<scalar_t, K, 1, Largest, IndexT>(
+        input, topK, indices, numSlices, sliceSize, k);
   }
 }
 
@@ -298,16 +348,16 @@ static void sbtopk_launch_kernel(
     scalar_t* topK,
     int64_t* indices,
     int64_t numSlices,
-    int sliceSize,
+    int64_t sliceSize,
     int k,
     bool largest) {
   constexpr int K = 16;
   // Dispatch on (largest, IndexT) at the outermost level:
   //   - largest: so tight insert/merge loops have no runtime direction branch
-  //   - IndexT: int32 when nsegments fits (common), int64 for huge batch.
-  //     Mirrors CUDA's canUse32BitIndexMath. int32 avoids 64-bit slice
+  //   - IndexT: int32 when total elements fit (common), int64 otherwise.
+  //     Mirrors CUDA's canUse32BitIndexMath. int32 avoids 64-bit
   //     arithmetic and reduces register pressure.
-  if (numSlices <= std::numeric_limits<int>::max()) {
+  if (numSlices * sliceSize <= std::numeric_limits<int>::max()) {
     int numSlices32 = static_cast<int>(numSlices);
     if (largest) {
       sbtopk_launch_vec_dispatch<scalar_t, K, true, int>(
@@ -357,7 +407,8 @@ SbtopkResult sbtopk_try_launch(
   //   thread_slots/4 is the conservative cutoff.
   //
   // On B580: thread_slots = 160 EU * 8 HW threads = 1280, threshold = 320.
-  int64_t thread_slots = ::xpu::sycl::syclGpuEuCount() * ::xpu::sycl::syclGpuHWThreadsPerEU();
+  int64_t thread_slots =
+      ::xpu::sycl::syclGpuEuCount() * ::xpu::sycl::syclGpuHWThreadsPerEU();
   int64_t sg_threshold = thread_slots / 4;
   if (k <= 16 && nsegments >= sg_threshold) {
     AT_DISPATCH_ALL_TYPES_AND2(
@@ -371,7 +422,7 @@ SbtopkResult sbtopk_try_launch(
               static_cast<scalar_t*>(values.data_ptr()),
               static_cast<int64_t*>(indices.data_ptr()),
               nsegments,
-              static_cast<int>(nelements),
+              nelements,
               static_cast<int>(k),
               largest);
         });

--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
@@ -1,0 +1,367 @@
+/*
+ * Subgroup top-k kernel for optimized topk on XPU.
+ *
+ * Each sub-group (32 lanes) handles one slice entirely in registers.
+ * Zero SLM, zero barriers.
+ *
+ * Algorithm:
+ *   Phase 1: Each lane scans dim/32 elements, maintains a sorted top-k
+ *            buffer via insertion sort (fully unrolled, no branches on
+ *            direction thanks to compile-time Largest template param).
+ *   Phase 2: 5 levels of pairwise bitonic merge via sub-group shuffles
+ *            to combine 32 per-lane buffers into one global top-k.
+ *   Phase 3: Lane 0 writes k results. Output is already sorted.
+ *
+ * Dispatch: k <= 16 and enough segments (large batch) and dim >= 1024
+ *           routes to subgroup top-k; otherwise falls back to original.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/Dispatch.h>
+#include <ATen/native/xpu/sycl/MemoryAccessUtils.h>
+#include <comm/DeviceProperties.h>
+#include <comm/SYCLHelpers.h>
+#include <ATen/native/xpu/sycl/TensorTopKSbtopkKernel.h>
+
+namespace at {
+namespace native {
+namespace xpu {
+
+static constexpr int SG_SIZE = 32;
+
+// ================================================================
+// SubgroupTopKFunctor
+//
+// K: compile-time max top-k (must be >= runtime k)
+// VEC_SIZE: vectorized load width
+// Largest: compile-time direction flag. Eliminates per-element branches
+//          on largest_ that otherwise pessimize the tight insert/merge loops.
+// IndexT: int32 for nsegments <= INT_MAX (common), int64_t for huge batch.
+//         Mirrors CUDA's canUse32BitIndexMath dispatch. Only numSlices_ and
+//         the slice variable need IndexT; sliceSize_ and k_ stay int because
+//         nelements is already checked <= INT_MAX.
+// ================================================================
+template <typename scalar_t, int K, int VEC_SIZE, bool Largest, typename IndexT = int>
+struct SubgroupTopKFunctor {
+
+  // Insert val into a K-sorted buffer. For Largest=true the buffer is sorted
+  // descending (top_vals[0] is max); for Largest=false it is sorted ascending
+  // (top_vals[0] is min). The comparator `better(a, b)` means "a should sit
+  // above b in the buffer" — i.e. strictly greater for largest, strictly less
+  // for smallest.
+  //
+  // Fully unrolled, no early break — SIMD-friendly.
+  inline void insert(
+      scalar_t* top_vals, int* top_idx, int count,
+      scalar_t val, int idx) const {
+    // Threshold is at the bottom of the buffer (top_vals[K-1]).
+    if constexpr (Largest) {
+      if (count >= K && !(val > top_vals[K - 1])) return;
+    } else {
+      if (count >= K && !(val < top_vals[K - 1])) return;
+    }
+    bool inserted = false;
+#pragma unroll
+    for (int i = K - 1; i >= 0; --i) {
+      bool stop;
+      if constexpr (Largest) {
+        stop = (i == 0) || !(val > top_vals[i - 1]);
+      } else {
+        stop = (i == 0) || !(val < top_vals[i - 1]);
+      }
+      if (!inserted && stop) {
+        top_vals[i] = val;
+        top_idx[i] = idx;
+        inserted = true;
+      } else if (!inserted) {
+        top_vals[i] = top_vals[i - 1];
+        top_idx[i] = top_idx[i - 1];
+      }
+    }
+  }
+
+  // Bitonic merge: A[K] and B[K] are both sorted in the "better" direction.
+  // Step 1: A[i] = better(A[i], B[K-1-i]) — produces bitonic sequence.
+  // Step 2: bitonic sort restores the sorted-by-better order on A.
+  inline void bitonic_merge(
+      scalar_t* A, int* A_idx,
+      const scalar_t* B, const int* B_idx) const {
+    // Step 1: compare with reversed partner
+#pragma unroll
+    for (int i = 0; i < K; ++i) {
+      scalar_t bv = B[K - 1 - i];
+      int bi = B_idx[K - 1 - i];
+      bool take;
+      if constexpr (Largest) {
+        take = bv > A[i];
+      } else {
+        take = bv < A[i];
+      }
+      if (take) {
+        A[i] = bv;
+        A_idx[i] = bi;
+      }
+    }
+    // Step 2: bitonic sort in the "better" direction
+#pragma unroll
+    for (int stride = K / 2; stride >= 1; stride >>= 1) {
+#pragma unroll
+      for (int i = 0; i < K; ++i) {
+        int j = i ^ stride;
+        bool swap;
+        if constexpr (Largest) {
+          swap = (j > i) && (A[i] < A[j]);
+        } else {
+          swap = (j > i) && (A[i] > A[j]);
+        }
+        if (swap) {
+          scalar_t tv = A[i]; A[i] = A[j]; A[j] = tv;
+          int ti = A_idx[i]; A_idx[i] = A_idx[j]; A_idx[j] = ti;
+        }
+      }
+    }
+  }
+
+  [[sycl::reqd_sub_group_size(32)]]
+  void operator()(sycl::nd_item<1> item) const {
+    sycl::sub_group sg = item.get_sub_group();
+    int sg_lid = sg.get_local_linear_id();
+
+    // Each sub-group handles one slice
+    int sgs_per_wg = item.get_local_range(0) / SG_SIZE;
+    IndexT slice = static_cast<IndexT>(item.get_group_linear_id()) * sgs_per_wg
+                   + sg.get_group_linear_id();
+    if (slice >= numSlices_) return;
+
+    const scalar_t* inputSlice = inputData_ + static_cast<int64_t>(slice) * sliceSize_;
+    scalar_t* topKSlice = topKData_ + static_cast<int64_t>(slice) * k_;
+    int64_t* indicesSlice = indicesData_ + static_cast<int64_t>(slice) * k_;
+
+    // Initialize sorted top-K buffer
+    scalar_t top_vals[K];
+    int top_idx_local[K];
+    scalar_t init_val;
+    if constexpr (Largest) {
+      init_val = -std::numeric_limits<scalar_t>::infinity();
+    } else {
+      init_val = std::numeric_limits<scalar_t>::infinity();
+    }
+#pragma unroll
+    for (int i = 0; i < K; ++i) {
+      top_vals[i] = init_val;
+      top_idx_local[i] = -1;
+    }
+    int count = 0;
+
+    // ---- Phase 1: scan data with vec loads ----
+    using LoadT = memory::aligned_vector<scalar_t, VEC_SIZE>;
+    int stride = SG_SIZE * VEC_SIZE;
+
+    int base;
+    for (base = sg_lid * VEC_SIZE; base + VEC_SIZE <= sliceSize_; base += stride) {
+      scalar_t src[VEC_SIZE];
+      *reinterpret_cast<LoadT*>(&src) =
+          *reinterpret_cast<const LoadT*>(&inputSlice[base]);
+#pragma unroll
+      for (int v = 0; v < VEC_SIZE; ++v) {
+        insert(top_vals, top_idx_local, count, src[v], base + v);
+        if (count < K) count++;
+      }
+    }
+    // Scalar tail
+    for (int idx = base; idx < sliceSize_ && idx < base + VEC_SIZE; ++idx) {
+      scalar_t val = inputSlice[idx];
+      insert(top_vals, top_idx_local, count, val, idx);
+      if (count < K) count++;
+    }
+
+    // ---- Phase 2: sub-group bitonic merge (5 levels for sg_size=32) ----
+#pragma unroll
+    for (int d = 0; d < 5; ++d) {
+      int partner = sg_lid ^ (1 << d);
+
+      scalar_t partner_vals[K];
+      int partner_idx[K];
+#pragma unroll
+      for (int i = 0; i < K; ++i) {
+        partner_vals[i] = sycl::select_from_group(sg, top_vals[i], partner);
+        partner_idx[i] = sycl::select_from_group(sg, top_idx_local[i], partner);
+      }
+
+      bitonic_merge(top_vals, top_idx_local, partner_vals, partner_idx);
+    }
+
+    // ---- Phase 3: lane 0 writes output ----
+    if (sg_lid == 0) {
+      for (int i = 0; i < k_; ++i) {
+        topKSlice[i] = top_vals[i];
+        indicesSlice[i] = static_cast<int64_t>(top_idx_local[i]);
+      }
+    }
+  }
+
+  SubgroupTopKFunctor(
+      const scalar_t* inputData,
+      scalar_t* topKData,
+      int64_t* indicesData,
+      IndexT numSlices,
+      int sliceSize,
+      int k)
+      : inputData_(inputData),
+        topKData_(topKData),
+        indicesData_(indicesData),
+        numSlices_(numSlices),
+        sliceSize_(sliceSize),
+        k_(k) {}
+
+  const scalar_t* inputData_;
+  scalar_t* topKData_;
+  int64_t* indicesData_;
+  IndexT numSlices_;
+  int sliceSize_;
+  int k_;
+};
+
+// ================================================================
+// Launch helpers
+// ================================================================
+template <typename scalar_t, int K, int VEC_SIZE, bool Largest, typename IndexT>
+static void sbtopk_launch_impl(
+    const scalar_t* input,
+    scalar_t* topK,
+    int64_t* indices,
+    IndexT numSlices,
+    int sliceSize,
+    int k) {
+  constexpr int WG_SIZE = 256; // 8 sub-groups per work-group
+  constexpr int SGS_PER_WG = WG_SIZE / SG_SIZE;
+  auto num_wgs = (static_cast<int64_t>(numSlices) + SGS_PER_WG - 1) / SGS_PER_WG;
+
+  SubgroupTopKFunctor<scalar_t, K, VEC_SIZE, Largest, IndexT> functor(
+      input, topK, indices, numSlices, sliceSize, k);
+
+  sycl_kernel_submit(
+      sycl::range<1>(num_wgs * WG_SIZE),
+      sycl::range<1>(WG_SIZE),
+      at::xpu::getCurrentSYCLQueue(),
+      functor);
+}
+
+// Vec-size dispatch: picks the largest VEC_SIZE compatible with (dtype, sliceSize).
+template <typename scalar_t, int K, bool Largest, typename IndexT>
+static void sbtopk_launch_vec_dispatch(
+    const scalar_t* input,
+    scalar_t* topK,
+    int64_t* indices,
+    IndexT numSlices,
+    int sliceSize,
+    int k) {
+  // Max VEC_SIZE for this dtype
+  constexpr int MAX_VEC = sizeof(scalar_t) <= 2 ? 8 : 4;
+
+  // Pick largest VEC_SIZE such that:
+  //   1. SG_SIZE * VEC_SIZE <= sliceSize  (all threads get at least one full vector)
+  //   2. sliceSize % VEC_SIZE == 0        (slice boundaries are aligned)
+  if (MAX_VEC >= 8 && sliceSize % 8 == 0 && SG_SIZE * 8 <= sliceSize) {
+    sbtopk_launch_impl<scalar_t, K, 8, Largest, IndexT>(input, topK, indices, numSlices, sliceSize, k);
+  } else if (MAX_VEC >= 4 && sliceSize % 4 == 0 && SG_SIZE * 4 <= sliceSize) {
+    sbtopk_launch_impl<scalar_t, K, 4, Largest, IndexT>(input, topK, indices, numSlices, sliceSize, k);
+  } else if (sliceSize % 2 == 0 && SG_SIZE * 2 <= sliceSize) {
+    sbtopk_launch_impl<scalar_t, K, 2, Largest, IndexT>(input, topK, indices, numSlices, sliceSize, k);
+  } else {
+    sbtopk_launch_impl<scalar_t, K, 1, Largest, IndexT>(input, topK, indices, numSlices, sliceSize, k);
+  }
+}
+
+template <typename scalar_t>
+static void sbtopk_launch_kernel(
+    const scalar_t* input,
+    scalar_t* topK,
+    int64_t* indices,
+    int64_t numSlices,
+    int sliceSize,
+    int k,
+    bool largest) {
+  constexpr int K = 16;
+  // Dispatch on (largest, IndexT) at the outermost level:
+  //   - largest: so tight insert/merge loops have no runtime direction branch
+  //   - IndexT: int32 when nsegments fits (common), int64 for huge batch.
+  //     Mirrors CUDA's canUse32BitIndexMath. int32 avoids 64-bit slice
+  //     arithmetic and reduces register pressure.
+  if (numSlices <= std::numeric_limits<int>::max()) {
+    int numSlices32 = static_cast<int>(numSlices);
+    if (largest) {
+      sbtopk_launch_vec_dispatch<scalar_t, K, true, int>(
+          input, topK, indices, numSlices32, sliceSize, k);
+    } else {
+      sbtopk_launch_vec_dispatch<scalar_t, K, false, int>(
+          input, topK, indices, numSlices32, sliceSize, k);
+    }
+  } else {
+    if (largest) {
+      sbtopk_launch_vec_dispatch<scalar_t, K, true, int64_t>(
+          input, topK, indices, numSlices, sliceSize, k);
+    } else {
+      sbtopk_launch_vec_dispatch<scalar_t, K, false, int64_t>(
+          input, topK, indices, numSlices, sliceSize, k);
+    }
+  }
+}
+
+// ================================================================
+// Dispatch: subgroup top-k vs original
+//
+// From benchmark on B580 (3 dtypes x 6 bs x 4 dims x 2 align x 3 k):
+//   - dim < 1024: original wins (kernel launch overhead dominates)
+//   - dim >= 1024, bs >= ~320 segments, k <= 16: subgroup top-k wins
+// ================================================================
+SbtopkResult sbtopk_try_launch(
+    const at::Tensor& self,
+    int64_t nsegments,
+    int64_t nelements,
+    int64_t k,
+    bool largest,
+    const at::Tensor& values,
+    const at::Tensor& indices) {
+  // Not beneficial for small dim
+  if (nelements < 1024) {
+    return SbtopkResult::FAILED;
+  }
+
+  // Subgroup top-k: best for large batch, k<=16.
+  // Output is ALREADY SORTED (descending for largest, ascending for smallest).
+  //
+  // Threshold: nsegments >= thread_slots / 4.
+  //   Subgroup top-k uses 1 sub-group per slice (reading data once), while
+  //   the original kernel reads data multiple times (~3 radix passes). So
+  //   subgroup top-k reaches memory-BW saturation at much lower occupancy.
+  //   thread_slots/4 is the conservative cutoff.
+  //
+  // On B580: thread_slots = 160 EU * 8 HW threads = 1280, threshold = 320.
+  int64_t thread_slots = ::xpu::sycl::syclGpuEuCount() * ::xpu::sycl::syclGpuHWThreadsPerEU();
+  int64_t sg_threshold = thread_slots / 4;
+  if (k <= 16 && nsegments >= sg_threshold) {
+    AT_DISPATCH_ALL_TYPES_AND2(
+        at::ScalarType::Half,
+        at::ScalarType::BFloat16,
+        self.scalar_type(),
+        "subgroup_topk_xpu",
+        [&]() {
+          sbtopk_launch_kernel<scalar_t>(
+              static_cast<const scalar_t*>(self.const_data_ptr()),
+              static_cast<scalar_t*>(values.data_ptr()),
+              static_cast<int64_t*>(indices.data_ptr()),
+              nsegments,
+              static_cast<int>(nelements),
+              static_cast<int>(k),
+              largest);
+        });
+    return SbtopkResult::SORTED;
+  }
+
+  return SbtopkResult::FAILED;
+}
+
+} // namespace xpu
+} // namespace native
+} // namespace at

--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
@@ -380,9 +380,8 @@ static void sbtopk_launch_kernel(
 // ================================================================
 // Dispatch: subgroup top-k vs original
 //
-// From benchmark on B580 (3 dtypes x 6 bs x 4 dims x 2 align x 3 k):
-//   - dim < 1024: original wins (kernel launch overhead dominates)
-//   - dim >= 1024, bs >= ~320 segments, k <= 16: subgroup top-k wins
+//   - dim < 1024: original (kernel launch overhead dominates)
+//   - dim >= 1024, large batch, k <= 16: subgroup top-k
 // ================================================================
 SbtopkResult sbtopk_try_launch(
     const at::Tensor& self,

--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
@@ -18,14 +18,18 @@
 
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
+#include <limits>
+#include <sycl/ext/intel/experimental/grf_size_properties.hpp>
 #include <ATen/native/xpu/sycl/MemoryAccessUtils.h>
 #include <comm/DeviceProperties.h>
-#include <comm/SYCLHelpers.h>
 #include <ATen/native/xpu/sycl/TensorTopKSbtopkKernel.h>
 
 namespace at {
 namespace native {
 namespace xpu {
+
+namespace syclex = sycl::ext::oneapi::experimental;
+namespace intelex = sycl::ext::intel::experimental;
 
 static constexpr int SG_SIZE = 32;
 
@@ -49,6 +53,9 @@ struct SubgroupTopKFunctor {
   // (top_vals[0] is min). The comparator `better(a, b)` means "a should sit
   // above b in the buffer" — i.e. strictly greater for largest, strictly less
   // for smallest.
+  //
+  // idx is the element position within a slice (0..sliceSize-1), always int
+  // because sliceSize <= INT_MAX. IndexT is only for the slice count.
   //
   // Fully unrolled, no early break — SIMD-friendly.
   inline void insert(
@@ -142,9 +149,17 @@ struct SubgroupTopKFunctor {
     int top_idx_local[K];
     scalar_t init_val;
     if constexpr (Largest) {
-      init_val = -std::numeric_limits<scalar_t>::infinity();
+      if constexpr (std::numeric_limits<scalar_t>::has_infinity) {
+        init_val = -std::numeric_limits<scalar_t>::infinity();
+      } else {
+        init_val = std::numeric_limits<scalar_t>::lowest();
+      }
     } else {
-      init_val = std::numeric_limits<scalar_t>::infinity();
+      if constexpr (std::numeric_limits<scalar_t>::has_infinity) {
+        init_val = std::numeric_limits<scalar_t>::infinity();
+      } else {
+        init_val = std::numeric_limits<scalar_t>::max();
+      }
     }
 #pragma unroll
     for (int i = 0; i < K; ++i) {
@@ -240,11 +255,15 @@ static void sbtopk_launch_impl(
   SubgroupTopKFunctor<scalar_t, K, VEC_SIZE, Largest, IndexT> functor(
       input, topK, indices, numSlices, sliceSize, k);
 
-  sycl_kernel_submit(
-      sycl::range<1>(num_wgs * WG_SIZE),
-      sycl::range<1>(WG_SIZE),
-      at::xpu::getCurrentSYCLQueue(),
-      functor);
+  auto q = at::xpu::getCurrentSYCLQueue();
+  q.submit([&](sycl::handler& cgh) {
+    cgh.parallel_for(
+        sycl::nd_range<1>(num_wgs * WG_SIZE, WG_SIZE),
+        syclex::properties{
+            syclex::sub_group_size<SG_SIZE>,
+            intelex::grf_size<128>},
+        functor);
+  });
 }
 
 // Vec-size dispatch: picks the largest VEC_SIZE compatible with (dtype, sliceSize).

--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
@@ -399,12 +399,15 @@ static void sbtopk_launch_kernel(
     SBTOPK_DISPATCH_K(K_VAL, false, INDEX_T, NUM_SLICES);   \
   }
 
-#define SBTOPK_DISPATCH_INDEX(K_VAL)                              \
-  if (numSlices * sliceSize <= std::numeric_limits<int>::max()) { \
-    int numSlices32 = static_cast<int>(numSlices);                \
-    SBTOPK_DISPATCH_LARGEST(K_VAL, int, numSlices32);             \
-  } else {                                                        \
-    SBTOPK_DISPATCH_LARGEST(K_VAL, int64_t, numSlices);           \
+#define SBTOPK_DISPATCH_INDEX(K_VAL)                                           \
+  if (numSlices <= std::numeric_limits<int>::max() &&                          \
+      sliceSize <= std::numeric_limits<int>::max() &&                          \
+      numSlices <=                                                             \
+          std::numeric_limits<int>::max() / (sliceSize > 0 ? sliceSize : 1)) { \
+    int numSlices32 = static_cast<int>(numSlices);                             \
+    SBTOPK_DISPATCH_LARGEST(K_VAL, int, numSlices32);                          \
+  } else {                                                                     \
+    SBTOPK_DISPATCH_LARGEST(K_VAL, int64_t, numSlices);                        \
   }
 
   switch (K_sel) {

--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.h
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#pragma once
+
+#include <ATen/ATen.h>
+
+namespace at {
+namespace native {
+namespace xpu {
+
+// Result of sbtopk_try_launch.
+//   FAILED   - did not run; caller should fall back to original kernel.
+//   UNSORTED - ran; output contains top-k values but is not sorted.
+//              Caller must sort if sorted output is requested.
+//   SORTED   - ran; output is already sorted (descending for largest,
+//              ascending for smallest). Caller can skip sort.
+enum class SbtopkResult : int {
+  FAILED   = 0,
+  UNSORTED = 1,
+  SORTED   = 2,
+};
+
+// Try to run topk using the subgroup topk kernel.
+//
+// This function is compiled in a separate translation unit
+// (TensorTopKSbtopkKernel.cpp) to isolate the kernel's template
+// instantiations from the original topk kernel. The SYCL compiler's global
+// optimization decisions are affected by the total set of templates in a
+// compilation unit; keeping them separate prevents regressing the original
+// kernel's performance on small-dim cases where the optimized path is not
+// even used.
+//
+// Currently dispatches to the subgroup topk kernel (sub-group bitonic merge,
+// output SORTED) when k <= 16 and batch size is large enough.
+TORCH_XPU_API SbtopkResult sbtopk_try_launch(
+    const at::Tensor& self,
+    int64_t nsegments,
+    int64_t nelements,
+    int64_t k,
+    bool largest,
+    const at::Tensor& values,
+    const at::Tensor& indices);
+
+} // namespace xpu
+} // namespace native
+} // namespace at

--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.h
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.h
@@ -23,14 +23,12 @@ namespace xpu {
 //   SORTED   - ran; output is already sorted (descending for largest,
 //              ascending for smallest). Caller can skip sort.
 enum class SbtopkResult : int {
-  FAILED   = 0,
+  FAILED = 0,
   UNSORTED = 1,
-  SORTED   = 2,
+  SORTED = 2,
 };
 
-// Try to run topk using the subgroup topk kernel (separate TU to avoid
-// SYCL compiler interference with the original kernel's codegen).
-TORCH_XPU_API SbtopkResult sbtopk_try_launch(
+SbtopkResult sbtopk_try_launch(
     const at::Tensor& self,
     int64_t nsegments,
     int64_t nelements,

--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.h
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.h
@@ -28,18 +28,8 @@ enum class SbtopkResult : int {
   SORTED   = 2,
 };
 
-// Try to run topk using the subgroup topk kernel.
-//
-// This function is compiled in a separate translation unit
-// (TensorTopKSbtopkKernel.cpp) to isolate the kernel's template
-// instantiations from the original topk kernel. The SYCL compiler's global
-// optimization decisions are affected by the total set of templates in a
-// compilation unit; keeping them separate prevents regressing the original
-// kernel's performance on small-dim cases where the optimized path is not
-// even used.
-//
-// Currently dispatches to the subgroup topk kernel (sub-group bitonic merge,
-// output SORTED) when k <= 16 and batch size is large enough.
+// Try to run topk using the subgroup topk kernel (separate TU to avoid
+// SYCL compiler interference with the original kernel's codegen).
 TORCH_XPU_API SbtopkResult sbtopk_try_launch(
     const at::Tensor& self,
     int64_t nsegments,

--- a/src/comm/SYCLHelpers.h
+++ b/src/comm/SYCLHelpers.h
@@ -148,6 +148,84 @@ sycl_kernel_submit(
   q.submit(cgf);
 }
 
+// Overloads accepting kernel properties (e.g., sub_group_size, grf_size).
+
+template <typename ker_t, typename Props, int dim>
+static inline typename std::enable_if<
+    std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
+    void>::type
+sycl_kernel_submit(
+    ::sycl::range<dim> global_range,
+    ::sycl::range<dim> local_range,
+    ::sycl::queue q,
+    Props properties,
+    ker_t ker) {
+  auto cgf = [&](::sycl::handler& cgh) {
+    ker.sycl_ker_config_convention(cgh);
+    cgh.parallel_for<ker_t>(
+        ::sycl::nd_range<dim>(global_range, local_range), properties, ker);
+  };
+  q.submit(cgf);
+}
+
+template <typename ker_t, typename Props, int dim>
+static inline typename std::enable_if<
+    !std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
+    void>::type
+sycl_kernel_submit(
+    ::sycl::range<dim> global_range,
+    ::sycl::range<dim> local_range,
+    ::sycl::queue q,
+    Props properties,
+    ker_t ker) {
+  auto cgf = [&](::sycl::handler& cgh) {
+    cgh.parallel_for<ker_t>(
+        ::sycl::nd_range<dim>(global_range, local_range), properties, ker);
+  };
+  q.submit(cgf);
+}
+
+template <typename ker_t, typename Props>
+static inline typename std::enable_if<
+    std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
+    void>::type
+sycl_kernel_submit(
+    int64_t global_range,
+    int64_t local_range,
+    ::sycl::queue q,
+    Props properties,
+    ker_t ker) {
+  auto cgf = [&](::sycl::handler& cgh) {
+    ker.sycl_ker_config_convention(cgh);
+    cgh.parallel_for<ker_t>(
+        ::sycl::nd_range<1>(
+            ::sycl::range<1>(global_range), ::sycl::range<1>(local_range)),
+        properties,
+        ker);
+  };
+  q.submit(cgf);
+}
+
+template <typename ker_t, typename Props>
+static inline typename std::enable_if<
+    !std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
+    void>::type
+sycl_kernel_submit(
+    int64_t global_range,
+    int64_t local_range,
+    ::sycl::queue q,
+    Props properties,
+    ker_t ker) {
+  auto cgf = [&](::sycl::handler& cgh) {
+    cgh.parallel_for<ker_t>(
+        ::sycl::nd_range<1>(
+            ::sycl::range<1>(global_range), ::sycl::range<1>(local_range)),
+        properties,
+        ker);
+  };
+  q.submit(cgf);
+}
+
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_KERNEL_STRING(var, str) \
   static const __attribute__((opencl_constant)) char var[] = str


### PR DESCRIPTION
## Summary

- **Speedup vs original XPU:** 1.3648x geomean over 432 cases, 130 wins (>1.05x), 40 regressions (<0.98x)
- **vs CUDA 4080S:** 0.4574x geomean (>1 means XPU faster)

### Approach

Add a **subgroup topk kernel** (`SubgroupTopKFunctor` in `TensorTopKSbtopkKernel.cpp`) where each 32-lane sub-group processes one slice entirely in registers:

- **Phase 1:** Each lane scans `dim/32` elements, maintaining a sorted top-k buffer via insertion sort (fully unrolled).
- **Phase 2:** 5-level bitonic merge across sub-group lanes via `sycl::select_from_group` shuffle.
- **Phase 3:** Lane 0 writes `k` results. Output is already sorted.

Key properties:
- Zero SLM (shared local memory), zero barriers
- `largest` as compile-time template parameter — eliminates per-element direction branches
- `int32`/`int64` index dispatch mirroring CUDA's `canUse32BitIndexMath`
- Kernel isolated in a separate translation unit to prevent SYCL compiler global optimization interference with the original kernel

**Dispatch:** `k <= 16` and `nsegments >= HW_thread_slots / 4` and `dim >= 32` → subgroup kernel (SORTED); otherwise → original kernel.

### Files changed

| File | Description |
|------|-------------|
| `TensorTopKSbtopkKernel.cpp` (new) | Subgroup topk kernel + dispatch logic |
| `TensorTopKSbtopkKernel.h` (new) | `SbtopkResult` enum + `sbtopk_try_launch` declaration |
| `TensorTopKKernel.cpp` | Modified caller — tries optimized path first, skips sort if already sorted |

### Correctness

- **Accuracy:** 432/432 pass (CPU vs XPU, sort-then-compare)
- **Sortedness:** 324/324 pass (`torch.topk(sorted=True)` output verified monotonic)

### Benchmark summary

**By batch size:**

| bs | speedup vs orig | vs CUDA 4080S | cases |
|----|:-:|:-:|:-:|
| 1 | 1.00x | 0.41x | 72 |
| 8 | 1.00x | 0.43x | 72 |
| 64 | 1.00x | 0.42x | 72 |
| 256 | 1.00x | 0.36x | 72 |
| 1024 | 2.53x | 0.63x | 72 |
| 2048 | 2.55x | 0.55x | 72 |

**By dim:**

| dim | speedup vs orig | vs CUDA 4080S | cases |
|-----|:-:|:-:|:-:|
| 128 | 1.00x | 0.36x | 54 |
| 129 | 1.00x | 0.39x | 54 |
| 1024 | 1.47x | 0.77x | 54 |
| 1025 | 1.35x | 0.63x | 54 |
| 8192 | 1.62x | 0.60x | 54 |
| 8193 | 1.30x | 0.48x | 54 |
| 131072 | 1.87x | 0.34x | 54 |
| 131073 | 1.53x | 0.28x | 54 |

### Full 432-case results

XPU: Intel Arc B580. CUDA: NVIDIA RTX 4080 SUPER. B580 peak memory bandwidth: 456 GB/s. Times in microseconds (us). Median of 3 runs x 50 iters.

<details>
<summary>Click to expand full table</summary>

| dtype | bs | dim | k | XPU orig (us) | XPU opt (us) | CUDA 4080S (us) | speedup | vs CUDA | BW (GB/s) | %peak |
|-------|---:|----:|--:|--------------:|------------:|----------------:|--------:|--------:|----------:|------:|
| bfloat16 | 1 | 128 | 4 | 30.6 | 30.7 | 14.4 | 1.00x | 0.47x | 0.0 | 0% |
| bfloat16 | 1 | 128 | 8 | 30.5 | 30.4 | 14.3 | 1.00x | 0.47x | 0.0 | 0% |
| bfloat16 | 1 | 128 | 16 | 30.4 | 30.4 | 14.3 | 1.00x | 0.47x | 0.0 | 0% |
| bfloat16 | 1 | 129 | 4 | 30.3 | 30.6 | 14.7 | 0.99x | 0.48x | 0.0 | 0% |
| bfloat16 | 1 | 129 | 8 | 30.4 | 30.5 | 14.6 | 1.00x | 0.48x | 0.0 | 0% |
| bfloat16 | 1 | 129 | 16 | 30.4 | 30.4 | 14.6 | 1.00x | 0.48x | 0.0 | 0% |
| bfloat16 | 1 | 1024 | 4 | 30.5 | 30.5 | 19.0 | 1.00x | 0.62x | 0.1 | 0% |
| bfloat16 | 1 | 1024 | 8 | 30.5 | 30.6 | 18.3 | 1.00x | 0.60x | 0.1 | 0% |
| bfloat16 | 1 | 1024 | 16 | 30.4 | 30.4 | 18.6 | 1.00x | 0.61x | 0.1 | 0% |
| bfloat16 | 1 | 1025 | 4 | 30.5 | 30.5 | 20.0 | 1.00x | 0.66x | 0.1 | 0% |
| bfloat16 | 1 | 1025 | 8 | 30.4 | 30.5 | 20.2 | 1.00x | 0.66x | 0.1 | 0% |
| bfloat16 | 1 | 1025 | 16 | 30.4 | 30.5 | 19.8 | 1.00x | 0.65x | 0.1 | 0% |
| bfloat16 | 1 | 8192 | 4 | 45.7 | 44.4 | 37.4 | 1.03x | 0.84x | 0.4 | 0% |
| bfloat16 | 1 | 8192 | 8 | 51.6 | 48.6 | 42.2 | 1.06x | 0.87x | 0.3 | 0% |
| bfloat16 | 1 | 8192 | 16 | 48.6 | 48.6 | 39.1 | 1.00x | 0.80x | 0.3 | 0% |
| bfloat16 | 1 | 8193 | 4 | 45.7 | 48.4 | 37.0 | 0.94x | 0.76x | 0.3 | 0% |
| bfloat16 | 1 | 8193 | 8 | 48.7 | 48.6 | 40.3 | 1.00x | 0.83x | 0.3 | 0% |
| bfloat16 | 1 | 8193 | 16 | 48.5 | 48.5 | 39.7 | 1.00x | 0.82x | 0.3 | 0% |
| bfloat16 | 1 | 131072 | 4 | 368.8 | 375.7 | 46.3 | 0.98x | 0.12x | 0.7 | 0% |
| bfloat16 | 1 | 131072 | 8 | 396.4 | 402.5 | 46.3 | 0.98x | 0.12x | 0.7 | 0% |
| bfloat16 | 1 | 131072 | 16 | 430.6 | 426.2 | 46.4 | 1.01x | 0.11x | 0.6 | 0% |
| bfloat16 | 1 | 131073 | 4 | 370.4 | 364.3 | 46.8 | 1.02x | 0.13x | 0.7 | 0% |
| bfloat16 | 1 | 131073 | 8 | 392.5 | 396.7 | 46.8 | 0.99x | 0.12x | 0.7 | 0% |
| bfloat16 | 1 | 131073 | 16 | 413.9 | 421.3 | 46.7 | 0.98x | 0.11x | 0.6 | 0% |
| bfloat16 | 8 | 128 | 4 | 30.4 | 30.4 | 14.9 | 1.00x | 0.49x | 0.1 | 0% |
| bfloat16 | 8 | 128 | 8 | 30.5 | 30.6 | 14.6 | 1.00x | 0.48x | 0.1 | 0% |
| bfloat16 | 8 | 128 | 16 | 30.4 | 30.3 | 14.6 | 1.00x | 0.48x | 0.1 | 0% |
| bfloat16 | 8 | 129 | 4 | 30.3 | 30.5 | 15.1 | 0.99x | 0.50x | 0.1 | 0% |
| bfloat16 | 8 | 129 | 8 | 30.3 | 30.5 | 15.1 | 0.99x | 0.50x | 0.1 | 0% |
| bfloat16 | 8 | 129 | 16 | 30.4 | 30.5 | 15.1 | 1.00x | 0.50x | 0.1 | 0% |
| bfloat16 | 8 | 1024 | 4 | 30.4 | 30.5 | 19.3 | 1.00x | 0.63x | 0.5 | 0% |
| bfloat16 | 8 | 1024 | 8 | 30.4 | 30.5 | 19.4 | 1.00x | 0.64x | 0.6 | 0% |
| bfloat16 | 8 | 1024 | 16 | 30.4 | 30.4 | 19.5 | 1.00x | 0.64x | 0.6 | 0% |
| bfloat16 | 8 | 1025 | 4 | 30.4 | 30.5 | 20.5 | 1.00x | 0.67x | 0.5 | 0% |
| bfloat16 | 8 | 1025 | 8 | 30.6 | 30.4 | 20.4 | 1.01x | 0.67x | 0.6 | 0% |
| bfloat16 | 8 | 1025 | 16 | 30.4 | 30.4 | 20.4 | 1.00x | 0.67x | 0.6 | 0% |
| bfloat16 | 8 | 8192 | 4 | 54.7 | 51.6 | 42.2 | 1.06x | 0.82x | 2.5 | 1% |
| bfloat16 | 8 | 8192 | 8 | 51.6 | 54.6 | 39.9 | 0.95x | 0.73x | 2.4 | 1% |
| bfloat16 | 8 | 8192 | 16 | 54.8 | 54.5 | 42.4 | 1.01x | 0.78x | 2.4 | 1% |
| bfloat16 | 8 | 8193 | 4 | 54.5 | 54.5 | 43.3 | 1.00x | 0.79x | 2.4 | 1% |
| bfloat16 | 8 | 8193 | 8 | 54.7 | 54.7 | 43.5 | 1.00x | 0.80x | 2.4 | 1% |
| bfloat16 | 8 | 8193 | 16 | 54.6 | 48.6 | 42.7 | 1.12x | 0.88x | 2.7 | 1% |
| bfloat16 | 8 | 131072 | 4 | 388.2 | 394.6 | 56.8 | 0.98x | 0.14x | 5.3 | 1% |
| bfloat16 | 8 | 131072 | 8 | 422.7 | 398.6 | 56.5 | 1.06x | 0.14x | 5.3 | 1% |
| bfloat16 | 8 | 131072 | 16 | 427.5 | 433.5 | 56.7 | 0.99x | 0.13x | 4.8 | 1% |
| bfloat16 | 8 | 131073 | 4 | 392.3 | 405.1 | 56.8 | 0.97x | 0.14x | 5.2 | 1% |
| bfloat16 | 8 | 131073 | 8 | 404.6 | 406.4 | 57.1 | 1.00x | 0.14x | 5.2 | 1% |
| bfloat16 | 8 | 131073 | 16 | 442.0 | 436.3 | 56.9 | 1.01x | 0.13x | 4.8 | 1% |
| bfloat16 | 64 | 128 | 4 | 30.5 | 30.5 | 14.9 | 1.00x | 0.49x | 0.6 | 0% |
| bfloat16 | 64 | 128 | 8 | 30.5 | 30.6 | 14.7 | 1.00x | 0.48x | 0.7 | 0% |
| bfloat16 | 64 | 128 | 16 | 30.6 | 30.4 | 14.8 | 1.01x | 0.49x | 0.9 | 0% |
| bfloat16 | 64 | 129 | 4 | 30.6 | 30.4 | 15.4 | 1.01x | 0.51x | 0.6 | 0% |
| bfloat16 | 64 | 129 | 8 | 30.5 | 30.4 | 15.5 | 1.00x | 0.51x | 0.7 | 0% |
| bfloat16 | 64 | 129 | 16 | 30.6 | 30.4 | 15.2 | 1.01x | 0.50x | 0.9 | 0% |
| bfloat16 | 64 | 1024 | 4 | 30.6 | 30.5 | 19.5 | 1.00x | 0.64x | 4.4 | 1% |
| bfloat16 | 64 | 1024 | 8 | 30.5 | 30.5 | 19.5 | 1.00x | 0.64x | 4.5 | 1% |
| bfloat16 | 64 | 1024 | 16 | 30.5 | 30.6 | 19.5 | 1.00x | 0.64x | 4.6 | 1% |
| bfloat16 | 64 | 1025 | 4 | 33.7 | 33.6 | 20.7 | 1.00x | 0.62x | 4.0 | 1% |
| bfloat16 | 64 | 1025 | 8 | 33.7 | 33.6 | 20.6 | 1.00x | 0.61x | 4.1 | 1% |
| bfloat16 | 64 | 1025 | 16 | 33.5 | 33.7 | 20.6 | 0.99x | 0.61x | 4.2 | 1% |
| bfloat16 | 64 | 8192 | 4 | 93.1 | 92.2 | 49.9 | 1.01x | 0.54x | 11.4 | 3% |
| bfloat16 | 64 | 8192 | 8 | 97.7 | 96.6 | 49.5 | 1.01x | 0.51x | 10.9 | 2% |
| bfloat16 | 64 | 8192 | 16 | 100.8 | 101.2 | 49.6 | 1.00x | 0.49x | 10.5 | 2% |
| bfloat16 | 64 | 8193 | 4 | 96.2 | 90.1 | 49.8 | 1.07x | 0.55x | 11.7 | 3% |
| bfloat16 | 64 | 8193 | 8 | 97.9 | 96.3 | 49.6 | 1.02x | 0.52x | 10.9 | 2% |
| bfloat16 | 64 | 8193 | 16 | 100.2 | 100.3 | 49.7 | 1.00x | 0.50x | 10.6 | 2% |
| bfloat16 | 64 | 131072 | 4 | 901.8 | 888.7 | 162.9 | 1.01x | 0.18x | 18.9 | 4% |
| bfloat16 | 64 | 131072 | 8 | 939.7 | 948.2 | 164.6 | 0.99x | 0.17x | 17.7 | 4% |
| bfloat16 | 64 | 131072 | 16 | 999.0 | 993.3 | 164.4 | 1.01x | 0.17x | 16.9 | 4% |
| bfloat16 | 64 | 131073 | 4 | 902.2 | 889.0 | 166.8 | 1.01x | 0.19x | 18.9 | 4% |
| bfloat16 | 64 | 131073 | 8 | 944.7 | 942.0 | 166.8 | 1.00x | 0.18x | 17.8 | 4% |
| bfloat16 | 64 | 131073 | 16 | 1002.6 | 1000.7 | 165.5 | 1.00x | 0.17x | 16.8 | 4% |
| bfloat16 | 256 | 128 | 4 | 33.7 | 33.7 | 15.7 | 1.00x | 0.47x | 2.2 | 0% |
| bfloat16 | 256 | 128 | 8 | 33.8 | 33.6 | 15.6 | 1.01x | 0.46x | 2.6 | 1% |
| bfloat16 | 256 | 128 | 16 | 33.6 | 33.6 | 15.7 | 1.00x | 0.47x | 3.2 | 1% |
| bfloat16 | 256 | 129 | 4 | 33.7 | 33.6 | 16.5 | 1.00x | 0.49x | 2.3 | 0% |
| bfloat16 | 256 | 129 | 8 | 33.6 | 33.6 | 16.3 | 1.00x | 0.49x | 2.6 | 1% |
| bfloat16 | 256 | 129 | 16 | 33.6 | 33.5 | 16.3 | 1.00x | 0.49x | 3.2 | 1% |
| bfloat16 | 256 | 1024 | 4 | 56.3 | 56.1 | 41.7 | 1.00x | 0.74x | 9.5 | 2% |
| bfloat16 | 256 | 1024 | 8 | 59.0 | 58.9 | 42.4 | 1.00x | 0.72x | 9.2 | 2% |
| bfloat16 | 256 | 1024 | 16 | 59.3 | 59.2 | 42.6 | 1.00x | 0.72x | 9.5 | 2% |
| bfloat16 | 256 | 1025 | 4 | 71.1 | 72.4 | 45.9 | 0.98x | 0.63x | 7.4 | 2% |
| bfloat16 | 256 | 1025 | 8 | 75.1 | 74.1 | 46.7 | 1.01x | 0.63x | 7.4 | 2% |
| bfloat16 | 256 | 1025 | 16 | 75.4 | 75.4 | 47.1 | 1.00x | 0.62x | 7.5 | 2% |
| bfloat16 | 256 | 8192 | 4 | 260.0 | 263.7 | 75.2 | 0.99x | 0.29x | 15.9 | 3% |
| bfloat16 | 256 | 8192 | 8 | 270.4 | 269.8 | 75.0 | 1.00x | 0.28x | 15.6 | 3% |
| bfloat16 | 256 | 8192 | 16 | 287.6 | 290.5 | 75.2 | 0.99x | 0.26x | 14.6 | 3% |
| bfloat16 | 256 | 8193 | 4 | 261.0 | 268.2 | 75.1 | 0.97x | 0.28x | 15.7 | 3% |
| bfloat16 | 256 | 8193 | 8 | 273.3 | 273.1 | 75.6 | 1.00x | 0.28x | 15.4 | 3% |
| bfloat16 | 256 | 8193 | 16 | 287.6 | 288.1 | 75.7 | 1.00x | 0.26x | 14.7 | 3% |
| bfloat16 | 256 | 131072 | 4 | 3096.6 | 3087.7 | 439.2 | 1.00x | 0.14x | 21.7 | 5% |
| bfloat16 | 256 | 131072 | 8 | 3283.4 | 3269.1 | 436.9 | 1.00x | 0.13x | 20.5 | 5% |
| bfloat16 | 256 | 131072 | 16 | 3464.5 | 3469.5 | 440.9 | 1.00x | 0.13x | 19.4 | 4% |
| bfloat16 | 256 | 131073 | 4 | 3085.3 | 3093.6 | 441.5 | 1.00x | 0.14x | 21.7 | 5% |
| bfloat16 | 256 | 131073 | 8 | 3282.4 | 3267.2 | 435.4 | 1.00x | 0.13x | 20.5 | 5% |
| bfloat16 | 256 | 131073 | 16 | 3462.5 | 3470.8 | 443.1 | 1.00x | 0.13x | 19.3 | 4% |
| bfloat16 | 1024 | 128 | 4 | 70.9 | 69.5 | 22.1 | 1.02x | 0.32x | 4.4 | 1% |
| bfloat16 | 1024 | 128 | 8 | 75.3 | 75.2 | 22.0 | 1.00x | 0.29x | 4.6 | 1% |
| bfloat16 | 1024 | 128 | 16 | 76.9 | 76.7 | 22.3 | 1.00x | 0.29x | 5.6 | 1% |
| bfloat16 | 1024 | 129 | 4 | 70.8 | 69.6 | 24.4 | 1.02x | 0.35x | 4.4 | 1% |
| bfloat16 | 1024 | 129 | 8 | 75.4 | 75.2 | 24.4 | 1.00x | 0.32x | 4.6 | 1% |
| bfloat16 | 1024 | 129 | 16 | 76.8 | 76.7 | 24.5 | 1.00x | 0.32x | 5.6 | 1% |
| bfloat16 | 1024 | 1024 | 4 | 152.6 | 56.2 | 63.1 | 2.72x | 1.12x | 38.0 | 8% |
| bfloat16 | 1024 | 1024 | 8 | 156.0 | 56.2 | 63.3 | 2.78x | 1.13x | 38.8 | 9% |
| bfloat16 | 1024 | 1024 | 16 | 157.2 | 57.5 | 63.4 | 2.73x | 1.10x | 39.3 | 9% |
| bfloat16 | 1024 | 1025 | 4 | 218.4 | 86.0 | 64.5 | 2.54x | 0.75x | 24.9 | 5% |
| bfloat16 | 1024 | 1025 | 8 | 223.7 | 86.8 | 64.7 | 2.58x | 0.75x | 25.1 | 6% |
| bfloat16 | 1024 | 1025 | 16 | 225.8 | 87.3 | 64.8 | 2.59x | 0.74x | 25.9 | 6% |
| bfloat16 | 1024 | 8192 | 4 | 939.4 | 248.0 | 147.6 | 3.79x | 0.60x | 67.8 | 15% |
| bfloat16 | 1024 | 8192 | 8 | 985.8 | 249.3 | 147.4 | 3.95x | 0.59x | 67.6 | 15% |
| bfloat16 | 1024 | 8192 | 16 | 1036.1 | 251.2 | 148.0 | 4.12x | 0.59x | 67.4 | 15% |
| bfloat16 | 1024 | 8193 | 4 | 941.7 | 406.6 | 149.2 | 2.32x | 0.37x | 41.4 | 9% |
| bfloat16 | 1024 | 8193 | 8 | 988.2 | 407.0 | 148.4 | 2.43x | 0.36x | 41.4 | 9% |
| bfloat16 | 1024 | 8193 | 16 | 1040.8 | 406.8 | 149.3 | 2.56x | 0.37x | 41.6 | 9% |
| bfloat16 | 1024 | 131072 | 4 | 11500.2 | 1762.5 | 1865.9 | 6.52x | 1.06x | 152.3 | 33% |
| bfloat16 | 1024 | 131072 | 8 | 12192.8 | 1762.8 | 1867.4 | 6.92x | 1.06x | 152.3 | 33% |
| bfloat16 | 1024 | 131072 | 16 | 12859.4 | 1767.0 | 1863.0 | 7.28x | 1.05x | 152.0 | 33% |
| bfloat16 | 1024 | 131073 | 4 | 11514.6 | 2998.5 | 1940.1 | 3.84x | 0.65x | 89.5 | 20% |
| bfloat16 | 1024 | 131073 | 8 | 12173.3 | 2998.4 | 1936.8 | 4.06x | 0.65x | 89.6 | 20% |
| bfloat16 | 1024 | 131073 | 16 | 12856.9 | 3002.4 | 1944.4 | 4.28x | 0.65x | 89.5 | 20% |
| bfloat16 | 2048 | 128 | 4 | 113.9 | 113.8 | 30.5 | 1.00x | 0.27x | 5.3 | 1% |
| bfloat16 | 2048 | 128 | 8 | 120.3 | 119.9 | 30.5 | 1.00x | 0.25x | 5.7 | 1% |
| bfloat16 | 2048 | 128 | 16 | 122.9 | 122.9 | 30.9 | 1.00x | 0.25x | 6.9 | 2% |
| bfloat16 | 2048 | 129 | 4 | 113.8 | 114.0 | 35.4 | 1.00x | 0.31x | 5.4 | 1% |
| bfloat16 | 2048 | 129 | 8 | 120.1 | 120.1 | 35.2 | 1.00x | 0.29x | 5.8 | 1% |
| bfloat16 | 2048 | 129 | 16 | 123.2 | 123.1 | 35.7 | 1.00x | 0.29x | 7.0 | 2% |
| bfloat16 | 2048 | 1024 | 4 | 276.3 | 96.4 | 85.7 | 2.87x | 0.89x | 44.4 | 10% |
| bfloat16 | 2048 | 1024 | 8 | 284.8 | 97.5 | 86.0 | 2.92x | 0.88x | 44.7 | 10% |
| bfloat16 | 2048 | 1024 | 16 | 286.1 | 99.3 | 86.4 | 2.88x | 0.87x | 45.5 | 10% |
| bfloat16 | 2048 | 1025 | 4 | 407.9 | 158.2 | 88.4 | 2.58x | 0.56x | 27.1 | 6% |
| bfloat16 | 2048 | 1025 | 8 | 423.7 | 158.8 | 88.7 | 2.67x | 0.56x | 27.5 | 6% |
| bfloat16 | 2048 | 1025 | 16 | 428.3 | 160.0 | 89.0 | 2.68x | 0.56x | 28.3 | 6% |
| bfloat16 | 2048 | 8192 | 4 | 1875.1 | 496.1 | 234.9 | 3.78x | 0.47x | 67.8 | 15% |
| bfloat16 | 2048 | 8192 | 8 | 1956.5 | 497.2 | 234.1 | 3.94x | 0.47x | 67.8 | 15% |
| bfloat16 | 2048 | 8192 | 16 | 2058.5 | 498.7 | 235.0 | 4.13x | 0.47x | 67.9 | 15% |
| bfloat16 | 2048 | 8193 | 4 | 1873.4 | 825.1 | 236.2 | 2.27x | 0.29x | 40.8 | 9% |
| bfloat16 | 2048 | 8193 | 8 | 1959.0 | 824.1 | 237.3 | 2.38x | 0.29x | 40.9 | 9% |
| bfloat16 | 2048 | 8193 | 16 | 2065.1 | 825.7 | 237.4 | 2.50x | 0.29x | 41.0 | 9% |
| bfloat16 | 2048 | 131072 | 4 | 22903.6 | 3485.4 | 3646.5 | 6.57x | 1.05x | 154.1 | 34% |
| bfloat16 | 2048 | 131072 | 8 | 24193.6 | 3484.6 | 3644.1 | 6.94x | 1.05x | 154.1 | 34% |
| bfloat16 | 2048 | 131072 | 16 | 25590.8 | 3487.7 | 3646.2 | 7.34x | 1.05x | 154.0 | 34% |
| bfloat16 | 2048 | 131073 | 4 | 22872.9 | 5925.0 | 3774.7 | 3.86x | 0.64x | 90.6 | 20% |
| bfloat16 | 2048 | 131073 | 8 | 24187.7 | 5933.4 | 3780.1 | 4.08x | 0.64x | 90.5 | 20% |
| bfloat16 | 2048 | 131073 | 16 | 25604.8 | 5934.5 | 3773.0 | 4.31x | 0.64x | 90.5 | 20% |
| float16 | 1 | 128 | 4 | 30.7 | 30.7 | 14.3 | 1.00x | 0.47x | 0.0 | 0% |
| float16 | 1 | 128 | 8 | 30.6 | 30.6 | 14.0 | 1.00x | 0.46x | 0.0 | 0% |
| float16 | 1 | 128 | 16 | 30.5 | 30.5 | 14.0 | 1.00x | 0.46x | 0.0 | 0% |
| float16 | 1 | 129 | 4 | 30.6 | 30.6 | 14.4 | 1.00x | 0.47x | 0.0 | 0% |
| float16 | 1 | 129 | 8 | 30.6 | 30.3 | 14.4 | 1.01x | 0.48x | 0.0 | 0% |
| float16 | 1 | 129 | 16 | 30.5 | 30.4 | 14.7 | 1.00x | 0.48x | 0.0 | 0% |
| float16 | 1 | 1024 | 4 | 30.6 | 30.7 | 17.4 | 1.00x | 0.57x | 0.1 | 0% |
| float16 | 1 | 1024 | 8 | 30.5 | 30.5 | 17.5 | 1.00x | 0.57x | 0.1 | 0% |
| float16 | 1 | 1024 | 16 | 30.4 | 30.5 | 17.5 | 1.00x | 0.57x | 0.1 | 0% |
| float16 | 1 | 1025 | 4 | 30.5 | 30.5 | 17.8 | 1.00x | 0.58x | 0.1 | 0% |
| float16 | 1 | 1025 | 8 | 30.4 | 30.4 | 18.6 | 1.00x | 0.61x | 0.1 | 0% |
| float16 | 1 | 1025 | 16 | 30.4 | 30.3 | 20.1 | 1.00x | 0.66x | 0.1 | 0% |
| float16 | 1 | 8192 | 4 | 41.4 | 38.2 | 33.6 | 1.08x | 0.88x | 0.4 | 0% |
| float16 | 1 | 8192 | 8 | 41.2 | 48.4 | 33.8 | 0.85x | 0.70x | 0.3 | 0% |
| float16 | 1 | 8192 | 16 | 45.6 | 48.4 | 31.5 | 0.94x | 0.65x | 0.3 | 0% |
| float16 | 1 | 8193 | 4 | 45.6 | 41.0 | 37.4 | 1.11x | 0.91x | 0.4 | 0% |
| float16 | 1 | 8193 | 8 | 42.6 | 44.1 | 36.9 | 0.97x | 0.84x | 0.4 | 0% |
| float16 | 1 | 8193 | 16 | 45.6 | 51.3 | 33.3 | 0.89x | 0.65x | 0.3 | 0% |
| float16 | 1 | 131072 | 4 | 297.2 | 304.4 | 46.2 | 0.98x | 0.15x | 0.9 | 0% |
| float16 | 1 | 131072 | 8 | 326.6 | 335.1 | 46.5 | 0.97x | 0.14x | 0.8 | 0% |
| float16 | 1 | 131072 | 16 | 348.1 | 355.4 | 46.1 | 0.98x | 0.13x | 0.7 | 0% |
| float16 | 1 | 131073 | 4 | 308.7 | 286.0 | 46.9 | 1.08x | 0.16x | 0.9 | 0% |
| float16 | 1 | 131073 | 8 | 321.3 | 325.3 | 46.8 | 0.99x | 0.14x | 0.8 | 0% |
| float16 | 1 | 131073 | 16 | 353.2 | 378.6 | 46.6 | 0.93x | 0.12x | 0.7 | 0% |
| float16 | 8 | 128 | 4 | 30.5 | 30.2 | 14.4 | 1.01x | 0.48x | 0.1 | 0% |
| float16 | 8 | 128 | 8 | 30.4 | 30.2 | 14.5 | 1.01x | 0.48x | 0.1 | 0% |
| float16 | 8 | 128 | 16 | 30.4 | 30.4 | 14.5 | 1.00x | 0.48x | 0.1 | 0% |
| float16 | 8 | 129 | 4 | 30.5 | 30.2 | 14.8 | 1.01x | 0.49x | 0.1 | 0% |
| float16 | 8 | 129 | 8 | 30.3 | 30.2 | 14.9 | 1.00x | 0.49x | 0.1 | 0% |
| float16 | 8 | 129 | 16 | 30.5 | 30.4 | 14.9 | 1.00x | 0.49x | 0.1 | 0% |
| float16 | 8 | 1024 | 4 | 30.6 | 30.4 | 19.1 | 1.01x | 0.63x | 0.5 | 0% |
| float16 | 8 | 1024 | 8 | 30.5 | 30.4 | 19.2 | 1.00x | 0.63x | 0.6 | 0% |
| float16 | 8 | 1024 | 16 | 30.4 | 30.3 | 19.3 | 1.00x | 0.64x | 0.6 | 0% |
| float16 | 8 | 1025 | 4 | 30.5 | 30.4 | 19.5 | 1.00x | 0.64x | 0.6 | 0% |
| float16 | 8 | 1025 | 8 | 30.5 | 30.3 | 20.4 | 1.01x | 0.67x | 0.6 | 0% |
| float16 | 8 | 1025 | 16 | 30.5 | 30.3 | 20.5 | 1.01x | 0.68x | 0.6 | 0% |
| float16 | 8 | 8192 | 4 | 45.6 | 45.5 | 37.9 | 1.00x | 0.83x | 2.9 | 1% |
| float16 | 8 | 8192 | 8 | 48.4 | 48.5 | 39.8 | 1.00x | 0.82x | 2.7 | 1% |
| float16 | 8 | 8192 | 16 | 48.5 | 51.5 | 41.7 | 0.94x | 0.81x | 2.6 | 1% |
| float16 | 8 | 8193 | 4 | 48.5 | 45.5 | 39.2 | 1.07x | 0.86x | 2.9 | 1% |
| float16 | 8 | 8193 | 8 | 45.6 | 48.6 | 40.7 | 0.94x | 0.84x | 2.7 | 1% |
| float16 | 8 | 8193 | 16 | 54.5 | 51.7 | 43.0 | 1.05x | 0.83x | 2.6 | 1% |
| float16 | 8 | 131072 | 4 | 309.9 | 334.0 | 56.0 | 0.93x | 0.17x | 6.3 | 1% |
| float16 | 8 | 131072 | 8 | 338.1 | 356.0 | 56.1 | 0.95x | 0.16x | 5.9 | 1% |
| float16 | 8 | 131072 | 16 | 393.3 | 387.7 | 56.3 | 1.01x | 0.15x | 5.4 | 1% |
| float16 | 8 | 131073 | 4 | 314.9 | 313.8 | 56.2 | 1.00x | 0.18x | 6.7 | 1% |
| float16 | 8 | 131073 | 8 | 341.7 | 344.2 | 56.3 | 0.99x | 0.16x | 6.1 | 1% |
| float16 | 8 | 131073 | 16 | 366.4 | 378.0 | 56.3 | 0.97x | 0.15x | 5.6 | 1% |
| float16 | 64 | 128 | 4 | 30.5 | 30.1 | 14.9 | 1.01x | 0.50x | 0.6 | 0% |
| float16 | 64 | 128 | 8 | 30.5 | 30.2 | 14.7 | 1.01x | 0.49x | 0.7 | 0% |
| float16 | 64 | 128 | 16 | 30.4 | 30.2 | 14.7 | 1.01x | 0.49x | 0.9 | 0% |
| float16 | 64 | 129 | 4 | 30.6 | 30.2 | 15.3 | 1.01x | 0.51x | 0.6 | 0% |
| float16 | 64 | 129 | 8 | 30.6 | 30.2 | 15.2 | 1.01x | 0.50x | 0.7 | 0% |
| float16 | 64 | 129 | 16 | 30.5 | 30.2 | 15.1 | 1.01x | 0.50x | 0.9 | 0% |
| float16 | 64 | 1024 | 4 | 30.4 | 30.4 | 19.2 | 1.00x | 0.63x | 4.4 | 1% |
| float16 | 64 | 1024 | 8 | 30.4 | 30.4 | 19.3 | 1.00x | 0.63x | 4.5 | 1% |
| float16 | 64 | 1024 | 16 | 30.4 | 30.3 | 19.4 | 1.00x | 0.64x | 4.7 | 1% |
| float16 | 64 | 1025 | 4 | 32.2 | 32.0 | 19.7 | 1.01x | 0.62x | 4.2 | 1% |
| float16 | 64 | 1025 | 8 | 32.1 | 32.1 | 20.4 | 1.00x | 0.64x | 4.2 | 1% |
| float16 | 64 | 1025 | 16 | 33.6 | 33.6 | 20.4 | 1.00x | 0.61x | 4.2 | 1% |
| float16 | 64 | 8192 | 4 | 81.3 | 84.2 | 49.4 | 0.97x | 0.59x | 12.5 | 3% |
| float16 | 64 | 8192 | 8 | 83.0 | 84.2 | 49.2 | 0.99x | 0.58x | 12.5 | 3% |
| float16 | 64 | 8192 | 16 | 88.7 | 90.4 | 49.2 | 0.98x | 0.54x | 11.7 | 3% |
| float16 | 64 | 8193 | 4 | 81.3 | 80.1 | 49.4 | 1.01x | 0.62x | 13.1 | 3% |
| float16 | 64 | 8193 | 8 | 87.2 | 84.0 | 49.4 | 1.04x | 0.59x | 12.5 | 3% |
| float16 | 64 | 8193 | 16 | 90.2 | 88.8 | 49.4 | 1.02x | 0.56x | 11.9 | 3% |
| float16 | 64 | 131072 | 4 | 752.0 | 723.7 | 162.1 | 1.04x | 0.22x | 23.2 | 5% |
| float16 | 64 | 131072 | 8 | 788.0 | 782.2 | 160.5 | 1.01x | 0.21x | 21.5 | 5% |
| float16 | 64 | 131072 | 16 | 853.1 | 866.5 | 162.4 | 0.98x | 0.19x | 19.4 | 4% |
| float16 | 64 | 131073 | 4 | 712.3 | 709.2 | 161.6 | 1.00x | 0.23x | 23.7 | 5% |
| float16 | 64 | 131073 | 8 | 784.4 | 775.9 | 163.9 | 1.01x | 0.21x | 21.6 | 5% |
| float16 | 64 | 131073 | 16 | 866.1 | 857.3 | 162.9 | 1.01x | 0.19x | 19.6 | 4% |
| float16 | 256 | 128 | 4 | 33.7 | 33.6 | 15.5 | 1.00x | 0.46x | 2.3 | 0% |
| float16 | 256 | 128 | 8 | 33.7 | 33.6 | 15.6 | 1.00x | 0.46x | 2.6 | 1% |
| float16 | 256 | 128 | 16 | 33.7 | 33.6 | 15.6 | 1.00x | 0.46x | 3.2 | 1% |
| float16 | 256 | 129 | 4 | 33.7 | 33.5 | 16.0 | 1.01x | 0.48x | 2.3 | 0% |
| float16 | 256 | 129 | 8 | 33.7 | 33.5 | 15.9 | 1.01x | 0.47x | 2.6 | 1% |
| float16 | 256 | 129 | 16 | 33.6 | 33.5 | 16.1 | 1.00x | 0.48x | 3.2 | 1% |
| float16 | 256 | 1024 | 4 | 50.6 | 50.8 | 37.9 | 1.00x | 0.75x | 10.5 | 2% |
| float16 | 256 | 1024 | 8 | 53.1 | 53.0 | 38.8 | 1.00x | 0.73x | 10.3 | 2% |
| float16 | 256 | 1024 | 16 | 55.0 | 56.0 | 39.9 | 0.98x | 0.71x | 10.1 | 2% |
| float16 | 256 | 1025 | 4 | 63.5 | 63.5 | 42.0 | 1.00x | 0.66x | 8.4 | 2% |
| float16 | 256 | 1025 | 8 | 64.6 | 66.3 | 43.1 | 0.97x | 0.65x | 8.2 | 2% |
| float16 | 256 | 1025 | 16 | 69.5 | 67.9 | 43.8 | 1.02x | 0.65x | 8.3 | 2% |
| float16 | 256 | 8192 | 4 | 219.8 | 221.4 | 74.1 | 0.99x | 0.33x | 19.0 | 4% |
| float16 | 256 | 8192 | 8 | 233.9 | 234.1 | 74.4 | 1.00x | 0.32x | 18.0 | 4% |
| float16 | 256 | 8192 | 16 | 248.0 | 250.8 | 74.7 | 0.99x | 0.30x | 16.9 | 4% |
| float16 | 256 | 8193 | 4 | 217.9 | 220.0 | 74.3 | 0.99x | 0.34x | 19.1 | 4% |
| float16 | 256 | 8193 | 8 | 235.5 | 232.7 | 74.8 | 1.01x | 0.32x | 18.1 | 4% |
| float16 | 256 | 8193 | 16 | 252.1 | 257.4 | 74.9 | 0.98x | 0.29x | 16.5 | 4% |
| float16 | 256 | 131072 | 4 | 2409.4 | 2421.9 | 428.9 | 0.99x | 0.18x | 27.7 | 6% |
| float16 | 256 | 131072 | 8 | 2673.7 | 2662.8 | 427.9 | 1.00x | 0.16x | 25.2 | 6% |
| float16 | 256 | 131072 | 16 | 2935.0 | 2934.9 | 428.2 | 1.00x | 0.15x | 22.9 | 5% |
| float16 | 256 | 131073 | 4 | 2405.3 | 2442.5 | 431.9 | 0.98x | 0.18x | 27.5 | 6% |
| float16 | 256 | 131073 | 8 | 2662.4 | 2677.0 | 429.8 | 0.99x | 0.16x | 25.1 | 5% |
| float16 | 256 | 131073 | 16 | 2941.0 | 2949.7 | 432.2 | 1.00x | 0.15x | 22.8 | 5% |
| float16 | 1024 | 128 | 4 | 67.6 | 67.6 | 20.9 | 1.00x | 0.31x | 4.5 | 1% |
| float16 | 1024 | 128 | 8 | 70.7 | 69.7 | 20.9 | 1.01x | 0.30x | 4.9 | 1% |
| float16 | 1024 | 128 | 16 | 71.4 | 71.4 | 21.4 | 1.00x | 0.30x | 6.0 | 1% |
| float16 | 1024 | 129 | 4 | 66.5 | 66.6 | 23.3 | 1.00x | 0.35x | 4.6 | 1% |
| float16 | 1024 | 129 | 8 | 70.8 | 70.1 | 23.1 | 1.01x | 0.33x | 4.9 | 1% |
| float16 | 1024 | 129 | 16 | 71.2 | 72.4 | 23.4 | 0.98x | 0.32x | 5.9 | 1% |
| float16 | 1024 | 1024 | 4 | 132.5 | 48.4 | 62.7 | 2.74x | 1.30x | 44.2 | 10% |
| float16 | 1024 | 1024 | 8 | 136.5 | 48.7 | 63.0 | 2.80x | 1.29x | 44.7 | 10% |
| float16 | 1024 | 1024 | 16 | 143.6 | 49.7 | 63.1 | 2.89x | 1.27x | 45.5 | 10% |
| float16 | 1024 | 1025 | 4 | 185.3 | 97.8 | 64.2 | 1.89x | 0.66x | 21.9 | 5% |
| float16 | 1024 | 1025 | 8 | 192.7 | 97.7 | 64.4 | 1.97x | 0.66x | 22.3 | 5% |
| float16 | 1024 | 1025 | 16 | 206.3 | 99.0 | 64.5 | 2.08x | 0.65x | 22.9 | 5% |
| float16 | 1024 | 8192 | 4 | 793.1 | 198.8 | 145.0 | 3.99x | 0.73x | 84.6 | 19% |
| float16 | 1024 | 8192 | 8 | 840.3 | 199.1 | 144.6 | 4.22x | 0.73x | 84.7 | 19% |
| float16 | 1024 | 8192 | 16 | 907.4 | 201.8 | 145.5 | 4.50x | 0.72x | 83.9 | 18% |
| float16 | 1024 | 8193 | 4 | 799.0 | 456.2 | 146.1 | 1.75x | 0.32x | 36.9 | 8% |
| float16 | 1024 | 8193 | 8 | 838.6 | 457.3 | 146.5 | 1.83x | 0.32x | 36.9 | 8% |
| float16 | 1024 | 8193 | 16 | 912.3 | 459.8 | 146.2 | 1.98x | 0.32x | 36.8 | 8% |
| float16 | 1024 | 131072 | 4 | 9033.3 | 1535.9 | 1846.9 | 5.88x | 1.20x | 174.8 | 38% |
| float16 | 1024 | 131072 | 8 | 9885.6 | 1542.6 | 1856.1 | 6.41x | 1.20x | 174.1 | 38% |
| float16 | 1024 | 131072 | 16 | 10870.4 | 1538.7 | 1858.5 | 7.06x | 1.21x | 174.6 | 38% |
| float16 | 1024 | 131073 | 4 | 9011.7 | 3193.9 | 1924.0 | 2.82x | 0.60x | 84.1 | 18% |
| float16 | 1024 | 131073 | 8 | 9922.9 | 3185.2 | 1921.5 | 3.12x | 0.60x | 84.3 | 18% |
| float16 | 1024 | 131073 | 16 | 10905.6 | 3186.0 | 1926.4 | 3.42x | 0.60x | 84.3 | 18% |
| float16 | 2048 | 128 | 4 | 106.8 | 107.8 | 28.3 | 0.99x | 0.26x | 5.6 | 1% |
| float16 | 2048 | 128 | 8 | 112.6 | 112.5 | 28.5 | 1.00x | 0.25x | 6.1 | 1% |
| float16 | 2048 | 128 | 16 | 115.6 | 114.5 | 29.2 | 1.01x | 0.26x | 7.4 | 2% |
| float16 | 2048 | 129 | 4 | 106.9 | 108.1 | 32.6 | 0.99x | 0.30x | 5.6 | 1% |
| float16 | 2048 | 129 | 8 | 112.5 | 112.4 | 32.7 | 1.00x | 0.29x | 6.2 | 1% |
| float16 | 2048 | 129 | 16 | 115.9 | 115.4 | 33.5 | 1.00x | 0.29x | 7.4 | 2% |
| float16 | 2048 | 1024 | 4 | 236.3 | 81.3 | 85.1 | 2.91x | 1.05x | 52.6 | 12% |
| float16 | 2048 | 1024 | 8 | 246.7 | 82.8 | 85.7 | 2.98x | 1.04x | 52.6 | 12% |
| float16 | 2048 | 1024 | 16 | 259.7 | 84.4 | 86.0 | 3.08x | 1.02x | 53.6 | 12% |
| float16 | 2048 | 1025 | 4 | 345.5 | 179.5 | 87.7 | 1.92x | 0.49x | 23.8 | 5% |
| float16 | 2048 | 1025 | 8 | 358.4 | 180.9 | 88.0 | 1.98x | 0.49x | 24.1 | 5% |
| float16 | 2048 | 1025 | 16 | 380.3 | 182.2 | 88.5 | 2.09x | 0.49x | 24.8 | 5% |
| float16 | 2048 | 8192 | 4 | 1572.3 | 399.3 | 228.7 | 3.94x | 0.57x | 84.2 | 18% |
| float16 | 2048 | 8192 | 8 | 1662.5 | 400.0 | 228.5 | 4.16x | 0.57x | 84.3 | 18% |
| float16 | 2048 | 8192 | 16 | 1808.5 | 401.1 | 230.5 | 4.51x | 0.57x | 84.5 | 19% |
| float16 | 2048 | 8193 | 4 | 1573.6 | 924.3 | 231.7 | 1.70x | 0.25x | 36.4 | 8% |
| float16 | 2048 | 8193 | 8 | 1672.3 | 926.3 | 231.6 | 1.81x | 0.25x | 36.4 | 8% |
| float16 | 2048 | 8193 | 16 | 1813.4 | 931.1 | 233.1 | 1.95x | 0.25x | 36.4 | 8% |
| float16 | 2048 | 131072 | 4 | 17900.0 | 3035.1 | 3622.2 | 5.90x | 1.19x | 176.9 | 39% |
| float16 | 2048 | 131072 | 8 | 19669.5 | 3028.6 | 3607.3 | 6.49x | 1.19x | 177.3 | 39% |
| float16 | 2048 | 131072 | 16 | 21602.8 | 3043.9 | 3607.4 | 7.10x | 1.19x | 176.5 | 39% |
| float16 | 2048 | 131073 | 4 | 17893.0 | 6305.2 | 3743.3 | 2.84x | 0.59x | 85.2 | 19% |
| float16 | 2048 | 131073 | 8 | 19693.7 | 6309.6 | 3747.1 | 3.12x | 0.59x | 85.1 | 19% |
| float16 | 2048 | 131073 | 16 | 21604.8 | 6307.9 | 3749.5 | 3.43x | 0.59x | 85.2 | 19% |
| float32 | 1 | 128 | 4 | 31.2 | 31.4 | 14.5 | 0.99x | 0.46x | 0.0 | 0% |
| float32 | 1 | 128 | 8 | 34.0 | 34.4 | 14.3 | 0.99x | 0.42x | 0.0 | 0% |
| float32 | 1 | 128 | 16 | 32.4 | 34.4 | 14.0 | 0.94x | 0.41x | 0.0 | 0% |
| float32 | 1 | 129 | 4 | 34.1 | 34.4 | 14.4 | 0.99x | 0.42x | 0.0 | 0% |
| float32 | 1 | 129 | 8 | 34.0 | 32.7 | 14.4 | 1.04x | 0.44x | 0.0 | 0% |
| float32 | 1 | 129 | 16 | 34.1 | 34.3 | 15.2 | 0.99x | 0.44x | 0.0 | 0% |
| float32 | 1 | 1024 | 4 | 35.3 | 32.7 | 17.8 | 1.08x | 0.54x | 0.1 | 0% |
| float32 | 1 | 1024 | 8 | 35.3 | 35.8 | 22.2 | 0.99x | 0.62x | 0.1 | 0% |
| float32 | 1 | 1024 | 16 | 35.3 | 35.7 | 19.1 | 0.99x | 0.54x | 0.1 | 0% |
| float32 | 1 | 1025 | 4 | 35.3 | 35.9 | 18.8 | 0.98x | 0.52x | 0.1 | 0% |
| float32 | 1 | 1025 | 8 | 38.5 | 35.8 | 19.7 | 1.08x | 0.55x | 0.1 | 0% |
| float32 | 1 | 1025 | 16 | 35.2 | 35.7 | 19.6 | 0.99x | 0.55x | 0.1 | 0% |
| float32 | 1 | 8192 | 4 | 54.6 | 51.1 | 39.6 | 1.07x | 0.77x | 0.6 | 0% |
| float32 | 1 | 8192 | 8 | 63.6 | 55.0 | 38.0 | 1.16x | 0.69x | 0.6 | 0% |
| float32 | 1 | 8192 | 16 | 54.6 | 58.0 | 38.7 | 0.94x | 0.67x | 0.6 | 0% |
| float32 | 1 | 8193 | 4 | 51.5 | 52.0 | 34.1 | 0.99x | 0.66x | 0.6 | 0% |
| float32 | 1 | 8193 | 8 | 56.5 | 54.9 | 41.6 | 1.03x | 0.76x | 0.6 | 0% |
| float32 | 1 | 8193 | 16 | 60.6 | 58.0 | 39.8 | 1.04x | 0.69x | 0.6 | 0% |
| float32 | 1 | 131072 | 4 | 410.5 | 393.7 | 63.3 | 1.04x | 0.16x | 1.3 | 0% |
| float32 | 1 | 131072 | 8 | 412.3 | 398.5 | 63.3 | 1.03x | 0.16x | 1.3 | 0% |
| float32 | 1 | 131072 | 16 | 423.5 | 467.2 | 63.3 | 0.91x | 0.14x | 1.1 | 0% |
| float32 | 1 | 131073 | 4 | 406.7 | 389.3 | 64.0 | 1.04x | 0.16x | 1.3 | 0% |
| float32 | 1 | 131073 | 8 | 425.0 | 417.1 | 64.0 | 1.02x | 0.15x | 1.3 | 0% |
| float32 | 1 | 131073 | 16 | 435.0 | 430.7 | 63.9 | 1.01x | 0.15x | 1.2 | 0% |
| float32 | 8 | 128 | 4 | 33.8 | 37.2 | 14.7 | 0.91x | 0.40x | 0.1 | 0% |
| float32 | 8 | 128 | 8 | 35.0 | 34.1 | 14.3 | 1.03x | 0.42x | 0.1 | 0% |
| float32 | 8 | 128 | 16 | 35.6 | 37.2 | 15.2 | 0.96x | 0.41x | 0.2 | 0% |
| float32 | 8 | 129 | 4 | 35.2 | 36.0 | 15.0 | 0.98x | 0.42x | 0.1 | 0% |
| float32 | 8 | 129 | 8 | 36.8 | 34.1 | 15.0 | 1.08x | 0.44x | 0.1 | 0% |
| float32 | 8 | 129 | 16 | 35.3 | 35.5 | 15.3 | 0.99x | 0.43x | 0.2 | 0% |
| float32 | 8 | 1024 | 4 | 39.8 | 35.6 | 20.9 | 1.12x | 0.59x | 0.9 | 0% |
| float32 | 8 | 1024 | 8 | 38.2 | 35.6 | 19.7 | 1.07x | 0.55x | 0.9 | 0% |
| float32 | 8 | 1024 | 16 | 38.3 | 40.2 | 19.7 | 0.95x | 0.49x | 0.9 | 0% |
| float32 | 8 | 1025 | 4 | 38.3 | 35.7 | 20.6 | 1.07x | 0.58x | 0.9 | 0% |
| float32 | 8 | 1025 | 8 | 38.4 | 38.7 | 21.4 | 0.99x | 0.55x | 0.9 | 0% |
| float32 | 8 | 1025 | 16 | 41.2 | 36.9 | 22.0 | 1.12x | 0.60x | 0.9 | 0% |
| float32 | 8 | 8192 | 4 | 57.5 | 62.6 | 41.0 | 0.92x | 0.65x | 4.2 | 1% |
| float32 | 8 | 8192 | 8 | 60.6 | 55.2 | 42.6 | 1.10x | 0.77x | 4.8 | 1% |
| float32 | 8 | 8192 | 16 | 66.7 | 61.1 | 44.7 | 1.09x | 0.73x | 4.3 | 1% |
| float32 | 8 | 8193 | 4 | 54.6 | 64.0 | 43.0 | 0.85x | 0.67x | 4.1 | 1% |
| float32 | 8 | 8193 | 8 | 66.5 | 61.0 | 43.5 | 1.09x | 0.71x | 4.3 | 1% |
| float32 | 8 | 8193 | 16 | 63.9 | 67.1 | 45.0 | 0.95x | 0.67x | 3.9 | 1% |
| float32 | 8 | 131072 | 4 | 412.1 | 410.8 | 76.0 | 1.00x | 0.19x | 10.2 | 2% |
| float32 | 8 | 131072 | 8 | 432.3 | 425.0 | 76.0 | 1.02x | 0.18x | 9.9 | 2% |
| float32 | 8 | 131072 | 16 | 470.7 | 458.5 | 76.2 | 1.03x | 0.17x | 9.2 | 2% |
| float32 | 8 | 131073 | 4 | 403.7 | 411.2 | 76.0 | 0.98x | 0.18x | 10.2 | 2% |
| float32 | 8 | 131073 | 8 | 424.4 | 425.9 | 75.8 | 1.00x | 0.18x | 9.8 | 2% |
| float32 | 8 | 131073 | 16 | 471.5 | 477.8 | 76.1 | 0.99x | 0.16x | 8.8 | 2% |
| float32 | 64 | 128 | 4 | 38.2 | 37.4 | 15.0 | 1.02x | 0.40x | 1.0 | 0% |
| float32 | 64 | 128 | 8 | 36.8 | 37.2 | 15.0 | 0.99x | 0.40x | 1.0 | 0% |
| float32 | 64 | 128 | 16 | 38.3 | 37.2 | 14.9 | 1.03x | 0.40x | 1.2 | 0% |
| float32 | 64 | 129 | 4 | 38.5 | 37.1 | 15.5 | 1.04x | 0.42x | 1.0 | 0% |
| float32 | 64 | 129 | 8 | 37.0 | 37.1 | 15.9 | 1.00x | 0.43x | 1.1 | 0% |
| float32 | 64 | 129 | 16 | 38.4 | 38.8 | 15.4 | 0.99x | 0.40x | 1.2 | 0% |
| float32 | 64 | 1024 | 4 | 39.6 | 38.9 | 20.4 | 1.02x | 0.52x | 6.8 | 1% |
| float32 | 64 | 1024 | 8 | 39.8 | 39.2 | 20.3 | 1.02x | 0.52x | 6.8 | 2% |
| float32 | 64 | 1024 | 16 | 41.4 | 40.2 | 20.3 | 1.03x | 0.50x | 6.8 | 1% |
| float32 | 64 | 1025 | 4 | 41.3 | 43.4 | 22.1 | 0.95x | 0.51x | 6.1 | 1% |
| float32 | 64 | 1025 | 8 | 42.9 | 43.3 | 22.1 | 0.99x | 0.51x | 6.2 | 1% |
| float32 | 64 | 1025 | 16 | 42.9 | 44.7 | 22.2 | 0.96x | 0.50x | 6.1 | 1% |
| float32 | 64 | 8192 | 4 | 96.8 | 99.2 | 65.6 | 0.98x | 0.66x | 21.2 | 5% |
| float32 | 64 | 8192 | 8 | 103.8 | 106.6 | 65.6 | 0.97x | 0.62x | 19.7 | 4% |
| float32 | 64 | 8192 | 16 | 109.6 | 109.9 | 65.6 | 1.00x | 0.60x | 19.2 | 4% |
| float32 | 64 | 8193 | 4 | 97.8 | 99.6 | 65.6 | 0.98x | 0.66x | 21.1 | 5% |
| float32 | 64 | 8193 | 8 | 104.9 | 112.7 | 65.5 | 0.93x | 0.58x | 18.7 | 4% |
| float32 | 64 | 8193 | 16 | 112.9 | 115.8 | 65.6 | 0.97x | 0.57x | 18.2 | 4% |
| float32 | 64 | 131072 | 4 | 956.6 | 940.0 | 221.1 | 1.02x | 0.24x | 35.7 | 8% |
| float32 | 64 | 131072 | 8 | 1024.0 | 1007.2 | 220.4 | 1.02x | 0.22x | 33.3 | 7% |
| float32 | 64 | 131072 | 16 | 1097.5 | 1082.4 | 222.6 | 1.01x | 0.21x | 31.0 | 7% |
| float32 | 64 | 131073 | 4 | 943.5 | 941.2 | 223.0 | 1.00x | 0.24x | 35.7 | 8% |
| float32 | 64 | 131073 | 8 | 1004.0 | 1010.3 | 225.0 | 0.99x | 0.22x | 33.2 | 7% |
| float32 | 64 | 131073 | 16 | 1095.1 | 1101.5 | 223.7 | 0.99x | 0.20x | 30.5 | 7% |
| float32 | 256 | 128 | 4 | 46.0 | 46.0 | 15.7 | 1.00x | 0.34x | 3.1 | 1% |
| float32 | 256 | 128 | 8 | 47.2 | 47.5 | 15.7 | 0.99x | 0.33x | 3.3 | 1% |
| float32 | 256 | 128 | 16 | 47.4 | 47.2 | 15.7 | 1.00x | 0.33x | 3.8 | 1% |
| float32 | 256 | 129 | 4 | 47.2 | 47.5 | 16.1 | 0.99x | 0.34x | 3.0 | 1% |
| float32 | 256 | 129 | 8 | 45.6 | 47.4 | 16.7 | 0.96x | 0.35x | 3.3 | 1% |
| float32 | 256 | 129 | 16 | 47.3 | 49.0 | 16.6 | 0.97x | 0.34x | 3.7 | 1% |
| float32 | 256 | 1024 | 4 | 66.7 | 68.3 | 41.7 | 0.98x | 0.61x | 15.5 | 3% |
| float32 | 256 | 1024 | 8 | 70.7 | 70.0 | 43.2 | 1.01x | 0.62x | 15.3 | 3% |
| float32 | 256 | 1024 | 16 | 71.1 | 71.6 | 43.8 | 0.99x | 0.61x | 15.3 | 3% |
| float32 | 256 | 1025 | 4 | 82.8 | 81.2 | 45.9 | 1.02x | 0.57x | 13.1 | 3% |
| float32 | 256 | 1025 | 8 | 85.8 | 84.6 | 46.6 | 1.01x | 0.55x | 12.7 | 3% |
| float32 | 256 | 1025 | 16 | 87.3 | 89.4 | 48.1 | 0.98x | 0.54x | 12.3 | 3% |
| float32 | 256 | 8192 | 4 | 274.6 | 277.6 | 101.0 | 0.99x | 0.36x | 30.3 | 7% |
| float32 | 256 | 8192 | 8 | 299.9 | 286.3 | 101.3 | 1.05x | 0.35x | 29.4 | 6% |
| float32 | 256 | 8192 | 16 | 313.3 | 315.7 | 100.9 | 0.99x | 0.32x | 26.7 | 6% |
| float32 | 256 | 8193 | 4 | 283.6 | 277.9 | 101.7 | 1.02x | 0.37x | 30.2 | 7% |
| float32 | 256 | 8193 | 8 | 292.0 | 292.6 | 101.6 | 1.00x | 0.35x | 28.8 | 6% |
| float32 | 256 | 8193 | 16 | 317.9 | 318.0 | 101.8 | 1.00x | 0.32x | 26.5 | 6% |
| float32 | 256 | 131072 | 4 | 3194.0 | 3202.4 | 1128.3 | 1.00x | 0.35x | 41.9 | 9% |
| float32 | 256 | 131072 | 8 | 3415.0 | 3445.5 | 1132.5 | 0.99x | 0.33x | 39.0 | 9% |
| float32 | 256 | 131072 | 16 | 3704.6 | 3711.3 | 1129.5 | 1.00x | 0.30x | 36.2 | 8% |
| float32 | 256 | 131073 | 4 | 3206.8 | 3195.1 | 1148.5 | 1.00x | 0.36x | 42.0 | 9% |
| float32 | 256 | 131073 | 8 | 3427.4 | 3420.5 | 1148.0 | 1.00x | 0.34x | 39.2 | 9% |
| float32 | 256 | 131073 | 16 | 3743.5 | 3721.6 | 1147.9 | 1.01x | 0.31x | 36.1 | 8% |
| float32 | 1024 | 128 | 4 | 100.9 | 102.1 | 22.3 | 0.99x | 0.22x | 5.6 | 1% |
| float32 | 1024 | 128 | 8 | 107.9 | 105.8 | 22.0 | 1.02x | 0.21x | 5.9 | 1% |
| float32 | 1024 | 128 | 16 | 108.2 | 110.0 | 22.2 | 0.98x | 0.20x | 6.6 | 1% |
| float32 | 1024 | 129 | 4 | 102.3 | 101.3 | 24.4 | 1.01x | 0.24x | 5.7 | 1% |
| float32 | 1024 | 129 | 8 | 108.0 | 108.2 | 24.4 | 1.00x | 0.23x | 5.8 | 1% |
| float32 | 1024 | 129 | 16 | 109.5 | 111.1 | 24.6 | 0.99x | 0.22x | 6.5 | 1% |
| float32 | 1024 | 1024 | 4 | 185.6 | 50.2 | 88.3 | 3.70x | 1.76x | 84.5 | 19% |
| float32 | 1024 | 1024 | 8 | 190.3 | 50.0 | 88.3 | 3.81x | 1.77x | 85.9 | 19% |
| float32 | 1024 | 1024 | 16 | 194.7 | 50.2 | 88.3 | 3.88x | 1.76x | 87.5 | 19% |
| float32 | 1024 | 1025 | 4 | 251.8 | 92.1 | 90.2 | 2.73x | 0.98x | 46.1 | 10% |
| float32 | 1024 | 1025 | 8 | 262.6 | 92.5 | 90.1 | 2.84x | 0.97x | 46.5 | 10% |
| float32 | 1024 | 1025 | 16 | 267.3 | 93.0 | 90.4 | 2.87x | 0.97x | 47.3 | 10% |
| float32 | 1024 | 8192 | 4 | 1000.9 | 230.7 | 200.8 | 4.34x | 0.87x | 145.7 | 32% |
| float32 | 1024 | 8192 | 8 | 1072.8 | 231.1 | 200.2 | 4.64x | 0.87x | 145.6 | 32% |
| float32 | 1024 | 8192 | 16 | 1140.4 | 231.5 | 201.7 | 4.93x | 0.87x | 145.8 | 32% |
| float32 | 1024 | 8193 | 4 | 1014.7 | 465.1 | 202.4 | 2.18x | 0.44x | 72.3 | 16% |
| float32 | 1024 | 8193 | 8 | 1076.7 | 465.9 | 201.3 | 2.31x | 0.43x | 72.2 | 16% |
| float32 | 1024 | 8193 | 16 | 1159.9 | 466.5 | 202.6 | 2.49x | 0.43x | 72.4 | 16% |
| float32 | 1024 | 131072 | 4 | 11911.6 | 1964.0 | 4191.1 | 6.06x | 2.13x | 273.4 | 60% |
| float32 | 1024 | 131072 | 8 | 12727.1 | 1966.1 | 4189.9 | 6.47x | 2.13x | 273.1 | 60% |
| float32 | 1024 | 131072 | 16 | 13772.9 | 1966.2 | 4190.6 | 7.00x | 2.13x | 273.1 | 60% |
| float32 | 1024 | 131073 | 4 | 11868.0 | 3547.2 | 4260.7 | 3.35x | 1.20x | 151.4 | 33% |
| float32 | 1024 | 131073 | 8 | 12770.6 | 3550.0 | 4261.2 | 3.60x | 1.20x | 151.3 | 33% |
| float32 | 1024 | 131073 | 16 | 13914.8 | 3557.8 | 4261.2 | 3.91x | 1.20x | 151.0 | 33% |
| float32 | 2048 | 128 | 4 | 170.5 | 170.2 | 30.2 | 1.00x | 0.18x | 6.7 | 1% |
| float32 | 2048 | 128 | 8 | 177.6 | 177.9 | 30.6 | 1.00x | 0.17x | 7.0 | 2% |
| float32 | 2048 | 128 | 16 | 180.7 | 181.4 | 31.2 | 1.00x | 0.17x | 7.9 | 2% |
| float32 | 2048 | 129 | 4 | 170.3 | 170.5 | 35.4 | 1.00x | 0.21x | 6.8 | 1% |
| float32 | 2048 | 129 | 8 | 176.5 | 176.7 | 35.3 | 1.00x | 0.20x | 7.1 | 2% |
| float32 | 2048 | 129 | 16 | 181.9 | 182.7 | 36.4 | 1.00x | 0.20x | 7.9 | 2% |
| float32 | 2048 | 1024 | 4 | 333.2 | 85.6 | 123.4 | 3.89x | 1.44x | 99.1 | 22% |
| float32 | 2048 | 1024 | 8 | 347.3 | 85.9 | 123.4 | 4.04x | 1.44x | 99.9 | 22% |
| float32 | 2048 | 1024 | 16 | 355.7 | 87.1 | 123.7 | 4.08x | 1.42x | 100.8 | 22% |
| float32 | 2048 | 1025 | 4 | 470.0 | 165.7 | 126.5 | 2.84x | 0.76x | 51.3 | 11% |
| float32 | 2048 | 1025 | 8 | 492.6 | 166.1 | 126.7 | 2.97x | 0.76x | 51.7 | 11% |
| float32 | 2048 | 1025 | 16 | 503.6 | 167.0 | 127.0 | 3.02x | 0.76x | 52.6 | 12% |
| float32 | 2048 | 8192 | 4 | 1972.4 | 442.5 | 421.7 | 4.46x | 0.95x | 151.9 | 33% |
| float32 | 2048 | 8192 | 8 | 2094.9 | 443.3 | 424.8 | 4.73x | 0.96x | 151.8 | 33% |
| float32 | 2048 | 8192 | 16 | 2251.3 | 444.0 | 424.0 | 5.07x | 0.95x | 152.0 | 33% |
| float32 | 2048 | 8193 | 4 | 1979.8 | 908.5 | 436.2 | 2.18x | 0.48x | 74.0 | 16% |
| float32 | 2048 | 8193 | 8 | 2127.7 | 907.9 | 437.6 | 2.34x | 0.48x | 74.1 | 16% |
| float32 | 2048 | 8193 | 16 | 2269.5 | 910.9 | 440.8 | 2.49x | 0.48x | 74.1 | 16% |
| float32 | 2048 | 131072 | 4 | 23642.3 | 3925.9 | 8254.2 | 6.02x | 2.10x | 273.5 | 60% |
| float32 | 2048 | 131072 | 8 | 25253.3 | 3926.0 | 8254.6 | 6.43x | 2.10x | 273.5 | 60% |
| float32 | 2048 | 131072 | 16 | 27390.4 | 3930.4 | 8250.2 | 6.97x | 2.10x | 273.3 | 60% |
| float32 | 2048 | 131073 | 4 | 23630.0 | 7033.7 | 8407.4 | 3.36x | 1.20x | 152.7 | 33% |
| float32 | 2048 | 131073 | 8 | 25309.8 | 7037.0 | 8407.4 | 3.60x | 1.19x | 152.6 | 33% |
| float32 | 2048 | 131073 | 16 | 27547.6 | 7041.9 | 8413.3 | 3.91x | 1.19x | 152.5 | 33% |

</details>

### Test methodology

- **Accuracy (432 cases):** 3 dtypes x 6 batch sizes x 4 dims x 2 alignments x 3 k values. CPU reference vs XPU, sort-then-compare.
- **Sortedness (324 cases):** Verify `torch.topk(sorted=True)` output is monotonic for both `largest=True/False`.
- **Benchmark (432 cases):** Median of 3 runs x 50 iterations each, with 20 warmup iterations. `largest=True`.
- **Bandwidth:** `(bs * dim * sizeof(dtype) + bs * k * (sizeof(dtype) + 8)) / time`. Peak B580 = 456 GB/s (192-bit x 19 Gbps GDDR6).
