### PR TITLE
Skip test_zeros_large_xpu_complex128 on BMG

### DIFF
--- a/test/xpu/skip_list_win_bmg.py
+++ b/test/xpu/skip_list_win_bmg.py
@@ -44,4 +44,9 @@ skip_dict = {
         "test_MaxUnpool_index_errors_case7_xpu",
         "test_MaxUnpool_index_errors_case9_xpu",
     ),
+    # https://github.com/intel/torch-xpu-ops/issues/2660
+    # out of memory issue
+    "test_tensor_creation_ops_xpu.py": (
+        "test_zeros_large_xpu_complex128",
+    ),
 }

--- a/test/xpu/skip_list_win_bmg.py
+++ b/test/xpu/skip_list_win_bmg.py
@@ -46,7 +46,5 @@ skip_dict = {
     ),
     # https://github.com/intel/torch-xpu-ops/issues/2660
     # out of memory issue
-    "test_tensor_creation_ops_xpu.py": (
-        "test_zeros_large_xpu_complex128",
-    ),
+    "test_tensor_creation_ops_xpu.py": ("test_zeros_large_xpu_complex128",),
 }


### PR DESCRIPTION
Skip `test_zeros_large_xpu_complex128` in `skip_list_win_bmg.py`.

Refs https://github.com/intel/torch-xpu-ops/issues/2660