### PR TITLE
ci(build): refactor _linux_build.yml into composite actions

### DIFF
--- a/.github/actions/build-domain-lib/action.yml
+++ b/.github/actions/build-domain-lib/action.yml
@@ -1,0 +1,90 @@
+name: build-domain-lib
+description: 'Build a PyTorch domain library at the commit pinned in PyTorch ci_commit_pins.'
+
+inputs:
+  name:
+    description: 'Wheel name prefix (e.g. torchvision, torchaudio).'
+    required: true
+  repo-url:
+    description: 'Git URL to clone.'
+    required: true
+  pin-file:
+    description: 'Pin file name under pytorch/.github/ci_commit_pins/ (e.g. vision.txt).'
+    required: true
+  pytorch-src:
+    description: 'Path to pytorch source checkout (used to read the pin and as parent dir for the clone).'
+    required: true
+  workspace:
+    description: 'Destination directory for the produced wheel and build log.'
+    required: true
+  src-dir-name:
+    description: 'Name of the local clone directory (under pytorch-src).'
+    required: false
+    default: ''
+  branch:
+    description: 'Branch to clone before checking out the pinned commit.'
+    required: false
+    default: 'main'
+  gcc-version:
+    description: 'gcc-toolset version to source.'
+    required: false
+    default: '13'
+  os-packages:
+    description: 'Space-separated OS packages to dnf-install before building.'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Build ${{ inputs.name }}
+      shell: bash
+      env:
+        NAME: ${{ inputs.name }}
+        REPO_URL: ${{ inputs.repo-url }}
+        PIN_FILE: ${{ inputs.pin-file }}
+        PYTORCH_SRC: ${{ inputs.pytorch-src }}
+        WORKSPACE: ${{ inputs.workspace }}
+        SRC_DIR_NAME: ${{ inputs.src-dir-name }}
+        BRANCH: ${{ inputs.branch }}
+        GCC_VERSION: ${{ inputs.gcc-version }}
+        OS_PACKAGES: ${{ inputs.os-packages }}
+      run: |
+        set -euo pipefail
+        # shellcheck disable=SC1091
+        source "/opt/rh/gcc-toolset-${GCC_VERSION}/enable"
+
+        if [[ ! -d "${PYTORCH_SRC}" ]]; then
+          echo "::error title=Missing PyTorch source::Expected at ${PYTORCH_SRC}"
+          exit 1
+        fi
+
+        if [[ -n "${OS_PACKAGES}" ]]; then
+          # shellcheck disable=SC2086
+          dnf install -y ${OS_PACKAGES}
+        fi
+
+        cd "${PYTORCH_SRC}"
+        commit="$(cat ".github/ci_commit_pins/${PIN_FILE}")"
+        src_dir="${SRC_DIR_NAME:-xpu-${NAME#torch}}"
+        rm -rf "${src_dir}"
+        git clone --single-branch -b "${BRANCH}" "${REPO_URL}" "${src_dir}"
+        ( cd "${src_dir}" && git checkout "${commit}" )
+
+        log="${WORKSPACE}/build_${NAME#torch}_${commit}.log"
+        ( cd "${src_dir}" && python setup.py bdist_wheel ) 2>&1 | tee "${log}"
+
+        if [ "$(ls "${src_dir}/dist/" | grep -c "${NAME}-.*\.whl")" -eq 0 ]; then
+          echo "::error title=${NAME} build failed::No wheel produced"
+          exit 1
+        fi
+        pip install "${src_dir}"/dist/*.whl
+        cp "${src_dir}"/dist/*.whl "${WORKSPACE}"
+
+        wheel=$(ls "${src_dir}/dist/" | grep -E "^${NAME}-.*\.whl$" | head -1)
+        {
+          echo "## ${NAME} build"
+          echo
+          echo "- commit: \`${commit}\`"
+          echo "- wheel: \`${wheel}\`"
+        } >> "${GITHUB_STEP_SUMMARY:-/dev/null}" || true

--- a/.github/actions/build-pytorch-xpu/action.yml
+++ b/.github/actions/build-pytorch-xpu/action.yml
@@ -1,0 +1,85 @@
+name: build-pytorch-xpu
+description: 'Run torch-xpu-ops build.sh to build PyTorch with XPU support.'
+
+inputs:
+  workspace:
+    description: 'Build workspace (where torch-*.whl will land). Typically ${{ github.workspace }}.'
+    required: true
+  torch-xpu-ops-src:
+    description: 'Path to the torch-xpu-ops checkout (where build.sh and env.sh live).'
+    required: true
+  pytorch:
+    description: 'PyTorch spec: commit, branch, or repo@ref.'
+    required: true
+  torch-xpu-ops:
+    description: 'torch-xpu-ops spec: commit, branch, or repo@ref.'
+    required: true
+  gcc-version:
+    description: 'gcc-toolset version to source.'
+    required: false
+    default: '13'
+
+runs:
+  using: composite
+  steps:
+    - name: Build PyTorch XPU
+      shell: bash
+      env:
+        WORKSPACE: ${{ inputs.workspace }}
+        TORCH_XPU_OPS_SRC: ${{ inputs.torch-xpu-ops-src }}
+        PYTORCH_SPEC: ${{ inputs.pytorch }}
+        TORCH_XPU_OPS_SPEC: ${{ inputs.torch-xpu-ops }}
+        GCC_VERSION: ${{ inputs.gcc-version }}
+        GITHUB_EVENT_NAME: ${{ github.event_name }}
+      run: |
+        set -euo pipefail
+        export USE_XCCL=1
+        export IS_XPU_CI=1
+        # only build pvc for CI
+        if [ "${GITHUB_EVENT_NAME}" == "pull_request" ]; then
+          export TORCH_XPU_ARCH_LIST='pvc'
+        fi
+
+        if [[ "${PYTORCH_SPEC}" == *"https://"* ]]; then
+          PYTORCH_REPO="$(echo "${PYTORCH_SPEC}" | sed 's/@.*//')"
+          PYTORCH_COMMIT="$(echo "${PYTORCH_SPEC}" | sed 's/.*@//')"
+        else
+          PYTORCH_REPO="https://github.com/pytorch/pytorch.git"
+          PYTORCH_COMMIT="${PYTORCH_SPEC}"
+        fi
+        if [[ "${TORCH_XPU_OPS_SPEC}" == *"https://"* ]]; then
+          TORCH_XPU_OPS_REPO="$(echo "${TORCH_XPU_OPS_SPEC}" | sed 's/@.*//')"
+          TORCH_XPU_OPS_COMMIT="$(echo "${TORCH_XPU_OPS_SPEC}" | sed 's/.*@//')"
+        else
+          TORCH_XPU_OPS_REPO="https://github.com/intel/torch-xpu-ops.git"
+          TORCH_XPU_OPS_COMMIT="${TORCH_XPU_OPS_SPEC}"
+        fi
+
+        # gcc
+        # shellcheck disable=SC1091
+        source "/opt/rh/gcc-toolset-${GCC_VERSION}/enable"
+        # shellcheck disable=SC1091
+        source "${TORCH_XPU_OPS_SRC}/.github/scripts/env.sh"
+
+        log="${WORKSPACE}/build_pytorch_${PYTORCH_COMMIT//\//-}.log"
+        "${TORCH_XPU_OPS_SRC}/.github/scripts/build.sh" \
+          --WORKSPACE="${WORKSPACE}" \
+          --PYTORCH_REPO="${PYTORCH_REPO}" \
+          --PYTORCH_COMMIT="${PYTORCH_COMMIT}" \
+          --TORCH_XPU_OPS_REPO="${TORCH_XPU_OPS_REPO}" \
+          --TORCH_XPU_OPS_COMMIT="${TORCH_XPU_OPS_COMMIT}" \
+          2>&1 | tee "${log}"
+
+        if [ "$(ls "${WORKSPACE}" | grep -c 'torch-.*\.whl')" -eq 0 ]; then
+          echo "::error title=PyTorch wheel build failed::No torch wheel produced in ${WORKSPACE}"
+          exit 1
+        fi
+
+        wheel=$(ls "${WORKSPACE}" | grep -E '^torch-.*\.whl$' | head -1)
+        {
+          echo "## PyTorch build"
+          echo
+          echo "- pytorch: \`${PYTORCH_REPO}@${PYTORCH_COMMIT}\`"
+          echo "- torch-xpu-ops: \`${TORCH_XPU_OPS_REPO}@${TORCH_XPU_OPS_COMMIT}\`"
+          echo "- wheel: \`${wheel}\`"
+        } >> "${GITHUB_STEP_SUMMARY:-/dev/null}" || true

