### PR TITLE
[SYCL-TLA] Add Conv2d/Conv3d via im2col + Xe GEMM

### DIFF
--- a/src/ATen/CMakeLists.txt
+++ b/src/ATen/CMakeLists.txt
@@ -8,9 +8,9 @@
 
 # ATen XPU sources
 
-file(GLOB xpu_native_cpp "native/xpu/*.cpp" "native/sparse/*.cpp" "native/sparse/xpu/*.cpp" "native/nested/*.cpp" "native/nested/xpu/*.cpp" "native/transformers/*.cpp" "native/quantized/*.cpp" "native/transformers/xpu/flash_attn/*.cpp")
+file(GLOB xpu_native_cpp "native/xpu/*.cpp" "native/xpu/conv/*.cpp" "native/sparse/*.cpp" "native/sparse/xpu/*.cpp" "native/nested/*.cpp" "native/nested/xpu/*.cpp" "native/transformers/*.cpp" "native/quantized/*.cpp" "native/transformers/xpu/flash_attn/*.cpp")
 file(GLOB xpu_sycl "native/xpu/sycl/*.cpp" "native/sparse/xpu/sycl/*.cpp" "native/nested/xpu/sycl/*.cpp" "native/transformers/sycl/*.cpp" "native/quantized/sycl/*.cpp")
-file(GLOB xpu_sycltla "native/transformers/xpu/flash_attn/sycltla/*.cpp")
+file(GLOB xpu_sycltla "native/transformers/xpu/flash_attn/sycltla/*.cpp" "native/xpu/conv/sycltla/*.cpp")
 
 if(USE_ONEMKL_XPU)
   file(GLOB xpu_mkl "native/xpu/mkl/*.cpp")

