### PR TITLE
Fix device_type parameter in test_triton_bsr_dense_addmm_meta

### DIFF
--- a/test/xpu/test_sparse_csr_xpu.py
+++ b/test/xpu/test_sparse_csr_xpu.py
@@ -5810,7 +5810,7 @@ class TestSparseCompressedTritonKernels(TestCase):
             key = (M, K, N, Ms, Ks, beta == 0, beta == 1, alpha == 1)
             update_bsr_dense_addmm_meta(
                 "bsr_dense_addmm",
-                device_type,
+                getattr(torch, device_type).get_device_name(),
                 ("test_triton_bsr_dense_addmm_meta", dtype, sparsity),
                 key,
                 value,


### PR DESCRIPTION
Fixes #2235

### Summary
Fixed incorrect parameter passed to update_bsr_dense_addmm_meta() in the sparse CSR test suite.

### Problem
The test was passing the generic device type string ("xpu" or "cuda") instead of the actual device name to the Triton metadata update function. This caused incorrect cache key generation for Triton kernel tuning parameters.

### Solution
Changed line 5773 to call torch.xpu.get_device_name() or torch.cuda.get_device_name() to get the actual GPU model name (e.g., "Intel(R) Data Center GPU Max 1550"), matching the pattern used elsewhere in the test file (line 5725).
