### PR TITLE
[#2811] Add long test to skip list to run it only on nightly

### DIFF
--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -56,6 +56,7 @@ skip_dict = {
     "test_decomp_xpu.py": (
         # Slow test case: it takes more than 10 minutes to run on XPU.
         "test_quick_core_backward_baddbmm_xpu_float64",
+        "test_quick_core_backward__unsafe_masked_index_put_accumulate_xpu_float64",
     ),
     "test_distributions_xpu.py": None,
     "test_dynamic_shapes_xpu.py": None,

--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -56,6 +56,7 @@ skip_dict = {
     "test_decomp_xpu.py": (
         # Slow test case: it takes more than 10 minutes to run on XPU.
         "test_quick_core_backward_baddbmm_xpu_float64",
+        # Slow test case: it takes more than 10 minutes to run on XPU.
         "test_quick_core_backward__unsafe_masked_index_put_accumulate_xpu_float64",
     ),
     "test_distributions_xpu.py": None,


### PR DESCRIPTION
Part of https://github.com/intel/torch-xpu-ops/issues/2811. The TestDecompXPU,test_quick_core_backward__unsafe_masked_index_put_accumulate_xpu_float64 executes more than 10 minutes because of that it's timeout and fails as 10 minutes timeout is set for all tests. The test is skipped to run it only on nightly with longer timeout as described in this issue: https://github.com/intel/torch-xpu-ops/issues/3106