### PR TITLE
Suppress a specific SYCL-related warning during the inclusion of the oneMKL BLAS header

### DIFF
--- a/src/ATen/native/xpu/mkl/TorchToMklType.h
+++ b/src/ATen/native/xpu/mkl/TorchToMklType.h
@@ -9,7 +9,9 @@
  */
 
 #include <ATen/ATen.h>
+#define SYCL_DISABLE_FSYCL_SYCLHPP_WARNING
 #include <oneapi/mkl/blas.hpp>
+#undef SYCL_DISABLE_FSYCL_SYCLHPP_WARNING
 
 template <typename T>
 struct get_mkl_type {


### PR DESCRIPTION
This pull request makes a small change to the `TorchToMklType.h` file to suppress a specific SYCL-related warning during the inclusion of the oneMKL BLAS header. This helps keep build logs cleaner without affecting functionality.