### PR TITLE
test: transformer_encoder_layer: allow xpu for fast_path_device

### DIFF
--- a/test/xpu/test_nn_xpu.py
+++ b/test/xpu/test_nn_xpu.py
@@ -17333,7 +17333,7 @@ if __name__ == '__main__':
             torch.testing.assert_close(result, ref_output, atol=atol, rtol=rtol)
             mask = torch.tensor([[1]], device=device) == 1
             result = model(encoder_input, src_key_padding_mask=mask)
-            fast_path_device = result.is_cuda or result.is_cpu
+            fast_path_device = result.is_cuda or result.is_cpu or result.is_xpu
             result = result.cpu().detach().numpy()
             # Non Fast Paths
             if (


### PR DESCRIPTION
It fixes:
op_ut,third_party.torch-xpu-ops.test.xpu.test_nn_xpu.TestNNDeviceTypeXPU,test_transformerencoderlayer_xpu_float64

from:
https://github.com/intel/torch-xpu-ops/issues/2529