### PR TITLE
[op_opt] Add vectorized scatter kernel

### DIFF
--- a/src/ATen/native/xpu/sycl/IndexKernelUtils.h
+++ b/src/ATen/native/xpu/sycl/IndexKernelUtils.h
@@ -48,6 +48,37 @@ inline bool fast_gather_kernel_eligible(
       get_alignment(static_cast<size_t>(iter.strides(0)[1])) == alignment;
 }
 
+// Eligibility check for vectorized scatter (is_scatter_like=true).
+//
+// For scatter with TensorAssign:
+//   dst[index[i], j] = src[i, j]
+// TensorIterator layout (fastest-to-slowest):
+//   strides(0) = dst: [element_size, 0]  ← dim restrided to 0
+//   strides(1) = src: [element_size, dim_size*element_size]  ← original
+//   strides(2) = idx: [0, idx_elem_size]  ← expanded along dim
+template <int alignment>
+inline bool fast_scatter_kernel_eligible(
+    const TensorIterator& iter,
+    char* const dst_ptr,
+    char* const src_ptr,
+    const size_t index_stride_bytes,
+    const size_t element_size) {
+  using at::native::memory::get_alignment;
+  const auto index_element_size = iter.element_size(2);
+
+  return iter.ndim() == 2 && iter.strides(2)[0] == 0 &&
+      iter.strides(2)[1] == index_element_size &&
+      static_cast<size_t>(iter.strides(0)[0]) == element_size &&
+      static_cast<size_t>(iter.strides(1)[0]) == element_size &&
+      static_cast<size_t>(iter.strides(0)[1]) == 0 &&
+      get_alignment(dst_ptr) == alignment &&
+      get_alignment(src_ptr) == alignment &&
+      get_alignment(static_cast<size_t>(iter.shape()[0] * element_size)) ==
+      alignment &&
+      get_alignment(static_cast<size_t>(index_stride_bytes)) == alignment &&
+      get_alignment(static_cast<size_t>(iter.strides(1)[1])) == alignment;
+}
+
 #define SIMD 32
 
 template <int Alignment, typename index_t>
@@ -160,5 +191,95 @@ template void vectorized_gather_kernel_launch<16, int32_t>(
     int64_t inp_stride_bytes,
     int64_t out_stride_bytes,
     bool allow_neg_indices);
+
+// Vectorized scatter kernel: copies contiguous slices from src to indexed
+// positions in dst using wide (Alignment-byte) loads and stores.
+//
+// For scatter_(dim, index, src):
+//   For each index i in [0, num_ind):
+//     dst[idx[i], :] = src[i, :]
+//
+// Each work-group handles one index entry and copies the entire slice
+// using Alignment-byte vector load/store operations.
+// This avoids narrow d16 stores for bf16/fp16 by packing multiple elements
+// into wider d32/d64/d128 transactions, matching fp32 store throughput.
+template <int Alignment, typename index_t>
+struct VectorizedScatterKernel {
+  SYCL_REQD_SUB_GROUP_SIZE(SIMD) void operator()(sycl::nd_item<2> item) const {
+    int64_t ind = idx_[item.get_group(1)];
+    SYCL_KERNEL_ASSERT(
+        ind >= 0 && ind < ind_dim_size_ &&
+        "vectorized scatter kernel index out of bounds");
+    int32_t off =
+        (item.get_local_range(1) * item.get_group(0) + item.get_local_id(1)) *
+        Alignment;
+    if (off >= slice_size_)
+      return;
+    const int64_t inp_group_offset =
+        static_cast<int64_t>(item.get_group(1)) * inp_stride_;
+    auto vec =
+        at::native::memory::ld_vec<Alignment>(inp_ + inp_group_offset + off);
+    at::native::memory::st_vec<Alignment>(out_ + ind * out_stride_ + off, vec);
+  }
+  VectorizedScatterKernel(
+      char* out,
+      char* inp,
+      index_t* idx,
+      int num_ind,
+      int64_t slice_size,
+      int64_t ind_dim_size,
+      int64_t inp_stride,
+      int64_t out_stride)
+      : out_(out),
+        inp_(inp),
+        idx_(idx),
+        num_ind_(num_ind),
+        slice_size_(slice_size),
+        ind_dim_size_(ind_dim_size),
+        inp_stride_(inp_stride),
+        out_stride_(out_stride) {}
+
+ private:
+  char* out_;
+  char* inp_;
+  index_t* idx_;
+  int num_ind_;
+  int64_t slice_size_;
+  int64_t ind_dim_size_;
+  int64_t inp_stride_;
+  int64_t out_stride_;
+};
+
+template <int64_t Alignment, typename index_t>
+void vectorized_scatter_kernel_launch(
+    char* out,
+    char* inp,
+    index_t* idx,
+    int num_ind,
+    int64_t slice_size_in_bytes,
+    int64_t ind_dim_size,
+    int64_t inp_stride_bytes,
+    int64_t out_stride_bytes) {
+  int64_t max_num_threads = syclMaxWorkItemsPerSubSlice();
+  auto num_threads = at::round_up(
+      at::ceil_div(slice_size_in_bytes, Alignment), static_cast<int64_t>(SIMD));
+  auto wg_size = std::min(max_num_threads, num_threads);
+  sycl::range<2> local_range(1, wg_size);
+  sycl::range<2> global_range(
+      static_cast<uint32_t>(
+          at::ceil_div(slice_size_in_bytes, max_num_threads * Alignment)),
+      static_cast<uint32_t>(num_ind) * wg_size);
+  auto caller = VectorizedScatterKernel<Alignment, index_t>(
+      out,
+      inp,
+      idx,
+      num_ind,
+      slice_size_in_bytes,
+      ind_dim_size,
+      inp_stride_bytes,
+      out_stride_bytes);
+  sycl_kernel_submit(
+      global_range, local_range, at::xpu::getCurrentSYCLQueue(), caller);
+}
 
 } // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/ScatterGatherKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ScatterGatherKernels.cpp
