### PR TITLE
pytorch-agent PR1: skeleton — full project structure with stub implementations

### DIFF
--- a/.github/pytorch-agent/.env.example
+++ b/.github/pytorch-agent/.env.example
@@ -1,0 +1,17 @@
+# Copy to .env and fill in values.  Never commit .env.
+
+# Repos
+UPSTREAM_ISSUE_REPO=intel/torch-xpu-ops
+PRIVATE_REVIEW_REPO=yourfork/pytorch
+PUBLIC_TARGET_REPO=pytorch/pytorch
+PYTORCH_DIR=/home/youruser/pytorch
+
+# Tokens
+GH_TOKEN=ghp_...              # read/write on UPSTREAM_ISSUE_REPO
+REVIEW_GH_TOKEN=ghp_...       # read/write on PRIVATE_REVIEW_REPO + PUBLIC_TARGET_REPO
+
+# Optional
+PUBLIC_PR_REVIEWER=yourhandle  # GitHub username to cc on public PRs
+AGENT_BACKEND=opencode
+OPENCODE_CMD=opencode
+POLL_INTERVAL=900

--- a/.github/pytorch-agent/AGENTS.md
+++ b/.github/pytorch-agent/AGENTS.md
@@ -1,0 +1,32 @@
+# pytorch-agent
+
+Autonomous pipeline that watches intel/torch-xpu-ops for CI failure issues,
+generates fixes, and submits them to pytorch/pytorch.
+
+## Quick start
+
+```bash
+cp .env.example .env   # fill in tokens and repo names
+python scripts/run_pipeline.py --issue 3509
+```
+
+## Slash commands (in issue / PR comments)
+
+| Command        | Effect                          |
+|----------------|---------------------------------|
+| `/agent pause` | Stop processing this issue      |
+| `/agent resume`| Resume processing               |
+
+## Stage machine
+
+```
+DISCOVERED → IMPLEMENTING → IN_REVIEW → PUBLIC_PR → CI_WATCH → MERGED → DONE
+                                                                       ↘ SKIPPED
+                                                                       ↘ NEEDS_HUMAN
+```
+
+## Hard rules for the coding agent
+
+- **Never** use `@skipIfXpu`, `@skip`, or any skip decorator — fix the test.
+- **Never** commit `third_party/*` submodule pointer changes.
+- **Never** force-push a branch that has been reviewed.

--- a/.github/pytorch-agent/docs/getting-started.md
+++ b/.github/pytorch-agent/docs/getting-started.md
@@ -1,0 +1,27 @@
+# Getting Started
+
+## Prerequisites
+
+- `gh` CLI authenticated
+- `opencode` CLI installed
+- Python 3.11+
+- A fork of pytorch/pytorch as your private review repo
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in values.
+2. Add a cron entry:
+   ```
+   */15 * * * * /path/to/scripts/cron.sh >> /path/to/logs/cron.log 2>&1
+   ```
+3. Label an issue with `agent:new` to trigger the pipeline.
+
+## Running manually
+
+```bash
+# Single issue
+./scripts/run_oneshot.sh --issue 3509
+
+# One cron cycle
+python scripts/run_pipeline.py --once
+```

--- a/.github/pytorch-agent/pytorch_agent/__init__.py
+++ b/.github/pytorch-agent/pytorch_agent/__init__.py
@@ -1,0 +1,1 @@
+"""pytorch-agent: autonomous CI issue fixing pipeline."""

--- a/.github/pytorch-agent/pytorch_agent/fixing_steps/__init__.py
+++ b/.github/pytorch-agent/pytorch_agent/fixing_steps/__init__.py
@@ -1,0 +1,1 @@
+"""Pipeline fixing stages."""

--- a/.github/pytorch-agent/pytorch_agent/fixing_steps/_issue_format.py
+++ b/.github/pytorch-agent/pytorch_agent/fixing_steps/_issue_format.py
@@ -1,0 +1,31 @@
+"""Shared helpers for building PR titles, bodies, and parsing issue sections."""
+from __future__ import annotations
+
+
+def parse_issue_sections(body: str) -> dict[str, str]:
+    """Parse a torch-xpu-ops issue body into named sections.
+
+    Sections are delimited by Markdown headings (## Section Name).
+    Returns a dict mapping section name → section text.
+    """
+    raise NotImplementedError
+
+
+def build_pr_body(
+    *,
+    upstream_issue_repo: str,
+    source_number: int,
+    title: str,
+    triage_reason: str | None,
+    issue_body: str,
+    reviewer: str = "",
+) -> str:
+    """Build a descriptive PR body for submission to pytorch/pytorch.
+
+    Includes:
+    - Link back to the upstream issue
+    - Triage summary
+    - Relevant excerpt from the issue body
+    - Optional cc @reviewer line
+    """
+    raise NotImplementedError

