### PR TITLE
[upstream_ut] Fix test_qsoftmax_qnnpack_xpu AttributeError

### DIFF
--- a/test/xpu/quantization/core/test_quantized_op_xpu.py
+++ b/test/xpu/quantization/core/test_quantized_op_xpu.py
@@ -75,7 +75,18 @@ def _test_max_pool2d_pt2e(self):
         self.assertEqual(a_pool, a_hat, msg="ops.quantized.max_pool2d results are off")
 
 
+def _test_qsoftmax_qnnpack(self):
+    from torch.testing._internal.common_quantized import override_quantized_engine
+    with override_quantized_engine('qnnpack'):
+        # After device instantiation, test_qsoftmax becomes test_qsoftmax_xpu
+        if hasattr(self, 'test_qsoftmax_xpu'):
+            self.test_qsoftmax_xpu()
+        else:
+            self.test_qsoftmax()
+
+
 TestQuantizedOps.test_max_pool2d_pt2e = _test_max_pool2d_pt2e
+TestQuantizedOps.test_qsoftmax_qnnpack = _test_qsoftmax_qnnpack
 
 instantiate_device_type_tests(
     TestQuantizedOps, globals(), only_for="xpu", allow_xpu=True

--- a/test/xpu/quantization/core/test_quantized_op_xpu.py
+++ b/test/xpu/quantization/core/test_quantized_op_xpu.py
@@ -12,6 +12,7 @@ import itertools
 import torch
 from torch.nn.modules.utils import _pair
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_quantized import override_quantized_engine
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 try:
@@ -76,10 +77,9 @@ def _test_max_pool2d_pt2e(self):
 
 
 def _test_qsoftmax_qnnpack(self):
-    from torch.testing._internal.common_quantized import override_quantized_engine
-    with override_quantized_engine('qnnpack'):
+    with override_quantized_engine("qnnpack"):
         # After device instantiation, test_qsoftmax becomes test_qsoftmax_xpu
-        if hasattr(self, 'test_qsoftmax_xpu'):
+        if hasattr(self, "test_qsoftmax_xpu"):
             self.test_qsoftmax_xpu()
         else:
             self.test_qsoftmax()


### PR DESCRIPTION
## Summary
Fixes AttributeError when running `test_qsoftmax_qnnpack_xpu`.

## Problem
The test method `test_qsoftmax_qnnpack` calls `self.test_qsoftmax()`, but after device type instantiation, the method is renamed to `test_qsoftmax_xpu`. This caused an AttributeError.

## Solution
Added override function `_test_qsoftmax_qnnpack` that checks for the device-suffixed method name and calls the correct one. Pattern follows existing override in the same file (`_test_max_pool2d_pt2e`).

## Testing
```bash
cd /pytorch && PYTORCH_TEST_WITH_SLOW=1 pytest -v third_party/torch-xpu-ops/test/xpu/quantization/core/test_quantized_op_xpu.py -k test_qsoftmax_qnnpack_xpu
```

✅ Test passes (0.243s)

Fixes: https://github.com/intel/torch-xpu-ops/issues/2533

🤖 Generated with [Claude Code](https://claude.com/claude-code)