### PR TITLE
Add variable-length support for Flash Attention in XPU

### DIFF
--- a/src/ATen/native/transformers/xpu/flash_attn/flash_api.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/flash_api.cpp
@@ -73,39 +73,34 @@ _flash_attention_forward(
   at::Tensor output, q_padded, k_padded, v_padded, logsumexp, philox_seed,
       philox_offset, debug_attn_mask;
   if (cumulative_sequence_length_q.has_value()) {
-    // std::tie(
-    //     output,
-    //     q_padded,
-    //     k_padded,
-    //     v_padded,
-    //     logsumexp,
-    //     philox_seed,
-    //     philox_offset,
-    //     debug_attn_mask) =
-    //     FLASH_NAMESPACE::mha_varlen_fwd(
-    //         query,
-    //         key,
-    //         value,
-    //         out,
-    //         cumulative_sequence_length_q.value(),
-    //         cumulative_sequence_length_k.value(),
-    //         seqused_k, /*seqused_k*/
-    //         block_table, /*block_table*/
-    //         alibi_slopes, /*alibi_slopes*/
-    //         max_seqlen_batch_q,
-    //         max_seqlen_batch_k,
-    //         dropout_p,
-    //         softmax_scale,
-    //         false /*zero_tensors*/,
-    //         is_causal,
-    //         window_left,
-    //         window_right,
-    //         softcap,
-    //         return_debug_mask,
-    //         std::nullopt /*gen_*/);
-    TORCH_CHECK(
-        false,
-        "_flash_attention_forward: Varseqlen path is not implemented yet.");
+    const auto& cu_seqlens_q = cumulative_sequence_length_q.value();
+    const auto& cu_seqlens_k = cumulative_sequence_length_k.value();
+
+    auto [varlen_output, varlen_logsumexp] =
+        flash_attention_forward_varlen_sycltla(
+            query,
+            key,
+            value,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            max_seqlen_batch_q,
+            max_seqlen_batch_k,
+            dropout_p,
+            is_causal,
+            softmax_scale);
+
+    at::Tensor philox_seed_v =
+        at::empty({}, at::dtype(c10::kLong).device(at::kXPU));
+    at::Tensor philox_offset_v =
+        at::empty({}, at::dtype(c10::kLong).device(at::kXPU));
+    debug_attn_mask = return_debug_mask ? at::empty({0}, query.options())
+                                        : at::empty({0}, query.options());
+    return std::make_tuple(
+        std::move(varlen_output),
+        std::move(varlen_logsumexp),
+        std::move(philox_seed_v),
+        std::move(philox_offset_v),
+        std::move(debug_attn_mask));
   } else {
     std::tie(
         output,
@@ -353,6 +348,37 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> flash_attention_backward(
       scale);
   return std::make_tuple(
       std::move(grad_query), std::move(grad_key), std::move(grad_value));
+#endif
+}
+
+std::tuple<at::Tensor, at::Tensor> flash_attention_forward_varlen(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& cu_seqlens_q,
+    const at::Tensor& cu_seqlens_k,
+    const int64_t max_seqlen_q,
+    const int64_t max_seqlen_k,
+    const double dropout,
+    const bool is_causal,
+    const float scale) {
+#ifndef USE_SYCLTLA
+  TORCH_CHECK(
+      false,
+      "flash_attention_forward_varlen: Torch XPU was not compiled with SYCLTLA support.");
+  return std::make_tuple(at::Tensor(), at::Tensor());
+#else
+  return flash_attention_forward_varlen_sycltla(
+      query,
+      key,
+      value,
+      cu_seqlens_q,
+      cu_seqlens_k,
+      max_seqlen_q,
+      max_seqlen_k,
+      dropout,
+      is_causal,
+      scale);
 #endif
 }
 } // namespace sycltla

--- a/src/ATen/native/transformers/xpu/flash_attn/flash_api.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/flash_api.h
@@ -75,6 +75,18 @@ flash_attention_forward(
     const bool is_causal,
     const float scale);
 
+std::tuple<at::Tensor, at::Tensor> flash_attention_forward_varlen(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& cu_seqlens_q,
+    const at::Tensor& cu_seqlens_k,
+    const int64_t max_seqlen_q,
+    const int64_t max_seqlen_k,
+    const double dropout,
+    const bool is_causal,
+    const float scale);
+
 // Deprecated: Use _flash_attention_backward instead.
 std::tuple<at::Tensor, at::Tensor, at::Tensor> flash_attention_backward(
     const at::Tensor& grad_out,

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/flash_api.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/flash_api.h
@@ -83,6 +83,18 @@ flash_attention_forward_sycltla(
     const bool is_causal,
     const float scale);
 
+std::tuple<at::Tensor, at::Tensor> flash_attention_forward_varlen_sycltla(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& cu_seqlens_q,
+    const at::Tensor& cu_seqlens_k,
+    const int64_t max_seqlen_q,
+    const int64_t max_seqlen_k,
+    const double dropout,
+    const bool is_causal,
+    const float scale);
+
 // Deprecated: Use mha_bwd instead.
 std::tuple<at::Tensor, at::Tensor, at::Tensor> flash_attention_backward_sycltla(
     const at::Tensor& grad_out,

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_common.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_common.h
@@ -104,6 +104,12 @@ struct FLASH_FWD_params : public QKV_params {
   bool is_causal;
   float scale;
   bool is_fp16;
+
+  // Variable-length (varlen) attention fields
+  int* cu_seqlens_q = nullptr;
+  int* cu_seqlens_k = nullptr;
+  int total_q = 0;
+  int total_k = 0;
 };
 
 struct FLASH_BWD_params : public FLASH_FWD_params {

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.cpp
@@ -39,6 +39,7 @@
 
 #include <sycltla/mha_common.h>
 #include <sycltla/mha_fwd.h>
+#include <sycltla/mha_fwd_launch.h>
 
 namespace cute {
 
@@ -75,6 +76,38 @@ void run_mha_fwd(sycl::queue& queue, FLASH_FWD_params& params) {
   FP16_SWITCH(params.is_fp16, [&] {
     BOOL_SWITCH(params.is_causal, IS_CAUSAL, [&] {
       run_mha_fwd_<elem_type, IS_CAUSAL>(queue, params);
+    });
+  });
+}
+
+template <typename T, bool IS_CAUSAL>
+void run_mha_fwd_varlen_(sycl::queue& queue, FLASH_FWD_params& params) {
+  const int headdim = params.head_size_vo;
+
+  if (headdim <= 32) {
+    run_mha_fwd_varlen_hdim32<T, IS_CAUSAL>(queue, params);
+  } else if (headdim <= 64) {
+    run_mha_fwd_varlen_hdim64<T, IS_CAUSAL>(queue, params);
+  } else if (headdim <= 96) {
+    run_mha_fwd_varlen_hdim96<T, IS_CAUSAL>(queue, params);
+  } else if (headdim <= 128) {
+    run_mha_fwd_varlen_hdim128<T, IS_CAUSAL>(queue, params);
+  } else if (headdim <= 192) {
+    run_mha_fwd_varlen_hdim192<T, IS_CAUSAL>(queue, params);
+  } else if (headdim <= 256) {
+    run_mha_fwd_varlen_hdim256<T, IS_CAUSAL>(queue, params);
+  } else {
+    TORCH_CHECK(
+        false,
+        "FlashAttentionVarlenForwardXPU only support headdim up to 256, got ",
+        headdim);
+  }
+}
+
+void run_mha_fwd_varlen(sycl::queue& queue, FLASH_FWD_params& params) {
+  FP16_SWITCH(params.is_fp16, [&] {
+    BOOL_SWITCH(params.is_causal, IS_CAUSAL, [&] {
+      run_mha_fwd_varlen_<elem_type, IS_CAUSAL>(queue, params);
     });
   });
 }
@@ -392,6 +425,143 @@ flash_attention_forward_sycltla(
       /* max_seqlen_batch_k */ c10::SymInt(seqlen_kv),
       std::move(philox_seed),
       std::move(philox_offset)};
+}
+
+std::tuple<at::Tensor, at::Tensor> flash_attention_forward_varlen_sycltla(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& cu_seqlens_q,
+    const at::Tensor& cu_seqlens_k,
+    const int64_t max_seqlen_q,
+    const int64_t max_seqlen_k,
+    const double dropout,
+    const bool is_causal,
+    const float scale) {
+  TORCH_CHECK(
+      dropout == 0.0,
+      "flash_attention_forward_varlen_sycltla: dropout is not supported yet");
+
+  auto sycl_queue = at::xpu::getCurrentXPUStream().queue();
+
+  auto dtype = query.scalar_type();
+  TORCH_CHECK(
+      dtype == at::kHalf || dtype == at::kBFloat16,
+      "flash_attention_forward_varlen_sycltla: only fp16 and bf16 supported");
+
+  // query: (total_q, num_heads, head_size)
+  // key:   (total_k, num_heads_k, head_size)
+  // value: (total_k, num_heads_k, head_size)
+  TORCH_CHECK(
+      query.dim() == 3, "query must be 3D (total_q, num_heads, head_size)");
+  TORCH_CHECK(
+      key.dim() == 3, "key must be 3D (total_k, num_heads_k, head_size)");
+  TORCH_CHECK(
+      value.dim() == 3, "value must be 3D (total_k, num_heads_k, head_size)");
+
+  const int total_q = query.sizes()[0];
+  const int total_k = key.sizes()[0];
+  const int num_heads_qo = query.sizes()[1];
+  const int num_heads_kv = key.sizes()[1];
+  const int head_size = query.sizes()[2];
+
+  // batch_size = len(cu_seqlens_q) - 1
+  const int batch_size = cu_seqlens_q.sizes()[0] - 1;
+
+  TORCH_CHECK(
+      head_size <= 256,
+      "flash_attention_forward_varlen_sycltla: only support head dimension at most 256");
+  TORCH_CHECK(
+      num_heads_qo % num_heads_kv == 0,
+      "flash_attention_forward_varlen_sycltla: num_heads_qo must be divisible by num_heads_kv");
+
+  const int head_size_padded = round_up_headdim(head_size);
+  const bool needs_pad = head_size_padded > head_size;
+
+  at::Tensor q_padded = query;
+  at::Tensor k_padded = key;
+  at::Tensor v_padded = value;
+  if (needs_pad) {
+    int pad = head_size_padded - head_size;
+    q_padded = at::constant_pad_nd(query, {0, pad}, 0);
+    k_padded = at::constant_pad_nd(key, {0, pad}, 0);
+    v_padded = at::constant_pad_nd(value, {0, pad}, 0);
+  }
+
+  auto opts = query.options();
+  at::Tensor out = at::empty({total_q, num_heads_qo, head_size}, opts);
+  at::Tensor out_padded = needs_pad
+      ? at::empty({total_q, num_heads_qo, head_size_padded}, opts)
+      : out;
+
+  // Ensure alignment
+  q_padded = ensure_alignment_for_sdpa(q_padded);
+  k_padded = ensure_alignment_for_sdpa(k_padded);
+  v_padded = ensure_alignment_for_sdpa(v_padded);
+  out_padded = ensure_alignment_for_sdpa(out_padded);
+
+  at::Tensor logsumexp = at::empty(
+      {batch_size, num_heads_qo, max_seqlen_q}, opts.dtype(at::kFloat));
+
+  FLASH_FWD_params params;
+  params = {};
+  params.is_fp16 = (dtype == at::kHalf);
+
+  // For varlen, tensors are 3D: (total, num_heads, head_size)
+  // We set batch_size=1 and treat the whole thing as one "batch"
+  // with cu_seqlens providing the actual sequence boundaries.
+  params.q_ptr = q_padded.data_ptr();
+  params.k_ptr = k_padded.data_ptr();
+  params.v_ptr = v_padded.data_ptr();
+  params.o_ptr = out_padded.data_ptr();
+  params.lse_ptr = logsumexp.data_ptr();
+
+  // Strides for 3D tensors (total, num_heads, head_size)
+  // batch_stride is unused for varlen (set to 0)
+  params.q_batch_stride = 0;
+  params.k_batch_stride = 0;
+  params.v_batch_stride = 0;
+  params.o_batch_stride = 0;
+  params.q_row_stride = q_padded.stride(0);
+  params.k_row_stride = k_padded.stride(0);
+  params.v_row_stride = v_padded.stride(0);
+  params.o_row_stride = out_padded.stride(0);
+  params.q_head_stride = q_padded.stride(1);
+  params.k_head_stride = k_padded.stride(1);
+  params.v_head_stride = v_padded.stride(1);
+  params.o_head_stride = out_padded.stride(1);
+
+  params.batch_size = batch_size;
+  params.num_heads_qo = num_heads_qo;
+  params.num_heads_kv = num_heads_kv;
+  params.seqlen_qo = static_cast<int>(max_seqlen_q);
+  params.seqlen_kv = static_cast<int>(max_seqlen_k);
+  params.head_size_qk = head_size_padded;
+  params.head_size_vo = head_size_padded;
+  params.seqlen_qo_pad = 0;
+  params.seqlen_kv_pad = 0;
+
+  params.is_causal = is_causal;
+  params.scale = scale;
+
+  // Varlen-specific fields
+  params.cu_seqlens_q = const_cast<int*>(cu_seqlens_q.data_ptr<int>());
+  params.cu_seqlens_k = const_cast<int*>(cu_seqlens_k.data_ptr<int>());
+  params.total_q = total_q;
+  params.total_k = total_k;
+
+  if (max_seqlen_k > 0) {
+    cute::run_mha_fwd_varlen(sycl_queue, params);
+  } else {
+    out_padded.zero_();
+    logsumexp.fill_(-std::numeric_limits<float>::infinity());
+  }
+
+  if (!out_padded.is_same(out)) {
+    out.copy_(out_padded.slice(/*dim=*/2, /*start=*/0, /*end=*/head_size));
+  }
+
+  return {std::move(out), std::move(logsumexp)};
 }
 
 } // namespace sycltla

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd_launch.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd_launch.h
@@ -100,8 +100,13 @@ struct FA2Runner {
     shape.batch = batch;
     shape.num_heads_q = num_heads_qo;
     shape.num_heads_kv = num_heads_kv;
-    shape.seq_len_qo = seq_len_qo;
-    shape.seq_len_kv = seq_len_kv;
+    if constexpr (isVarLen) {
+      shape.seq_len_qo = {seq_len_qo, params.cu_seqlens_q};
+      shape.seq_len_kv = {seq_len_kv, params.cu_seqlens_k};
+    } else {
+      shape.seq_len_qo = seq_len_qo;
+      shape.seq_len_kv = seq_len_kv;
+    }
     shape.head_size_qk = head_size_qk;
     shape.head_size_vo = head_size_vo;
 
@@ -382,6 +387,119 @@ void run_mha_fwd_hdim256(sycl::queue& queue, FLASH_FWD_params& params) {
 template <typename T, int Headdim, bool IS_CAUSAL>
 void run_mha_fwd_(sycl::queue& queue, FLASH_FWD_params& params);
 
+// Convenience macro for invoking run_mha_fwd_impl with isVarLen=true
+#define run_mha_fwd_varlen_specialized( \
+    TileShapeQK_,                       \
+    TileShapePV_,                       \
+    TileShapeOutPut_,                   \
+    SubgroupLayoutQK_,                  \
+    PipelineStages_)                    \
+  run_mha_fwd_impl<                     \
+      T,                                \
+      IS_CAUSAL,                        \
+      TileShapeQK_,                     \
+      TileShapePV_,                     \
+      TileShapeOutPut_,                 \
+      SubgroupLayoutQK_,                \
+      PipelineStages_,                  \
+      /* isVarLen= */ true>(queue, params)
+
+// Per-headdim varlen dispatch functions.
+template <typename T, bool IS_CAUSAL>
+void run_mha_fwd_varlen_hdim32(sycl::queue& queue, FLASH_FWD_params& params) {
+  constexpr int PipelineStages = 2;
+  using TileShapeQK = Shape<_128, _64, _32>;
+  using TileShapePV = Shape<_128, _32, _64>;
+  using TileShapeOutPut = Shape<_128, _32>;
+  using SubgroupLayoutQK = Layout<Shape<_8, _1, _1>>;
+  run_mha_fwd_varlen_specialized(
+      TileShapeQK,
+      TileShapePV,
+      TileShapeOutPut,
+      SubgroupLayoutQK,
+      PipelineStages);
+}
+
+template <typename T, bool IS_CAUSAL>
+void run_mha_fwd_varlen_hdim64(sycl::queue& queue, FLASH_FWD_params& params) {
+  constexpr int PipelineStages = 2;
+  using TileShapeQK = Shape<_128, _64, _32>;
+  using TileShapePV = Shape<_128, _32, _64>;
+  using TileShapeOutPut = Shape<_128, _64>;
+  using SubgroupLayoutQK = Layout<Shape<_8, _1, _1>>;
+  run_mha_fwd_varlen_specialized(
+      TileShapeQK,
+      TileShapePV,
+      TileShapeOutPut,
+      SubgroupLayoutQK,
+      PipelineStages);
+}
+
+template <typename T, bool IS_CAUSAL>
+void run_mha_fwd_varlen_hdim96(sycl::queue& queue, FLASH_FWD_params& params) {
+  constexpr int PipelineStages = 2;
+  using TileShapeQK = Shape<_128, _64, _32>;
+  using TileShapePV = Shape<_128, _32, _64>;
+  using TileShapeOutPut = Shape<_128, _96>;
+  using SubgroupLayoutQK = Layout<Shape<_8, _1, _1>>;
+  run_mha_fwd_varlen_specialized(
+      TileShapeQK,
+      TileShapePV,
+      TileShapeOutPut,
+      SubgroupLayoutQK,
+      PipelineStages);
+}
+
+template <typename T, bool IS_CAUSAL>
+void run_mha_fwd_varlen_hdim128(sycl::queue& queue, FLASH_FWD_params& params) {
+  constexpr int PipelineStages = 2;
+  using TileShapeQK = Shape<_128, _32, _32>;
+  using TileShapePV = Shape<_128, _32, _32>;
+  using TileShapeOutPut = Shape<_128, _128>;
+  using SubgroupLayoutQK = Layout<Shape<_8, _1, _1>>;
+  run_mha_fwd_varlen_specialized(
+      TileShapeQK,
+      TileShapePV,
+      TileShapeOutPut,
+      SubgroupLayoutQK,
+      PipelineStages);
+}
+
+template <typename T, bool IS_CAUSAL>
+void run_mha_fwd_varlen_hdim192(sycl::queue& queue, FLASH_FWD_params& params) {
+  constexpr int PipelineStages = 2;
+  using TileShapeQK = Shape<_256, _64, _32>;
+  using TileShapePV = Shape<_256, _32, _64>;
+  using TileShapeOutPut = Shape<_256, _192>;
+  using SubgroupLayoutQK = Layout<Shape<_32, _1, _1>>;
+  run_mha_fwd_varlen_specialized(
+      TileShapeQK,
+      TileShapePV,
+      TileShapeOutPut,
+      SubgroupLayoutQK,
+      PipelineStages);
+}
+
+template <typename T, bool IS_CAUSAL>
+void run_mha_fwd_varlen_hdim256(sycl::queue& queue, FLASH_FWD_params& params) {
+  constexpr int PipelineStages = 2;
+  using TileShapeQK = Shape<_256, _64, _32>;
+  using TileShapePV = Shape<_256, _32, _64>;
+  using TileShapeOutPut = Shape<_256, _256>;
+  using SubgroupLayoutQK = Layout<Shape<_32, _1, _1>>;
+  run_mha_fwd_varlen_specialized(
+      TileShapeQK,
+      TileShapePV,
+      TileShapeOutPut,
+      SubgroupLayoutQK,
+      PipelineStages);
+}
+
+// Primary template declaration for varlen -- defined in mha_fwd.cpp.
+template <typename T, bool IS_CAUSAL>
+void run_mha_fwd_varlen_(sycl::queue& queue, FLASH_FWD_params& params);
+
+#undef run_mha_fwd_varlen_specialized
 #undef run_mha_fwd_specialized
 
 } // namespace cute

--- a/test/xpu/test_nestedtensor_xpu.py
+++ b/test/xpu/test_nestedtensor_xpu.py
@@ -7390,7 +7390,6 @@ torch.cuda.synchronize()
     @skipIfTorchDynamo("compiles internally")
     @unittest.skipIf(IS_WINDOWS, reason="Windows not yet supported for torch.compile")
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
-    @skipXPUIf(True, "XPU does not support NestedTensor for SDPA operations.")
     @parametrize("use_legacy_api", [True, False])
     @skipCPUIf(True, "SPDA Math NT fallback causes failure: see issue #133644")
     @unittest.skipIf(
@@ -7439,6 +7438,7 @@ torch.cuda.synchronize()
                     [
                         torch.nn.attention.SDPBackend.FLASH_ATTENTION,
                         torch.nn.attention.SDPBackend.EFFICIENT_ATTENTION,
+                        torch.nn.attention.SDPBackend.MATH,
                     ]
                 ):
                     attn_output = torch.nn.functional.scaled_dot_product_attention(


### PR DESCRIPTION
Depends on: pytorch/pytorch#180857
Resolves: intel/torch-xpu-ops#3093

### Summary
Add variable-length (packed/nested tensor) support for Flash Attention forward pass on XPU. This enables flash attention to work with nested tensors using the packed format, where sequences of different lengths are packed into a single tensor with cumulative sequence length offsets.

### Key changes:
- Implement flash_attention_forward_varlen API supporting packed tensor format
- Add SYCLTLA backend implementation with specialized tile configurations for different head dimensions (64, 96, 128, 192)
- Support both dense and varlen paths through unified kernel templates
- Enable nested tensor SDPA test that was previously skipped for XPU

### Technical details:

- Packed format: Q is [total_q, num_heads, head_dim], K/V are [total_k, num_heads_kv, head_dim]
- Uses cu_seqlens_q and cu_seqlens_k int32 arrays of shape [batch_size + 1] for sequence offsets
- Tile shape selection is workload-dependent for optimal performance (e.g., smaller tiles for small batch sizes)
- Pipeline stages set to 2 for balance between occupancy and register pressure

Limitations:

- Dropout not yet supported in varlen path
- Only supports fp16 and bf16 dtypes
- Requires contiguous last dimension for inputs

### Test plan
Existing nested tensor SDPA tests now pass on XPU (test re-enabled in test_nestedtensor_xpu.py)
Validates correctness against MATH backend fallback