--- a/.github/pytorch-agent/pytorch_agent/fixing_steps/ci_watch.py
+++ b/.github/pytorch-agent/pytorch_agent/fixing_steps/ci_watch.py
@@ -1,0 +1,53 @@
+"""CI_WATCH stage: monitor CI and auto-fix failures.
+
+Loop (each cron cycle)
+----------------------
+1. Check if public PR is already merged → MERGED.
+2. Fetch CI check-runs for the PR head commit.
+3. If any are still pending → wait (return, try next cycle).
+4. If all passed → wait for maintainer to merge (return).
+5. If failures:
+   a. Increment ci_iteration (saved before work to prevent lost counts).
+   b. If ci_iteration > MAX_CI_ITERATIONS → NEEDS_HUMAN.
+   c. Dispatch agent with failure details.
+   d. Commit + push fixes.
+
+Entry point
+-----------
+    python -m pytorch_agent.fixing_steps.ci_watch --issue 123
+"""
+from __future__ import annotations
+
+import argparse
+
+from ..utils.state import TrackedIssue, load_tracked
+
+
+MAX_CI_ITERATIONS = 3
+
+CI_FIX_PROMPT_TEMPLATE = """CI is failing on the public PR for your PyTorch fix.
+
+## Failing checks
+{failures}
+
+## Instructions
+1. Analyse each failure — related to your change or pre-existing?
+2. If related: fix the code.
+3. If unrelated: note it but do not change code.
+"""
+
+
+def run(tracked: TrackedIssue) -> None:
+    """Run one CI-watch cycle for *tracked*."""
+    raise NotImplementedError
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--issue", type=int, required=True)
+    args = parser.parse_args()
+    run(load_tracked(args.issue))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/pytorch-agent/pytorch_agent/fixing_steps/close_issue.py
+++ b/.github/pytorch-agent/pytorch_agent/fixing_steps/close_issue.py
@@ -1,0 +1,35 @@
+"""MERGED stage: close the source issue and clean up.
+
+Steps
+-----
+1. Verify public PR is actually merged (guard against stage race).
+2. Post a ✅ "Fixed in pytorch/pytorch#N" comment on the source issue.
+3. Close the source issue.
+4. Delete the agent branch from PRIVATE_REVIEW_REPO.
+5. Transition → DONE.
+
+Entry point
+-----------
+    python -m pytorch_agent.fixing_steps.close_issue --issue 123
+"""
+from __future__ import annotations
+
+import argparse
+
+from ..utils.state import TrackedIssue, load_tracked
+
+
+def run(tracked: TrackedIssue) -> None:
+    """Close source issue and transition to DONE."""
+    raise NotImplementedError
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--issue", type=int, required=True)
+    args = parser.parse_args()
+    run(load_tracked(args.issue))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/pytorch-agent/pytorch_agent/fixing_steps/implement.py
+++ b/.github/pytorch-agent/pytorch_agent/fixing_steps/implement.py
@@ -1,0 +1,54 @@
+"""IMPLEMENTING stage: generate a fix using an AI coding agent.
+
+Steps
+-----
+1. Fetch issue body and parse sections (error log, reproduce steps, …).
+2. Build an implementation prompt with the issue context.
+3. Run the agent inside ~/pytorch (private fork working directory).
+4. Auto-commit any changes the agent left uncommitted.
+5. Push the branch to PRIVATE_REVIEW_REPO.
+6. Open a PR on PRIVATE_REVIEW_REPO for human review.
+7. Transition → IN_REVIEW.
+
+Entry point
+-----------
+    python -m pytorch_agent.fixing_steps.implement --issue 123
+"""
+from __future__ import annotations
+
+import argparse
+
+from ..utils.state import TrackedIssue, load_tracked
+
+
+IMPLEMENT_PROMPT_TEMPLATE = """Fix the following PyTorch XPU CI failure.
+
+## Issue #{number}: {title}
+
+### Error log
+{error_log}
+
+### Reproduce steps
+{reproduce}
+
+## Hard rules
+- NEVER use @skipIfXpu, @skip, or any skip decorator — fix the test.
+- Do NOT commit submodule changes (third_party/*).
+- Run the affected test locally and confirm it passes before finishing.
+"""
+
+
+def run(tracked: TrackedIssue) -> None:
+    """Run the implement stage for *tracked*."""
+    raise NotImplementedError
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--issue", type=int, required=True)
+    args = parser.parse_args()
+    run(load_tracked(args.issue))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/pytorch-agent/pytorch_agent/fixing_steps/private_review.py
+++ b/.github/pytorch-agent/pytorch_agent/fixing_steps/private_review.py
@@ -1,0 +1,59 @@
+"""IN_REVIEW stage: respond to review feedback on the private fork PR.
+
+Review loop
+-----------
+1. Check review state (approved / changes_requested / pending / paused).
+2. If approved        →  transition to PUBLIC_PR.
+3. If paused          →  set tracked.paused, wait for /agent resume.
+4. If pending         →  nothing to do yet.
+5. If changes_requested:
+   a. Extract actionable tasks from review comments (LLM + regex fallback).
+   b. Post a task-list comment on the PR.
+   c. Dispatch agent to address feedback.
+   d. Commit + push changes.
+   e. Update task-list comment with completion status.
+   f. If review_iteration > MAX_REVIEW_ITERATIONS → NEEDS_HUMAN.
+
+Entry point
+-----------
+    python -m pytorch_agent.fixing_steps.private_review --issue 123
+"""
+from __future__ import annotations
+
+import argparse
+
+from ..utils.state import TrackedIssue, load_tracked
+
+
+REVIEW_FIX_PROMPT_TEMPLATE = """Address the following code review feedback on your PyTorch fix.
+
+## Original Issue #{number}: {title}
+
+## Review Feedback
+{reviews}
+
+## Instructions
+1. Address EACH comment — do not skip any.
+2. Make the requested changes.
+3. Ensure tests still pass.
+
+## Hard rules
+- NEVER use @skipIfXpu or any skip decorator.
+- Do NOT commit submodule changes (third_party/*).
+"""
+
+
+def run(tracked: TrackedIssue) -> None:
+    """Run one review-response cycle for *tracked*."""
+    raise NotImplementedError
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--issue", type=int, required=True)
+    args = parser.parse_args()
+    run(load_tracked(args.issue))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/pytorch-agent/pytorch_agent/fixing_steps/public_submit.py
+++ b/.github/pytorch-agent/pytorch_agent/fixing_steps/public_submit.py
@@ -1,0 +1,36 @@
+"""PUBLIC_PR stage: open a cross-fork PR to pytorch/pytorch.
+
+Steps
+-----
+1. Build a clean PR title (strip [Agent] prefix if present).
+2. Build PR body from issue details via build_pr_body().
+3. Check if a PR from the same branch already exists (idempotent).
+4. Create the cross-fork PR using REVIEW_GH_TOKEN.
+5. Post the public PR link back to the source issue.
+6. Transition → CI_WATCH.
+
+Entry point
+-----------
+    python -m pytorch_agent.fixing_steps.public_submit --issue 123
+"""
+from __future__ import annotations
+
+import argparse
+
+from ..utils.state import TrackedIssue, load_tracked
+
+
+def run(tracked: TrackedIssue) -> None:
+    """Create (or find existing) public PR and transition to CI_WATCH."""
+    raise NotImplementedError
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--issue", type=int, required=True)
+    args = parser.parse_args()
+    run(load_tracked(args.issue))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/pytorch-agent/pytorch_agent/issue_discovery.py
+++ b/.github/pytorch-agent/pytorch_agent/issue_discovery.py
@@ -1,0 +1,24 @@
+"""Discover new issues labeled `agent:new` and register them for tracking.
+
+Flow
+----
+1. Query intel/torch-xpu-ops for issues with label "agent:new".
+2. Skip any issue already tracked (state comment present).
+3. Call process_issue() to create the initial TrackedIssue and state comment.
+"""
+from __future__ import annotations
+
+from .utils.state import TrackedIssue
+
+
+def discover_new_issues() -> list[dict]:
+    """Return open issues with label "agent:new" that are not yet tracked."""
+    raise NotImplementedError
+
+
+def process_issue(issue_number: int) -> TrackedIssue:
+    """Register *issue_number*: create TrackedIssue + state comment if not present.
+
+    Idempotent — safe to call multiple times for the same issue.
+    """
+    raise NotImplementedError

