### PR TITLE
Add tolerance override for conv_transpose3d in test_jvpvjp.

### DIFF
--- a/test/xpu/functorch/test_ops_xpu.py
+++ b/test/xpu/functorch/test_ops_xpu.py
@@ -1883,6 +1883,11 @@ class TestOperators(TestCase):
             tol2(
                 "linalg.pinv", "hermitian", {torch.float32: tol(atol=5e-03, rtol=5e-03)}
             ),
+            tol1(
+                "nn.functional.conv_transpose3d",
+                {torch.float32: tol(atol=3e-05, rtol=5e-6)},
+                device_type="xpu",
+            ),
         ),
     )
     def test_jvpvjp(self, device, dtype, op):


### PR DESCRIPTION
Fix for: #3553 

## Summary

This PR increases tolerance for `conv_transpose3d` in `test_jvpvjp`.
This operator uses non-deterministic oneDNN kernel under the hood. That means when the same non-deterministic kernel is launched several times with identical inputs, it can return slightly different results. It is caused by floating point operations being not associative, so different order of mathematically equivalent operations can produce slightly different results.

To confirm this root cause, I launched test with `DeterministicGuard`, which enforced deterministic mode in the oneDNN kernel. With this deterministic mode, the test passes, so it confirms that the root cause is the non-deterministic oneDNN kernel behavior in default mode.

The test passes every time in 100 launches with currently set tolerances.