--- a/src/ATen/native/xpu/conv/conv_api.cpp
+++ b/src/ATen/native/xpu/conv/conv_api.cpp
@@ -1,0 +1,421 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include <ATen/native/xpu/conv/conv_api.h>
+#include <torch/library.h>
+
+#ifdef USE_SYCLTLA
+#define SYCL_DISABLE_FSYCL_SYCLHPP_WARNING
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#include <ATen/xpu/XPUContext.h>
+#pragma GCC diagnostic pop
+
+namespace sycltla {
+
+// --- conv2d impl forward declarations ---
+at::Tensor conv2d_fprop_impl(
+    sycl::queue& queue,
+    const at::Tensor& input,
+    const at::Tensor& weight,
+    const at::Tensor& bias,
+    bool has_bias,
+    int strideH,
+    int strideW,
+    int padH,
+    int padW,
+    int dilH,
+    int dilW,
+    int64_t groups);
+
+at::Tensor conv2d_dgrad_impl(
+    sycl::queue& queue,
+    const at::Tensor& grad_output,
+    const at::Tensor& weight,
+    int H,
+    int W,
+    int strideH,
+    int strideW,
+    int padH,
+    int padW,
+    int dilH,
+    int dilW,
+    int64_t groups);
+
+at::Tensor conv2d_wgrad_impl(
+    sycl::queue& queue,
+    const at::Tensor& grad_output,
+    const at::Tensor& input,
+    int kH,
+    int kW,
+    int strideH,
+    int strideW,
+    int padH,
+    int padW,
+    int dilH,
+    int dilW,
+    int64_t groups);
+
+// --- conv3d impl forward declarations ---
+at::Tensor conv3d_fprop_impl(
+    sycl::queue& queue,
+    const at::Tensor& input,
+    const at::Tensor& weight,
+    const at::Tensor& bias,
+    bool has_bias,
+    int strideD,
+    int strideH,
+    int strideW,
+    int padD,
+    int padH,
+    int padW,
+    int dilD,
+    int dilH,
+    int dilW,
+    int64_t groups);
+
+at::Tensor conv3d_dgrad_impl(
+    sycl::queue& queue,
+    const at::Tensor& grad_output,
+    const at::Tensor& weight,
+    int D,
+    int H,
+    int W,
+    int strideD,
+    int strideH,
+    int strideW,
+    int padD,
+    int padH,
+    int padW,
+    int dilD,
+    int dilH,
+    int dilW,
+    int64_t groups);
+
+at::Tensor conv3d_wgrad_impl(
+    sycl::queue& queue,
+    const at::Tensor& grad_output,
+    const at::Tensor& input,
+    int kD,
+    int kH,
+    int kW,
+    int strideD,
+    int strideH,
+    int strideW,
+    int padD,
+    int padH,
+    int padW,
+    int dilD,
+    int dilH,
+    int dilW,
+    int64_t groups);
+
+} // namespace sycltla
+#endif // USE_SYCLTLA
+
+// Helper macros for common checks
+#define CONV_CHECK_DTYPE(name, t)                               \
+  TORCH_CHECK(                                                  \
+      (t).dtype() == at::kBFloat16 || (t).dtype() == at::kHalf, \
+      "sycltla::" name ": only bf16/fp16 supported, got ",      \
+      (t).dtype())
+
+#define CONV_CHECK_XPU(name, t) \
+  TORCH_CHECK((t).is_xpu(), "sycltla::" name ": tensor must be on XPU")
+
+namespace sycltla {
+
+bool is_conv_available() {
+#ifndef USE_SYCLTLA
+  return false;
+#else
+  return true;
+#endif
+}
+
+// =========================================================================
+// Conv2d fprop
+// =========================================================================
+at::Tensor conv2d_fprop(
+    const at::Tensor& input,
+    const at::Tensor& weight,
+    const std::optional<at::Tensor>& bias,
+    at::IntArrayRef stride,
+    at::IntArrayRef padding,
+    at::IntArrayRef dilation,
+    int64_t groups) {
+#ifndef USE_SYCLTLA
+  TORCH_CHECK(false, "sycltla::conv2d_fprop: not compiled with SYCLTLA.");
+  return at::Tensor();
+#else
+  CONV_CHECK_XPU("conv2d_fprop", input);
+  CONV_CHECK_XPU("conv2d_fprop", weight);
+  CONV_CHECK_DTYPE("conv2d_fprop", input);
+  CONV_CHECK_DTYPE("conv2d_fprop", weight);
+  TORCH_CHECK(
+      input.dtype() == weight.dtype(), "sycltla::conv2d_fprop: dtype mismatch");
+  TORCH_CHECK(input.dim() == 4 && weight.dim() == 4);
+  TORCH_CHECK(input.is_contiguous() && weight.is_contiguous());
+  TORCH_CHECK(
+      stride.size() == 2 && padding.size() == 2 && dilation.size() == 2);
+  TORCH_CHECK(input.size(1) == weight.size(1) * groups);
+
+  auto& queue = at::xpu::getCurrentXPUStream().queue();
+  bool has_bias = bias.has_value() && bias->defined();
+  at::Tensor bias_tensor = has_bias ? *bias : at::Tensor();
+  return sycltla::conv2d_fprop_impl(
+      queue,
+      input,
+      weight,
+      bias_tensor,
+      has_bias,
+      (int)stride[0],
+      (int)stride[1],
+      (int)padding[0],
+      (int)padding[1],
+      (int)dilation[0],
+      (int)dilation[1],
+      groups);
+#endif
+}
+
+// =========================================================================
+// Conv2d dgrad
+// =========================================================================
+at::Tensor conv2d_dgrad(
+    const at::Tensor& grad_output,
+    const at::Tensor& weight,
+    at::IntArrayRef input_size,
+    at::IntArrayRef stride,
+    at::IntArrayRef padding,
+    at::IntArrayRef dilation,
+    int64_t groups) {
+#ifndef USE_SYCLTLA
+  TORCH_CHECK(false, "not compiled with SYCLTLA");
+  return at::Tensor();
+#else
+  CONV_CHECK_XPU("conv2d_dgrad", grad_output);
+  CONV_CHECK_XPU("conv2d_dgrad", weight);
+  CONV_CHECK_DTYPE("conv2d_dgrad", grad_output);
+  TORCH_CHECK(grad_output.dtype() == weight.dtype());
+  TORCH_CHECK(input_size.size() == 4); // [N, C, H, W]
+
+  auto& queue = at::xpu::getCurrentXPUStream().queue();
+  return sycltla::conv2d_dgrad_impl(
+      queue,
+      grad_output.contiguous(),
+      weight.contiguous(),
+      (int)input_size[2],
+      (int)input_size[3],
+      (int)stride[0],
+      (int)stride[1],
+      (int)padding[0],
+      (int)padding[1],
+      (int)dilation[0],
+      (int)dilation[1],
+      groups);
+#endif
+}
+
+// =========================================================================
+// Conv2d wgrad
+// =========================================================================
+at::Tensor conv2d_wgrad(
+    const at::Tensor& grad_output,
+    const at::Tensor& input,
+    at::IntArrayRef kernel_size,
+    at::IntArrayRef stride,
+    at::IntArrayRef padding,
+    at::IntArrayRef dilation,
+    int64_t groups) {
+#ifndef USE_SYCLTLA
+  TORCH_CHECK(false, "not compiled with SYCLTLA");
+  return at::Tensor();
+#else
+  CONV_CHECK_XPU("conv2d_wgrad", grad_output);
+  CONV_CHECK_XPU("conv2d_wgrad", input);
+  CONV_CHECK_DTYPE("conv2d_wgrad", grad_output);
+  TORCH_CHECK(grad_output.dtype() == input.dtype());
+  TORCH_CHECK(kernel_size.size() == 2); // [kH, kW]
+
+  auto& queue = at::xpu::getCurrentXPUStream().queue();
+  return sycltla::conv2d_wgrad_impl(
+      queue,
+      grad_output.contiguous(),
+      input.contiguous(),
+      (int)kernel_size[0],
+      (int)kernel_size[1],
+      (int)stride[0],
+      (int)stride[1],
+      (int)padding[0],
+      (int)padding[1],
+      (int)dilation[0],
+      (int)dilation[1],
+      groups);
+#endif
+}
+
+// =========================================================================
+// Conv3d fprop
+// =========================================================================
+at::Tensor conv3d_fprop(
+    const at::Tensor& input,
+    const at::Tensor& weight,
+    const std::optional<at::Tensor>& bias,
+    at::IntArrayRef stride,
+    at::IntArrayRef padding,
+    at::IntArrayRef dilation,
+    int64_t groups) {
+#ifndef USE_SYCLTLA
+  TORCH_CHECK(false, "not compiled with SYCLTLA");
+  return at::Tensor();
+#else
+  CONV_CHECK_XPU("conv3d_fprop", input);
+  CONV_CHECK_XPU("conv3d_fprop", weight);
+  CONV_CHECK_DTYPE("conv3d_fprop", input);
+  CONV_CHECK_DTYPE("conv3d_fprop", weight);
+  TORCH_CHECK(input.dtype() == weight.dtype());
+  TORCH_CHECK(input.dim() == 5 && weight.dim() == 5);
+  TORCH_CHECK(input.is_contiguous() && weight.is_contiguous());
+  TORCH_CHECK(
+      stride.size() == 3 && padding.size() == 3 && dilation.size() == 3);
+  TORCH_CHECK(input.size(1) == weight.size(1) * groups);
+
+  auto& queue = at::xpu::getCurrentXPUStream().queue();
+  bool has_bias = bias.has_value() && bias->defined();
+  at::Tensor bias_tensor = has_bias ? *bias : at::Tensor();
+  return sycltla::conv3d_fprop_impl(
+      queue,
+      input,
+      weight,
+      bias_tensor,
+      has_bias,
+      (int)stride[0],
+      (int)stride[1],
+      (int)stride[2],
+      (int)padding[0],
+      (int)padding[1],
+      (int)padding[2],
+      (int)dilation[0],
+      (int)dilation[1],
+      (int)dilation[2],
+      groups);
+#endif
+}
+
+// =========================================================================
+// Conv3d dgrad
+// =========================================================================
+at::Tensor conv3d_dgrad(
+    const at::Tensor& grad_output,
+    const at::Tensor& weight,
+    at::IntArrayRef input_size,
+    at::IntArrayRef stride,
+    at::IntArrayRef padding,
+    at::IntArrayRef dilation,
+    int64_t groups) {
+#ifndef USE_SYCLTLA
+  TORCH_CHECK(false, "not compiled with SYCLTLA");
+  return at::Tensor();
+#else
+  CONV_CHECK_XPU("conv3d_dgrad", grad_output);
+  CONV_CHECK_XPU("conv3d_dgrad", weight);
+  CONV_CHECK_DTYPE("conv3d_dgrad", grad_output);
+  TORCH_CHECK(grad_output.dtype() == weight.dtype());
+  TORCH_CHECK(input_size.size() == 5); // [N, C, D, H, W]
+
+  auto& queue = at::xpu::getCurrentXPUStream().queue();
+  return sycltla::conv3d_dgrad_impl(
+      queue,
+      grad_output.contiguous(),
+      weight.contiguous(),
+      (int)input_size[2],
+      (int)input_size[3],
+      (int)input_size[4],
+      (int)stride[0],
+      (int)stride[1],
+      (int)stride[2],
+      (int)padding[0],
+      (int)padding[1],
+      (int)padding[2],
+      (int)dilation[0],
+      (int)dilation[1],
+      (int)dilation[2],
+      groups);
+#endif
+}
+
+// =========================================================================
+// Conv3d wgrad
+// =========================================================================
+at::Tensor conv3d_wgrad(
+    const at::Tensor& grad_output,
+    const at::Tensor& input,
+    at::IntArrayRef kernel_size,
+    at::IntArrayRef stride,
+    at::IntArrayRef padding,
+    at::IntArrayRef dilation,
+    int64_t groups) {
+#ifndef USE_SYCLTLA
+  TORCH_CHECK(false, "not compiled with SYCLTLA");
+  return at::Tensor();
+#else
+  CONV_CHECK_XPU("conv3d_wgrad", grad_output);
+  CONV_CHECK_XPU("conv3d_wgrad", input);
+  CONV_CHECK_DTYPE("conv3d_wgrad", grad_output);
+  TORCH_CHECK(grad_output.dtype() == input.dtype());
+  TORCH_CHECK(kernel_size.size() == 3); // [kD, kH, kW]
+
+  auto& queue = at::xpu::getCurrentXPUStream().queue();
+  return sycltla::conv3d_wgrad_impl(
+      queue,
+      grad_output.contiguous(),
+      input.contiguous(),
+      (int)kernel_size[0],
+      (int)kernel_size[1],
+      (int)kernel_size[2],
+      (int)stride[0],
+      (int)stride[1],
+      (int)stride[2],
+      (int)padding[0],
+      (int)padding[1],
+      (int)padding[2],
+      (int)dilation[0],
+      (int)dilation[1],
+      (int)dilation[2],
+      groups);
+#endif
+}
+
+} // namespace sycltla
+
+TORCH_LIBRARY(sycltla_conv, m) {
+  m.def(
+      "conv2d_fprop(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor");
+  m.def(
+      "conv2d_dgrad(Tensor grad_output, Tensor weight, int[] input_size, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor");
+  m.def(
+      "conv2d_wgrad(Tensor grad_output, Tensor input, int[] kernel_size, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor");
+  m.def(
+      "conv3d_fprop(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor");
+  m.def(
+      "conv3d_dgrad(Tensor grad_output, Tensor weight, int[] input_size, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor");
+  m.def(
+      "conv3d_wgrad(Tensor grad_output, Tensor input, int[] kernel_size, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(sycltla_conv, XPU, m) {
+  m.impl("conv2d_fprop", &sycltla::conv2d_fprop);
+  m.impl("conv2d_dgrad", &sycltla::conv2d_dgrad);
+  m.impl("conv2d_wgrad", &sycltla::conv2d_wgrad);
+  m.impl("conv3d_fprop", &sycltla::conv3d_fprop);
+  m.impl("conv3d_dgrad", &sycltla::conv3d_dgrad);
+  m.impl("conv3d_wgrad", &sycltla::conv3d_wgrad);
+}

--- a/src/ATen/native/xpu/conv/conv_api.h
+++ b/src/ATen/native/xpu/conv/conv_api.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#pragma once
+
+#include <ATen/ATen.h>
+#include <optional>
+
+namespace sycltla {
+
+bool is_conv_available();
+
+// --- Conv2d ---
+at::Tensor conv2d_fprop(
+    const at::Tensor& input,
+    const at::Tensor& weight,
+    const std::optional<at::Tensor>& bias,
+    at::IntArrayRef stride,
+    at::IntArrayRef padding,
+    at::IntArrayRef dilation,
+    int64_t groups);
+
+at::Tensor conv2d_dgrad(
+    const at::Tensor& grad_output,
+    const at::Tensor& weight,
+    at::IntArrayRef input_size,
+    at::IntArrayRef stride,
+    at::IntArrayRef padding,
+    at::IntArrayRef dilation,
+    int64_t groups);
+
+at::Tensor conv2d_wgrad(
+    const at::Tensor& grad_output,
+    const at::Tensor& input,
+    at::IntArrayRef kernel_size,
+    at::IntArrayRef stride,
+    at::IntArrayRef padding,
+    at::IntArrayRef dilation,
+    int64_t groups);
+
+// --- Conv3d ---
+at::Tensor conv3d_fprop(
+    const at::Tensor& input,
+    const at::Tensor& weight,
+    const std::optional<at::Tensor>& bias,
+    at::IntArrayRef stride,
+    at::IntArrayRef padding,
+    at::IntArrayRef dilation,
+    int64_t groups);
+
+at::Tensor conv3d_dgrad(
+    const at::Tensor& grad_output,
+    const at::Tensor& weight,
+    at::IntArrayRef input_size,
+    at::IntArrayRef stride,
+    at::IntArrayRef padding,
+    at::IntArrayRef dilation,
+    int64_t groups);
+
+at::Tensor conv3d_wgrad(
+    const at::Tensor& grad_output,
+    const at::Tensor& input,
+    at::IntArrayRef kernel_size,
+    at::IntArrayRef stride,
+    at::IntArrayRef padding,
+    at::IntArrayRef dilation,
+    int64_t groups);
+
+} // namespace sycltla

--- a/src/ATen/native/xpu/conv/sycltla/conv2d_bwd.cpp
+++ b/src/ATen/native/xpu/conv/sycltla/conv2d_bwd.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/*
+ * Conv2d backward: dgrad (input gradient) + wgrad (weight gradient).
+ * Uses im2col/col2im + Xe GEMM. Supports BF16 and FP16.
+ */
+
+#include <conv_gemm.h>
+
+// ---------------------------------------------------------------------------
+// im2col_2d (shared with fprop, duplicated here to keep files independent)
+// ---------------------------------------------------------------------------
+
+static at::Tensor im2col_2d(
+    const at::Tensor& input,
+    int kH,
+    int kW,
+    int strideH,
+    int strideW,
+    int padH,
+    int padW,
+    int dilH,
+    int dilW) {
+  at::Tensor padded = input;
+  if (padH > 0 || padW > 0)
+    padded = at::constant_pad_nd(input, {padW, padW, padH, padH}, 0.0);
+  auto unfolded = padded.unfold(2, kH * dilH - (dilH - 1), strideH)
+                      .unfold(3, kW * dilW - (dilW - 1), strideW);
+  if (dilH > 1 || dilW > 1)
+    unfolded =
+        unfolded.slice(4, 0, kH * dilH, dilH).slice(5, 0, kW * dilW, dilW);
+  const int N = input.size(0);
+  const int C = input.size(1);
+  const int H_out = unfolded.size(2);
+  const int W_out = unfolded.size(3);
+  return unfolded.permute({0, 2, 3, 1, 4, 5})
+      .contiguous()
+      .reshape({N * H_out * W_out, C * kH * kW});
+}
+
+// ---------------------------------------------------------------------------
+// col2im_2d: reshape columns back to spatial input
+// ---------------------------------------------------------------------------
+
+static at::Tensor col2im_2d(
+    const at::Tensor& columns,
+    int N,
+    int C,
+    int H,
+    int W,
+    int kH,
+    int kW,
+    int strideH,
+    int strideW,
+    int padH,
+    int padW,
+    int dilH,
+    int dilW) {
+  const int H_out = (H + 2 * padH - dilH * (kH - 1) - 1) / strideH + 1;
+  const int W_out = (W + 2 * padW - dilW * (kW - 1) - 1) / strideW + 1;
+  auto cols =
+      columns.reshape({N, H_out * W_out, C * kH * kW}).permute({0, 2, 1});
+  return at::col2im(
+      cols, {H, W}, {kH, kW}, {dilH, dilW}, {padH, padW}, {strideH, strideW});
+}
+
+// ---------------------------------------------------------------------------
+// Conv2d dgrad: grad_input = col2im(grad_output_2d × weight)
+// ---------------------------------------------------------------------------
+
+namespace sycltla {
+
+at::Tensor conv2d_dgrad_impl(
+    sycl::queue& queue,
+    const at::Tensor& grad_output,
+    const at::Tensor& weight,
+    int H,
+    int W,
+    int strideH,
+    int strideW,
+    int padH,
+    int padW,
+    int dilH,
+    int dilW,
+    int64_t groups) {
+  const int N = grad_output.size(0), K = grad_output.size(1);
+  const int H_out = grad_output.size(2), W_out = grad_output.size(3);
+  const int C_per_group = weight.size(1);
+  const int C = C_per_group * groups;
+  const int kH = weight.size(2), kW = weight.size(3);
+  const int K_per_group = K / groups;
+
+  if (groups == 1) {
+    at::Tensor grad_2d = grad_output.permute({0, 2, 3, 1})
+                             .contiguous()
+                             .reshape({N * H_out * W_out, K});
+    at::Tensor weight_2d = weight.reshape({K, C * kH * kW}).contiguous();
+    at::Tensor columns = run_conv_gemm(queue, grad_2d, weight_2d);
+    return col2im_2d(
+        columns, N, C, H, W, kH, kW, strideH, strideW, padH, padW, dilH, dilW);
+  } else {
+    auto grad_groups = grad_output.chunk(groups, 1);
+    auto weight_groups = weight.chunk(groups, 0);
+    std::vector<at::Tensor> input_grad_groups;
+    input_grad_groups.reserve(groups);
+    for (int64_t g = 0; g < groups; ++g) {
+      at::Tensor grad_2d = grad_groups[g]
+                               .permute({0, 2, 3, 1})
+                               .contiguous()
+                               .reshape({N * H_out * W_out, K_per_group});
+      at::Tensor w2d = weight_groups[g]
+                           .reshape({K_per_group, C_per_group * kH * kW})
+                           .contiguous();
+      at::Tensor cols = run_conv_gemm(queue, grad_2d, w2d);
+      input_grad_groups.push_back(col2im_2d(
+          cols,
+          N,
+          C_per_group,
+          H,
+          W,
+          kH,
+          kW,
+          strideH,
+          strideW,
+          padH,
+          padW,
+          dilH,
+          dilW));
+    }
+    return at::cat(input_grad_groups, 1).contiguous();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Conv2d wgrad: grad_weight = im2col(input)^T × grad_output_2d
+// ---------------------------------------------------------------------------
+
+at::Tensor conv2d_wgrad_impl(
+    sycl::queue& queue,
+    const at::Tensor& grad_output,
+    const at::Tensor& input,
+    int kH,
+    int kW,
+    int strideH,
+    int strideW,
+    int padH,
+    int padW,
+    int dilH,
+    int dilW,
+    int64_t groups) {
+  const int N = input.size(0), C = input.size(1);
+  const int K = grad_output.size(1);
+  const int C_per_group = C / groups;
+  const int K_per_group = K / groups;
+  const int H_out = grad_output.size(2), W_out = grad_output.size(3);
+
+  if (groups == 1) {
+    at::Tensor columns =
+        im2col_2d(input, kH, kW, strideH, strideW, padH, padW, dilH, dilW);
+    at::Tensor grad_2d = grad_output.permute({0, 2, 3, 1})
+                             .contiguous()
+                             .reshape({N * H_out * W_out, K});
+    at::Tensor columns_t = columns.t().contiguous();
+    at::Tensor grad_weight_2d = run_conv_gemm(queue, columns_t, grad_2d);
+    return grad_weight_2d.t().contiguous().reshape({K, C, kH, kW});
+  } else {
+    auto input_groups = input.chunk(groups, 1);
+    auto grad_groups = grad_output.chunk(groups, 1);
+    std::vector<at::Tensor> wgrad_groups;
+    wgrad_groups.reserve(groups);
+    for (int64_t g = 0; g < groups; ++g) {
+      at::Tensor cols = im2col_2d(
+          input_groups[g], kH, kW, strideH, strideW, padH, padW, dilH, dilW);
+      at::Tensor grad_2d = grad_groups[g]
+                               .permute({0, 2, 3, 1})
+                               .contiguous()
+                               .reshape({N * H_out * W_out, K_per_group});
+      at::Tensor cols_t = cols.t().contiguous();
+      at::Tensor gw = run_conv_gemm(queue, cols_t, grad_2d);
+      wgrad_groups.push_back(
+          gw.t().contiguous().reshape({K_per_group, C_per_group, kH, kW}));
+    }
+    return at::cat(wgrad_groups, 0).contiguous();
+  }
+}
+
+} // namespace sycltla

--- a/src/ATen/native/xpu/conv/sycltla/conv2d_fprop.cpp
+++ b/src/ATen/native/xpu/conv/sycltla/conv2d_fprop.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/*
+ * Conv2d fprop: im2col + Xe GEMM. Supports BF16 and FP16.
+ */
+
+#include <conv_gemm.h>
+
+// ---------------------------------------------------------------------------
+// im2col_2d
+// ---------------------------------------------------------------------------
+
+static at::Tensor im2col_2d(
+    const at::Tensor& input,
+    int kH,
+    int kW,
+    int strideH,
+    int strideW,
+    int padH,
+    int padW,
+    int dilH,
+    int dilW) {
+  at::Tensor padded = input;
+  if (padH > 0 || padW > 0)
+    padded = at::constant_pad_nd(input, {padW, padW, padH, padH}, 0.0);
+  auto unfolded = padded.unfold(2, kH * dilH - (dilH - 1), strideH)
+                      .unfold(3, kW * dilW - (dilW - 1), strideW);
+  if (dilH > 1 || dilW > 1)
+    unfolded =
+        unfolded.slice(4, 0, kH * dilH, dilH).slice(5, 0, kW * dilW, dilW);
+  const int N = input.size(0);
+  const int C = input.size(1);
+  const int H_out = unfolded.size(2);
+  const int W_out = unfolded.size(3);
+  return unfolded.permute({0, 2, 3, 1, 4, 5})
+      .contiguous()
+      .reshape({N * H_out * W_out, C * kH * kW});
+}
+
+// ---------------------------------------------------------------------------
+// Public API - fprop only
+// ---------------------------------------------------------------------------
+
+namespace sycltla {
+
+at::Tensor conv2d_fprop_impl(
+    sycl::queue& queue,
+    const at::Tensor& input,
+    const at::Tensor& weight,
+    const at::Tensor& bias,
+    bool has_bias,
+    int strideH,
+    int strideW,
+    int padH,
+    int padW,
+    int dilH,
+    int dilW,
+    int64_t groups) {
+  const int N = input.size(0), C = input.size(1), H = input.size(2),
+            W = input.size(3);
+  const int K = weight.size(0), C_per_group = weight.size(1);
+  const int kH = weight.size(2), kW = weight.size(3);
+  const int K_per_group = K / groups;
+  const int H_out = (H + 2 * padH - dilH * (kH - 1) - 1) / strideH + 1;
+  const int W_out = (W + 2 * padW - dilW * (kW - 1) - 1) / strideW + 1;
+
+  at::Tensor output;
+
+  if (groups == 1) {
+    at::Tensor columns =
+        im2col_2d(input, kH, kW, strideH, strideW, padH, padW, dilH, dilW);
+    at::Tensor weight_2d = weight.reshape({K, C * kH * kW}).t().contiguous();
+    at::Tensor output_2d = run_conv_gemm(queue, columns, weight_2d);
+    output = output_2d.reshape({N, H_out, W_out, K})
+                 .permute({0, 3, 1, 2})
+                 .contiguous();
+  } else {
+    auto input_groups = input.chunk(groups, 1);
+    auto weight_groups = weight.chunk(groups, 0);
+    std::vector<at::Tensor> output_groups;
+    output_groups.reserve(groups);
+    for (int64_t g = 0; g < groups; ++g) {
+      at::Tensor columns_g = im2col_2d(
+          input_groups[g], kH, kW, strideH, strideW, padH, padW, dilH, dilW);
+      at::Tensor weight_2d_g =
+          weight_groups[g]
+              .reshape({K_per_group, C_per_group * kH * kW})
+              .t()
+              .contiguous();
+      at::Tensor out_g = run_conv_gemm(queue, columns_g, weight_2d_g);
+      out_g =
+          out_g.reshape({N, H_out, W_out, K_per_group}).permute({0, 3, 1, 2});
+      output_groups.push_back(out_g);
+    }
+    output = at::cat(output_groups, 1).contiguous();
+  }
+
+  if (has_bias && bias.defined())
+    output = output + bias.reshape({1, K, 1, 1});
+  return output;
+}
+
+} // namespace sycltla

--- a/src/ATen/native/xpu/conv/sycltla/conv3d_bwd.cpp
+++ b/src/ATen/native/xpu/conv/sycltla/conv3d_bwd.cpp
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/*
+ * Conv3d backward: dgrad (input gradient) + wgrad (weight gradient).
+ * Uses im2col/col2im + Xe GEMM. Supports BF16 and FP16.
+ */
+
+#include <conv_gemm.h>
+
+// ---------------------------------------------------------------------------
+// im2col_3d (shared with fprop, duplicated here to keep files independent)
+// ---------------------------------------------------------------------------
+
+static at::Tensor im2col_3d(
+    const at::Tensor& input,
+    int kD,
+    int kH,
+    int kW,
+    int strideD,
+    int strideH,
+    int strideW,
+    int padD,
+    int padH,
+    int padW,
+    int dilD,
+    int dilH,
+    int dilW) {
+  const int N = input.size(0), C = input.size(1);
+  at::Tensor padded = input;
+  if (padD > 0 || padH > 0 || padW > 0)
+    padded =
+        at::constant_pad_nd(input, {padW, padW, padH, padH, padD, padD}, 0.0);
+  auto unfolded = padded.unfold(2, kD * dilD - (dilD - 1), strideD)
+                      .unfold(3, kH * dilH - (dilH - 1), strideH)
+                      .unfold(4, kW * dilW - (dilW - 1), strideW);
+  if (dilD > 1 || dilH > 1 || dilW > 1)
+    unfolded = unfolded.slice(5, 0, kD * dilD, dilD)
+                   .slice(6, 0, kH * dilH, dilH)
+                   .slice(7, 0, kW * dilW, dilW);
+  const int D_out = unfolded.size(2), H_out = unfolded.size(3),
+            W_out = unfolded.size(4);
+  return unfolded.permute({0, 2, 3, 4, 1, 5, 6, 7})
+      .contiguous()
+      .reshape({N * D_out * H_out * W_out, C * kD * kH * kW});
+}
+
+// ---------------------------------------------------------------------------
+// col2im_3d: scatter columns back to volumetric input
+// ---------------------------------------------------------------------------
+
+static at::Tensor col2im_3d(
+    const at::Tensor& columns,
+    int N,
+    int C,
+    int D,
+    int H,
+    int W,
+    int kD,
+    int kH,
+    int kW,
+    int strideD,
+    int strideH,
+    int strideW,
+    int padD,
+    int padH,
+    int padW,
+    int dilD,
+    int dilH,
+    int dilW) {
+  const int D_out = (D + 2 * padD - dilD * (kD - 1) - 1) / strideD + 1;
+  const int H_out = (H + 2 * padH - dilH * (kH - 1) - 1) / strideH + 1;
+  const int W_out = (W + 2 * padW - dilW * (kW - 1) - 1) / strideW + 1;
+
+  auto cols = columns.reshape({N, D_out, H_out, W_out, C, kD, kH, kW});
+
+  int D_pad = D + 2 * padD;
+  int H_pad = H + 2 * padH;
+  int W_pad = W + 2 * padW;
+  at::Tensor output_padded =
+      at::zeros({N, C, D_pad, H_pad, W_pad}, columns.options());
+
+  for (int kd = 0; kd < kD; ++kd) {
+    for (int kh = 0; kh < kH; ++kh) {
+      for (int kw = 0; kw < kW; ++kw) {
+        auto patch = cols.select(7, kw).select(6, kh).select(5, kd);
+        patch = patch.permute({0, 4, 1, 2, 3}).contiguous();
+
+        int d_start = kd * dilD, h_start = kh * dilH, w_start = kw * dilW;
+        auto dst =
+            output_padded.slice(2, d_start, d_start + D_out * strideD, strideD)
+                .slice(3, h_start, h_start + H_out * strideH, strideH)
+                .slice(4, w_start, w_start + W_out * strideW, strideW);
+        dst.add_(patch);
+      }
+    }
+  }
+
+  if (padD > 0 || padH > 0 || padW > 0) {
+    return output_padded.slice(2, padD, padD + D)
+        .slice(3, padH, padH + H)
+        .slice(4, padW, padW + W)
+        .contiguous();
+  }
+  return output_padded;
+}
+
+// ---------------------------------------------------------------------------
+// Conv3d dgrad
+// ---------------------------------------------------------------------------
+
+namespace sycltla {
+
+at::Tensor conv3d_dgrad_impl(
+    sycl::queue& queue,
+    const at::Tensor& grad_output,
+    const at::Tensor& weight,
+    int D,
+    int H,
+    int W,
+    int strideD,
+    int strideH,
+    int strideW,
+    int padD,
+    int padH,
+    int padW,
+    int dilD,
+    int dilH,
+    int dilW,
+    int64_t groups) {
+  const int N = grad_output.size(0), K = grad_output.size(1);
+  const int D_out = grad_output.size(2), H_out = grad_output.size(3),
+            W_out = grad_output.size(4);
+  const int C_per_group = weight.size(1);
+  const int C = C_per_group * groups;
+  const int kD = weight.size(2), kH = weight.size(3), kW = weight.size(4);
+  const int K_per_group = K / groups;
+
+  if (groups == 1) {
+    at::Tensor grad_2d = grad_output.permute({0, 2, 3, 4, 1})
+                             .contiguous()
+                             .reshape({N * D_out * H_out * W_out, K});
+    at::Tensor weight_2d = weight.reshape({K, C * kD * kH * kW}).contiguous();
+    at::Tensor columns = run_conv_gemm(queue, grad_2d, weight_2d);
+    return col2im_3d(
+        columns,
+        N,
+        C,
+        D,
+        H,
+        W,
+        kD,
+        kH,
+        kW,
+        strideD,
+        strideH,
+        strideW,
+        padD,
+        padH,
+        padW,
+        dilD,
+        dilH,
+        dilW);
+  } else {
+    auto grad_groups = grad_output.chunk(groups, 1);
+    auto weight_groups = weight.chunk(groups, 0);
+    std::vector<at::Tensor> input_grad_groups;
+    input_grad_groups.reserve(groups);
+    for (int64_t g = 0; g < groups; ++g) {
+      at::Tensor g2d = grad_groups[g]
+                           .permute({0, 2, 3, 4, 1})
+                           .contiguous()
+                           .reshape({N * D_out * H_out * W_out, K_per_group});
+      at::Tensor w2d = weight_groups[g]
+                           .reshape({K_per_group, C_per_group * kD * kH * kW})
+                           .contiguous();
+      at::Tensor cols = run_conv_gemm(queue, g2d, w2d);
+      input_grad_groups.push_back(col2im_3d(
+          cols,
+          N,
+          C_per_group,
+          D,
+          H,
+          W,
+          kD,
+          kH,
+          kW,
+          strideD,
+          strideH,
+          strideW,
+          padD,
+          padH,
+          padW,
+          dilD,
+          dilH,
+          dilW));
+    }
+    return at::cat(input_grad_groups, 1).contiguous();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Conv3d wgrad
+// ---------------------------------------------------------------------------
+
+at::Tensor conv3d_wgrad_impl(
+    sycl::queue& queue,
+    const at::Tensor& grad_output,
+    const at::Tensor& input,
+    int kD,
+    int kH,
+    int kW,
+    int strideD,
+    int strideH,
+    int strideW,
+    int padD,
+    int padH,
+    int padW,
+    int dilD,
+    int dilH,
+    int dilW,
+    int64_t groups) {
+  const int N = input.size(0), C = input.size(1);
+  const int K = grad_output.size(1);
+  const int C_per_group = C / groups;
+  const int K_per_group = K / groups;
+  const int D_out = grad_output.size(2), H_out = grad_output.size(3),
+            W_out = grad_output.size(4);
+
+  if (groups == 1) {
+    at::Tensor columns = im2col_3d(
+        input,
+        kD,
+        kH,
+        kW,
+        strideD,
+        strideH,
+        strideW,
+        padD,
+        padH,
+        padW,
+        dilD,
+        dilH,
+        dilW);
+    at::Tensor grad_2d = grad_output.permute({0, 2, 3, 4, 1})
+                             .contiguous()
+                             .reshape({N * D_out * H_out * W_out, K});
+    at::Tensor cols_t = columns.t().contiguous();
+    at::Tensor gw = run_conv_gemm(queue, cols_t, grad_2d);
+    return gw.t().contiguous().reshape({K, C, kD, kH, kW});
+  } else {
+    auto input_groups = input.chunk(groups, 1);
+    auto grad_groups = grad_output.chunk(groups, 1);
+    std::vector<at::Tensor> wgrad_groups;
+    wgrad_groups.reserve(groups);
+    for (int64_t g = 0; g < groups; ++g) {
+      at::Tensor cols = im2col_3d(
+          input_groups[g],
+          kD,
+          kH,
+          kW,
+          strideD,
+          strideH,
+          strideW,
+          padD,
+          padH,
+          padW,
+          dilD,
+          dilH,
+          dilW);
+      at::Tensor g2d = grad_groups[g]
+                           .permute({0, 2, 3, 4, 1})
+                           .contiguous()
+                           .reshape({N * D_out * H_out * W_out, K_per_group});
+      at::Tensor cols_t = cols.t().contiguous();
+      at::Tensor gw = run_conv_gemm(queue, cols_t, g2d);
+      wgrad_groups.push_back(
+          gw.t().contiguous().reshape({K_per_group, C_per_group, kD, kH, kW}));
+    }
+    return at::cat(wgrad_groups, 0).contiguous();
+  }
+}
+
+} // namespace sycltla

--- a/src/ATen/native/xpu/conv/sycltla/conv3d_fprop.cpp
+++ b/src/ATen/native/xpu/conv/sycltla/conv3d_fprop.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/*
+ * Conv3d forward propagation: im2col + Xe GEMM. Supports BF16 and FP16.
+ */
+
+#include <conv_gemm.h>
+
+// ---------------------------------------------------------------------------
+// im2col_3d
+// ---------------------------------------------------------------------------
+
+static at::Tensor im2col_3d(
+    const at::Tensor& input,
+    int kD,
+    int kH,
+    int kW,
+    int strideD,
+    int strideH,
+    int strideW,
+    int padD,
+    int padH,
+    int padW,
+    int dilD,
+    int dilH,
+    int dilW) {
+  const int N = input.size(0), C = input.size(1);
+  at::Tensor padded = input;
+  if (padD > 0 || padH > 0 || padW > 0)
+    padded =
+        at::constant_pad_nd(input, {padW, padW, padH, padH, padD, padD}, 0.0);
+  auto unfolded = padded.unfold(2, kD * dilD - (dilD - 1), strideD)
+                      .unfold(3, kH * dilH - (dilH - 1), strideH)
+                      .unfold(4, kW * dilW - (dilW - 1), strideW);
+  if (dilD > 1 || dilH > 1 || dilW > 1)
+    unfolded = unfolded.slice(5, 0, kD * dilD, dilD)
+                   .slice(6, 0, kH * dilH, dilH)
+                   .slice(7, 0, kW * dilW, dilW);
+  const int D_out = unfolded.size(2), H_out = unfolded.size(3),
+            W_out = unfolded.size(4);
+  return unfolded.permute({0, 2, 3, 4, 1, 5, 6, 7})
+      .contiguous()
+      .reshape({N * D_out * H_out * W_out, C * kD * kH * kW});
+}
+
+// ---------------------------------------------------------------------------
+// Conv3d fprop
+// ---------------------------------------------------------------------------
+
+namespace sycltla {
+
+at::Tensor conv3d_fprop_impl(
+    sycl::queue& queue,
+    const at::Tensor& input,
+    const at::Tensor& weight,
+    const at::Tensor& bias,
+    bool has_bias,
+    int strideD,
+    int strideH,
+    int strideW,
+    int padD,
+    int padH,
+    int padW,
+    int dilD,
+    int dilH,
+    int dilW,
+    int64_t groups) {
+  const int N = input.size(0), C = input.size(1);
+  const int D = input.size(2), H = input.size(3), W = input.size(4);
+  const int K = weight.size(0), C_per_group = weight.size(1);
+  const int kD = weight.size(2), kH = weight.size(3), kW = weight.size(4);
+  const int K_per_group = K / groups;
+  const int D_out = (D + 2 * padD - dilD * (kD - 1) - 1) / strideD + 1;
+  const int H_out = (H + 2 * padH - dilH * (kH - 1) - 1) / strideH + 1;
+  const int W_out = (W + 2 * padW - dilW * (kW - 1) - 1) / strideW + 1;
+
+  at::Tensor output;
+  if (groups == 1) {
+    at::Tensor columns = im2col_3d(
+        input,
+        kD,
+        kH,
+        kW,
+        strideD,
+        strideH,
+        strideW,
+        padD,
+        padH,
+        padW,
+        dilD,
+        dilH,
+        dilW);
+    at::Tensor weight_2d =
+        weight.reshape({K, C * kD * kH * kW}).t().contiguous();
+    at::Tensor output_2d = run_conv_gemm(queue, columns, weight_2d);
+    output = output_2d.reshape({N, D_out, H_out, W_out, K})
+                 .permute({0, 4, 1, 2, 3})
+                 .contiguous();
+  } else {
+    auto input_groups = input.chunk(groups, 1);
+    auto weight_groups = weight.chunk(groups, 0);
+    std::vector<at::Tensor> output_groups;
+    output_groups.reserve(groups);
+    for (int64_t g = 0; g < groups; ++g) {
+      at::Tensor cols_g = im2col_3d(
+          input_groups[g],
+          kD,
+          kH,
+          kW,
+          strideD,
+          strideH,
+          strideW,
+          padD,
+          padH,
+          padW,
+          dilD,
+          dilH,
+          dilW);
+      at::Tensor w2d_g = weight_groups[g]
+                             .reshape({K_per_group, C_per_group * kD * kH * kW})
+                             .t()
+                             .contiguous();
+      at::Tensor out_g = run_conv_gemm(queue, cols_g, w2d_g);
+      out_g = out_g.reshape({N, D_out, H_out, W_out, K_per_group})
+                  .permute({0, 4, 1, 2, 3});
+      output_groups.push_back(out_g);
+    }
+    output = at::cat(output_groups, 1).contiguous();
+  }
+
+  if (has_bias && bias.defined())
+    output = output + bias.reshape({1, K, 1, 1, 1});
+  return output;
+}
+
+} // namespace sycltla

--- a/src/ATen/native/xpu/conv/sycltla/conv_gemm.h
+++ b/src/ATen/native/xpu/conv/sycltla/conv_gemm.h
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/*
+ * Shared GEMM runner for conv ops. Supports BF16 and FP16.
+ * Templated on ElementType (bfloat16_t or half_t).
+ */
+
+#pragma once
+
+// sycl-tla headers trigger many warnings that conflict with -Werror.
+// Use system_header to suppress all warnings from included headers.
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC system_header
+#endif
+
+#include <cute/config.hpp>
+#include <cute/util/xe_split_barrier.hpp>
+
+#include <cutlass/epilogue/collective/default_epilogue.hpp>
+#include <cutlass/epilogue/collective/xe_epilogue.hpp>
+#include <cutlass/epilogue/fusion/xe_callbacks.hpp>
+#include <cutlass/gemm/collective/collective_mma.hpp>
+#include <cutlass/gemm/device/gemm_universal.h>
+#include <cutlass/gemm/device/gemm_universal_adapter.h>
+
+#include <cute/tensor.hpp>
+#include <cute/util/compat.hpp>
+#include <cutlass/util/packed_stride.hpp>
+#include <sycl/sycl.hpp>
+
+#include <ATen/ATen.h>
+
+using namespace cute;
+
+// ---------------------------------------------------------------------------
+// Templated GEMM kernel definition
+// ---------------------------------------------------------------------------
+
+template <typename ElementT>
+struct ConvGemm {
+  using ElementInputA = ElementT;
+  using ElementInputB = ElementT;
+  using ElementOutput = ElementT;
+  using ElementAcc = float;
+  using ElementCompute = float;
+
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::RowMajor;
+  using LayoutC = cutlass::layout::RowMajor;
+  using LayoutD = cutlass::layout::RowMajor;
+
+  static constexpr int PipelineStages = 2;
+  using GEMMDispatchPolicy = cutlass::gemm::MainloopXeL1Staged<PipelineStages>;
+  using EpilogueDispatchPolicy = cutlass::epilogue::IntelXeGeneric;
+
+  using TileShape = Shape<_256, _256, _32>;
+  using SubgroupLayout = Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>;
+
+  // Select MMA atom based on type
+  using MMAAtom = std::conditional_t<
+      std::is_same_v<ElementT, bfloat16_t>,
+      XE_DPAS_TT<8, float, cute::bfloat16_t>,
+      XE_DPAS_TT<8, float, cute::half_t>>;
+
+  using TiledMma = typename TiledMMAHelper<
+      MMA_Atom<MMAAtom>,
+      Layout<TileShape>,
+      SubgroupLayout>::TiledMMA;
+
+  using EpilogueOp = cutlass::epilogue::fusion::LinearCombination<
+      ElementOutput,
+      ElementCompute,
+      ElementAcc,
+      ElementAcc,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using FusionCallBacks = cutlass::epilogue::fusion::FusionCallbacks<
+      EpilogueDispatchPolicy,
+      EpilogueOp,
+      TileShape,
+      decltype(tile_shape(TiledMma()))>;
+
+  using CollectiveEpilogue = cutlass::epilogue::collective::CollectiveEpilogue<
+      EpilogueDispatchPolicy,
+      TileShape,
+      void,
+      ElementAcc,
+      cutlass::gemm::TagToStrideC_t<LayoutC>,
+      ElementOutput,
+      cutlass::gemm::TagToStrideC_t<LayoutD>,
+      FusionCallBacks,
+      void,
+      void>;
+
+  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
+      GEMMDispatchPolicy,
+      TileShape,
+      ElementInputA,
+      cutlass::gemm::TagToStrideA_t<LayoutA>,
+      ElementInputB,
+      cutlass::gemm::TagToStrideB_t<LayoutB>,
+      TiledMma,
+      void,
+      void,
+      void,
+      cute::identity,
+      void,
+      void,
+      void,
+      cute::identity>;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      Shape<int, int, int, int>,
+      CollectiveMainloop,
+      CollectiveEpilogue>;
+
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+  static at::Tensor run(
+      sycl::queue& queue,
+      const at::Tensor& a,
+      const at::Tensor& b) {
+    const int M = static_cast<int>(a.size(0));
+    const int K = static_cast<int>(a.size(1));
+    const int N = static_cast<int>(b.size(1));
+    const int L = 1;
+
+    using StrideA = typename GemmKernel::StrideA;
+    using StrideB = typename GemmKernel::StrideB;
+    using StrideC = typename GemmKernel::StrideC;
+    using StrideD = typename GemmKernel::StrideD;
+
+    StrideA stride_A =
+        cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(M, K, L));
+    StrideB stride_B =
+        cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(N, K, L));
+    StrideC stride_C =
+        cutlass::make_cute_packed_stride(StrideC{}, cute::make_shape(M, N, L));
+    StrideD stride_D =
+        cutlass::make_cute_packed_stride(StrideD{}, cute::make_shape(M, N, L));
+
+    at::Tensor out = at::empty({M, N}, a.options());
+
+    typename Gemm::Arguments arguments{
+        cutlass::gemm::GemmUniversalMode::kGemm,
+        {M, N, K, L},
+        {static_cast<const ElementInputA*>(a.data_ptr()),
+         stride_A,
+         static_cast<const ElementInputB*>(b.data_ptr()),
+         stride_B},
+        {{1.0f, 0.0f},
+         nullptr,
+         stride_C,
+         static_cast<ElementOutput*>(out.data_ptr()),
+         stride_D},
+        cutlass::KernelHardwareInfo{}};
+
+    Gemm gemm_op;
+
+    size_t workspace_size = Gemm::get_workspace_size(arguments);
+    at::Tensor workspace;
+    void* workspace_ptr = nullptr;
+    if (workspace_size > 0) {
+      workspace = at::empty(
+          {static_cast<int64_t>(workspace_size)},
+          at::device(at::kXPU).dtype(at::kByte));
+      workspace_ptr = workspace.data_ptr();
+    }
+
+    auto can_impl = gemm_op.can_implement(arguments);
+    TORCH_CHECK(
+        can_impl == cutlass::Status::kSuccess,
+        "sycltla conv GEMM: invalid size M=",
+        M,
+        " K=",
+        K,
+        " N=",
+        N);
+
+    auto init_status = gemm_op.initialize(arguments, workspace_ptr);
+    TORCH_CHECK(
+        init_status == cutlass::Status::kSuccess,
+        "sycltla conv GEMM init failed");
+
+    auto run_status = gemm_op.run(&queue);
+    TORCH_CHECK(
+        run_status == cutlass::Status::kSuccess,
+        "sycltla conv GEMM run failed");
+
+    return out;
+  }
+};
+
+// Dispatch GEMM based on dtype
+inline at::Tensor run_conv_gemm(
+    sycl::queue& queue,
+    const at::Tensor& a,
+    const at::Tensor& b) {
+  if (a.dtype() == at::kBFloat16) {
+    return ConvGemm<bfloat16_t>::run(queue, a, b);
+  } else {
+    return ConvGemm<half_t>::run(queue, a, b);
+  }
+}

--- a/test/xpu/test_sycltla_conv_xpu.py
+++ b/test/xpu/test_sycltla_conv_xpu.py
@@ -1,0 +1,229 @@
+# Copyright 2020-2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Owner(s): ["module: intel"]
+
+"""
+Unit tests for sycltla conv2d/conv3d: fprop, dgrad, wgrad with BF16/FP16.
+
+Correctness is verified by comparing sycltla results against:
+  - PyTorch XPU conv (oneDNN backend) for fprop (same dtype, same device)
+  - FP32 CPU reference for dgrad/wgrad (gold standard)
+
+Both comparisons use the SAME input tensors to ensure determinism.
+"""
+
+import unittest
+
+import torch
+import torch.nn.functional as F
+
+
+@unittest.skipIf(not torch.xpu.is_available(), "XPU not available")
+class TestSycltlaConv(unittest.TestCase):
+    """Test sycltla_conv ops against oneDNN XPU reference and FP32 CPU gold."""
+
+    # Tolerance: sycltla vs oneDNN (both low-precision on XPU)
+    # should be very tight since both operate on same dtype
+    ATOL_ONEDNN = {torch.bfloat16: 1.0, torch.float16: 0.125}
+    RTOL_ONEDNN = {torch.bfloat16: 0.02, torch.float16: 0.01}
+
+    # Tolerance: sycltla vs FP32 CPU gold (cross-precision comparison)
+    ATOL_GOLD = {torch.bfloat16: 4.0, torch.float16: 0.6}
+    RTOL_GOLD = {torch.bfloat16: 0.05, torch.float16: 0.02}
+
+    def _check(self, actual, expected, dtype, tol_type="onednn", msg=""):
+        if tol_type == "onednn":
+            atol, rtol = self.ATOL_ONEDNN[dtype], self.RTOL_ONEDNN[dtype]
+        else:
+            atol, rtol = self.ATOL_GOLD[dtype], self.RTOL_GOLD[dtype]
+        maxdiff = (actual.float() - expected.float()).abs().max().item()
+        self.assertTrue(
+            torch.allclose(actual.float(), expected.float(), atol=atol, rtol=rtol),
+            f"{msg}: maxdiff={maxdiff:.4f}, atol={atol}, rtol={rtol} (vs {tol_type})",
+        )
+
+    # ========================================================================
+    # Conv2d fprop: compare vs oneDNN XPU (same dtype)
+    # ========================================================================
+    def _test_conv2d_fprop(self, dtype):
+        torch.manual_seed(42)
+        N, C, H, W, K, kH, kW = 2, 64, 32, 32, 128, 3, 3
+        s, p, d = [1, 1], [1, 1], [1, 1]
+        x = torch.randn(N, C, H, W, device="xpu", dtype=dtype)
+        w = torch.randn(K, C, kH, kW, device="xpu", dtype=dtype)
+        b = torch.randn(K, device="xpu", dtype=dtype)
+
+        # oneDNN reference (same dtype, same device)
+        ref = F.conv2d(x, w, b, stride=s, padding=p, dilation=d)
+        out = torch.ops.sycltla_conv.conv2d_fprop(x, w, b, s, p, d, 1)
+        self._check(out, ref, dtype, "onednn", "conv2d_fprop")
+
+        # Also without bias
+        ref_nb = F.conv2d(x, w, None, stride=s, padding=p, dilation=d)
+        out_nb = torch.ops.sycltla_conv.conv2d_fprop(x, w, None, s, p, d, 1)
+        self._check(out_nb, ref_nb, dtype, "onednn", "conv2d_fprop_no_bias")
+
+    def test_conv2d_fprop_bf16(self):
+        self._test_conv2d_fprop(torch.bfloat16)
+
+    def test_conv2d_fprop_fp16(self):
+        self._test_conv2d_fprop(torch.float16)
+
+    # ========================================================================
+    # Conv2d dgrad: compare vs FP32 CPU gold
+    # ========================================================================
+    def _test_conv2d_dgrad(self, dtype):
+        torch.manual_seed(42)
+        N, C, H, W, K, kH, kW = 2, 64, 32, 32, 128, 3, 3
+        s, p, d = [1, 1], [1, 1], [1, 1]
+        x = torch.randn(N, C, H, W, device="xpu", dtype=dtype)
+        w = torch.randn(K, C, kH, kW, device="xpu", dtype=dtype)
+
+        # FP32 CPU gold reference
+        x_cpu = x.float().cpu().requires_grad_(True)
+        w_cpu = w.float().cpu()
+        out_cpu = F.conv2d(x_cpu, w_cpu, stride=s, padding=p, dilation=d)
+        grad_out_cpu = torch.randn_like(out_cpu)
+        out_cpu.backward(grad_out_cpu)
+        gold = x_cpu.grad  # FP32 CPU
+
+        # sycltla
+        grad_out_xpu = grad_out_cpu.to(dtype).to("xpu")
+        result = torch.ops.sycltla_conv.conv2d_dgrad(
+            grad_out_xpu, w, list(x.shape), s, p, d, 1
+        )
+
+        # Compare sycltla (converted to float) vs FP32 gold
+        self._check(result.cpu(), gold.to(dtype), dtype, "gold", "conv2d_dgrad")
+
+    def test_conv2d_dgrad_bf16(self):
+        self._test_conv2d_dgrad(torch.bfloat16)
+
+    def test_conv2d_dgrad_fp16(self):
+        self._test_conv2d_dgrad(torch.float16)
+
+    # ========================================================================
+    # Conv2d wgrad: compare vs FP32 CPU gold
+    # ========================================================================
+    def _test_conv2d_wgrad(self, dtype):
+        torch.manual_seed(42)
+        N, C, H, W, K, kH, kW = 2, 64, 32, 32, 128, 3, 3
+        s, p, d = [1, 1], [1, 1], [1, 1]
+        x = torch.randn(N, C, H, W, device="xpu", dtype=dtype)
+        w = torch.randn(K, C, kH, kW, device="xpu", dtype=dtype)
+
+        x_cpu = x.float().cpu()
+        w_cpu = w.float().cpu().requires_grad_(True)
+        out_cpu = F.conv2d(x_cpu, w_cpu, stride=s, padding=p, dilation=d)
+        grad_out_cpu = torch.randn_like(out_cpu)
+        out_cpu.backward(grad_out_cpu)
+        gold = w_cpu.grad
+
+        grad_out_xpu = grad_out_cpu.to(dtype).to("xpu")
+        result = torch.ops.sycltla_conv.conv2d_wgrad(
+            grad_out_xpu, x, [kH, kW], s, p, d, 1
+        )
+
+        self._check(result.cpu(), gold.to(dtype), dtype, "gold", "conv2d_wgrad")
+
+    def test_conv2d_wgrad_bf16(self):
+        self._test_conv2d_wgrad(torch.bfloat16)
+
+    def test_conv2d_wgrad_fp16(self):
+        self._test_conv2d_wgrad(torch.float16)
+
+    # ========================================================================
+    # Conv3d fprop: compare vs oneDNN XPU
+    # ========================================================================
+    def _test_conv3d_fprop(self, dtype):
+        torch.manual_seed(42)
+        N, C, D, H, W, K = 2, 32, 8, 16, 16, 64
+        kD, kH, kW = 3, 3, 3
+        s, p, d = [1, 1, 1], [1, 1, 1], [1, 1, 1]
+        x = torch.randn(N, C, D, H, W, device="xpu", dtype=dtype)
+        w = torch.randn(K, C, kD, kH, kW, device="xpu", dtype=dtype)
+        b = torch.randn(K, device="xpu", dtype=dtype)
+
+        ref = F.conv3d(x, w, b, stride=s, padding=p, dilation=d)
+        out = torch.ops.sycltla_conv.conv3d_fprop(x, w, b, s, p, d, 1)
+        self._check(out, ref, dtype, "onednn", "conv3d_fprop")
+
+    def test_conv3d_fprop_bf16(self):
+        self._test_conv3d_fprop(torch.bfloat16)
+
+    def test_conv3d_fprop_fp16(self):
+        self._test_conv3d_fprop(torch.float16)
+
+    # ========================================================================
+    # Conv3d dgrad: compare vs FP32 CPU gold
+    # ========================================================================
+    def _test_conv3d_dgrad(self, dtype):
+        torch.manual_seed(42)
+        N, C, D, H, W, K = 2, 32, 8, 16, 16, 64
+        kD, kH, kW = 3, 3, 3
+        s, p, d = [1, 1, 1], [1, 1, 1], [1, 1, 1]
+        x = torch.randn(N, C, D, H, W, device="xpu", dtype=dtype)
+        w = torch.randn(K, C, kD, kH, kW, device="xpu", dtype=dtype)
+
+        x_cpu = x.float().cpu().requires_grad_(True)
+        w_cpu = w.float().cpu()
+        out_cpu = F.conv3d(x_cpu, w_cpu, stride=s, padding=p, dilation=d)
+        grad_out_cpu = torch.randn_like(out_cpu)
+        out_cpu.backward(grad_out_cpu)
+        gold = x_cpu.grad
+
+        grad_out_xpu = grad_out_cpu.to(dtype).to("xpu")
+        result = torch.ops.sycltla_conv.conv3d_dgrad(
+            grad_out_xpu, w, list(x.shape), s, p, d, 1
+        )
+
+        self._check(result.cpu(), gold.to(dtype), dtype, "gold", "conv3d_dgrad")
+
+    def test_conv3d_dgrad_bf16(self):
+        self._test_conv3d_dgrad(torch.bfloat16)
+
+    def test_conv3d_dgrad_fp16(self):
+        self._test_conv3d_dgrad(torch.float16)
+
+    # ========================================================================
+    # Conv3d wgrad: compare vs FP32 CPU gold
+    # ========================================================================
+    def _test_conv3d_wgrad(self, dtype):
+        torch.manual_seed(42)
+        N, C, D, H, W, K = 2, 32, 8, 16, 16, 64
+        kD, kH, kW = 3, 3, 3
+        s, p, d = [1, 1, 1], [1, 1, 1], [1, 1, 1]
+        x = torch.randn(N, C, D, H, W, device="xpu", dtype=dtype)
+        w = torch.randn(K, C, kD, kH, kW, device="xpu", dtype=dtype)
+
+        x_cpu = x.float().cpu()
+        w_cpu = w.float().cpu().requires_grad_(True)
+        out_cpu = F.conv3d(x_cpu, w_cpu, stride=s, padding=p, dilation=d)
+        grad_out_cpu = torch.randn_like(out_cpu)
+        out_cpu.backward(grad_out_cpu)
+        gold = w_cpu.grad
+
+        grad_out_xpu = grad_out_cpu.to(dtype).to("xpu")
+        result = torch.ops.sycltla_conv.conv3d_wgrad(
+            grad_out_xpu, x, [kD, kH, kW], s, p, d, 1
+        )
+
+        self._check(result.cpu(), gold.to(dtype), dtype, "gold", "conv3d_wgrad")
+
+    def test_conv3d_wgrad_bf16(self):
+        self._test_conv3d_wgrad(torch.bfloat16)
+
+    def test_conv3d_wgrad_fp16(self):
+        self._test_conv3d_wgrad(torch.float16)
+
+
+from torch.testing._internal.common_utils import run_tests
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
**Summary**
Add SYCL-TLA based Conv2d and Conv3d operators for Intel XPU, using im2col/col2im + Xe GEMM approach. Supports forward (fprop), input gradient (dgrad), and weight gradient (wgrad) for both Conv2d and Conv3d.

What's included
Conv2d/Conv3d forward pass (fprop) — im2col transforms spatial convolution into matrix multiplication, then uses Xe GEMM (GemmUniversalAdapter, TileShape 256×256×32, MainloopXeL1Staged) to compute output. Supports bias and grouped convolution.
Conv2d/Conv3d input gradient (dgrad) — Computes grad_output × weight via Xe GEMM, then col2im to reconstruct spatial input gradient.
Conv2d/Conv3d weight gradient (wgrad) — Computes im2col(input)^T × grad_output via Xe GEMM to get weight gradient.
BF16 and FP16 support — Shared templated GEMM header auto-selects MMA atom (XE_DPAS_TT<8, float, bfloat16_t> or XE_DPAS_TT<8, float, half_t>) based on input dtype.
TORCH_LIBRARY registration — 6 ops registered under sycltla_conv namespace: conv2d_fprop, conv2d_dgrad, conv2d_wgrad, conv3d_fprop, conv3d_dgrad, conv3d_wgrad.

Unit tests — 12 test cases verifying correctness:
fprop compared against oneDNN XPU reference (same dtype, same device)
dgrad/wgrad compared against FP32 CPU gold standard