--- a/.github/pytorch-agent/pytorch_agent/issue_fixing_agent.py
+++ b/.github/pytorch-agent/pytorch_agent/issue_fixing_agent.py
@@ -1,0 +1,22 @@
+"""Stage router: advance an issue by one step in the pipeline.
+
+advance() loads the current stage and dispatches to the correct handler:
+
+    IMPLEMENTING  →  fixing_steps.implement.run()
+    IN_REVIEW     →  fixing_steps.private_review.run()
+    PUBLIC_PR     →  fixing_steps.public_submit.run()
+    CI_WATCH      →  fixing_steps.ci_watch.run()
+    MERGED        →  fixing_steps.close_issue.run()
+    (terminal)    →  no-op
+"""
+from __future__ import annotations
+
+
+
+def advance(issue_number: int) -> None:
+    """Load *issue_number* state and run the handler for its current stage.
+
+    Called by the polling loop on every cron cycle.  Each handler is
+    idempotent — calling advance() on an already-completed stage is safe.
+    """
+    raise NotImplementedError

--- a/.github/pytorch-agent/pytorch_agent/issue_triaging_agent.py
+++ b/.github/pytorch-agent/pytorch_agent/issue_triaging_agent.py
@@ -1,0 +1,41 @@
+"""Triage stage: AI decides whether to accept or skip an issue.
+
+Accepts
+-------
+- CI failures with a clear reproduction path
+- Failing XPU op tests with stack trace
+
+Skips
+-----
+- Feature requests, docs, questions
+- Issues already fixed or duplicate
+- Insufficient reproduction info
+
+On accept  →  stage becomes IMPLEMENTING, triage_reason recorded
+On skip    →  stage becomes SKIPPED, reason posted to issue
+"""
+from __future__ import annotations
+
+from .utils.state import TrackedIssue
+
+
+TRIAGE_PROMPT_TEMPLATE = """You are triaging a PyTorch XPU CI issue. Decide: ACCEPT or SKIP.
+
+## Issue #{number}: {title}
+
+{body}
+
+## Instructions
+Reply with exactly one of:
+  ACCEPT: <one-line reason why this is actionable>
+  SKIP: <one-line reason why this should not be auto-fixed>
+"""
+
+
+def triage_issue(issue_number: int) -> TrackedIssue:
+    """Run triage for *issue_number*. Returns the updated TrackedIssue.
+
+    Posts a session-started comment, dispatches the agent, parses
+    ACCEPT/SKIP verdict, and transitions stage accordingly.
+    """
+    raise NotImplementedError

