### PR TITLE
Skip cond errors and warnings test

### DIFF
--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -90,6 +90,7 @@ skip_dict = {
         "test_compile_dyn_quant_matmul_4bit_m_32_k_128_n_4096_xpu",
         "test_compile_dyn_quant_matmul_4bit_m_32_k_64_n_11008_xpu",
         "test_compile_dyn_quant_matmul_4bit_m_32_k_64_n_4096_xpu",
+        "test_cond_errors_and_warnings_xpu_complex128",
         "_tunableop_",
         "_tuning_tunableop_",
     ),


### PR DESCRIPTION
Skip test failing due to missing SVD XPU implementation.
Explanation: https://github.com/intel/torch-xpu-ops/pull/2982#issuecomment-4037365881

Fixes: https://github.com/intel/torch-xpu-ops/issues/2389