### PR TITLE
Add .flake8 lint configuration with test/xpu paths

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,29 +2,37 @@
 # NOTE: **Mirror any changes** to this file the [tool.ruff] config in pyproject.toml
 # before we can fully move to use ruff
 enable-extensions = G
-select = B,C,E,F,G,P,SIM1,T4,W,B9
+select = B,C,E,F,G,P,SIM1,SIM911,T4,W,B9
 max-line-length = 120
 # C408 ignored because we like the dict keyword argument syntax
 # E501 is not flexible enough, we're using B950 instead
 ignore =
-    E203,E305,E402,E501,E721,E741,F405,F841,F999,W503,W504,C408,E302,W291,E303,
+    E203,E305,E402,E501,E704,E741,F405,F841,F999,W503,W504,C408,E302,W291,E303,F824,
     # shebang has extra meaning in fbcode lints, so I think it's not worth trying
     # to line this up with executable bit
     EXE001,
     # these ignores are from flake8-bugbear; please fix!
-    B007,B008,B017,B019,B023,B028,B903,B904,B905,B906,B907
-    # these ignores are from flake8-comprehensions; please fix!
-    C407,
-    # these ignores are from flake8-logging-format; please fix!
-    G100,G101,G200
+    B007,B008,B017,B019,B023,B028,B903,B905,B906,B907,B908,B910,
     # these ignores are from flake8-simplify. please fix or ignore with commented reason
     SIM105,SIM108,SIM110,SIM111,SIM113,SIM114,SIM115,SIM116,SIM117,SIM118,SIM119,SIM12,
+    # SIM104 is already covered by pyupgrade ruff
+    SIM104,
     # flake8-simplify code styles
-    SIM102,SIM103,SIM106,SIM112
+    SIM102,SIM103,SIM106,SIM112,
+    # Codes where ruff is the source of truth. Ruff handles these (sometimes
+    # differently than flake8). As ruff promotes preview codes, move them here
+    # from ruff's external list.
+    B001,B036,B902,B904,B950,
+    C406,C417,C419,C901,
+    E121,E122,E124,E128,E131,E712,E722,E723,E731,
+    F401,F722,F723,F811,F812,
+    G001,G003,G004,G010,G200,G201,G202
 per-file-ignores =
     __init__.py: F401
     test/**: F821
     test/**/__init__.py: F401,F821
+    test/xpu/dynamo/test_higher_order_ops_xpu.py: B950
+    test/xpu/dynamo/test_error_messages_xpu.py: B950
 optional-ascii-coding = True
 exclude =
     ./.git,


### PR DESCRIPTION
## Summary
- Copy flake8 ignore rules from pytorch's `.flake8` configuration
- Convert per-file-ignores paths from `test/` to `test/xpu/` for XPU-specific tests
- Add B950 ignore for XPU test files: `test_higher_order_ops_xpu.py` and `test_error_messages_xpu.py`

This enables proper lint checking for torch-xpu-ops test files with consistent rules as pytorch main repository.