--- a/.github/pytorch-agent/pytorch_agent/utils/__init__.py
+++ b/.github/pytorch-agent/pytorch_agent/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utilities for pytorch-agent."""

--- a/.github/pytorch-agent/pytorch_agent/utils/agent_backend.py
+++ b/.github/pytorch-agent/pytorch_agent/utils/agent_backend.py
@@ -1,0 +1,63 @@
+"""AI agent backend abstraction.
+
+Backends
+--------
+OpenCodeBackend  —  wraps the `opencode` CLI, streams JSON events,
+                    captures session ID and output text, writes a log file.
+
+Usage
+-----
+    backend = get_backend()
+    output, log_path, session_id = backend.run(
+        prompt,
+        workdir=str(PYTORCH_DIR),
+        skill="xpu-ops-implement",
+        timeout=3600,
+        issue=tracked.source_number,
+        stage="IMPLEMENTING",
+        on_session_start=lambda sid: ...,
+    )
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from collections.abc import Callable
+
+
+class AgentBackend:
+    """Abstract base class for AI coding agent backends."""
+
+    def run(
+        self,
+        prompt: str,
+        *,
+        workdir: str,
+        skill: str | None = None,
+        timeout: int = 3600,
+        issue: int | None = None,
+        stage: str | None = None,
+        on_session_start: Callable[[str], None] | None = None,
+    ) -> tuple[str, Path, str | None]:
+        """Run the agent on *prompt* and return (output_text, log_path, session_id)."""
+        raise NotImplementedError
+
+
+class OpenCodeBackend(AgentBackend):
+    """Runs `opencode run --format json …` and streams the response."""
+
+    def run(self, prompt: str, *, workdir: str, skill: str | None = None,
+            timeout: int = 3600, issue: int | None = None,
+            stage: str | None = None,
+            on_session_start: Callable[[str], None] | None = None,
+            ) -> tuple[str, Path, str | None]:
+        raise NotImplementedError
+
+
+def get_backend() -> AgentBackend:
+    """Return the configured backend (OpenCodeBackend by default)."""
+    raise NotImplementedError
+
+
+def parse_opencode_events(raw_json_lines: str) -> str:
+    """Extract assistant text from a newline-delimited stream of opencode JSON events."""
+    raise NotImplementedError

