### PR TITLE
test_transformers_xpu: skip test_disable_fastpath in transformer suite

### DIFF
--- a/test/xpu/test_transformers_xpu.py
+++ b/test/xpu/test_transformers_xpu.py
@@ -1900,6 +1900,7 @@ class TestTransformers(NNTestCase):
         torch.jit.script(mha)
 
     @unittest.skipIf(TEST_WITH_CROSSREF, "Fastpath not available with crossref")
+    @skipIfXpu(msg="MHA fastpath is not available on XPU")
     @torch.no_grad()
     def test_disable_fastpath(self, device):
         def _test_te_fastpath_called(


### PR DESCRIPTION
TestTransformersXPU::test_disable_fastpath_xpu currently fails because it asserts MHA fastpath invocation. MHA fast would be deprecated. Add an explicit XPU skip on test_disable_fastpath in test_transformers_xpu.py.