@@ -269,8 +269,11 @@ struct ScatterGatherInternalKernelLoopFunctor {
   func_t f_;
 };
 
-template <bool is_scatter_like, typename scalar_t, typename index_t,
-          bool enable_vectorized_scatter = false>
+template <
+    bool is_scatter_like,
+    typename scalar_t,
+    typename index_t,
+    bool enable_vectorized_scatter = false>
 struct ScatterGatherInternalKernel {
   template <typename func_t>
   void operator()(
@@ -281,8 +284,11 @@ struct ScatterGatherInternalKernel {
       func_t f) {
     if (!iter.can_use_32bit_indexing()) {
       for (auto& sub_iter : iter.with_32bit_indexing()) {
-        ScatterGatherInternalKernel<is_scatter_like, scalar_t, index_t,
-                                    enable_vectorized_scatter>()(
+        ScatterGatherInternalKernel<
+            is_scatter_like,
+            scalar_t,
+            index_t,
+            enable_vectorized_scatter>()(
             sub_iter, index_size, index_stride, numel, f);
       }
       return;
@@ -494,8 +500,11 @@ struct ScatterGatherBaseKernel {
             scalar_t>::type;
         AT_DISPATCH_INDEX_TYPES(
             index.scalar_type(), "xpu_scatter_gather_base_kernel_func", [&]() {
-              ScatterGatherInternalKernel<is_scatter_like, dtype, index_t,
-                                          /*enable_vectorized_scatter=*/true>()(
+              ScatterGatherInternalKernel<
+                  is_scatter_like,
+                  dtype,
+                  index_t,
+                  /*enable_vectorized_scatter=*/true>()(
                   iter, index_size, index_stride, self.numel(), f);
             });
       });

--- a/src/ATen/native/xpu/sycl/ScatterGatherKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ScatterGatherKernels.cpp
@@ -269,7 +269,8 @@ struct ScatterGatherInternalKernelLoopFunctor {
   func_t f_;
 };
 
-template <bool is_scatter_like, typename scalar_t, typename index_t>
+template <bool is_scatter_like, typename scalar_t, typename index_t,
+          bool enable_vectorized_scatter = false>
 struct ScatterGatherInternalKernel {
   template <typename func_t>
   void operator()(
@@ -280,7 +281,8 @@ struct ScatterGatherInternalKernel {
       func_t f) {
     if (!iter.can_use_32bit_indexing()) {
       for (auto& sub_iter : iter.with_32bit_indexing()) {
-        ScatterGatherInternalKernel<is_scatter_like, scalar_t, index_t>()(
+        ScatterGatherInternalKernel<is_scatter_like, scalar_t, index_t,
+                                    enable_vectorized_scatter>()(
             sub_iter, index_size, index_stride, numel, f);
       }
       return;
@@ -307,6 +309,39 @@ struct ScatterGatherInternalKernel {
         if (iter.numel() == 0)
           return;
         at::native::xpu::vectorized_gather_kernel_launch<alignment, index_t>(
+            self_ptr,
+            src_ptr,
+            (index_t*)index_ptr,
+            num_ind,
+            slice_size,
+            ind_dim_size,
+            inp_stride_bytes,
+            out_stride_bytes);
+        return;
+      }
+    }
+
+    // Vectorized scatter fast path for TensorAssign (non-reduce scatter).
+    // Copies entire slices using wide vector loads/stores instead of
+    // element-by-element. Critical for bf16/fp16: avoids narrow d16 stores
+    // that underutilize LSC message throughput on Xe2 architecture.
+    if constexpr (is_scatter_like && enable_vectorized_scatter) {
+      constexpr size_t element_size = sizeof(scalar_t);
+      constexpr int64_t alignment = 16;
+      if (fast_scatter_kernel_eligible<alignment>(
+              iter,
+              self_ptr,
+              src_ptr,
+              index_stride * element_size,
+              element_size)) {
+        auto slice_size = iter.shape()[0] * element_size;
+        auto num_ind = iter.shape()[1];
+        auto ind_dim_size = index_size;
+        auto out_stride_bytes = index_stride * element_size;
+        auto inp_stride_bytes = iter.strides(1)[1];
+        if (iter.numel() == 0)
+          return;
+        at::native::xpu::vectorized_scatter_kernel_launch<alignment, index_t>(
             self_ptr,
             src_ptr,
             (index_t*)index_ptr,
@@ -459,7 +494,8 @@ struct ScatterGatherBaseKernel {
             scalar_t>::type;
         AT_DISPATCH_INDEX_TYPES(
             index.scalar_type(), "xpu_scatter_gather_base_kernel_func", [&]() {
-              ScatterGatherInternalKernel<is_scatter_like, dtype, index_t>()(
+              ScatterGatherInternalKernel<is_scatter_like, dtype, index_t,
+                                          /*enable_vectorized_scatter=*/true>()(
                   iter, index_size, index_stride, self.numel(), f);
             });
       });
@@ -479,7 +515,8 @@ struct ScatterGatherBaseKernel {
                   ScatterGatherInternalKernel<
                       is_scatter_like,
                       dtype,
-                      index_t>()(
+                      index_t,
+                      /*enable_vectorized_scatter=*/true>()(
                       iter, index_size, index_stride, self.numel(), f);
                 });
           }),


### PR DESCRIPTION
Add a vectorized scatter fast path mirroring the existing vectorized
gather kernel. For scatter_(dim=0) with TensorAssign, contiguous slices
are copied using 16-byte wide vector load/store operations instead of
element-by-element stores.

Results on Intel B60 (BMG, 0xE211):
- bf16 scatter bandwidth: 224 GB/s -> 377 GB/s (1.68x speedup)

## update: (from Jianyi)

### Summary

Add a vectorized scatter kernel to eliminate the **4× L3 write amplification** caused by LSC `d16u32` partial-write stores on Intel Xe2 GPUs (BMG/B580).

### Root Cause

On BMG (Xe2), a SIMD-32 scatter store with `d16u32` (2-byte data, 4-byte address) writes 32×2B = 64B per instruction. However, each 16B-aligned partial write touches only 2B within that 16B block, forcing the L3 cache to perform **4 separate 16B read-modify-write** cycles per cache line. This results in 4× write amplification compared to fp32 (`d32` store, 1 write per cache line).

**unitrace -g ComputeBasic evidence (B580, shape=[4096, 4096], scatter dim=0):**

| Metric | fp32 baseline | bf16 baseline | bf16 vectorized |
|--------|--------------|---------------|-----------------|
| L3_WRITE | 2.10M | **8.39M** | **2.10M** |
| SEND_ALL | 4.20M | 4.20M | 2.23M |
| XVE_STALL | 67.9% | 79.1% | 62.3% |
| Latency (µs) | 415 | 754 | **387** |
| BW (GB/s) | 323 | 178 | **347** |

- bf16 baseline L3_WRITE = 8.39M ≈ 4 × fp32's 2.10M → confirms **4× write amplification**
- bf16 vectorized L3_WRITE = 2.10M = fp32 level → amplification eliminated
- bf16 vectorized is **~1.95× faster** than bf16 baseline, and even slightly faster than fp32

### Approach

Pack 8 consecutive `bf16`/`fp16` elements into a `uint4` (16 bytes) and issue a single `d128` (128-bit) vector store per work-item, avoiding partial writes entirely.

**Eligibility conditions** (`fast_scatter_kernel_eligible`):
1. All tensors (dst, src, index) are contiguous with matching sizes
2. Inner dimension is 16-byte aligned (≥ 8 elements for bf16/fp16)
3. Scatter dim = 0 (gather dimension matches scatter dimension)

When eligible, the kernel dispatches to `VectorizedScatterKernel`; otherwise falls back to the existing elementwise path.