--- a/.github/pytorch-agent/pytorch_agent/utils/config.py
+++ b/.github/pytorch-agent/pytorch_agent/utils/config.py
@@ -1,0 +1,60 @@
+"""Configuration constants for pytorch-agent.
+
+All tuneable values come from environment variables (see .env.example).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Repos
+# ---------------------------------------------------------------------------
+UPSTREAM_ISSUE_REPO: str   # e.g. "intel/torch-xpu-ops"
+PRIVATE_REVIEW_REPO: str   # e.g. "yourfork/pytorch"
+PUBLIC_TARGET_REPO: str    # e.g. "pytorch/pytorch"
+
+# ---------------------------------------------------------------------------
+# Labels — one label per stage; pipeline updates issues automatically
+# ---------------------------------------------------------------------------
+ISSUE_LABEL: str
+STAGE_TO_LABEL: dict[str, str]
+ALL_AGENT_LABELS: list[str]
+
+# ---------------------------------------------------------------------------
+# Limits
+# ---------------------------------------------------------------------------
+MAX_REVIEW_ITERATIONS: int
+MAX_AGENT_ATTEMPTS: int
+
+# ---------------------------------------------------------------------------
+# Local paths
+# ---------------------------------------------------------------------------
+PYTORCH_DIR: Path     # ~/pytorch by default
+AGENT_DIR: Path       # .github/pytorch-agent/
+LOG_DIR: Path
+SKILLS_DIR: Path
+
+# ---------------------------------------------------------------------------
+# Git
+# ---------------------------------------------------------------------------
+REVIEW_REMOTE: str    # name of the remote pointing at PRIVATE_REVIEW_REPO
+BRANCH_PREFIX: str
+AGENT_PR_PREFIX: str
+
+# ---------------------------------------------------------------------------
+# Polling (temporary — replaced by webhooks in a future PR)
+# ---------------------------------------------------------------------------
+POLL_INTERVAL: int
+
+# ---------------------------------------------------------------------------
+# Per-stage agent timeouts (seconds)
+# ---------------------------------------------------------------------------
+STAGE_TIMEOUTS: dict[str, int]
+
+# ---------------------------------------------------------------------------
+# Agent backend
+# ---------------------------------------------------------------------------
+AGENT_BACKEND: str    # "opencode" | "copilot"
+OPENCODE_CMD: str
+
+raise NotImplementedError("config.py: stub — implementation added in PR 2")

--- a/.github/pytorch-agent/pytorch_agent/utils/git.py
+++ b/.github/pytorch-agent/pytorch_agent/utils/git.py
@@ -1,0 +1,27 @@
+"""Shared git helpers for the pytorch-agent pipeline."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def git(*args: str, workdir: Path | None = None, check: bool = True,
+        issue: int | None = None) -> subprocess.CompletedProcess[str]:
+    """Run a git command inside PYTORCH_DIR (or *workdir*) with logging."""
+    raise NotImplementedError("git.py: stub — implementation added in PR 2")
+
+
+def git_out(*args: str, **kwargs) -> str:
+    """Run git and return stdout string."""
+    raise NotImplementedError("git.py: stub — implementation added in PR 2")
+
+
+def add_and_commit(message: str, *,
+                   issue: int | None = None,
+                   workdir: Path | None = None) -> bool:
+    """Stage all tracked files (excluding third_party/*) and commit if dirty.
+
+    Returns True if a commit was made, False if the tree was already clean.
+    Handles renamed files (porcelain R old -> new) correctly.
+    """
+    raise NotImplementedError("git.py: stub — implementation added in PR 2")

