### PR TITLE
pytorch-agent PR2: infrastructure — real utils layer implementations

### DIFF
--- a/.github/pytorch-agent/pytorch_agent/utils/agent_backend.py
+++ b/.github/pytorch-agent/pytorch_agent/utils/agent_backend.py
@@ -1,63 +1,176 @@
-"""AI agent backend abstraction.
+"""Agent backend abstraction — pluggable LLM agent dispatch.
 
-Backends
---------
-OpenCodeBackend  —  wraps the `opencode` CLI, streams JSON events,
-                    captures session ID and output text, writes a log file.
-
-Usage
------
-    backend = get_backend()
-    output, log_path, session_id = backend.run(
-        prompt,
-        workdir=str(PYTORCH_DIR),
-        skill="xpu-ops-implement",
-        timeout=3600,
-        issue=tracked.source_number,
-        stage="IMPLEMENTING",
-        on_session_start=lambda sid: ...,
-    )
+OpenCode CLI notes (from `opencode run --help`):
+  - Message is positional (not --prompt)
+  - Use --dir for working directory (not cwd kwarg)
+  - Use --dangerously-skip-permissions for autonomous operation
 """
-from __future__ import annotations
-
-from pathlib import Path
+from abc import ABC, abstractmethod
 from collections.abc import Callable
+from datetime import datetime
+import json
+from pathlib import Path
+import subprocess
+
+from .config import OPENCODE_CMD, PYTORCH_DIR, SKILLS_DIR, LOG_DIR
+from .logger import log as pipeline_log
 
 
-class AgentBackend:
-    """Abstract base class for AI coding agent backends."""
+def parse_opencode_events(raw_output: str) -> str:
+    """Parse OpenCode JSON event stream and return concatenated text output."""
+    text_parts = []
+    for line in raw_output.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("type") == "text":
+            part = event.get("part", {})
+            text_parts.append(part.get("text", "") or event.get("content", ""))
+    return "".join(text_parts)
 
-    def run(
-        self,
-        prompt: str,
-        *,
-        workdir: str,
-        skill: str | None = None,
-        timeout: int = 3600,
-        issue: int | None = None,
-        stage: str | None = None,
-        on_session_start: Callable[[str], None] | None = None,
-    ) -> tuple[str, Path, str | None]:
-        """Run the agent on *prompt* and return (output_text, log_path, session_id)."""
-        raise NotImplementedError
+
+class AgentBackend(ABC):
+    @abstractmethod
+    def run(self, prompt: str, workdir: str | None = None,
+            skill: str | None = None, timeout: int | None = None,
+            issue: int | None = None, stage: str | None = None,
+            on_session_start: 'Callable[[str], None] | None' = None) -> tuple[str, Path, str | None]:
+        """Run LLM agent with prompt.
+
+        Returns (agent_output_text, log_file_path, session_id_or_None).
+        on_session_start: optional callback(session_id) called as soon as
+            the agent session ID is known (while still running).
+        """
+        ...
 
 
 class OpenCodeBackend(AgentBackend):
-    """Runs `opencode run --format json …` and streams the response."""
+    def run(self, prompt: str, workdir: str | None = None,
+            skill: str | None = None, timeout: int | None = None,
+            issue: int | None = None, stage: str | None = None,
+            on_session_start: 'Callable[[str], None] | None' = None) -> tuple[str, Path, str | None]:
+        workdir = workdir or str(PYTORCH_DIR)
+        timeout = timeout or 1800
 
-    def run(self, prompt: str, *, workdir: str, skill: str | None = None,
-            timeout: int = 3600, issue: int | None = None,
-            stage: str | None = None,
-            on_session_start: Callable[[str], None] | None = None,
-            ) -> tuple[str, Path, str | None]:
-        raise NotImplementedError
+        # Point OpenCode to XPU agent skills in torch-xpu-ops.
+        # OpenCode runs in ~/pytorch, so it won't auto-discover them.
+        # We inline a short pointer — OpenCode reads the files itself.
+        skills_hint = (
+            "\n\n## Context\n"
+            f"XPU agent skills and instructions are in {SKILLS_DIR} "
+            f"and {SKILLS_DIR.parent / 'instructions'}. "
+            "Read the relevant SKILL.md before starting work."
+        )
+        if skill:
+            skill_path = SKILLS_DIR / skill / "SKILL.md"
+            if skill_path.exists():
+                skills_hint += f"\nThe skill for this task is: {skill_path}"
+
+        full_prompt = prompt + skills_hint
+
+        # OpenCode CLI: --format json streams structured events to stdout
+        cmd = [OPENCODE_CMD, "run", "--format", "json", "--dir", workdir,
+               "--dangerously-skip-permissions", full_prompt]
+
+        # Log the command (redact the full prompt, just show length)
+        pipeline_log("INFO", f"Running: {' '.join(cmd[:6])} <prompt {len(full_prompt)} chars> "
+                     f"(timeout={timeout}s)", issue=issue)
+
+        # Stream output to log file in real-time (not buffered until exit)
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+        prefix = f"issue-{issue}" if issue else "unknown"
+        stage_str = f"-{stage.lower()}" if stage else ""
+        log_path = LOG_DIR / f"agent-{prefix}{stage_str}-{ts}.log"
+
+        with open(log_path, "w") as log_f:
+            log_f.write(f"=== COMMAND ===\n{' '.join(cmd[:6])} <prompt>\n\n")
+            log_f.write("=== OUTPUT (real-time) ===\n")
+            log_f.flush()
+
+            # stdout = JSON events; discard stderr to avoid pipe buffer deadlock
+            # Log full prompt to file for debugging
+            prompt_log = log_path.with_suffix('.prompt.txt')
+            with open(prompt_log, 'w') as pf:
+                pf.write(full_prompt)
+            proc = subprocess.Popen(
+                cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                stdin=subprocess.DEVNULL, text=True,
+            )
+            log_f.write(f"=== PID ===\n{proc.pid}\n\n")
+
+            session_id = None
+            text_parts = []
+            try:
+                for line in proc.stdout:
+                    log_f.write(line)
+                    log_f.flush()
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        event = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    # Extract session ID from first event
+                    if session_id is None and event.get("sessionID"):
+                        session_id = event["sessionID"]
+                        pipeline_log("INFO",
+                                     f"OpenCode session: {session_id}  "
+                                     f"(attach: cd {workdir} && opencode -s {session_id})",
+                                     issue=issue)
+                        log_f.write(f"\n=== SESSION ID ===\n{session_id}\n\n")
+                        log_f.flush()
+                        if on_session_start:
+                            try:
+                                on_session_start(session_id)
+                            except Exception:
+                                pass
+                    # Collect text output from assistant
+                    # Note: intentionally separate from parse_opencode_events() —
+                    # streaming side effects (session-id extraction, live logging)
+                    if event.get("type") == "text":
+                        part = event.get("part", {})
+                        text_parts.append(part.get("text", ""))
+                proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+                log_f.write("\n=== TIMEOUT ===\n")
+                raise
+
+            log_f.write(f"\n=== EXIT CODE ===\n{proc.returncode}\n")
+
+        full_output = "".join(text_parts)
+
+        pipeline_log("INFO", f"Agent finished (rc={proc.returncode}), "
+                     f"log: {log_path}", issue=issue)
+
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"OpenCode failed (rc={proc.returncode}), "
+                f"log: {log_path}\n{full_output[-500:]}"
+            )
+        return full_output, log_path, session_id
+
+
+class CopilotBackend(AgentBackend):
+    """Future: GitHub Copilot cloud agent.
+    Placeholder — implement when migrating to cloud.
+    """
+    def run(self, prompt: str, workdir: str | None = None,
+            skill: str | None = None, timeout: int | None = None,
+            issue: int | None = None, stage: str | None = None,
+            on_session_start: 'Callable[[str], None] | None' = None) -> tuple[str, Path, str | None]:
+        raise NotImplementedError("Copilot backend not yet implemented")
 
 
 def get_backend() -> AgentBackend:
-    """Return the configured backend (OpenCodeBackend by default)."""
-    raise NotImplementedError
-
-
-def parse_opencode_events(raw_json_lines: str) -> str:
-    """Extract assistant text from a newline-delimited stream of opencode JSON events."""
-    raise NotImplementedError
+    from .config import AGENT_BACKEND
+    if AGENT_BACKEND == "copilot":
+        return CopilotBackend()
+    return OpenCodeBackend()

--- a/.github/pytorch-agent/pytorch_agent/utils/config.py
+++ b/.github/pytorch-agent/pytorch_agent/utils/config.py
@@ -1,60 +1,54 @@
-"""Configuration constants for pytorch-agent.
-
-All tuneable values come from environment variables (see .env.example).
-"""
-from __future__ import annotations
-
+"""Configuration constants for pytorch-agent."""
 from pathlib import Path
+import os
 
-# ---------------------------------------------------------------------------
-# Repos
-# ---------------------------------------------------------------------------
-UPSTREAM_ISSUE_REPO: str   # e.g. "intel/torch-xpu-ops"
-PRIVATE_REVIEW_REPO: str   # e.g. "yourfork/pytorch"
-PUBLIC_TARGET_REPO: str    # e.g. "pytorch/pytorch"
+# Repos (configure via env — no personal forks hardcoded)
+UPSTREAM_ISSUE_REPO = os.environ.get("UPSTREAM_ISSUE_REPO", "intel/torch-xpu-ops")
+PRIVATE_REVIEW_REPO = os.environ.get("PRIVATE_REVIEW_REPO", "")  # e.g. "yourfork/pytorch"
+PUBLIC_TARGET_REPO = os.environ.get("PUBLIC_TARGET_REPO", "pytorch/pytorch")
 
-# ---------------------------------------------------------------------------
-# Labels — one label per stage; pipeline updates issues automatically
-# ---------------------------------------------------------------------------
-ISSUE_LABEL: str
-STAGE_TO_LABEL: dict[str, str]
-ALL_AGENT_LABELS: list[str]
+# Labels
+ISSUE_LABEL = "ai_generated"
+STAGE_TO_LABEL = {
+    "DISCOVERED": "agent:active",
+    "IMPLEMENTING": "agent:active",
+    "IN_REVIEW": "agent:blocked",
+    "PUBLIC_PR": "agent:blocked",
+    "CI_WATCH": "agent:active",
+    "MERGED": "agent:active",
 
-# ---------------------------------------------------------------------------
+    "DONE": "agent:done",
+    "SKIPPED": "agent:skipped",
+    "NEEDS_HUMAN": "agent:needs-human",
+}
+ALL_AGENT_LABELS = sorted(set(STAGE_TO_LABEL.values()))
+
 # Limits
-# ---------------------------------------------------------------------------
-MAX_REVIEW_ITERATIONS: int
-MAX_AGENT_ATTEMPTS: int
+MAX_REVIEW_ITERATIONS = 3
+MAX_AGENT_ATTEMPTS = 3
 
-# ---------------------------------------------------------------------------
 # Local paths
-# ---------------------------------------------------------------------------
-PYTORCH_DIR: Path     # ~/pytorch by default
-AGENT_DIR: Path       # .github/pytorch-agent/
-LOG_DIR: Path
-SKILLS_DIR: Path
+PYTORCH_DIR = Path(os.environ.get("PYTORCH_DIR", os.path.expanduser("~/pytorch")))
+AGENT_DIR = Path(__file__).resolve().parent.parent.parent  # .github/pytorch-agent/
+LOG_DIR = AGENT_DIR / "logs"
+SKILLS_DIR = AGENT_DIR.parent / "skills"
 
-# ---------------------------------------------------------------------------
 # Git
-# ---------------------------------------------------------------------------
-REVIEW_REMOTE: str    # name of the remote pointing at PRIVATE_REVIEW_REPO
-BRANCH_PREFIX: str
-AGENT_PR_PREFIX: str
+REVIEW_REMOTE = "review"
+BRANCH_PREFIX = "agent/"
+AGENT_PR_PREFIX = "[Agent]"
 
-# ---------------------------------------------------------------------------
-# Polling (temporary — replaced by webhooks in a future PR)
-# ---------------------------------------------------------------------------
-POLL_INTERVAL: int
+# Polling (temporary — removed when moving to webhooks)
+POLL_INTERVAL = int(os.environ.get("POLL_INTERVAL", "60"))
 
-# ---------------------------------------------------------------------------
-# Per-stage agent timeouts (seconds)
-# ---------------------------------------------------------------------------
-STAGE_TIMEOUTS: dict[str, int]
+# Per-stage timeouts (seconds)
+STAGE_TIMEOUTS = {
+    "TRIAGING": 300,
+    "IMPLEMENTING": 3600,
+    "IN_REVIEW": 1800,
+    "CI_WATCH": 600,
+}
 
-# ---------------------------------------------------------------------------
 # Agent backend
-# ---------------------------------------------------------------------------
-AGENT_BACKEND: str    # "opencode" | "copilot"
-OPENCODE_CMD: str
-
-raise NotImplementedError("config.py: stub — implementation added in PR 2")
+AGENT_BACKEND = os.environ.get("AGENT_BACKEND", "opencode")  # or "copilot"
+OPENCODE_CMD = os.environ.get("OPENCODE_CMD", "opencode")

--- a/.github/pytorch-agent/pytorch_agent/utils/git.py
+++ b/.github/pytorch-agent/pytorch_agent/utils/git.py
@@ -1,27 +1,60 @@
-"""Shared git helpers for the pytorch-agent pipeline."""
+"""Shared git helpers."""
 from __future__ import annotations
 
 import subprocess
 from pathlib import Path
 
+from .config import PYTORCH_DIR
+from .logger import log
+
 
 def git(*args: str, workdir: Path | None = None, check: bool = True,
         issue: int | None = None) -> subprocess.CompletedProcess[str]:
-    """Run a git command inside PYTORCH_DIR (or *workdir*) with logging."""
-    raise NotImplementedError("git.py: stub — implementation added in PR 2")
+    """Run a git command with logging."""
+    cwd = str(workdir or PYTORCH_DIR)
+    cmd_str = "git " + " ".join(args)
+    log("INFO", f"$ {cmd_str}", issue=issue)
+    return subprocess.run(
+        ["git", *args], cwd=cwd, check=check,
+        capture_output=True, text=True,
+    )
 
 
 def git_out(*args: str, **kwargs) -> str:
-    """Run git and return stdout string."""
-    raise NotImplementedError("git.py: stub — implementation added in PR 2")
+    """Run git and return stdout. Convenience wrapper around git()."""
+    return git(*args, **kwargs).stdout
 
 
-def add_and_commit(message: str, *,
-                   issue: int | None = None,
+def add_and_commit(message: str, *, issue: int | None = None,
                    workdir: Path | None = None) -> bool:
-    """Stage all tracked files (excluding third_party/*) and commit if dirty.
+    """Stage tracked files (excluding third_party/*) and commit if dirty.
 
-    Returns True if a commit was made, False if the tree was already clean.
-    Handles renamed files (porcelain R old -> new) correctly.
+    Returns True if a commit was made, False if tree was clean.
     """
-    raise NotImplementedError("git.py: stub — implementation added in PR 2")
+    cwd = workdir or PYTORCH_DIR
+    status = git("status", "--porcelain", workdir=cwd, issue=issue).stdout
+    if not status.strip():
+        return False
+
+    # Filter out submodule pointer changes (third_party/*)
+    files = []
+    for line in status.splitlines():
+        # porcelain format: XY filename  or  XY old -> new
+        parts = line.split(maxsplit=1)
+        if len(parts) < 2:
+            continue
+        fname = parts[1].strip()
+        # Handle rename porcelain: "R  old -> new"
+        if " -> " in fname:
+            fname = fname.split(" -> ", 1)[1]
+        if fname.startswith("third_party/"):
+            log("INFO", f"Skipping submodule change: {fname}", issue=issue)
+            continue
+        files.append(fname)
+
+    if not files:
+        return False
+
+    git("add", "--", *files, workdir=cwd, issue=issue)
+    git("commit", "-m", message, workdir=cwd, issue=issue)
+    return True

--- a/.github/pytorch-agent/pytorch_agent/utils/github_client.py
+++ b/.github/pytorch-agent/pytorch_agent/utils/github_client.py
@@ -1,116 +1,227 @@
-"""Thin wrappers around the `gh` CLI for all GitHub API operations.
-
-Token routing
--------------
-- REVIEW_GH_TOKEN  →  PRIVATE_REVIEW_REPO and PUBLIC_TARGET_REPO operations
-- GH_TOKEN         →  everything else (upstream issues, labels, comments)
-"""
-from __future__ import annotations
-
+"""Thin wrappers around `gh` CLI for GitHub API operations."""
+import json
+import os
+import subprocess
 from typing import Any
 
 
-# ---------------------------------------------------------------------------
-# Low-level helpers
-# ---------------------------------------------------------------------------
-
 def _token_for_repo(repo: str) -> str | None:
-    """Return the correct GH token for *repo*."""
-    raise NotImplementedError
+    """Pick the right GH token based on which repo we're accessing.
+
+    REVIEW_GH_TOKEN → for PRIVATE_REVIEW_REPO operations
+    GH_TOKEN → for everything else (upstream issues, public PRs)
+    """
+    review_repo = os.environ.get("PRIVATE_REVIEW_REPO", "")
+    public_target = os.environ.get("PUBLIC_TARGET_REPO", "")
+    review_token = os.environ.get("REVIEW_GH_TOKEN")
+    if review_token and repo in (review_repo, public_target):
+        return review_token
+    return os.environ.get("GH_TOKEN")
 
 
 def _gh(args: list[str], input_text: str | None = None,
         token: str | None = None) -> str:
-    """Run `gh <args>` and return stdout. Raises CalledProcessError on failure."""
-    raise NotImplementedError
+    """Run gh command, return stdout."""
+    env = None
+    gh_token = token or os.environ.get("GH_TOKEN")
+    if gh_token:
+        env = {**os.environ, "GH_TOKEN": gh_token}
+    result = subprocess.run(
+        ["gh"] + args, capture_output=True, text=True,
+        input=input_text, env=env,
+    )
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode, ["gh"] + args,
+            output=result.stdout,
+            stderr=result.stderr,
+        )
+    return result.stdout
 
 
 def _gh_api(endpoint: str, method: str = "GET",
             token: str | None = None, **fields: Any) -> dict | list:
-    """Call `gh api` and return parsed JSON."""
-    raise NotImplementedError
+    """Call gh api, return parsed JSON.
+
+    Type dispatch: strings use -f, others use -F with JSON encoding.
+    """
+    cmd = ["api", endpoint, "--method", method]
+    for k, v in fields.items():
+        if isinstance(v, str):
+            cmd += ["-f", f"{k}={v}"]
+        else:
+            cmd += ["-F", f"{k}={json.dumps(v)}"]
+    raw = _gh(cmd, token=token)
+    return json.loads(raw) if raw.strip() else {}
 
 
 # ---------------------------------------------------------------------------
-# Issues
+# Issues (intel/torch-xpu-ops)
 # ---------------------------------------------------------------------------
 
 def get_issues(repo: str, label: str) -> list[dict]:
-    """List open issues carrying *label*."""
-    raise NotImplementedError
+    """List open issues with a given label."""
+    raw = _gh([
+        "issue", "list", "--repo", repo, "--label", label,
+        "--state", "open", "--json",
+        "number,title,labels,body,createdAt,url", "--limit", "100",
+    ])
+    return json.loads(raw) if raw.strip() else []
 
 
 def get_issue_detail(repo: str, number: int) -> dict:
-    """Return full issue details including body, labels, comments."""
-    raise NotImplementedError
+    """Get full issue details."""
+    raw = _gh([
+        "issue", "view", str(number), "--repo", repo,
+        "--json", "number,title,body,labels,comments,url,state,createdAt",
+    ])
+    return json.loads(raw)
 
 
 def add_issue_comment(repo: str, number: int, body: str) -> None:
-    """Post a comment on an issue."""
-    raise NotImplementedError
+    """Add a comment to an issue."""
+    _gh(["issue", "comment", str(number), "--repo", repo, "--body", body])
 
 
-def get_issue_comments(repo: str, number: int) -> list[dict]:
-    """Return all comments on an issue."""
-    raise NotImplementedError
+def add_pr_comment(repo: str, number: int, body: str) -> dict:
+    """Add a comment to a PR (uses correct token for repo)."""
+    return _gh_api(f"/repos/{repo}/issues/{number}/comments",
+                   method="POST", token=_token_for_repo(repo), body=body)
 
 
-def update_issue_comment(repo: str, comment_id: int, body: str) -> None:
-    """Edit an existing issue comment."""
-    raise NotImplementedError
+def update_pr_comment(repo: str, comment_id: int, body: str) -> None:
+    """Update an existing PR comment (uses correct token for repo)."""
+    _gh_api(f"/repos/{repo}/issues/comments/{comment_id}",
+            method="PATCH", token=_token_for_repo(repo), body=body)
 
 
 def close_issue(repo: str, number: int) -> None:
     """Close an issue."""
-    raise NotImplementedError
+    _gh(["issue", "close", str(number), "--repo", repo])
 
 
 def add_label(repo: str, number: int, label: str) -> None:
-    """Add a label to an issue, creating it if necessary."""
-    raise NotImplementedError
+    """Add a label to an issue. Creates the label if it doesn't exist."""
+    try:
+        _gh(["issue", "edit", str(number), "--repo", repo, "--add-label", label])
+    except subprocess.CalledProcessError:
+        # Label may not exist — create it and retry
+        try:
+            _gh_api(f"/repos/{repo}/labels", method="POST",
+                    name=label, color="c5def5")
+        except subprocess.CalledProcessError:
+            pass  # Label may already exist on repo but issue edit failed for other reason
+        _gh(["issue", "edit", str(number), "--repo", repo, "--add-label", label])
 
 
 def remove_label(repo: str, number: int, label: str) -> None:
     """Remove a label from an issue."""
-    raise NotImplementedError
+    _gh(["issue", "edit", str(number), "--repo", repo, "--remove-label", label])
+
+
+def get_issue_comments(repo: str, number: int) -> list[dict]:
+    """Get all comments on an issue."""
+    return _gh_api(f"/repos/{repo}/issues/{number}/comments")
+
+
+def update_issue_comment(repo: str, comment_id: int, body: str) -> None:
+    """Update an existing issue comment."""
+    _gh_api(f"/repos/{repo}/issues/comments/{comment_id}",
+            method="PATCH", body=body)
 
 
 # ---------------------------------------------------------------------------
-# Pull requests
+# Pull Requests (PRIVATE_REVIEW_REPO, PUBLIC_TARGET_REPO)
 # ---------------------------------------------------------------------------
 
-def create_pr(repo: str, title: str, body: str, head: str,
-              base: str = "main") -> dict:
-    """Create a PR inside *repo*."""
-    raise NotImplementedError
+def create_draft_pr(repo: str, title: str, body: str, head: str,
+                    base: str = "main") -> dict:
+    """Create a draft PR via gh api."""
+    token = _token_for_repo(repo)
+    return _gh_api(
+        f"/repos/{repo}/pulls", method="POST",
+        token=token, title=title, body=body, head=head, base=base, draft=True,
+    )
 
 
-def create_cross_fork_pr(head_repo: str, head_branch: str,
-                         base_repo: str, title: str, body: str) -> dict:
-    """Open a PR from *head_repo*:*head_branch* into *base_repo*:main."""
-    raise NotImplementedError
+def update_pr_body(repo: str, pr_number: int, body: str) -> None:
+    """Update a PR's body."""
+    _gh_api(f"/repos/{repo}/pulls/{pr_number}", method="PATCH",
+            token=_token_for_repo(repo), body=body)
 
 
-def add_pr_comment(repo: str, number: int, body: str) -> dict:
-    """Post a comment on a PR and return the created comment dict."""
-    raise NotImplementedError
+def mark_pr_ready(repo: str, pr_number: int) -> None:
+    """Mark a draft PR as ready for review."""
+    _gh(["pr", "ready", str(pr_number), "--repo", repo],
+        token=_token_for_repo(repo))
 
 
-def update_pr_comment(repo: str, comment_id: int, body: str) -> None:
-    """Edit an existing PR comment."""
-    raise NotImplementedError
+def get_pr_reviews(repo: str, pr_number: int) -> list[dict]:
+    """Get all reviews on a PR."""
+    return _gh_api(f"/repos/{repo}/pulls/{pr_number}/reviews",
+                   token=_token_for_repo(repo))
+
+
+def get_pr_review_comments(repo: str, pr_number: int) -> list[dict]:
+    """Get all review comments on a PR."""
+    return _gh_api(f"/repos/{repo}/pulls/{pr_number}/comments",
+                   token=_token_for_repo(repo))
 
 
 def get_pr_status(repo: str, pr_number: int) -> str:
-    """Return PR state: "open" | "closed" | "merged"."""
-    raise NotImplementedError
+    """Get PR merge status: 'open', 'closed', or 'merged'."""
+    pr = _gh_api(f"/repos/{repo}/pulls/{pr_number}",
+                 token=_token_for_repo(repo))
+    if pr.get("merged"):
+        return "merged"
+    return pr.get("state", "unknown")
 
+
+def create_cross_fork_pr(head_repo: str, head_branch: str,
+                         base_repo: str, title: str, body: str,
+                         base_branch: str = "main") -> dict:
+    """Create a cross-fork PR (e.g. reviewfork:branch → pytorch/pytorch:main)."""
+    owner = head_repo.split("/")[0]
+    return _gh_api(
+        f"/repos/{base_repo}/pulls", method="POST",
+        token=_token_for_repo(base_repo), title=title, body=body,
+        head=f"{owner}:{head_branch}", base=base_branch,
+    )
+
+
+def list_prs(repo: str, state: str = "open",
+             search: str | None = None) -> list[dict]:
+    """List PRs with optional search filter."""
+    cmd = [
+        "pr", "list", "--repo", repo, "--state", state,
+        "--json", "number,title,body,url,state,isDraft,headRefName",
+        "--limit", "100",
+    ]
+    if search:
+        cmd += ["--search", search]
+    raw = _gh(cmd, token=_token_for_repo(repo))
+    return json.loads(raw) if raw.strip() else []
+
+
+# ---------------------------------------------------------------------------
+# CI
+# ---------------------------------------------------------------------------
 
 def get_ci_checks(repo: str, pr_number: int) -> list[dict]:
-    """Return all check-runs for the latest commit of a PR."""
-    raise NotImplementedError
+    """Get CI check runs for a PR's head commit."""
+    token = _token_for_repo(repo)
+    pr = _gh_api(f"/repos/{repo}/pulls/{pr_number}", token=token)
+    sha = pr.get("head", {}).get("sha")
+    if not sha:
+        return []
+    result = _gh_api(f"/repos/{repo}/commits/{sha}/check-runs", token=token)
+    return result.get("check_runs", [])
 
 
 def delete_branch(repo: str, branch: str) -> None:
-    """Delete *branch* from *repo* (best-effort, ignores 404)."""
-    raise NotImplementedError
+    """Delete a branch from a remote repo."""
+    try:
+        _gh_api(f"/repos/{repo}/git/refs/heads/{branch}", method="DELETE",
+                token=_token_for_repo(repo))
+    except subprocess.CalledProcessError:
+        pass  # Branch may already be deleted

--- a/.github/pytorch-agent/pytorch_agent/utils/logger.py
+++ b/.github/pytorch-agent/pytorch_agent/utils/logger.py
@@ -1,15 +1,39 @@
-"""Structured logger: writes to a daily log file and stderr."""
-from __future__ import annotations
+"""Simple structured file + console logger for pytorch-agent."""
+import sys
+import traceback
+from datetime import datetime
+from .config import LOG_DIR
 
 
-def log(level: str, message: str, *,
-        issue: int | None = None, exc: Exception | None = None) -> None:
-    """Append a timestamped log line to the daily log file and print to stderr.
+def _ensure_log_dir() -> None:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
 
-    Args:
-        level:   Log level string (INFO / WARN / ERROR).
-        message: Human-readable message.
-        issue:   Source issue number for correlation.
-        exc:     Optional exception — full traceback is appended when set.
+
+def log(level: str, message: str, *, issue: int | None = None,
+        exc: Exception | None = None) -> None:
+    """Append a log line to daily log file AND print to stderr.
+
+    Format: YYYY-MM-DD HH:MM:SS [LEVEL] (issue #N) message
+    If exc is provided, appends the full traceback.
     """
-    raise NotImplementedError("logger.py: stub — implementation added in PR 2")
+    _ensure_log_dir()
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    prefix = f"(issue #{issue}) " if issue is not None else ""
+    line = f"{ts} [{level.upper()}] {prefix}{message}"
+
+    # Append traceback if exception provided
+    tb = ""
+    if exc is not None:
+        tb = "\n" + "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+
+    full_line = line + tb + "\n"
+
+    # Write to file
+    log_file = LOG_DIR / f"pipeline-{datetime.now().strftime('%Y-%m-%d')}.log"
+    with open(log_file, "a") as f:
+        f.write(full_line)
+
+    # Also print to stderr for live monitoring
+    print(line, file=sys.stderr, flush=True)
+    if tb:
+        print(tb, file=sys.stderr, flush=True)

--- a/.github/pytorch-agent/pytorch_agent/utils/notify.py
+++ b/.github/pytorch-agent/pytorch_agent/utils/notify.py
@@ -1,33 +1,34 @@
-"""Helpers for posting agent status comments to GitHub issues."""
+"""Shared notification helpers for agent sessions."""
 from __future__ import annotations
 
 from pathlib import Path
 
+from . import github_client as gh
 
-def post_session_started(repo: str, issue: int, stage: str, session_id: str) -> None:
-    """Comment on *issue* that an agent session has started.
 
-    Args:
-        repo:       Source issue repo (e.g. "intel/torch-xpu-ops").
-        issue:      Issue number.
-        stage:      Human-readable stage name (e.g. "Implement").
-        session_id: opencode session ID for cross-referencing logs.
-    """
-    raise NotImplementedError
+def post_session_started(
+    repo: str, issue: int, stage: str, sid: str, workdir: str = "~/pytorch",
+) -> None:
+    """Post a standardised session-started comment to the source issue."""
+    gh.add_issue_comment(
+        repo, issue,
+        f"\U0001f517 **{stage} agent session started**\n\n"
+        f"**Attach to watch live:**\n"
+        f"```bash\ncd {workdir} && opencode -s {sid}\n```\n"
+        f"Session ID: `{sid}`",
+    )
 
 
 def post_agent_completed(
     repo: str, issue: int, header: str, log_path: Path,
     output: str, *, tail: int = 50,
 ) -> None:
-    """Comment on *issue* with a summary of agent output + last *tail* lines of log.
-
-    Args:
-        repo:      Source issue repo.
-        issue:     Issue number.
-        header:    One-line summary shown at the top of the comment.
-        log_path:  Path to the agent run log file.
-        output:    Full agent output text (trimmed to *tail* lines in comment).
-        tail:      Number of log lines to include in the comment.
-    """
-    raise NotImplementedError
+    """Post a standardised agent-completed comment with log tail."""
+    lines = output.strip().splitlines()[-tail:] if output.strip() else ["(empty)"]
+    gh.add_issue_comment(
+        repo, issue,
+        f"\U0001f916 **{header}** — log: `{log_path.name}`\n\n"
+        f"<details><summary>Agent output (last {tail} lines)</summary>\n\n"
+        f"```\n{chr(10).join(lines)}\n```\n"
+        f"</details>",
+    )

--- a/.github/pytorch-agent/pytorch_agent/utils/review_handler.py
+++ b/.github/pytorch-agent/pytorch_agent/utils/review_handler.py
@@ -1,34 +1,221 @@
-"""Parse GitHub PR review state and /agent slash commands.
-
-Review states
--------------
-- "approved"          — at least one approving review since last push
-- "changes_requested" — reviewer requested changes (no approval yet)
-- "pending"           — no reviews yet
-- "paused"            — a /agent pause comment was found
-
-Slash commands (in PR or issue comments, prefixed with /agent)
---------------------------------------------------------------
-- /agent pause    →  tracked.paused = True
-- /agent resume   →  tracked.paused = False
-"""
+"""Review handler — parse and format PR reviews for LLM prompts."""
 from __future__ import annotations
 
+from datetime import datetime
+from typing import Optional
 
-def get_review_state(pr_number: int, last_push_sha: str | None) -> str:
-    """Return the current review state for *pr_number*.
+from . import github_client as gh
+from .config import PRIVATE_REVIEW_REPO
 
-    Only considers reviews posted *after* the commit at *last_push_sha*
-    so that stale approvals / rejections are ignored after a new push.
+
+def _resolve_push_dt(last_push_sha: str | None) -> Optional[datetime]:
+    """Get the timestamp of a commit SHA, or None if unavailable."""
+    if not last_push_sha:
+        return None
+    try:
+        commit = gh._gh_api(
+            f"/repos/{PRIVATE_REVIEW_REPO}/commits/{last_push_sha}"
+        )
+        push_ts = commit.get("commit", {}).get("committer", {}).get("date", "")
+        if push_ts:
+            return datetime.fromisoformat(push_ts.replace("Z", "+00:00"))
+    except Exception:
+        pass
+    return None
+
+
+def _is_after(timestamp: str, push_dt: Optional[datetime]) -> bool:
+    """Return True if timestamp is after push_dt (or if either is unknown)."""
+    if not push_dt or not timestamp:
+        return True
+    try:
+        return datetime.fromisoformat(timestamp.replace("Z", "+00:00")) > push_dt
+    except Exception:
+        return True
+
+
+def get_pending_reviews(tracking_pr_number: int,
+                        last_push_sha: str | None = None) -> list[dict]:
+    """Get unaddressed review feedback on the tracking PR.
+
+    Collects from three sources:
+    1. PR reviews (CHANGES_REQUESTED, COMMENTED with body)
+    2. PR review comments (inline code comments)
+    3. Issue comments on the PR (general comments, owner workaround)
+
+    If last_push_sha is provided, filters to feedback submitted after
+    the push that produced that SHA (by comparing timestamps).
     """
-    raise NotImplementedError
+    push_dt = _resolve_push_dt(last_push_sha)
 
+    feedback: list[dict] = []
 
-def get_pending_reviews(pr_number: int, last_push_sha: str | None) -> list[dict]:
-    """Return review objects with change requests since *last_push_sha*."""
-    raise NotImplementedError
+    # 1. PR reviews
+    reviews = gh.get_pr_reviews(PRIVATE_REVIEW_REPO, tracking_pr_number)
+    for r in reviews:
+        state = r.get("state", "")
+        body = (r.get("body") or "").strip()
+        if state == "CHANGES_REQUESTED" or (state == "COMMENTED" and body):
+            if _is_after(r.get("submitted_at", ""), push_dt):
+                feedback.append(r)
+
+    # 2. PR review comments (inline)
+    try:
+        review_comments = gh.get_pr_review_comments(PRIVATE_REVIEW_REPO, tracking_pr_number)
+        for c in review_comments:
+            if _is_after(c.get("created_at", ""), push_dt):
+                feedback.append({
+                    "user": c.get("user", {}),
+                    "state": "INLINE_COMMENT",
+                    "body": f"File: `{c.get('path', '?')}` line {c.get('line', '?')}\n{c.get('body', '')}",
+                    "submitted_at": c.get("created_at", ""),
+                })
+    except Exception:
+        pass
+
+    # 3. Issue comments on the PR — only /agent prefixed commands
+    try:
+        pr_comments = gh._gh_api(
+            f"/repos/{PRIVATE_REVIEW_REPO}/issues/{tracking_pr_number}/comments"
+        )
+        for c in pr_comments:
+            login = c.get("user", {}).get("login", "")
+            body = (c.get("body") or "").strip()
+            if (login.endswith("[bot]") or "AGENT_STATE:" in body
+                    or "🤖" in body or not body):
+                continue
+            # Only process comments starting with /agent
+            if not body.lower().startswith("/agent"):
+                continue
+            # Skip approval keywords — these aren't feedback to address
+            body_lower = body.lower()
+            if any(kw in body_lower for kw in
+                   ("lgtm", "approved", "looks good", "ship it")):
+                continue
+            # Strip the /agent prefix for the task body
+            agent_body = body[len("/agent"):].strip()
+            if not agent_body or agent_body.lower() == "pause":
+                continue
+            if _is_after(c.get("created_at", ""), push_dt):
+                feedback.append({
+                    "user": c.get("user", {}),
+                    "state": "COMMENT",
+                    "body": agent_body,
+                    "submitted_at": c.get("created_at", ""),
+                })
+    except Exception:
+        pass
+
+    return feedback
 
 
 def format_reviews_for_prompt(reviews: list[dict]) -> str:
-    """Format *reviews* into a clean block suitable for an agent prompt."""
-    raise NotImplementedError
+    """Format review comments as structured text for LLM prompt."""
+    if not reviews:
+        return "No pending reviews."
+
+    parts = []
+    for i, review in enumerate(reviews, 1):
+        user = review.get("user", {}).get("login", "unknown")
+        state = review.get("state", "unknown")
+        body = review.get("body", "").strip()
+        parts.append(f"### Review {i} by @{user} ({state})\n{body}")
+
+    return "\n\n".join(parts)
+
+
+def get_review_state(tracking_pr_number: int,
+                     last_push_sha: str | None = None) -> str:
+    """Return 'approved', 'changes_requested', or 'pending'.
+
+    Three feedback sources (since repo owner can't "request changes" on own PR):
+    1. PR reviews with APPROVED/CHANGES_REQUESTED state
+    2. PR review comments (inline code comments)
+    3. Issue comments on the PR (general comments)
+
+    Any unaddressed comment/review after the last agent push = 'changes_requested'.
+    Explicit APPROVED review = 'approved'.
+    No feedback = 'pending'.
+    """
+    push_dt = _resolve_push_dt(last_push_sha)
+
+    reviews = gh.get_pr_reviews(PRIVATE_REVIEW_REPO, tracking_pr_number)
+
+    # --- /agent commands take highest priority ---
+    # Check issue comments for /agent prefixed commands FIRST.
+    # These are explicit user signals that override all other review state.
+    try:
+        pr_comments = gh._gh_api(
+            f"/repos/{PRIVATE_REVIEW_REPO}/issues/{tracking_pr_number}/comments"
+        )
+        human_comments = [
+            c for c in pr_comments
+            if not (c.get("user", {}).get("login", "").endswith("[bot]"))
+            and "AGENT_STATE:" not in c.get("body", "")
+            and "🤖" not in c.get("body", "")
+        ]
+        new_comments = [
+            c for c in human_comments
+            if _is_after(c.get("created_at", ""), push_dt)
+        ]
+        agent_commands = [
+            c for c in new_comments
+            if (c.get("body") or "").strip().lower().startswith("/agent")
+        ]
+        if agent_commands:
+            latest = agent_commands[-1]
+            body = (latest.get("body") or "").strip()
+            cmd = body[len("/agent"):].strip().lower()
+            if cmd == "pause":
+                return "paused"
+            if cmd in ("approve", "lgtm", "approved", "looks good", "ship it"):
+                return "approved"
+            if cmd:
+                return "changes_requested"
+    except Exception:
+        pass
+
+    # --- GitHub review UI (APPROVED / CHANGES_REQUESTED) ---
+    # Get latest review per user
+    latest: dict[str, str] = {}
+    for review in reviews:
+        user = review.get("user", {}).get("login", "")
+        state = review.get("state", "")
+        if state in ("APPROVED", "CHANGES_REQUESTED"):
+            latest[user] = state
+
+    # Check for explicit states first
+    if latest:
+        states = set(latest.values())
+        if "CHANGES_REQUESTED" in states:
+            # Only count if there's new feedback after last push
+            if not push_dt:
+                return "changes_requested"
+            # Check if any CHANGES_REQUESTED review is after push
+            for review in reviews:
+                if (review.get("state") == "CHANGES_REQUESTED"
+                        and _is_after(review.get("submitted_at", ""), push_dt)):
+                    return "changes_requested"
+        if all(s == "APPROVED" for s in states):
+            return "approved"
+
+    # Check for COMMENTED reviews with non-empty body (owner workaround)
+    comment_reviews = [
+        r for r in reviews
+        if r.get("state") == "COMMENTED" and (r.get("body") or "").strip()
+        and _is_after(r.get("submitted_at", ""), push_dt)
+    ]
+    if comment_reviews:
+        return "changes_requested"
+
+    # Check for inline PR review comments after last push
+    try:
+        review_comments = gh.get_pr_review_comments(
+            PRIVATE_REVIEW_REPO, tracking_pr_number)
+        for c in review_comments:
+            if _is_after(c.get("created_at", ""), push_dt):
+                return "changes_requested"
+    except Exception:
+        pass
+
+    return "pending"

--- a/.github/pytorch-agent/pytorch_agent/utils/state.py
+++ b/.github/pytorch-agent/pytorch_agent/utils/state.py
@@ -1,24 +1,22 @@
-"""Issue state management via GitHub issue comments + labels.
+"""State management via source issue comments + labels.
 
-State storage
--------------
-State lives entirely on the source issue in intel/torch-xpu-ops:
-
-- A hidden HTML comment  <!-- AGENT_STATE: {...} -->  holds the full
-  TrackedIssue JSON.  The pipeline reads/writes this on every transition.
-- GitHub labels  (agent:active, agent:blocked, …) mirror the current
-  stage for human visibility and issue-list filtering.
-
-Stage machine
--------------
-DISCOVERED → IMPLEMENTING → IN_REVIEW → PUBLIC_PR → CI_WATCH → MERGED → DONE
-                                                                       ↘ SKIPPED
-                                                                       ↘ NEEDS_HUMAN
+State is stored on intel/torch-xpu-ops issues:
+- Labels track current stage (agent:tracking, agent:implementing, etc.)
+- JSON state lives in a hidden HTML comment in a dedicated issue comment
+- Stage transitions post human-readable comments; detailed logs stay in logs/
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+import json
+import re
+from dataclasses import dataclass, field, asdict
+from datetime import datetime
 
+from . import github_client as gh
+from .config import (
+    UPSTREAM_ISSUE_REPO, STAGE_TO_LABEL, ALL_AGENT_LABELS,
+)
+from .logger import log
 
 STAGES = [
     "DISCOVERED", "IMPLEMENTING", "IN_REVIEW",
@@ -31,58 +29,219 @@ STATE_COMMENT_END = "-->"
 
 @dataclass
 class TrackedIssue:
-    """All pipeline state for one tracked issue.
-
-    Persisted as JSON inside a hidden HTML comment on the source issue.
-    """
     source_repo: str
     source_number: int
     title: str
     stage: str = "DISCOVERED"
-    tracking_pr_number: int | None = None   # PR on PRIVATE_REVIEW_REPO
+    tracking_pr_number: int | None = None
     tracking_pr_url: str | None = None
-    public_pr_number: int | None = None     # PR on PUBLIC_TARGET_REPO
+    public_pr_number: int | None = None
     public_pr_url: str | None = None
     branch: str | None = None
     triage_reason: str | None = None
-    review_iteration: int = 0               # how many review cycles run
+    review_iteration: int = 0
     attempt_count: int = 0
     last_push_sha: str | None = None
-    paused: bool = False                    # set by /agent pause comment
-    ci_iteration: int = 0                   # how many CI-fix cycles run
+    paused: bool = False
+    ci_iteration: int = 0
     _state_comment_id: int | None = field(default=None, repr=False)
 
 
 def render_state_comment(tracked: TrackedIssue) -> str:
-    """Render *tracked* as a GitHub comment (human-visible + hidden JSON)."""
-    raise NotImplementedError
+    """Render TrackedIssue as hidden HTML comment with JSON."""
+    data = asdict(tracked)
+    # Remove internal field
+    data.pop("_state_comment_id", None)
+    json_str = json.dumps(data, indent=2)
+    return (
+        f"{STATE_COMMENT_MARKER}\n{json_str}\n{STATE_COMMENT_END}\n\n"
+        f"🤖 **Agent tracking state** — do not edit this comment manually.\n"
+        f"Stage: `{tracked.stage}` | Branch: `{tracked.branch or 'N/A'}`"
+    )
 
 
 def parse_state_comment(comment_body: str) -> TrackedIssue | None:
-    """Parse state from a comment body. Returns None if no marker found."""
-    raise NotImplementedError
+    """Parse hidden HTML comment back into TrackedIssue. Returns None if no marker."""
+    match = re.search(
+        rf"{re.escape(STATE_COMMENT_MARKER)}\s*\n(.*?)\n\s*{re.escape(STATE_COMMENT_END)}",
+        comment_body, re.DOTALL,
+    )
+    if not match:
+        return None
+    try:
+        data = json.loads(match.group(1))
+    except (json.JSONDecodeError, ValueError):
+        return None
+    comment_id = data.pop("_state_comment_id", None)
+    try:
+        tracked = TrackedIssue(**data)
+    except TypeError:
+        return None
+    tracked._state_comment_id = comment_id
+    return tracked
+
+
+def _find_state_comment(repo: str, issue_number: int) -> tuple[int | None, TrackedIssue | None]:
+    """Find the state comment on an issue. Returns (comment_id, TrackedIssue)."""
+    comments = gh.get_issue_comments(repo, issue_number)
+    for comment in comments:
+        body = comment.get("body", "")
+        if STATE_COMMENT_MARKER in body:
+            tracked = parse_state_comment(body)
+            if tracked:
+                tracked._state_comment_id = comment["id"]
+                return comment["id"], tracked
+    return None, None
 
 
 def save_state(tracked: TrackedIssue) -> None:
-    """Upsert the state comment and sync GitHub labels."""
-    raise NotImplementedError
+    """Update (or create) the state comment on the source issue. Sync labels."""
+    repo = tracked.source_repo
+    number = tracked.source_number
+    body = render_state_comment(tracked)
+
+    if tracked._state_comment_id:
+        gh.update_issue_comment(repo, tracked._state_comment_id, body)
+    else:
+        gh.add_issue_comment(repo, number, body)
+        # Re-fetch to get the comment ID
+        comment_id, _ = _find_state_comment(repo, number)
+        tracked._state_comment_id = comment_id
+
+    # Sync labels: set the label matching current stage, remove others
+    target_label = STAGE_TO_LABEL.get(tracked.stage)
+    for label in ALL_AGENT_LABELS:
+        if label == target_label:
+            gh.add_label(repo, number, label)
+        else:
+            try:
+                gh.remove_label(repo, number, label)
+            except Exception:
+                pass  # Label may not be on this issue
 
 
 def update_stage(tracked: TrackedIssue, new_stage: str, message: str) -> None:
-    """Transition to *new_stage*, post a human-readable comment, save state."""
-    raise NotImplementedError
+    """Update stage, post human-readable comment, sync label, save state.
+
+    Also updates the Action Items checklist in the issue body (if present).
+    """
+    old_stage = tracked.stage
+    tracked.stage = new_stage
+    save_state(tracked)
+
+    # Update Action Items checklist in issue body
+    _update_action_items_checklist(tracked)
+
+    # Post human-readable transition comment
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    comment = (
+        f"🤖 **Stage transition:** `{old_stage}` → `{new_stage}`\n"
+        f"📅 {ts}\n\n{message}"
+    )
+    gh.add_issue_comment(tracked.source_repo, tracked.source_number, comment)
+    log("INFO", f"Stage {old_stage} → {new_stage}: {message}",
+        issue=tracked.source_number)
+
+
+# Maps each pipeline stage to which Action Items should be checked off (cumulative).
+# These match the checklist from the CI failure tracking issue template.
+_ALL_ITEMS = [
+    "Reproduce on dev machine", "Identify root cause", "Implement fix",
+    "Verify fix locally", "PR proposal", "Human review", "PR creation",
+]
+_STAGE_CHECKLIST: dict[str, list[str]] = {
+    "DISCOVERED":    [],
+    "IMPLEMENTING":  _ALL_ITEMS[:4],
+    "IN_REVIEW":     _ALL_ITEMS[:5],
+    "PUBLIC_PR":     _ALL_ITEMS[:6],
+    "CI_WATCH":      _ALL_ITEMS,
+    "MERGED":        _ALL_ITEMS,
+    "DONE":          _ALL_ITEMS,
+}
+
+
+def _update_action_items_checklist(tracked: TrackedIssue) -> None:
+    """Update the Action Items checklist in the issue body to reflect current stage.
+
+    Checks off completed items and unchecks future items based on _STAGE_CHECKLIST.
+    No-op if the issue body has no Action Items section.
+    """
+    repo = tracked.source_repo
+    number = tracked.source_number
+
+    try:
+        detail = gh.get_issue_detail(repo, number)
+    except Exception:
+        return
+
+    body = detail.get("body", "") or ""
+    if "### Action Items" not in body:
+        return
+
+    checked_items = set(_STAGE_CHECKLIST.get(tracked.stage, []))
+
+    # Replace checkbox lines in the Action Items section
+    lines = body.split("\n")
+    in_action_items = False
+    new_lines = []
+    for line in lines:
+        if line.strip().startswith("### Action Items"):
+            in_action_items = True
+            new_lines.append(line)
+            continue
+
+        if in_action_items and line.startswith("### "):
+            # Entered a new section — stop modifying
+            in_action_items = False
+
+        if in_action_items and re.match(r"^- \[[ xX]\] ", line):
+            # Extract the item text
+            item_text = re.sub(r"^- \[[ xX]\] ", "", line).strip()
+            if item_text in checked_items:
+                new_lines.append(f"- [x] {item_text}")
+            else:
+                new_lines.append(f"- [ ] {item_text}")
+            continue
+
+        new_lines.append(line)
+
+    new_body = "\n".join(new_lines)
+    if new_body != body:
+        try:
+            gh._gh_api(f"/repos/{repo}/issues/{number}", method="PATCH", body=new_body)
+        except Exception as e:
+            log("WARN", f"Failed to update Action Items checklist for #{number}: {e}",
+                issue=number)
 
 
 def get_all_tracked() -> list[TrackedIssue]:
-    """Return all issues currently carrying any agent: label."""
-    raise NotImplementedError
+    """List all issues with any agent: label, parse state comments."""
+    seen = set()
+    tracked_list = []
+    for label in ALL_AGENT_LABELS:
+        issues = gh.get_issues(UPSTREAM_ISSUE_REPO, label)
+        for issue in issues:
+            if issue["number"] in seen:
+                continue
+            seen.add(issue["number"])
+            _, tracked = _find_state_comment(UPSTREAM_ISSUE_REPO, issue["number"])
+            if tracked:
+                tracked_list.append(tracked)
+    return tracked_list
 
 
 def find_tracked_by_issue(source_number: int) -> TrackedIssue | None:
-    """Return existing TrackedIssue for *source_number*, or None."""
-    raise NotImplementedError
+    """Check if issue already has agent:tracking label + state comment."""
+    _, tracked = _find_state_comment(UPSTREAM_ISSUE_REPO, source_number)
+    return tracked
 
 
 def load_tracked(issue_number: int) -> TrackedIssue:
-    """Load TrackedIssue or raise ValueError if none found."""
-    raise NotImplementedError
+    """Load TrackedIssue from source issue state comment (for CLI entry points)."""
+    _, tracked = _find_state_comment(UPSTREAM_ISSUE_REPO, issue_number)
+    if tracked is None:
+        raise ValueError(
+            f"No agent state found on issue #{issue_number}. "
+            "Run issue_discovery first."
+        )
+    return tracked


### PR DESCRIPTION
## Overview
Stacked on #3563. Fills in the entire `pytorch_agent/utils/` layer introduced as stubs in PR 1.

## Changes
| File | What's implemented |
|------|-------------------|
| `config.py` | Env-driven constants — repos, token env-var names, paths, timeouts |
| `state.py` | `TrackedIssue` dataclass; GitHub issue comment + label state machine; `load_tracked`, `save_state`, `update_stage` |
| `logger.py` | Structured file + console logger with per-issue log files |
| `git.py` | `git()`, `git_out()`, `add_and_commit()`; handles `old -> new` rename in porcelain output |
| `github_client.py` | Thin `gh`-CLI wrappers: issues, comments, labels, PRs, CI status |
| `notify.py` | `post_session_started()`, `post_agent_completed()` |
| `agent_backend.py` | `AgentBackend` ABC + `OpenCodeBackend`; `parse_opencode_events()` |
| `review_handler.py` | PR review fetch, parse, and LLM-prompt formatting |

## Stacked PRs
- **PR 1** #3563 — skeleton
- **PR 2 (this)** — infrastructure (utils)
- **PR 3** — stage implementations (fixing_steps + top-level agents)