### PR TITLE
Specify where to put headeronly enum_tags.h based

### DIFF
--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -40,6 +40,7 @@ set(XPU_CODEGEN_COMMAND
   "${Python_EXECUTABLE}" -m torchgen.gen
   --source-path ${CODEGEN_XPU_YAML_DIR}
   --install-dir ${BUILD_TORCH_XPU_ATEN_GENERATED}
+  --headeronly-install-dir ${BUILD_TORCH_XPU_ATEN_GENERATED}
   --per-operator-headers
   --backend-whitelist XPU SparseXPU SparseCsrXPU NestedTensorXPU
   --xpu


### PR DESCRIPTION
Otherwise the default path clashes with torch as the tags.yaml used in torch-xpu-ops is not aligned with our tags.yaml. We still intend to add more tags to tags.yaml, so the ideal change is for torch-xpu-ops to not have its own misaligned version.