--- a/.github/pytorch-agent/pytorch_agent/utils/github_client.py
+++ b/.github/pytorch-agent/pytorch_agent/utils/github_client.py
@@ -1,0 +1,116 @@
+"""Thin wrappers around the `gh` CLI for all GitHub API operations.
+
+Token routing
+-------------
+- REVIEW_GH_TOKEN  →  PRIVATE_REVIEW_REPO and PUBLIC_TARGET_REPO operations
+- GH_TOKEN         →  everything else (upstream issues, labels, comments)
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Low-level helpers
+# ---------------------------------------------------------------------------
+
+def _token_for_repo(repo: str) -> str | None:
+    """Return the correct GH token for *repo*."""
+    raise NotImplementedError
+
+
+def _gh(args: list[str], input_text: str | None = None,
+        token: str | None = None) -> str:
+    """Run `gh <args>` and return stdout. Raises CalledProcessError on failure."""
+    raise NotImplementedError
+
+
+def _gh_api(endpoint: str, method: str = "GET",
+            token: str | None = None, **fields: Any) -> dict | list:
+    """Call `gh api` and return parsed JSON."""
+    raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Issues
+# ---------------------------------------------------------------------------
+
+def get_issues(repo: str, label: str) -> list[dict]:
+    """List open issues carrying *label*."""
+    raise NotImplementedError
+
+
+def get_issue_detail(repo: str, number: int) -> dict:
+    """Return full issue details including body, labels, comments."""
+    raise NotImplementedError
+
+
+def add_issue_comment(repo: str, number: int, body: str) -> None:
+    """Post a comment on an issue."""
+    raise NotImplementedError
+
+
+def get_issue_comments(repo: str, number: int) -> list[dict]:
+    """Return all comments on an issue."""
+    raise NotImplementedError
+
+
+def update_issue_comment(repo: str, comment_id: int, body: str) -> None:
+    """Edit an existing issue comment."""
+    raise NotImplementedError
+
+
+def close_issue(repo: str, number: int) -> None:
+    """Close an issue."""
+    raise NotImplementedError
+
+
+def add_label(repo: str, number: int, label: str) -> None:
+    """Add a label to an issue, creating it if necessary."""
+    raise NotImplementedError
+
+
+def remove_label(repo: str, number: int, label: str) -> None:
+    """Remove a label from an issue."""
+    raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Pull requests
+# ---------------------------------------------------------------------------
+
+def create_pr(repo: str, title: str, body: str, head: str,
+              base: str = "main") -> dict:
+    """Create a PR inside *repo*."""
+    raise NotImplementedError
+
+
+def create_cross_fork_pr(head_repo: str, head_branch: str,
+                         base_repo: str, title: str, body: str) -> dict:
+    """Open a PR from *head_repo*:*head_branch* into *base_repo*:main."""
+    raise NotImplementedError
+
+
+def add_pr_comment(repo: str, number: int, body: str) -> dict:
+    """Post a comment on a PR and return the created comment dict."""
+    raise NotImplementedError
+
+
+def update_pr_comment(repo: str, comment_id: int, body: str) -> None:
+    """Edit an existing PR comment."""
+    raise NotImplementedError
+
+
+def get_pr_status(repo: str, pr_number: int) -> str:
+    """Return PR state: "open" | "closed" | "merged"."""
+    raise NotImplementedError
+
+
+def get_ci_checks(repo: str, pr_number: int) -> list[dict]:
+    """Return all check-runs for the latest commit of a PR."""
+    raise NotImplementedError
+
+
+def delete_branch(repo: str, branch: str) -> None:
+    """Delete *branch* from *repo* (best-effort, ignores 404)."""
+    raise NotImplementedError

--- a/.github/pytorch-agent/pytorch_agent/utils/logger.py
+++ b/.github/pytorch-agent/pytorch_agent/utils/logger.py
@@ -1,0 +1,15 @@
+"""Structured logger: writes to a daily log file and stderr."""
+from __future__ import annotations
+
+
+def log(level: str, message: str, *,
+        issue: int | None = None, exc: Exception | None = None) -> None:
+    """Append a timestamped log line to the daily log file and print to stderr.
+
+    Args:
+        level:   Log level string (INFO / WARN / ERROR).
+        message: Human-readable message.
+        issue:   Source issue number for correlation.
+        exc:     Optional exception — full traceback is appended when set.
+    """
+    raise NotImplementedError("logger.py: stub — implementation added in PR 2")

--- a/.github/pytorch-agent/pytorch_agent/utils/notify.py
+++ b/.github/pytorch-agent/pytorch_agent/utils/notify.py
@@ -1,0 +1,33 @@
+"""Helpers for posting agent status comments to GitHub issues."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def post_session_started(repo: str, issue: int, stage: str, session_id: str) -> None:
+    """Comment on *issue* that an agent session has started.
+
+    Args:
+        repo:       Source issue repo (e.g. "intel/torch-xpu-ops").
+        issue:      Issue number.
+        stage:      Human-readable stage name (e.g. "Implement").
+        session_id: opencode session ID for cross-referencing logs.
+    """
+    raise NotImplementedError
+
+
+def post_agent_completed(
+    repo: str, issue: int, header: str, log_path: Path,
+    output: str, *, tail: int = 50,
+) -> None:
+    """Comment on *issue* with a summary of agent output + last *tail* lines of log.
+
+    Args:
+        repo:      Source issue repo.
+        issue:     Issue number.
+        header:    One-line summary shown at the top of the comment.
+        log_path:  Path to the agent run log file.
+        output:    Full agent output text (trimmed to *tail* lines in comment).
+        tail:      Number of log lines to include in the comment.
+    """
+    raise NotImplementedError

