### PR TITLE
Enable Op _flash_attention_forward/_flash_attention_backward

### DIFF
--- a/src/ATen/native/transformers/xpu/flash_attn/flash_api.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/flash_api.cpp
@@ -21,6 +21,242 @@ bool is_flash_attention_available() {
 #endif
 }
 
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>
+_flash_attention_forward(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const std::optional<at::Tensor>& cumulative_sequence_length_q,
+    const std::optional<at::Tensor>& cumulative_sequence_length_k,
+    int64_t max_seqlen_batch_q,
+    int64_t max_seqlen_batch_k,
+    double dropout_p,
+    bool is_causal,
+    bool return_debug_mask,
+    std::optional<double> scale,
+    std::optional<int64_t> window_size_left,
+    std::optional<int64_t> window_size_right,
+    const std::optional<at::Tensor>& _seqused_k,
+    const std::optional<at::Tensor>& _alibi_slopes,
+    const std::optional<at::Tensor>& _block_table,
+    std::optional<at::Tensor> out,
+    std::optional<int64_t> num_splits) {
+#ifndef USE_SYCLTLA
+  TORCH_CHECK(
+      false,
+      "_flash_attention_forward: Torch XPU was not compiled with SYCLTLA support.");
+  return std::make_tuple(
+      at::Tensor(), at::Tensor(), at::Tensor(), at::Tensor(), at::Tensor());
+#else
+  TORCH_CHECK(
+      !num_splits.has_value(),
+      "num_splits requires FA3. Register FA3 with `register_flash_attention_fa3()` to set num_splits.");
+
+  const auto softmax_scale = sdp::calculate_scale(query, scale).expect_float();
+  std::optional<at::Tensor> seqused_k = _seqused_k;
+  std::optional<at::Tensor> block_table = _block_table;
+  std::optional<at::Tensor> alibi_slopes = _alibi_slopes;
+  const float softcap = 0.0;
+  const int window_left = window_size_left.value_or(-1);
+  const int window_right = window_size_right.value_or(-1);
+  static_cast<void>(seqused_k);
+  static_cast<void>(block_table);
+
+  // We are going to have two paths:
+  // 1. The standard MHA path for dense tensors
+  // 2. The Varseqlen path
+  TORCH_CHECK(
+      cumulative_sequence_length_q.has_value() ==
+          cumulative_sequence_length_k.has_value(),
+      "cumulative_sequence_length_q and cumulative_sequence_length_k must be both set or both not set");
+
+  at::Tensor output, q_padded, k_padded, v_padded, logsumexp, philox_seed,
+      philox_offset, debug_attn_mask;
+  if (cumulative_sequence_length_q.has_value()) {
+    // std::tie(
+    //     output,
+    //     q_padded,
+    //     k_padded,
+    //     v_padded,
+    //     logsumexp,
+    //     philox_seed,
+    //     philox_offset,
+    //     debug_attn_mask) =
+    //     FLASH_NAMESPACE::mha_varlen_fwd(
+    //         query,
+    //         key,
+    //         value,
+    //         out,
+    //         cumulative_sequence_length_q.value(),
+    //         cumulative_sequence_length_k.value(),
+    //         seqused_k, /*seqused_k*/
+    //         block_table, /*block_table*/
+    //         alibi_slopes, /*alibi_slopes*/
+    //         max_seqlen_batch_q,
+    //         max_seqlen_batch_k,
+    //         dropout_p,
+    //         softmax_scale,
+    //         false /*zero_tensors*/,
+    //         is_causal,
+    //         window_left,
+    //         window_right,
+    //         softcap,
+    //         return_debug_mask,
+    //         std::nullopt /*gen_*/);
+    TORCH_CHECK(
+        false,
+        "_flash_attention_forward: Varseqlen path is not implemented yet.");
+  } else {
+    std::tie(
+        output,
+        q_padded,
+        k_padded,
+        v_padded,
+        logsumexp,
+        philox_seed,
+        philox_offset,
+        debug_attn_mask) =
+        mha_fwd(
+            query,
+            key,
+            value,
+            out,
+            alibi_slopes,
+            dropout_p,
+            softmax_scale,
+            is_causal,
+            window_left,
+            window_right,
+            softcap,
+            return_debug_mask, /*return_softmax (this is used for testing)*/
+            std::nullopt);
+    static_cast<void>(q_padded);
+    static_cast<void>(k_padded);
+    static_cast<void>(v_padded);
+  }
+  debug_attn_mask =
+      return_debug_mask ? debug_attn_mask : at::empty({0}, query.options());
+  return std::make_tuple(
+      std::move(output),
+      std::move(logsumexp),
+      std::move(philox_seed),
+      std::move(philox_offset),
+      std::move(debug_attn_mask));
+#endif
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> _flash_attention_backward(
+    const at::Tensor& grad_out,
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& out,
+    const at::Tensor& logsumexp,
+    const at::Tensor& cumulative_sequence_length_q,
+    const at::Tensor& cumulative_sequence_length_k,
+    int64_t max_seqlen_batch_q,
+    int64_t max_seqlen_batch_k,
+    double dropout_p,
+    bool is_causal,
+    const at::Tensor& philox_seed,
+    const at::Tensor& philox_offset,
+    std::optional<double> scale,
+    std::optional<int64_t> window_size_left,
+    std::optional<int64_t> window_size_right) {
+#ifndef USE_SYCLTLA
+  TORCH_CHECK(
+      false,
+      "_flash_attention_backward: Torch XPU was not compiled with SYCLTLA support.");
+  return std::make_tuple(at::Tensor(), at::Tensor(), at::Tensor());
+#else
+  const auto softmax_scale = sdp::calculate_scale(query, scale).expect_float();
+  //  XPU code assumes that dout is contiguous
+  auto contiguous_grad_out = grad_out.contiguous();
+
+  const int window_left = window_size_left.value_or(-1);
+  const int window_right = window_size_right.value_or(-1);
+
+  std::optional<at::Tensor> dq{std::nullopt};
+  std::optional<at::Tensor> dk{std::nullopt};
+  std::optional<at::Tensor> dv{std::nullopt};
+
+  // Currently unused args:
+  std::optional<at::Tensor> alibi_slopes{std::nullopt};
+  const float softcap = 0.0;
+
+  bool deterministic{false};
+  auto& ctx = at::globalContext();
+  if (ctx.deterministicAlgorithms()) {
+    if (ctx.deterministicAlgorithmsWarnOnly()) {
+      TORCH_WARN_ONCE(
+          "Flash Attention defaults to a non-deterministic algorithm. ",
+          "To explicitly enable determinism call torch.use_deterministic_algorithms(True, warn_only=False).");
+    } else {
+      deterministic = true;
+    }
+  }
+
+  // We check the whether the cumulative_sequence_length_q is defined
+  // in order to determine whether we are using varlen or dense backward
+  if (cumulative_sequence_length_q.defined()) {
+    // auto [dQuery, dKey, dValue, dSoftmax] = mha_varlen_bwd(
+    //     contiguous_grad_out,
+    //     query,
+    //     key,
+    //     value,
+    //     out,
+    //     logsumexp,
+    //     dq,
+    //     dk,
+    //     dv,
+    //     cumulative_sequence_length_q,
+    //     cumulative_sequence_length_k,
+    //     alibi_slopes,
+    //     max_seqlen_batch_q,
+    //     max_seqlen_batch_k,
+    //     dropout_p,
+    //     softmax_scale,
+    //     false /*zero_tensors*/,
+    //     is_causal,
+    //     window_left,
+    //     window_right,
+    //     softcap,
+    //     deterministic,
+    //     philox_seed,
+    //     philox_offset);
+    // return std::make_tuple(std::move(dQuery), std::move(dKey),
+    // std::move(dValue));
+    TORCH_CHECK(
+        false,
+        "_flash_attention_backward: Varseqlen path is not implemented yet.");
+  } else {
+    auto [dQuery, dKey, dValue, dSoftmax] = mha_bwd(
+        contiguous_grad_out,
+        query,
+        key,
+        value,
+        out,
+        logsumexp,
+        dq,
+        dk,
+        dv,
+        alibi_slopes,
+        dropout_p,
+        softmax_scale,
+        is_causal,
+        window_left,
+        window_right,
+        softcap,
+        deterministic,
+        philox_seed,
+        philox_offset);
+    return std::make_tuple(
+        std::move(dQuery), std::move(dKey), std::move(dValue));
+  }
+#endif
+}
+
+// Deprecated: Use _flash_attention_forward instead.
 std::tuple<
     at::Tensor,
     at::Tensor,
@@ -74,6 +310,7 @@ flash_attention_forward(
 #endif
 }
 
+// Deprecated: Use _flash_attention_backward instead.
 std::tuple<at::Tensor, at::Tensor, at::Tensor> flash_attention_backward(
     const at::Tensor& grad_out,
     const at::Tensor& query,
@@ -96,8 +333,10 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> flash_attention_backward(
       "flash_attention_backward: Torch XPU was not compiled with SYCLTLA support.");
   return std::make_tuple(at::Tensor(), at::Tensor(), at::Tensor());
 #else
+  //  XPU code assumes that dout is contiguous
+  auto contiguous_grad_out = grad_out.contiguous();
   auto [grad_query, grad_key, grad_value] = flash_attention_backward_sycltla(
-      grad_out,
+      contiguous_grad_out,
       query,
       key,
       value,

--- a/src/ATen/native/transformers/xpu/flash_attn/flash_api.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/flash_api.h
@@ -11,11 +11,53 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <ATen/native/transformers/sdp_utils_cpp.h>
 
 namespace sycltla {
 
 bool is_flash_attention_available();
 
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>
+_flash_attention_forward(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const std::optional<at::Tensor>& cumulative_sequence_length_q,
+    const std::optional<at::Tensor>& cumulative_sequence_length_k,
+    int64_t max_seqlen_batch_q,
+    int64_t max_seqlen_batch_k,
+    double dropout_p,
+    bool is_causal,
+    bool return_debug_mask,
+    std::optional<double> scale,
+    std::optional<int64_t> window_size_left,
+    std::optional<int64_t> window_size_right,
+    const std::optional<at::Tensor>& _seqused_k,
+    const std::optional<at::Tensor>& _alibi_slopes,
+    const std::optional<at::Tensor>& _block_table,
+    std::optional<at::Tensor> out,
+    std::optional<int64_t> num_splits);
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> _flash_attention_backward(
+    const at::Tensor& grad_out,
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& out,
+    const at::Tensor& logsumexp,
+    const at::Tensor& cumulative_sequence_length_q,
+    const at::Tensor& cumulative_sequence_length_k,
+    int64_t max_seqlen_batch_q,
+    int64_t max_seqlen_batch_k,
+    double dropout_p,
+    bool is_causal,
+    const at::Tensor& philox_seed,
+    const at::Tensor& philox_offset,
+    std::optional<double> scale,
+    std::optional<int64_t> window_size_left,
+    std::optional<int64_t> window_size_right);
+
+// Deprecated: Use _flash_attention_forward instead.
 std::tuple<
     at::Tensor,
     at::Tensor,
@@ -33,6 +75,7 @@ flash_attention_forward(
     const bool is_causal,
     const float scale);
 
+// Deprecated: Use _flash_attention_backward instead.
 std::tuple<at::Tensor, at::Tensor, at::Tensor> flash_attention_backward(
     const at::Tensor& grad_out,
     const at::Tensor& query,

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/flash_api.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/flash_api.h
@@ -19,6 +19,58 @@ std::tuple<
     at::Tensor,
     at::Tensor,
     at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor>
+mha_fwd(
+    const at::Tensor& q, // batch_size x seqlen_q x num_heads x head_size
+    const at::Tensor& k, // batch_size x seqlen_k x num_heads_k x head_size
+    const at::Tensor& v, // batch_size x seqlen_k x num_heads_k x head_size
+    std::optional<at::Tensor>&
+        out_, // batch_size x seqlen_q x num_heads x head_size
+    std::optional<at::Tensor>&
+        alibi_slopes_, // num_heads or batch_size x num_heads
+    const float p_dropout,
+    const float softmax_scale,
+    bool is_causal,
+    int window_size_left,
+    int window_size_right,
+    const float softcap,
+    const bool return_softmax,
+    std::optional<at::Generator> gen_);
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_bwd(
+    const at::Tensor& dout, // batch_size x seqlen_q x num_heads, x head_size_og
+    const at::Tensor& q, // batch_size x seqlen_q x num_heads x head_size
+    const at::Tensor& k, // batch_size x seqlen_k x num_heads_k x head_size
+    const at::Tensor& v, // batch_size x seqlen_k x num_heads_k x head_size
+    const at::Tensor& out, // batch_size x seqlen_q x num_heads x head_size
+    const at::Tensor& softmax_lse, // b x h x seqlen_q
+    std::optional<at::Tensor>&
+        dq_, // batch_size x seqlen_q x num_heads x head_size
+    std::optional<at::Tensor>&
+        dk_, // batch_size x seqlen_k x num_heads_k x head_size
+    std::optional<at::Tensor>&
+        dv_, // batch_size x seqlen_k x num_heads_k x head_size
+    std::optional<at::Tensor>&
+        alibi_slopes_, // num_heads or batch_size x num_heads
+    const float p_dropout, // probability to drop
+    const float softmax_scale,
+    const bool is_causal,
+    int window_size_left,
+    int window_size_right,
+    const float softcap,
+    const bool deterministic,
+    const at::Tensor philox_seed,
+    const at::Tensor philox_offset);
+
+// Deprecated: Use mha_fwd instead.
+std::tuple<
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
     c10::SymInt,
     c10::SymInt,
     at::Tensor,
@@ -31,6 +83,7 @@ flash_attention_forward_sycltla(
     const bool is_causal,
     const float scale);
 
+// Deprecated: Use mha_bwd instead.
 std::tuple<at::Tensor, at::Tensor, at::Tensor> flash_attention_backward_sycltla(
     const at::Tensor& grad_out,
     const at::Tensor& query,

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.cpp
@@ -8,10 +8,8 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include <ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h>
-#include <ATen/native/transformers/xpu/flash_attn/sycltla/mha_common.h>
-// batch, numhead_qo,numhead_kv,seqlen_qo,seqlen_kv,headsize_qk,headsize_vo
-using ProblemShapeRegular = cute::tuple<int, int, int, int, int, int, int>;
+#include <sycltla/mha_bwd.h>
+#include <sycltla/mha_common.h>
 
 namespace cute {
 
@@ -1187,108 +1185,41 @@ void run_mha_bwd(sycl::queue& queue, FLASH_BWD_params& params) {
 
 namespace sycltla {
 
-std::tuple<at::Tensor, at::Tensor, at::Tensor> flash_attention_backward_sycltla(
-    const at::Tensor& grad_out,
-    const at::Tensor& query,
-    const at::Tensor& key,
-    const at::Tensor& value,
-    const at::Tensor& out,
-    const at::Tensor& logsumexp,
-    const at::Tensor& cumulative_sequence_length_q,
-    const at::Tensor& cumulative_sequence_length_k,
-    const int64_t max_seqlen_batch_q,
-    const int64_t max_seqlen_batch_k,
-    const double dropout,
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_bwd(
+    const at::Tensor& dout, // batch_size x seqlen_q x num_heads, x head_size_og
+    const at::Tensor& q, // batch_size x seqlen_q x num_heads x head_size
+    const at::Tensor& k, // batch_size x seqlen_k x num_heads_k x head_size
+    const at::Tensor& v, // batch_size x seqlen_k x num_heads_k x head_size
+    const at::Tensor& out, // batch_size x seqlen_q x num_heads x head_size
+    const at::Tensor& softmax_lse, // b x h x seqlen_q
+    std::optional<at::Tensor>&
+        dq_, // batch_size x seqlen_q x num_heads x head_size
+    std::optional<at::Tensor>&
+        dk_, // batch_size x seqlen_k x num_heads_k x head_size
+    std::optional<at::Tensor>&
+        dv_, // batch_size x seqlen_k x num_heads_k x head_size
+    std::optional<at::Tensor>&
+        alibi_slopes_, // num_heads or batch_size x num_heads
+    const float p_dropout, // probability to drop
+    const float softmax_scale,
     const bool is_causal,
-    const at::Tensor& philox_seed,
-    const at::Tensor& philox_offset,
-    const float scale) {
+    int window_size_left,
+    int window_size_right,
+    const float softcap,
+    const bool deterministic,
+    const at::Tensor philox_seed,
+    const at::Tensor philox_offset) {
   TORCH_CHECK(
-      dropout == 0.0,
-      "FlashAttentionBackwardXPU does not only support dropout > 0.0 yet");
-
-  at::Tensor contiguous_grad_out = grad_out.contiguous();
-
-  CHECK_DEVICE(query);
-  CHECK_DEVICE(key);
-  CHECK_DEVICE(value);
-  CHECK_DEVICE(out);
-  CHECK_DEVICE(contiguous_grad_out);
-  CHECK_DEVICE(logsumexp);
-
+      p_dropout == 0.0, "mha_bwd on xpu does not support dropout > 0.0 yet");
   TORCH_CHECK(
-      !query.is_nested() && !key.is_nested() && !value.is_nested() &&
-          !out.is_nested() && !grad_out.is_nested() && !logsumexp.is_nested(),
-      "FlashAttentionBackwardXPU only support dense inputs");
-
-  auto dtype = query.scalar_type();
+      !alibi_slopes_.has_value(),
+      "mha_bwd on xpu does not support alibi slopes yet");
   TORCH_CHECK(
-      dtype == at::kHalf || dtype == at::kBFloat16,
-      "FlashAttentionBackwardXPU only support fp16 and bf16 data type");
+      window_size_left == -1 && window_size_right == -1,
+      "mha_bwd on xpu does not support windowed attention yet");
+  TORCH_CHECK(softcap == 0.0, "mha_bwd on xpu does not support softcap yet");
   TORCH_CHECK(
-      logsumexp.scalar_type() == at::kFloat,
-      "FlashAttentionBackwardXPU: logsumexp must have the dtype float32");
-  TORCH_CHECK(
-      key.scalar_type() == dtype,
-      "FlashAttentionBackwardXPU: query and key must have the same dtype");
-  TORCH_CHECK(
-      value.scalar_type() == dtype,
-      "FlashAttentionBackwardXPU: query and value must have the same dtype");
-  TORCH_CHECK(
-      out.scalar_type() == dtype,
-      "FlashAttentionBackwardXPU: query and out must have the same dtype");
-  TORCH_CHECK(
-      contiguous_grad_out.scalar_type() == dtype,
-      "FlashAttentionBackwardXPU: query and grad_out must have the same dtype");
-
-  TORCH_CHECK(
-      query.dim() == 4 && key.dim() == 4 && value.dim() == 4 &&
-          out.dim() == 4 && contiguous_grad_out.dim() == 4 &&
-          logsumexp.dim() == 3,
-      "FlashAttentionBackwardXPU requires query, key, value, out, grad_out to be 4 dimensional and logsumexp to be 3 dimensional");
-
-  const int batch_size = query.sizes()[0];
-  const int numhead_qo = query.sizes()[1];
-  const int numhead_kv = key.sizes()[1];
-  const int seqlen_qo = query.sizes()[2];
-  const int seqlen_kv = key.sizes()[2];
-  const int headsize_qk = query.sizes()[3];
-  const int headsize_vo = value.sizes()[3];
-  CHECK_SHAPE(query, batch_size, numhead_qo, seqlen_qo, headsize_qk);
-  CHECK_SHAPE(key, batch_size, numhead_kv, seqlen_kv, headsize_qk);
-  CHECK_SHAPE(value, batch_size, numhead_kv, seqlen_kv, headsize_vo);
-  CHECK_SHAPE(out, batch_size, numhead_qo, seqlen_qo, headsize_vo);
-  CHECK_SHAPE(
-      contiguous_grad_out, batch_size, numhead_qo, seqlen_qo, headsize_vo);
-  CHECK_SHAPE(logsumexp, batch_size, numhead_qo, seqlen_qo);
-  TORCH_CHECK(
-      numhead_qo % numhead_kv == 0,
-      "FlashAttentionBackwardXPU: number of heads in key/value must divide number of heads in query");
-  TORCH_CHECK(
-      headsize_qk == headsize_vo,
-      "FlashAttentionBackwardXPU: headsize_qk must be equal to headsize_vo");
-
-  TORCH_CHECK(
-      query.stride(-1) == 1,
-      "FlashAttentionBackwardXPU: input tensor must have contiguous last dimension");
-  TORCH_CHECK(
-      key.stride(-1) == 1,
-      "FlashAttentionBackwardXPU: input tensor must have contiguous last dimension");
-  TORCH_CHECK(
-      value.stride(-1) == 1,
-      "FlashAttentionBackwardXPU: input tensor must have contiguous last dimension");
-  TORCH_CHECK(
-      out.stride(-1) == 1,
-      "FlashAttentionBackwardXPU: out tensor must have contiguous last dimension");
-  TORCH_CHECK(
-      contiguous_grad_out.stride(-1) == 1,
-      "FlashAttentionBackwardXPU: dout tensor must have contiguous last dimension");
-  TORCH_CHECK(
-      logsumexp.stride(-1) == 1,
-      "FlashAttentionBackwardXPU: logsumexp tensor must have contiguous last dimension");
-  TORCH_CHECK(
-      logsumexp.is_contiguous(),
-      "FlashAttentionBackwardXPU: logsumexp must be contiguous in [batch_size, numhead_qo, seqlen_qo]");
+      !deterministic, "mha_bwd on xpu does not support deterministic mode yet");
 
   auto sycl_queue = at::xpu::getCurrentXPUStream().queue();
   auto device_architecture =
@@ -1310,21 +1241,171 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> flash_attention_backward_sycltla(
         "XPU device architecture does not support flash attention backward. Supported architectures are: intel_gpu_pvc, intel_gpu_pvc_vg, intel_gpu_bmg_g21, intel_gpu_bmg_g31.");
   }
 
-  auto grad_query = at::empty_like(query);
-  auto grad_key = at::empty_like(key);
-  auto grad_value = at::empty_like(value);
+  TORCH_CHECK(
+      !q.is_nested() && !k.is_nested() && !v.is_nested() && !out.is_nested() &&
+          !dout.is_nested() && !softmax_lse.is_nested(),
+      "mha_bwd on xpu only support dense inputs");
 
-  auto opts = query.options();
+  auto dtype = q.scalar_type();
+  TORCH_CHECK(
+      dtype == at::kHalf || dtype == at::kBFloat16,
+      "mha_bwd on xpu only support fp16 and bf16 data type");
+  TORCH_CHECK(
+      softmax_lse.scalar_type() == at::kFloat,
+      "mha_bwd on xpu: logsumexp must have the dtype float32");
+  TORCH_CHECK(
+      k.scalar_type() == dtype,
+      "mha_bwd on xpu: query and key must have the same dtype");
+  TORCH_CHECK(
+      v.scalar_type() == dtype,
+      "mha_bwd on xpu: query and value must have the same dtype");
+  TORCH_CHECK(
+      out.scalar_type() == dtype,
+      "mha_bwd on xpu: query and out must have the same dtype");
+  TORCH_CHECK(
+      dout.scalar_type() == dtype,
+      "mha_bwd on xpu: query and grad_out must have the same dtype");
 
-  at::Tensor grad_key_expanded, grad_value_expanded;
-  if (numhead_kv != numhead_qo) { // MQA / GQA
-    grad_key_expanded =
-        at::empty({batch_size, numhead_qo, seqlen_kv, headsize_qk}, opts);
-    grad_value_expanded =
-        at::empty({batch_size, numhead_qo, seqlen_kv, headsize_vo}, opts);
+  TORCH_CHECK(
+      q.dim() == 4 && k.dim() == 4 && v.dim() == 4 && out.dim() == 4 &&
+          dout.dim() == 4 && softmax_lse.dim() == 3,
+      "mha_bwd on xpu requires query, key, value, out, grad_out to be 4 dimensional and logsumexp to be 3 dimensional");
+
+  CHECK_DEVICE(q);
+  CHECK_DEVICE(k);
+  CHECK_DEVICE(v);
+  CHECK_DEVICE(out);
+  CHECK_DEVICE(dout);
+  CHECK_DEVICE(softmax_lse);
+
+  TORCH_CHECK(
+      q.stride(-1) == 1,
+      "mha_bwd on xpu: input tensor must have contiguous last dimension");
+  TORCH_CHECK(
+      k.stride(-1) == 1,
+      "mha_bwd on xpu: input tensor must have contiguous last dimension");
+  TORCH_CHECK(
+      v.stride(-1) == 1,
+      "mha_bwd on xpu: input tensor must have contiguous last dimension");
+  TORCH_CHECK(
+      out.stride(-1) == 1,
+      "mha_bwd on xpu: out tensor must have contiguous last dimension");
+  TORCH_CHECK(
+      dout.stride(-1) == 1,
+      "mha_bwd on xpu: dout tensor must have contiguous last dimension");
+  TORCH_CHECK(
+      softmax_lse.stride(-1) == 1,
+      "mha_bwd on xpu: softmax_lse tensor must have contiguous last dimension");
+  TORCH_CHECK(
+      softmax_lse.is_contiguous(),
+      "mha_bwd on xpu: softmax_lse must be contiguous in [batch_size, numhead_qo, seqlen_qo]");
+
+  const int batch_size = q.sizes()[0];
+  const int seqlen_qo = q.sizes()[1];
+  const int seqlen_kv = k.sizes()[1];
+  const int numhead_qo = q.sizes()[2];
+  const int numhead_kv = k.sizes()[2];
+  const int headsize_qk = q.sizes()[3];
+  const int headsize_vo = v.sizes()[3];
+
+  TORCH_CHECK(
+      headsize_qk == headsize_vo,
+      "mha_bwd on xpu: headsize_qk must be equal to headsize_vo");
+
+  if (batch_size == 0) {
+    auto opts = q.options();
+    at::Tensor dq = at::empty_like(q);
+    at::Tensor dk = at::empty_like(k);
+    at::Tensor dv = at::empty_like(v);
+    at::Tensor softmax_d =
+        at::empty({0, numhead_qo, seqlen_qo}, opts.dtype(at::kFloat));
+    return {dq, dk, dv, softmax_d};
+  }
+  TORCH_CHECK(batch_size > 0, "mha_bwd on xpu: batch size must be positive");
+  TORCH_CHECK(
+      headsize_qk <= 192,
+      "mha_bwd on xpu: only supports head dimension at most 192");
+  TORCH_CHECK(
+      numhead_qo % numhead_kv == 0,
+      "mha_bwd on xpu: number of heads in key/value must divide number of heads in query");
+
+  CHECK_SHAPE(q, batch_size, seqlen_qo, numhead_qo, headsize_qk);
+  CHECK_SHAPE(k, batch_size, seqlen_kv, numhead_kv, headsize_qk);
+  CHECK_SHAPE(v, batch_size, seqlen_kv, numhead_kv, headsize_vo);
+  CHECK_SHAPE(out, batch_size, seqlen_qo, numhead_qo, headsize_vo);
+  CHECK_SHAPE(dout, batch_size, seqlen_qo, numhead_qo, headsize_vo);
+  CHECK_SHAPE(softmax_lse, batch_size, numhead_qo, seqlen_qo);
+
+  at::Tensor dq, dk, dv;
+  if (dq_.has_value()) {
+    dq = dq_.value();
+    TORCH_CHECK(dq.dtype() == dtype, "dq must have the same dtype as q");
+    CHECK_DEVICE(dq);
+    TORCH_CHECK(dq.stride(-1) == 1, "dq must have contiguous last dimension");
+    CHECK_SHAPE(dq, batch_size, seqlen_qo, numhead_qo, headsize_qk);
   } else {
-    grad_key_expanded = grad_key;
-    grad_value_expanded = grad_value;
+    dq = at::empty_like(q);
+  }
+  if (dk_.has_value()) {
+    dk = dk_.value();
+    TORCH_CHECK(dk.dtype() == dtype, "dk must have the same dtype as q");
+    CHECK_DEVICE(dk);
+    TORCH_CHECK(dk.stride(-1) == 1, "dk must have contiguous last dimension");
+    CHECK_SHAPE(dk, batch_size, seqlen_kv, numhead_kv, headsize_qk);
+  } else {
+    dk = at::empty_like(k);
+  }
+  if (dv_.has_value()) {
+    dv = dv_.value();
+    TORCH_CHECK(dv.dtype() == dtype, "dv must have the same dtype as q");
+    CHECK_DEVICE(dv);
+    TORCH_CHECK(dv.stride(-1) == 1, "dv must have contiguous last dimension");
+    CHECK_SHAPE(dv, batch_size, seqlen_kv, numhead_kv, headsize_vo);
+  } else {
+    dv = at::empty_like(v);
+  }
+
+  auto softmax_d = at::empty({0}, q.options().dtype(at::kFloat));
+
+  const int headsize_padded = headsize_qk;
+  const bool needs_headsize_pad = headsize_padded > headsize_qk;
+
+  at::Tensor q_padded = q;
+  at::Tensor k_padded = k;
+  at::Tensor v_padded = v;
+  at::Tensor out_padded = out;
+  at::Tensor dout_padded = dout;
+  if (needs_headsize_pad) {
+    int pad = headsize_padded - headsize_qk;
+    q_padded = at::constant_pad_nd(q, {0, pad}, 0);
+    k_padded = at::constant_pad_nd(k, {0, pad}, 0);
+    v_padded = at::constant_pad_nd(v, {0, pad}, 0);
+    out_padded = at::constant_pad_nd(out, {0, pad}, 0);
+    dout_padded = at::constant_pad_nd(dout, {0, pad}, 0);
+  }
+
+  auto opts = q.options();
+  // Allocate padded buffers for the kernel when headsize padding is needed.
+  auto dq_padded = needs_headsize_pad
+      ? at::empty({batch_size, seqlen_qo, numhead_qo, headsize_padded}, opts)
+      : dq;
+  auto dk_padded = needs_headsize_pad
+      ? at::empty({batch_size, seqlen_kv, numhead_kv, headsize_padded}, opts)
+      : dk;
+  auto dv_padded = needs_headsize_pad
+      ? at::empty({batch_size, seqlen_kv, numhead_kv, headsize_padded}, opts)
+      : dv;
+
+  const bool is_gqa = (numhead_kv != numhead_qo);
+  at::Tensor dk_expanded, dv_expanded;
+  if (is_gqa) {
+    dk_expanded =
+        at::empty({batch_size, seqlen_kv, numhead_qo, headsize_padded}, opts);
+    dv_expanded =
+        at::empty({batch_size, seqlen_kv, numhead_qo, headsize_padded}, opts);
+  } else {
+    dk_expanded = dk_padded;
+    dv_expanded = dv_padded;
   }
 
   constexpr int kMPad = 128;
@@ -1334,10 +1415,10 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> flash_attention_backward_sycltla(
   auto tensor_odo =
       at::empty({batch_size, numhead_qo, seqlen_qo}, opts.dtype(at::kFloat));
   auto tensor_dqaccum = at::zeros(
-      {batch_size, numhead_qo, seqlen_qo_pad, headsize_qk},
+      {batch_size, numhead_qo, seqlen_qo_pad, headsize_padded},
       opts.dtype(at::kFloat));
   auto tensor_pbuff =
-      at::empty({batch_size, numhead_qo, seqlen_kv_pad, 2 * kMPad}, opts);
+      at::empty({batch_size, numhead_qo, seqlen_kv_pad, 2 * kNPad}, opts);
 
   FLASH_BWD_params params;
   set_params_dgrad(
@@ -1347,51 +1428,144 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> flash_attention_backward_sycltla(
       numhead_kv,
       seqlen_qo,
       seqlen_kv,
-      headsize_qk,
-      headsize_vo,
+      headsize_padded,
+      headsize_padded,
       seqlen_qo_pad,
       seqlen_kv_pad,
-      query,
-      key,
-      value,
-      out,
-      contiguous_grad_out,
-      logsumexp,
-      grad_query,
-      grad_key_expanded,
-      grad_value_expanded,
+      q_padded,
+      k_padded,
+      v_padded,
+      out_padded,
+      dout_padded,
+      softmax_lse,
+      dq_padded,
+      dk_expanded,
+      dv_expanded,
       tensor_odo,
       tensor_dqaccum,
       tensor_pbuff,
-      scale,
+      softmax_scale,
       is_causal);
 
-  cute::run_mha_bwd<kMPad, kNPad>(sycl_queue, params);
+  if (seqlen_qo > 0) {
+    cute::run_mha_bwd<kMPad, kNPad>(sycl_queue, params);
+  } else {
+    dk_expanded.zero_();
+    dv_expanded.zero_();
+  }
 
-  if (numhead_kv != numhead_qo) {
-    at::sum_out(
-        grad_key,
-        at::reshape(
-            grad_key_expanded,
-            {batch_size,
-             numhead_kv,
-             numhead_qo / numhead_kv,
-             seqlen_kv,
-             headsize_qk}),
-        {2});
-    at::sum_out(
-        grad_value,
-        at::reshape(
-            grad_value_expanded,
-            {batch_size,
-             numhead_kv,
-             numhead_qo / numhead_kv,
-             seqlen_kv,
-             headsize_vo}),
-        {2});
+  if (is_gqa) {
+    if (needs_headsize_pad) {
+      auto dk_reduced =
+          at::empty({batch_size, seqlen_kv, numhead_kv, headsize_padded}, opts);
+      auto dv_reduced =
+          at::empty({batch_size, seqlen_kv, numhead_kv, headsize_padded}, opts);
+      at::sum_out(
+          dk_reduced,
+          at::reshape(
+              dk_expanded,
+              {batch_size,
+               seqlen_kv,
+               numhead_kv,
+               numhead_qo / numhead_kv,
+               headsize_padded}),
+          {3});
+      at::sum_out(
+          dv_reduced,
+          at::reshape(
+              dv_expanded,
+              {batch_size,
+               seqlen_kv,
+               numhead_kv,
+               numhead_qo / numhead_kv,
+               headsize_padded}),
+          {3});
+      dk_padded = dk_reduced;
+      dv_padded = dv_reduced;
+    } else {
+      at::sum_out(
+          dk,
+          at::reshape(
+              dk_expanded,
+              {batch_size,
+               seqlen_kv,
+               numhead_kv,
+               numhead_qo / numhead_kv,
+               headsize_padded}),
+          {3});
+      at::sum_out(
+          dv,
+          at::reshape(
+              dv_expanded,
+              {batch_size,
+               seqlen_kv,
+               numhead_kv,
+               numhead_qo / numhead_kv,
+               headsize_padded}),
+          {3});
+    }
+  }
+
+  if (needs_headsize_pad) {
+    dq.copy_(dq_padded.slice(/*dim=*/3, /*start=*/0, /*end=*/headsize_qk));
+    dk.copy_(dk_padded.slice(/*dim=*/3, /*start=*/0, /*end=*/headsize_qk));
+    dv.copy_(dv_padded.slice(/*dim=*/3, /*start=*/0, /*end=*/headsize_vo));
   }
 
   return std::make_tuple(
-      std::move(grad_query), std::move(grad_key), std::move(grad_value));
+      std::move(dq), std::move(dk), std::move(dv), std::move(softmax_d));
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> flash_attention_backward_sycltla(
+    const at::Tensor& grad_out,
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& out,
+    const at::Tensor& logsumexp,
+    const at::Tensor& cumulative_sequence_length_q,
+    const at::Tensor& cumulative_sequence_length_k,
+    const int64_t max_seqlen_batch_q,
+    const int64_t max_seqlen_batch_k,
+    const double dropout,
+    const bool is_causal,
+    const at::Tensor& philox_seed,
+    const at::Tensor& philox_offset,
+    const float scale) {
+  at::Tensor q_t = query.transpose(1, 2);
+  at::Tensor k_t = key.transpose(1, 2);
+  at::Tensor v_t = value.transpose(1, 2);
+
+  at::Tensor grad_out_t = grad_out.transpose(1, 2);
+  at::Tensor out_t = out.transpose(1, 2);
+
+  std::optional<at::Tensor> dq = std::nullopt, dk = std::nullopt,
+                            dv = std::nullopt, alibi_slopes = std::nullopt;
+  auto [grad_q, grad_k, grad_v, softmax_d] = mha_bwd(
+      grad_out_t,
+      q_t,
+      k_t,
+      v_t,
+      out_t,
+      logsumexp,
+      dq,
+      dk,
+      dv,
+      alibi_slopes,
+      dropout,
+      scale,
+      is_causal,
+      -1,
+      -1,
+      0.0,
+      false,
+      philox_seed,
+      philox_offset);
+
+  grad_q = grad_q.transpose(1, 2);
+  grad_k = grad_k.transpose(1, 2);
+  grad_v = grad_v.transpose(1, 2);
+
+  return std::make_tuple(grad_q, grad_k, grad_v);
 }
 } // namespace sycltla

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_common.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_common.h
@@ -173,14 +173,14 @@ void set_params_fprop(
   params.k_batch_stride = k.stride(0);
   params.v_batch_stride = v.stride(0);
   params.o_batch_stride = out.stride(0);
-  params.q_head_stride = q.stride(1);
-  params.k_head_stride = k.stride(1);
-  params.v_head_stride = v.stride(1);
-  params.o_head_stride = out.stride(1);
-  params.q_row_stride = q.stride(2);
-  params.k_row_stride = k.stride(2);
-  params.v_row_stride = v.stride(2);
-  params.o_row_stride = out.stride(2);
+  params.q_head_stride = q.stride(2);
+  params.k_head_stride = k.stride(2);
+  params.v_head_stride = v.stride(2);
+  params.o_head_stride = out.stride(2);
+  params.q_row_stride = q.stride(1);
+  params.k_row_stride = k.stride(1);
+  params.v_row_stride = v.stride(1);
+  params.o_row_stride = out.stride(1);
 
   // Set the dimensions.
   params.batch_size = batch_size;
@@ -260,12 +260,12 @@ void set_params_dgrad(
   params.dq_batch_stride = dq.stride(0);
   params.dk_batch_stride = dk.stride(0);
   params.dv_batch_stride = dv.stride(0);
-  params.do_head_stride = grad_out.stride(1);
-  params.dq_head_stride = dq.stride(1);
-  params.dk_head_stride = dk.stride(1);
-  params.dv_head_stride = dv.stride(1);
-  params.do_row_stride = grad_out.stride(2);
-  params.dq_row_stride = dq.stride(2);
-  params.dk_row_stride = dk.stride(2);
-  params.dv_row_stride = dv.stride(2);
+  params.do_head_stride = grad_out.stride(2);
+  params.dq_head_stride = dq.stride(2);
+  params.dk_head_stride = dk.stride(2);
+  params.dv_head_stride = dv.stride(2);
+  params.do_row_stride = grad_out.stride(1);
+  params.dq_row_stride = dq.stride(1);
+  params.dk_row_stride = dk.stride(1);
+  params.dv_row_stride = dv.stride(1);
 }

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.cpp
@@ -366,82 +366,41 @@ std::tuple<
     at::Tensor,
     at::Tensor,
     at::Tensor,
-    c10::SymInt,
-    c10::SymInt,
+    at::Tensor,
+    at::Tensor,
     at::Tensor,
     at::Tensor>
-flash_attention_forward_sycltla(
-    const at::Tensor& query,
-    const at::Tensor& key,
-    const at::Tensor& value,
-    const double dropout,
-    const bool is_causal,
-    const float scale) {
+mha_fwd(
+    const at::Tensor& q, // batch_size x seqlen_q x num_heads x head_size
+    const at::Tensor& k, // batch_size x seqlen_k x num_heads_k x head_size
+    const at::Tensor& v, // batch_size x seqlen_k x num_heads_k x head_size
+    std::optional<at::Tensor>&
+        out_, // batch_size x seqlen_q x num_heads x head_size
+    std::optional<at::Tensor>&
+        alibi_slopes_, // num_heads or batch_size x num_heads
+    const float p_dropout,
+    const float softmax_scale,
+    bool is_causal,
+    int window_size_left,
+    int window_size_right,
+    const float softcap,
+    const bool return_softmax,
+    std::optional<at::Generator> gen_) {
   TORCH_CHECK(
-      dropout == 0.0,
-      "FlashAttentionForwardXPU does not only support dropout > 0.0 yet");
-
-  CHECK_DEVICE(query);
-  CHECK_DEVICE(key);
-  CHECK_DEVICE(value);
-
+      p_dropout == 0.0, "mha_fwd on xpu does not support p_dropout > 0.0 yet");
   TORCH_CHECK(
-      !query.is_nested() && !key.is_nested() && !value.is_nested(),
-      "FlashAttentionForwardXPU only support dense inputs");
-
-  auto dtype = query.scalar_type();
+      alibi_slopes_.has_value() == false,
+      "mha_fwd on xpu does not support alibi_slopes yet");
   TORCH_CHECK(
-      dtype == at::kHalf || dtype == at::kBFloat16,
-      "FlashAttentionForwardXPU only support fp16 and bf16 data type");
+      window_size_left == -1 && window_size_right == -1,
+      "mha_fwd on xpu does not support window_size yet");
+  TORCH_CHECK(softcap == 0.0, "mha_fwd on xpu does not support softcap yet");
   TORCH_CHECK(
-      key.scalar_type() == dtype,
-      "FlashAttentionForwardXPU: query and key must have the same dtype");
+      return_softmax == false,
+      "mha_fwd on xpu does not support return_softmax yet");
   TORCH_CHECK(
-      value.scalar_type() == dtype,
-      "FlashAttentionForwardXPU: query and value must have the same dtype");
-
-  TORCH_CHECK(
-      query.dim() == 4 && key.dim() == 4 && value.dim() == 4,
-      "FlashAttentionForwardXPU requires query, key, value to be 4 dimensional");
-
-  const int batch_size = query.sizes()[0];
-  const int numhead_qo = query.sizes()[1];
-  const int numhead_kv = key.sizes()[1];
-  const int seqlen_qo = query.sizes()[2];
-  const int seqlen_kv = key.sizes()[2];
-  const int headsize_qk = query.sizes()[3];
-  const int headsize_vo = value.sizes()[3];
-
-  CHECK_SHAPE(query, batch_size, numhead_qo, seqlen_qo, headsize_qk);
-  CHECK_SHAPE(key, batch_size, numhead_kv, seqlen_kv, headsize_qk);
-  CHECK_SHAPE(value, batch_size, numhead_kv, seqlen_kv, headsize_vo);
-
-  TORCH_CHECK(
-      numhead_qo % numhead_kv == 0,
-      "FlashAttentionForwardXPU: numhead_qo must be divisible by numhead_kv");
-
-  TORCH_CHECK(
-      query.stride(-1) == 1,
-      "FlashAttentionForwardXPU: input tensor must have contiguous last dimension");
-  TORCH_CHECK(
-      key.stride(-1) == 1,
-      "FlashAttentionForwardXPU: input tensor must have contiguous last dimension");
-  TORCH_CHECK(
-      value.stride(-1) == 1,
-      "FlashAttentionForwardXPU: input tensor must have contiguous last dimension");
-
-  auto opts = query.options();
-  at::Tensor out = at::empty_like(query);
-
-  if (seqlen_qo > seqlen_kv && is_causal) {
-    // When seqlen_qo is greater than seqlen_kv and is_causal(lower_right causal
-    // mask) is true, some output positions will skip computation for better
-    // performance.
-    out.zero_();
-  }
-
-  at::Tensor logsumexp =
-      at::empty({batch_size, numhead_qo, seqlen_qo}, opts.dtype(at::kFloat));
+      !gen_.has_value(),
+      "mha_fwd on xpu does not support custom generator yet");
 
   auto sycl_queue = at::xpu::getCurrentXPUStream().queue();
   auto device_architecture =
@@ -463,6 +422,133 @@ flash_attention_forward_sycltla(
         "XPU device architecture does not support flash attention. Supported architectures are: intel_gpu_pvc, intel_gpu_pvc_vg, intel_gpu_bmg_g21, intel_gpu_bmg_g31.");
   }
 
+  TORCH_CHECK(
+      !q.is_nested() && !k.is_nested() && !v.is_nested(),
+      "mha_fwd on xpu only supports dense inputs");
+
+  auto dtype = q.scalar_type();
+  TORCH_CHECK(
+      dtype == at::kHalf || dtype == at::kBFloat16,
+      "mha_fwd on xpu only support fp16 and bf16 data type");
+  TORCH_CHECK(
+      k.scalar_type() == dtype,
+      "mha_fwd on xpu: query and key must have the same dtype");
+  TORCH_CHECK(
+      v.scalar_type() == dtype,
+      "mha_fwd on xpu: query and value must have the same dtype");
+
+  CHECK_DEVICE(q);
+  CHECK_DEVICE(k);
+  CHECK_DEVICE(v);
+
+  TORCH_CHECK(
+      q.stride(-1) == 1,
+      "mha_fwd on xpu: input tensor must have contiguous last dimension");
+  TORCH_CHECK(
+      k.stride(-1) == 1,
+      "mha_fwd on xpu: input tensor must have contiguous last dimension");
+  TORCH_CHECK(
+      v.stride(-1) == 1,
+      "mha_fwd on xpu: input tensor must have contiguous last dimension");
+
+  TORCH_CHECK(
+      q.dim() == 4 && k.dim() == 4 && v.dim() == 4,
+      "mha_fwd on xpu requires query, key, value to be 4 dimensional");
+
+  const int batch_size = q.sizes()[0];
+  const int seqlen_qo = q.sizes()[1];
+  const int seqlen_kv = k.sizes()[1];
+  const int numhead_qo = q.sizes()[2];
+  const int numhead_kv = k.sizes()[2];
+  const int headsize_qk = q.sizes()[3];
+  const int headsize_vo = v.sizes()[3];
+
+  CHECK_SHAPE(q, batch_size, seqlen_qo, numhead_qo, headsize_qk);
+  CHECK_SHAPE(k, batch_size, seqlen_kv, numhead_kv, headsize_qk);
+  CHECK_SHAPE(v, batch_size, seqlen_kv, numhead_kv, headsize_vo);
+
+  if (batch_size == 0) {
+    auto opts = q.options();
+    at::Tensor out = at::empty({0, seqlen_qo, numhead_qo, headsize_qk}, opts);
+    at::Tensor q_padded =
+        at::empty({0, seqlen_qo, numhead_qo, headsize_qk}, opts);
+    at::Tensor k_padded =
+        at::empty({0, seqlen_kv, numhead_kv, headsize_qk}, opts);
+    at::Tensor v_padded =
+        at::empty({0, seqlen_kv, numhead_kv, headsize_vo}, opts);
+    at::Tensor softmax_lse =
+        at::empty({0, numhead_qo, seqlen_qo}, opts.dtype(at::kFloat));
+    at::Tensor philox_seed = at::empty({}, opts.dtype(at::kLong));
+    at::Tensor philox_offset = at::empty({}, opts.dtype(at::kLong));
+    at::Tensor p = at::empty({0}, opts);
+    if (return_softmax) {
+      p = at::empty({0, numhead_qo, seqlen_qo, seqlen_kv}, opts);
+    }
+    return {
+        std::move(out),
+        std::move(q_padded),
+        std::move(k_padded),
+        std::move(v_padded),
+        std::move(softmax_lse),
+        std::move(philox_seed),
+        std::move(philox_offset),
+        std::move(p)};
+  }
+  TORCH_CHECK(batch_size > 0, "mha_fwd on xpu: batch size must be positive");
+  TORCH_CHECK(
+      numhead_qo % numhead_kv == 0,
+      "mha_fwd on xpu: numhead_qo must be divisible by numhead_kv");
+  TORCH_CHECK(
+      headsize_vo == headsize_qk,
+      "mha_fwd on xpu: only support headsize_qk equal to headsize_vo");
+  TORCH_CHECK(
+      headsize_qk <= 192,
+      "mha_fwd on xpu: only support head dimension at most 192");
+
+  const int headsize_padded = headsize_qk;
+  const bool needs_headsize_pad = headsize_padded > headsize_qk;
+
+  at::Tensor q_padded = q;
+  at::Tensor k_padded = k;
+  at::Tensor v_padded = v;
+  if (needs_headsize_pad) {
+    int pad = headsize_padded - headsize_qk;
+    q_padded = at::constant_pad_nd(q, {0, pad}, 0);
+    k_padded = at::constant_pad_nd(k, {0, pad}, 0);
+    v_padded = at::constant_pad_nd(v, {0, pad}, 0);
+  }
+
+  auto opts = q.options();
+  at::Tensor out;
+  if (out_.has_value()) {
+    out = out_.value();
+    TORCH_CHECK(
+        out.dtype() == dtype, "Output must have the same dtype as inputs");
+    CHECK_DEVICE(out);
+    TORCH_CHECK(
+        out.stride(-1) == 1,
+        "Output tensor must have contiguous last dimension");
+    CHECK_SHAPE(out, batch_size, seqlen_qo, numhead_qo, headsize_vo);
+  } else {
+    out = at::empty_like(q);
+  }
+
+  at::Tensor out_padded = needs_headsize_pad
+      ? at::empty({batch_size, seqlen_qo, numhead_qo, headsize_padded}, opts)
+      : out;
+
+  if (seqlen_qo > seqlen_kv && is_causal) {
+    // When seqlen_qo is greater than seqlen_kv and is_causal(lower_right causal
+    // mask) is true, some output positions will skip computation for better
+    // performance.
+    out_padded.zero_();
+  }
+
+  at::Tensor logsumexp =
+      at::empty({batch_size, numhead_qo, seqlen_qo}, opts.dtype(at::kFloat));
+
+  at::Tensor p = at::empty({0}, opts);
+
   FLASH_FWD_params params;
   set_params_fprop(
       params,
@@ -471,37 +557,114 @@ flash_attention_forward_sycltla(
       numhead_kv,
       seqlen_qo,
       seqlen_kv,
-      headsize_qk,
-      headsize_vo,
+      headsize_padded,
+      headsize_padded,
       0, // unused seqlen_qo_pad
       0, // unused seqlen_kv_pad
-      query,
-      key,
-      value,
-      out,
+      q_padded,
+      k_padded,
+      v_padded,
+      out_padded,
       logsumexp,
-      scale,
+      softmax_scale,
       is_causal);
 
-  cute::run_mha_fwd(sycl_queue, params);
+  at::Tensor philox_seed =
+      at::empty({}, at::dtype(c10::kLong).device(at::kXPU));
+  at::Tensor philox_offset =
+      at::empty({}, at::dtype(c10::kLong).device(at::kXPU));
 
-  return std::tuple<
-      at::Tensor,
-      at::Tensor,
-      at::Tensor,
-      at::Tensor,
-      c10::SymInt,
-      c10::SymInt,
-      at::Tensor,
-      at::Tensor>{
-      out,
-      logsumexp,
+  if (seqlen_kv > 0) {
+    cute::run_mha_fwd(sycl_queue, params);
+  } else {
+    // If seqlen_k == 0, then we have an empty tensor. We need to set the output
+    // to 0.
+    out_padded.zero_();
+    logsumexp.fill_(-std::numeric_limits<float>::infinity());
+  }
+
+  if (needs_headsize_pad) {
+    out.copy_(out_padded.slice(/*dim=*/3, /*start=*/0, /*end=*/headsize_qk));
+  }
+
+  return {
+      std::move(out),
+      std::move(q_padded),
+      std::move(k_padded),
+      std::move(v_padded),
+      std::move(logsumexp),
+      std::move(philox_seed),
+      std::move(philox_offset),
+      std::move(p)};
+}
+
+std::tuple<
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    c10::SymInt,
+    c10::SymInt,
+    at::Tensor,
+    at::Tensor>
+flash_attention_forward_sycltla(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const double dropout,
+    const bool is_causal,
+    const float scale) {
+  // Query (Batch x Num_heads x Q_seq_len  x Dim_per_head)
+  // Key   (Batch x Num_heads x KV_seq_len x Dim_per_head)
+  // Value (Batch x Num_heads x KV_seq_len x Dim_per_head)
+  const int seqlen_qo = query.sizes()[2];
+  const int seqlen_kv = key.sizes()[2];
+
+  // Query -> Query(Batch x Q_seq_len  x Num_heads x Dim_per_head)
+  // Key   -> Key  (Batch x KV_seq_len x Num_heads x Dim_per_head)
+  // Value -> Value(Batch x KV_seq_len x Num_heads x Dim_per_head)
+  at::Tensor q_t = query.transpose(1, 2);
+  at::Tensor k_t = key.transpose(1, 2);
+  at::Tensor v_t = value.transpose(1, 2);
+
+  std::optional<at::Tensor> _out = std::nullopt;
+  std::optional<at::Tensor> _alibi_slopes = std::nullopt;
+
+  auto
+      [out,
+       q_padded,
+       k_padded,
+       v_padded,
+       logsumexp,
+       philox_seed,
+       philox_offset,
+       debug_attn_mask] =
+          mha_fwd(
+              q_t,
+              k_t,
+              v_t,
+              _out,
+              _alibi_slopes,
+              dropout,
+              scale,
+              is_causal,
+              -1,
+              -1,
+              0.0,
+              false,
+              std::nullopt);
+
+  // Reshape output to convert nnz to batch_size and seq_len
+  at::Tensor attention = out.transpose(1, 2);
+  return {
+      std::move(attention),
+      std::move(logsumexp),
       /* cumulative_sequence_length_q */ at::Tensor(),
       /* cumulative_sequence_length_k */ at::Tensor(),
       /* max_seqlen_batch_q */ c10::SymInt(seqlen_qo),
       /* max_seqlen_batch_k */ c10::SymInt(seqlen_kv),
-      /* philox_seed */ at::empty({}, at::dtype(at::kLong)),
-      /* philox_offset */ at::empty({}, at::dtype(at::kLong))};
+      std::move(philox_seed),
+      std::move(philox_offset)};
 }
 
 } // namespace sycltla

--- a/src/ATen/native/xpu/XPUFallback.template
+++ b/src/ATen/native/xpu/XPUFallback.template
@@ -230,7 +230,6 @@ TORCH_LIBRARY_IMPL(aten, XPU, m) {
     "cholesky_inverse.out",
     "_cholesky_solve_helper",
     "_efficient_attention_forward",
-    "_flash_attention_forward",
     "geqrf",
     "geqrf.a",
     "hash_tensor.out",


### PR DESCRIPTION
Fix https://github.com/intel/torch-xpu-ops/issues/2442 https://github.com/intel/torch-xpu-ops/issues/2853

`at::_flash_attention_forward` and `at::_flash_attention_backward` are two ops which is one-one mapping to Tridao's FlashAttention2 API.

`at::_scaled_dot_product_flash_attention` and `at::_scaled_dot_product_flash_attention_backward` are two ops of SDPA FlashAttention backend. They only support part of `at::_flash_attention_forward` and `at::_flash_attention_backward`'s functionality. 

`at::_scaled_dot_product_flash_attention` and `at::_scaled_dot_product_flash_attention_backward` will dispatch to  `at::_flash_attention_forward` and `at::_flash_attention_backward`.

This PR and https://github.com/pytorch/pytorch/pull/181559 enable `at::_flash_attention_forward` and `at::_flash_attention_backward`.