### PR TITLE
Disable custom Copilot environment setup

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
-  copilot-setup-steps:
+  copilot-setup-steps-disabled:
     runs-on: copilot_runner
     timeout-minutes: 59
 


### PR DESCRIPTION
## Summary
- Rename the `copilot-setup-steps` job to `copilot-setup-steps-disabled` so GitHub Copilot no longer picks up the custom environment configuration and falls back to the default environment.