### PR TITLE
Fix SYCL deprecated warnings for oneAPI 2025.3

### DIFF
--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.cpp
@@ -144,7 +144,7 @@ void compute_o_dot_do(
     stensor(mi, sg_group_id, sg_local_id) = accum;
   }
 
-  sg.barrier();
+  sycl::group_barrier(sg);
 
   if (sg_local_id == 0) {
     CUTLASS_PRAGMA_UNROLL

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
@@ -19,6 +19,8 @@
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wchanges-meaning"
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wdangling-pointer"
 #include <cute/tensor.hpp>
 #include <cute/util/compat.hpp>
 #include <cutlass/numeric_conversion.h>

--- a/src/comm/SYCLHelpers.h
+++ b/src/comm/SYCLHelpers.h
@@ -149,6 +149,24 @@ sycl_kernel_submit(
 }
 
 // Overloads accepting kernel properties (e.g., sub_group_size, grf_size).
+// Uses kernel functor with get(properties_tag) — the official non-deprecated
+// way to attach compile-time properties to a kernel.
+
+template <typename KernelType, typename PropsType>
+struct __SyclKernelWithProps__ {
+  KernelType kernel_;
+  template <typename ItemT>
+  void operator()(ItemT&& item) const {
+    kernel_(std::forward<ItemT>(item));
+  }
+  template <typename ItemT, typename... Rest>
+  void operator()(ItemT&& item, Rest&&...) const {
+    kernel_(std::forward<ItemT>(item));
+  }
+  auto get(::sycl::ext::oneapi::experimental::properties_tag) const {
+    return PropsType{};
+  }
+};
 
 template <typename ker_t, typename Props, int dim>
 static inline typename std::enable_if<
@@ -160,10 +178,12 @@ sycl_kernel_submit(
     ::sycl::queue q,
     Props properties,
     ker_t ker) {
+  (void)properties;
   auto cgf = [&](::sycl::handler& cgh) {
     ker.sycl_ker_config_convention(cgh);
+    __SyclKernelWithProps__<ker_t, Props> wrapped{ker};
     cgh.parallel_for<ker_t>(
-        ::sycl::nd_range<dim>(global_range, local_range), properties, ker);
+        ::sycl::nd_range<dim>(global_range, local_range), wrapped);
   };
   q.submit(cgf);
 }
@@ -178,9 +198,11 @@ sycl_kernel_submit(
     ::sycl::queue q,
     Props properties,
     ker_t ker) {
+  (void)properties;
   auto cgf = [&](::sycl::handler& cgh) {
+    __SyclKernelWithProps__<ker_t, Props> wrapped{ker};
     cgh.parallel_for<ker_t>(
-        ::sycl::nd_range<dim>(global_range, local_range), properties, ker);
+        ::sycl::nd_range<dim>(global_range, local_range), wrapped);
   };
   q.submit(cgf);
 }
@@ -195,13 +217,14 @@ sycl_kernel_submit(
     ::sycl::queue q,
     Props properties,
     ker_t ker) {
+  (void)properties;
   auto cgf = [&](::sycl::handler& cgh) {
     ker.sycl_ker_config_convention(cgh);
+    __SyclKernelWithProps__<ker_t, Props> wrapped{ker};
     cgh.parallel_for<ker_t>(
         ::sycl::nd_range<1>(
             ::sycl::range<1>(global_range), ::sycl::range<1>(local_range)),
-        properties,
-        ker);
+        wrapped);
   };
   q.submit(cgf);
 }
@@ -216,12 +239,13 @@ sycl_kernel_submit(
     ::sycl::queue q,
     Props properties,
     ker_t ker) {
+  (void)properties;
   auto cgf = [&](::sycl::handler& cgh) {
+    __SyclKernelWithProps__<ker_t, Props> wrapped{ker};
     cgh.parallel_for<ker_t>(
         ::sycl::nd_range<1>(
             ::sycl::range<1>(global_range), ::sycl::range<1>(local_range)),
-        properties,
-        ker);
+        wrapped);
   };
   q.submit(cgf);
 }


### PR DESCRIPTION
- mha_bwd.cpp: Replace deprecated sg.barrier() with sycl::group_barrier(sg)
- mha_bwd.h: Suppress -Warray-bounds and -Wdangling-pointer for third-party sycl-tla headers (cutlass/array_subbyte.h, cute/algorithm/copy.hpp)
- SYCLHelpers.h: Replace deprecated parallel_for(nd_range, properties, kernel) with kernel functor get(properties_tag) approach per the official sycl_ext_oneapi_kernel_properties extension