--- a/.github/pytorch-agent/pytorch_agent/utils/review_handler.py
+++ b/.github/pytorch-agent/pytorch_agent/utils/review_handler.py
@@ -1,0 +1,34 @@
+"""Parse GitHub PR review state and /agent slash commands.
+
+Review states
+-------------
+- "approved"          — at least one approving review since last push
+- "changes_requested" — reviewer requested changes (no approval yet)
+- "pending"           — no reviews yet
+- "paused"            — a /agent pause comment was found
+
+Slash commands (in PR or issue comments, prefixed with /agent)
+--------------------------------------------------------------
+- /agent pause    →  tracked.paused = True
+- /agent resume   →  tracked.paused = False
+"""
+from __future__ import annotations
+
+
+def get_review_state(pr_number: int, last_push_sha: str | None) -> str:
+    """Return the current review state for *pr_number*.
+
+    Only considers reviews posted *after* the commit at *last_push_sha*
+    so that stale approvals / rejections are ignored after a new push.
+    """
+    raise NotImplementedError
+
+
+def get_pending_reviews(pr_number: int, last_push_sha: str | None) -> list[dict]:
+    """Return review objects with change requests since *last_push_sha*."""
+    raise NotImplementedError
+
+
+def format_reviews_for_prompt(reviews: list[dict]) -> str:
+    """Format *reviews* into a clean block suitable for an agent prompt."""
+    raise NotImplementedError