--- a/.github/actions/build-triton-xpu/action.yml
+++ b/.github/actions/build-triton-xpu/action.yml
@@ -1,0 +1,98 @@
+name: build-triton-xpu
+description: 'Provide a triton-xpu wheel by either downloading a pre-built nightly or building from source.'
+
+inputs:
+  pytorch-src:
+    description: 'Path to pytorch source checkout (used for build_triton_wheel.py and the default triton commit pin).'
+    required: true
+  workspace:
+    description: 'Destination directory for the wheel and build log.'
+    required: true
+  triton:
+    description: |
+      Triton spec: empty/"pinned" => use pytorch's pinned commit;
+      otherwise treated as a commit/branch.
+    required: false
+    default: ''
+  default-repo:
+    description: 'Default Triton repository (owner/repo).'
+    required: false
+    default: 'intel/intel-xpu-backend-for-triton'
+  index-url:
+    description: 'pip index URL for pre-built nightly wheels.'
+    required: false
+    default: 'https://download.pytorch.org/whl/nightly/xpu'
+  gcc-version:
+    description: 'gcc-toolset version to source.'
+    required: false
+    default: '13'
+
+runs:
+  using: composite
+  steps:
+    - name: Build or fetch Triton (XPU)
+      shell: bash
+      env:
+        PYTORCH_SRC: ${{ inputs.pytorch-src }}
+        WORKSPACE: ${{ inputs.workspace }}
+        TRITON_SPEC: ${{ inputs.triton }}
+        DEFAULT_REPO: ${{ inputs.default-repo }}
+        INDEX_URL: ${{ inputs.index-url }}
+        GCC_VERSION: ${{ inputs.gcc-version }}
+      run: |
+        set -euo pipefail
+        cd "${PYTORCH_SRC}"
+        rm -rf triton_xpu-*.whl
+
+        if [ -z "${TRITON_SPEC}" ] || [ "${TRITON_SPEC}" == "pinned" ]; then
+          TRITON_COMMIT_ID="$(cat .ci/docker/ci_commit_pins/triton-xpu.txt)"
+        else
+          TRITON_COMMIT_ID="${TRITON_SPEC}"
+        fi
+        echo "Triton: ${DEFAULT_REPO}@${TRITON_COMMIT_ID}"
+
+        built_version="$(pip index versions --index-url "${INDEX_URL}" --pre triton-xpu 2>/dev/null \
+          | awk -F '[ |,]' -v p="$(echo "${TRITON_COMMIT_ID}" | awk '{print substr($1,0,7)}')" 'BEGIN{
+            v = "None";
+          }{
+            for (i=1;i<=NF;i++) {if ($i ~ p) {v = $i;}};
+          }END{
+            printf("%s", v);
+          }')"
+
+        if [ "${built_version}" != "None" ]; then
+          echo "Using pre-built triton-xpu==${built_version}"
+          pip download --no-deps --index-url "${INDEX_URL}" --pre \
+            "triton-xpu==${built_version}" --dest "${WORKSPACE}/"
+          pip install "${WORKSPACE}"/*triton*.whl
+          source_or_prebuilt="prebuilt"
+        else
+          echo "No matching pre-built wheel; building from source"
+          TRITON_VERSION_NAME="$(
+            curl -sSL "https://raw.githubusercontent.com/${DEFAULT_REPO}/${TRITON_COMMIT_ID}/python/triton/__init__.py" 2>&1 \
+              | grep '__version__' | head -n 1 | awk -F "'" '{print $2}'
+          )"
+          # shellcheck disable=SC1091
+          source "/opt/rh/gcc-toolset-${GCC_VERSION}/enable"
+          dnf install -y zlib-devel
+          pip install cmake ninja pybind11
+          python .github/scripts/build_triton_wheel.py \
+            --device xpu \
+            --commit-hash "${TRITON_COMMIT_ID}" \
+            --triton-version "${TRITON_VERSION_NAME}" \
+            2>&1 | tee "${WORKSPACE}/build_triton_${TRITON_COMMIT_ID}.log"
+          if [ "$(ls | grep -c 'triton_xpu-.*\.whl')" -eq 0 ]; then
+            echo "::error title=Triton build failed::No triton_xpu wheel produced"
+            exit 1
+          fi
+          pip install triton_xpu-*.whl
+          cp triton_xpu-*.whl "${WORKSPACE}"
+          source_or_prebuilt="source"
+        fi
+
+        {
+          echo "## Triton build"
+          echo
+          echo "- commit: \`${TRITON_COMMIT_ID}\`"
+          echo "- source: \`${source_or_prebuilt}\`"
+        } >> "${GITHUB_STEP_SUMMARY:-/dev/null}" || true

--- a/.github/actions/setup-build-python/action.yml
+++ b/.github/actions/setup-build-python/action.yml
@@ -1,0 +1,39 @@
+name: setup-build-python
+description: 'Locate cp interpreter under /opt/python and create a fresh build venv.'
+
+inputs:
+  python-version:
+    description: 'Python version, e.g. 3.10.'
+    required: true
+  venv-dir:
+    description: 'Where to create the build venv.'
+    required: false
+    default: '/tmp/xpu-tool/myvenv'
+  setuptools-spec:
+    description: 'setuptools pin (passed verbatim to pip install).'
+    required: false
+    default: 'setuptools==81.0.0'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup python ${{ inputs.python-version }}
+      shell: bash
+      env:
+        PY_VER: ${{ inputs.python-version }}
+        VENV_DIR: ${{ inputs.venv-dir }}
+        SETUPTOOLS_SPEC: ${{ inputs.setuptools-spec }}
+      run: |
+        set -euo pipefail
+        rm -rf "${VENV_DIR}"
+        local_python=$(echo "${PY_VER}" | awk -F. '{printf("cp%s%s-cp%s%s", $1, $2, $1, $2)}')
+        py_bin="/opt/python/${local_python}/bin/python"
+        if [[ ! -x "${py_bin}" ]]; then
+          echo "::error title=Python not found::${py_bin} (version ${PY_VER}) not found"
+          ls -1 /opt/python || true
+          exit 1
+        fi
+        "${py_bin}" -m venv "${VENV_DIR}"
+        which python && python -V
+        which pip && pip list
+        pip install -U pip wheel "${SETUPTOOLS_SPEC}"

--- a/.github/actions/verify-pytorch-build/action.yml
+++ b/.github/actions/verify-pytorch-build/action.yml
@@ -1,0 +1,59 @@
+name: verify-pytorch-build
+description: 'Import smoke tests for torch, triton, and domain libs with a step-summary table.'
+
+inputs:
+  pytorch-src:
+    description: 'Path to pytorch source (used for collect_env.py).'
+    required: false
+    default: 'pytorch'
+
+runs:
+  using: composite
+  steps:
+    - name: Torch Config
+      shell: bash
+      env:
+        PYTORCH_SRC: ${{ inputs.pytorch-src }}
+      run: |
+        set -uo pipefail
+        rc=0
+        : > /tmp/_verify_rows
+
+        check() {
+          local name="$1"; shift
+          local expr="$1"
+          local out
+          if out=$(python -c "${expr}" 2>&1); then
+            printf '  %-12s OK   %s\n' "${name}" "${out}"
+            echo "| ${name} | OK | \`${out}\` |" >> /tmp/_verify_rows
+          else
+            printf '  %-12s FAIL %s\n' "${name}" "${out}" >&2
+            echo "| ${name} | FAIL | \`${out}\` |" >> /tmp/_verify_rows
+            rc=1
+          fi
+        }
+
+        printenv
+        python -c "import torch; print(torch.__config__.show())" || true
+        python -c "import torch; print(torch.__config__.parallel_info())" || true
+
+        check torch        "import torch; print(torch.__version__)"
+        check 'torch.xpu'  "import torch; print('devices=' + str(torch.xpu.device_count()))"
+        check triton       "import triton; print(triton.__version__)"
+        check torchvision  "import torchvision; print(torchvision.__version__)"
+        check torchaudio   "import torchaudio; print(torchaudio.__version__)"
+
+        if [[ -d "${PYTORCH_SRC}" && -f "${PYTORCH_SRC}/torch/utils/collect_env.py" ]]; then
+          python "${PYTORCH_SRC}/torch/utils/collect_env.py" || true
+        fi
+        pip list | grep -E 'torch|intel' || true
+
+        {
+          echo "## Build verification"
+          echo
+          echo "| Component | Status | Detail |"
+          echo "|-----------|--------|--------|"
+          cat /tmp/_verify_rows
+        } >> "${GITHUB_STEP_SUMMARY:-/dev/null}" || true
+
+        exit "${rc}"

--- a/.github/workflows/_linux_build.yml
+++ b/.github/workflows/_linux_build.yml
@@ -74,135 +74,63 @@ jobs:
         run: |
           cat /etc/os-release
           hostname && id
-          # install gh
           dnf install -y 'dnf-command(config-manager)'
           dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
           dnf install -y gh --repo gh-cli
           gh --version
-          # cleanup files
           rm -rf ${{ github.workspace }}/*.whl ${{ github.workspace }}/*.log
-      - name: Setup python-${{ inputs.python }}
-        run: |
-          rm -rf /tmp/xpu-tool/myvenv
-          local_python=$(echo ${{ inputs.python }} |awk -F. '{printf("cp%s%s-cp%s%s", $1, $2, $1, $2)}')
-          /opt/python/${local_python}/bin/python -m venv /tmp/xpu-tool/myvenv
-          which python && python -V
-          which pip && pip list
-          pip install -U pip wheel setuptools==81.0.0
+
       - name: Checkout torch-xpu-ops
         uses: actions/checkout@v4
         with:
           path: torch-xpu-ops
+
+      - name: Setup python-${{ inputs.python }}
+        uses: ./torch-xpu-ops/.github/actions/setup-build-python
+        with:
+          python-version: ${{ inputs.python }}
+
       - name: Build Pytorch on ${{ needs.runner.outputs.hostname }}
-        run: |
-          export USE_XCCL=1
-          export IS_XPU_CI=1
-          # only build pvc for CI
-          if [ "${{ github.event_name }}" == "pull_request" ];then
-            export TORCH_XPU_ARCH_LIST='pvc'
-          fi
-          if [[ "${{ inputs.pytorch }}" == *"https://"* ]];then
-            PYTORCH_REPO="$(echo ${{ inputs.pytorch }} |sed 's/@.*//')"
-            PYTORCH_COMMIT="$(echo ${{ inputs.pytorch }} |sed 's/.*@//')"
-          else
-            PYTORCH_REPO="https://github.com/pytorch/pytorch.git"
-            PYTORCH_COMMIT="${{ inputs.pytorch }}"
-          fi
-          if [[ "${{ inputs.torch_xpu_ops }}" == *"https://"* ]];then
-            TORCH_XPU_OPS_REPO="$(echo ${{ inputs.torch_xpu_ops }} |sed 's/@.*//')"
-            TORCH_XPU_OPS_COMMIT="$(echo ${{ inputs.torch_xpu_ops }} |sed 's/.*@//')"
-          else
-            TORCH_XPU_OPS_REPO="https://github.com/intel/torch-xpu-ops.git"
-            TORCH_XPU_OPS_COMMIT="${{ inputs.torch_xpu_ops }}"
-          fi
-          # gcc 13
-          source /opt/rh/gcc-toolset-13/enable
-          source ${{ github.workspace }}/torch-xpu-ops/.github/scripts/env.sh
-          ${{ github.workspace }}/torch-xpu-ops/.github/scripts/build.sh \
-            --WORKSPACE="${{ github.workspace }}" \
-            --PYTORCH_REPO="${PYTORCH_REPO}" \
-            --PYTORCH_COMMIT="${PYTORCH_COMMIT}" \
-            --TORCH_XPU_OPS_REPO="${TORCH_XPU_OPS_REPO}" \
-            --TORCH_XPU_OPS_COMMIT="${TORCH_XPU_OPS_COMMIT}" \
-            2>&1 |tee ${{ github.workspace }}/build_pytorch_${PYTORCH_COMMIT//\//-}.log
-          if [ $(ls ${{ github.workspace }} |grep -c "torch-.*.whl") -eq 0 ];then
-            echo "Build pytorch got failed"
-            exit 1
-          fi
-      - name: Build Torchvision and Torchaudio
-        run: |
-          # gcc 13
-          source /opt/rh/gcc-toolset-13/enable
-          cd ./pytorch
-          TORCHVISION_COMMIT_ID="$(cat .github/ci_commit_pins/vision.txt)"
-          TORCHAUDIO_COMMIT_ID="$(cat .github/ci_commit_pins/audio.txt)"
-          git clone --single-branch -b main https://github.com/pytorch/vision.git xpu-vision
-          cd xpu-vision && git checkout ${TORCHVISION_COMMIT_ID}
-          python setup.py bdist_wheel 2>&1 |tee ${{ github.workspace }}/build_vision_${TRITON_COMMIT_ID}.log
-          if [ $(ls dist/ |grep -c "torchvision-.*.whl") -eq 0 ];then
-            echo "Build torchvision got failed"
-            exit 1
-          fi
-          pip install dist/*.whl
-          cp dist/*.whl ${{ github.workspace }}
-          git clone --single-branch -b main https://github.com/pytorch/audio.git xpu-audio
-          cd xpu-audio && git checkout ${TORCHAUDIO_COMMIT_ID}
-          python setup.py bdist_wheel 2>&1 |tee ${{ github.workspace }}/build_audio_${TRITON_COMMIT_ID}.log
-          if [ $(ls dist/ |grep -c "torchaudio-.*.whl") -eq 0 ];then
-            echo "Build torchaudio got failed"
-            exit 1
-          fi
-          pip install dist/*.whl
-          cp dist/*.whl ${{ github.workspace }}
+        uses: ./torch-xpu-ops/.github/actions/build-pytorch-xpu
+        with:
+          workspace: ${{ github.workspace }}
+          torch-xpu-ops-src: ${{ github.workspace }}/torch-xpu-ops
+          pytorch: ${{ inputs.pytorch }}
+          torch-xpu-ops: ${{ inputs.torch_xpu_ops }}
+
+      - name: Build Torchvision
+        uses: ./torch-xpu-ops/.github/actions/build-domain-lib
+        with:
+          name: torchvision
+          repo-url: https://github.com/pytorch/vision.git
+          pin-file: vision.txt
+          pytorch-src: ${{ github.workspace }}/pytorch
+          workspace: ${{ github.workspace }}
+          src-dir-name: xpu-vision
+          os-packages: libpng-devel libjpeg-devel
+
+      - name: Build Torchaudio
+        uses: ./torch-xpu-ops/.github/actions/build-domain-lib
+        with:
+          name: torchaudio
+          repo-url: https://github.com/pytorch/audio.git
+          pin-file: audio.txt
+          pytorch-src: ${{ github.workspace }}/pytorch
+          workspace: ${{ github.workspace }}
+          src-dir-name: xpu-audio
+
       - name: Build Triton
-        run: |
-          cd ./pytorch
-          rm -rf triton_xpu-*.whl
-          if [ -z ${{ inputs.triton }} ] || [ "${{ inputs.triton }}" == "pinned" ];then
-            TRITON_COMMIT_ID="$(cat .ci/docker/ci_commit_pins/triton-xpu.txt)"
-          else
-            TRITON_COMMIT_ID="${{ inputs.triton }}"
-          fi
-          built_version="$(pip index versions --index-url https://download.pytorch.org/whl/nightly/xpu --pre \
-                  triton-xpu 2> /dev/null |awk -F '[ |,]' -v p="$(echo ${TRITON_COMMIT_ID} |awk '{print substr($1,0,7)}')" 'BEGIN{
-            v = "None";
-          }{
-            for (i=1;i<=NF;i++) {if ($i ~ p) {v = $i;}};
-          }END{
-            printf("%s", v);
-          }')"
-          if [ "${built_version}" != "None" ];then
-            pip download --no-deps --index-url https://download.pytorch.org/whl/nightly/xpu --pre triton-xpu==${built_version} --dest ${{ github.workspace }}/
-            pip install ${{ github.workspace }}/*triton*.whl
-          else
-            TRITON_VERSION_NAME="$(
-              curl -sSL https://raw.githubusercontent.com/intel/intel-xpu-backend-for-triton/${TRITON_COMMIT_ID}/python/triton/__init__.py 2>&1 |\
-                      grep '__version__' |head -n 1 |awk -F "'" '{print $2}'
-            )"
-            # gcc 13
-            source /opt/rh/gcc-toolset-13/enable
-            dnf install -y zlib-devel
-            pip install cmake ninja pybind11
-            python .github/scripts/build_triton_wheel.py --device xpu --commit-hash ${TRITON_COMMIT_ID} --triton-version ${TRITON_VERSION_NAME} \
-              2>&1 |tee ${{ github.workspace }}/build_triton_${TRITON_COMMIT_ID}.log
-            if [ $(ls |grep -c "triton_xpu-.*.whl") -eq 0 ];then
-              echo "Build triton got failed"
-              exit 1
-            fi
-            pip install triton_xpu-*.whl
-            cp triton_xpu-*.whl ${{ github.workspace }}
-          fi
+        uses: ./torch-xpu-ops/.github/actions/build-triton-xpu
+        with:
+          pytorch-src: ${{ github.workspace }}/pytorch
+          workspace: ${{ github.workspace }}
+          triton: ${{ inputs.triton }}
+
       - name: Torch Config
-        run: |
-          printenv
-          python -c "import torch; print(torch.__config__.show())"
-          python -c "import torch; print(torch.__config__.parallel_info())"
-          python -c "import torch; print(torch.__config__.torch.xpu.device_count())"
-          python -c "import triton; print(triton.__version__)"
-          python -c "import torchvision; print(torchvision.__version__)"
-          python -c "import torchaudio; print(torchaudio.__version__)"
-          python pytorch/torch/utils/collect_env.py
-          pip list |grep -E 'torch|intel'
+        uses: ./torch-xpu-ops/.github/actions/verify-pytorch-build
+        with:
+          pytorch-src: ${{ github.workspace }}/pytorch
+
       - name: Upload Torch XPU Wheel
         if: ${{ success() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Refactor `.github/workflows/_linux_build.yml` by extracting its inline build bash into a small set of reusable **composite actions** under `.github/actions/`. The build job is reduced from ~150 lines of inline shell to a sequence of declarative `uses:` calls. Each stage emits its own `$GITHUB_STEP_SUMMARY` section so failures are easier to diagnose.

This PR is **structure-only** — no functional changes:

- Same `build.sh` CLI (`--PYTORCH_REPO`, `--PYTORCH_COMMIT`, `--TORCH_XPU_OPS_REPO`, `--TORCH_XPU_OPS_COMMIT`).
- Same workflow inputs (`runner`, `pytorch`, `torch_xpu_ops`, `triton`, `python`).
- Same container (`pytorch/manylinux2_28-builder:xpu-main`) and env (`PATH`, `AGENT_TOOLSDIRECTORY`, `PIP_CACHE_DIR`).
- Same artifact names (`Torch-XPU-Wheel-...`, `Torch-XPU-Build-Log-...`).
- Same pin sources (`pytorch/.github/ci_commit_pins/{vision,audio}.txt`, `pytorch/.ci/docker/ci_commit_pins/triton-xpu.txt`).
- Same triton handling (try pre-built nightly first, fall back to source build).

## New composite actions

| Action | Purpose |
| --- | --- |
| `setup-build-python` | Locate `/opt/python/cp<ver>-cp<ver>` interpreter and create the build venv at `/tmp/xpu-tool/myvenv`. |
| `build-pytorch-xpu`  | Resolve `PYTORCH` / `TORCH_XPU_OPS` specs (commit, branch, or `repo@ref`) and run `torch-xpu-ops/.github/scripts/build.sh`; verify wheel. |
| `build-domain-lib`   | Parameterized TorchVision / TorchAudio builder (repo URL, pin file, OS deps, src dir name). |
| `build-triton-xpu`   | Try pre-built nightly wheel matching the pinned commit's short hash; fall back to source build via `pytorch/.github/scripts/build_triton_wheel.py`. |
| `verify-pytorch-build` | Import smoke tests for torch / triton / domain libs with a step-summary status table. |

## Why

- **Readability**: `_linux_build.yml` becomes ~70 lines of declarative orchestration.
- **Reuse**: The same building blocks can be invoked by future workflows (nightly, release, debug runs) without copy/paste.
- **Diagnostics**: Each stage writes its own step-summary section, so PR authors see at a glance which stage failed.

## Risk / rollout

- Behavior-preserving refactor — no CLI, env, container, or artifact changes.
- Recommend a single dry-run on a normal PR before merge.

## Stack

Part of a small refactor series for `.github/`. This is the build slice; the lint slice was #3524.
