### PR TITLE
[CI] Remove contents write permission in auto merge workflow

### DIFF
--- a/.github/workflows/auto_merge_by_comment.yml
+++ b/.github/workflows/auto_merge_by_comment.yml
@@ -5,10 +5,10 @@ on:
     types: [created]
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
   checks: read
+  issues: write
+  pull-requests: read
+  statuses: read
 
 jobs:
   auto-merge:


### PR DESCRIPTION
This PR tightens the GitHub Actions token permissions for the auto-merge-by-comment workflow to reduce unnecessary write access, addressing a potential security concern.

Changes:

- Removes contents: write permission from the workflow token.
- Downgrades pull-requests permission from write to read.
- Adds explicit read permissions for checks/status APIs (checks: read, statuses: read).