--- a/.github/pytorch-agent/pytorch_agent/utils/state.py
+++ b/.github/pytorch-agent/pytorch_agent/utils/state.py
@@ -1,0 +1,88 @@
+"""Issue state management via GitHub issue comments + labels.
+
+State storage
+-------------
+State lives entirely on the source issue in intel/torch-xpu-ops:
+
+- A hidden HTML comment  <!-- AGENT_STATE: {...} -->  holds the full
+  TrackedIssue JSON.  The pipeline reads/writes this on every transition.
+- GitHub labels  (agent:active, agent:blocked, …) mirror the current
+  stage for human visibility and issue-list filtering.
+
+Stage machine
+-------------
+DISCOVERED → IMPLEMENTING → IN_REVIEW → PUBLIC_PR → CI_WATCH → MERGED → DONE
+                                                                       ↘ SKIPPED
+                                                                       ↘ NEEDS_HUMAN
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+STAGES = [
+    "DISCOVERED", "IMPLEMENTING", "IN_REVIEW",
+    "PUBLIC_PR", "CI_WATCH", "MERGED", "DONE", "SKIPPED", "NEEDS_HUMAN",
+]
+
+STATE_COMMENT_MARKER = "<!-- AGENT_STATE:"
+STATE_COMMENT_END = "-->"
+
+
+@dataclass
+class TrackedIssue:
+    """All pipeline state for one tracked issue.
+
+    Persisted as JSON inside a hidden HTML comment on the source issue.
+    """
+    source_repo: str
+    source_number: int
+    title: str
+    stage: str = "DISCOVERED"
+    tracking_pr_number: int | None = None   # PR on PRIVATE_REVIEW_REPO
+    tracking_pr_url: str | None = None
+    public_pr_number: int | None = None     # PR on PUBLIC_TARGET_REPO
+    public_pr_url: str | None = None
+    branch: str | None = None
+    triage_reason: str | None = None
+    review_iteration: int = 0               # how many review cycles run
+    attempt_count: int = 0
+    last_push_sha: str | None = None
+    paused: bool = False                    # set by /agent pause comment
+    ci_iteration: int = 0                   # how many CI-fix cycles run
+    _state_comment_id: int | None = field(default=None, repr=False)
+
+
+def render_state_comment(tracked: TrackedIssue) -> str:
+    """Render *tracked* as a GitHub comment (human-visible + hidden JSON)."""
+    raise NotImplementedError
+
+
+def parse_state_comment(comment_body: str) -> TrackedIssue | None:
+    """Parse state from a comment body. Returns None if no marker found."""
+    raise NotImplementedError
+
+
+def save_state(tracked: TrackedIssue) -> None:
+    """Upsert the state comment and sync GitHub labels."""
+    raise NotImplementedError
+
+
+def update_stage(tracked: TrackedIssue, new_stage: str, message: str) -> None:
+    """Transition to *new_stage*, post a human-readable comment, save state."""
+    raise NotImplementedError
+
+
+def get_all_tracked() -> list[TrackedIssue]:
+    """Return all issues currently carrying any agent: label."""
+    raise NotImplementedError
+
+
+def find_tracked_by_issue(source_number: int) -> TrackedIssue | None:
+    """Return existing TrackedIssue for *source_number*, or None."""
+    raise NotImplementedError
+
+
+def load_tracked(issue_number: int) -> TrackedIssue:
+    """Load TrackedIssue or raise ValueError if none found."""
+    raise NotImplementedError

--- a/.github/pytorch-agent/scripts/cron.sh
+++ b/.github/pytorch-agent/scripts/cron.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Cron entry point — runs one pipeline cycle.
+# Scheduled via: */15 * * * * /path/to/cron.sh >> /path/to/logs/cron.log 2>&1
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Load .env (bare KEY=value format exported into environment)
+[[ -f "$AGENT_DIR/.env" ]] && set -a && source "$AGENT_DIR/.env" && set +a
+
+exec python3 "$AGENT_DIR/scripts/run_pipeline.py" --once "$@"

--- a/.github/pytorch-agent/scripts/run_oneshot.sh
+++ b/.github/pytorch-agent/scripts/run_oneshot.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Ad-hoc single-issue run.
+# Usage: ./scripts/run_oneshot.sh --issue 3509
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$AGENT_DIR"
+set -a && source .env && set +a
+
+python3 scripts/run_pipeline.py "$@"

--- a/.github/pytorch-agent/scripts/run_pipeline.py
+++ b/.github/pytorch-agent/scripts/run_pipeline.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Polling loop that discovers and advances issues.
+
+Usage
+-----
+    python scripts/run_pipeline.py --once          # single cycle
+    python scripts/run_pipeline.py --issue 3509    # single issue
+    python scripts/run_pipeline.py                 # continuous loop
+
+NOTE: This polling loop is temporary and will be replaced by
+      GitHub Actions webhooks in a future PR.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import os
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from pytorch_agent.utils.config import POLL_INTERVAL  # noqa: E402 (after sys.path)
+from pytorch_agent.utils.logger import log  # noqa: E402
+
+# Stages where the pipeline should not call advance()
+TERMINAL_STAGES = {"DONE", "SKIPPED", "NEEDS_HUMAN"}
+
+
+def run_cycle() -> None:
+    """Discover new issues and advance all active tracked issues by one step."""
+    raise NotImplementedError
+
+
+def run_single(issue_number: int) -> None:
+    """Run the full pipeline for *issue_number*: triage → loop advance → terminal."""
+    raise NotImplementedError
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="pytorch-agent polling loop")
+    parser.add_argument("--once", action="store_true", help="Run a single cycle")
+    parser.add_argument("--issue", type=int, help="Run pipeline for one issue")
+    parser.add_argument("--interval", type=int, default=POLL_INTERVAL)
+    args = parser.parse_args()
+
+    if args.issue:
+        run_single(args.issue)
+    elif args.once:
+        run_cycle()
+    else:
+        while True:
+            try:
+                run_cycle()
+            except Exception as e:
+                log("ERROR", f"Cycle failed: {e}")
+            time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Overview
Introduces the complete `pytorch-agent` directory under `.github/pytorch-agent/`, with every module, class, and function signature in place but bodies stubbed as `raise NotImplementedError`.

The goal of this PR is to let reviewers see the **full architecture** before the implementation details land in PR 2 and PR 3.

## What's included
- `pytorch_agent/utils/` — config, state, logger, git, github_client, notify, agent_backend, review_handler
- `pytorch_agent/fixing_steps/` — implement, private_review, public_submit, ci_watch, close_issue, _issue_format
- `pytorch_agent/issue_discovery.py`, `issue_triaging_agent.py`, `issue_fixing_agent.py`
- `scripts/` — run_pipeline.py, run_oneshot.sh, cron.sh
- `.env.example`, `AGENTS.md`, `docs/getting-started.md`

## Stage machine
```
DISCOVERED → IMPLEMENTING → IN_REVIEW → PUBLIC_PR → CI_WATCH → MERGED → DONE
                                                                ↓
                                                         SKIPPED / NEEDS_HUMAN
```

## Stacked PRs
- **PR 1 (this)** — skeleton (all stubs)
- **PR 2** — infrastructure fill-in (utils layer)
- **PR 3** — stage implementations (fixing_steps + top-level agents)