### PR TITLE
Relax XPU Muon state_dict parity tolerance

### DIFF
--- a/test/xpu/test_optim_xpu.py
+++ b/test/xpu/test_optim_xpu.py
@@ -254,13 +254,17 @@ def _test_state_dict_with_cuda_params(self, device, dtype, optim_info):
         for _ in range(5):
             optimizer.step(closure)
             optimizer_cuda.step(closure)
-            self.assertEqual(params, params_cuda, atol=2e-5, rtol=1.3e-6)
-            self.assertEqual(
-                optimizer.state_dict(),
-                optimizer_cuda.state_dict(),
-                atol=2e-5,
-                rtol=1.3e-6,
-            )
+            if optim_cls.__name__ == "Muon":
+                self.assertEqual(params, params_cuda, atol=2e-5, rtol=1.3e-6)
+                self.assertEqual(
+                    optimizer.state_dict(),
+                    optimizer_cuda.state_dict(),
+                    atol=2e-5,
+                    rtol=1.3e-6,
+                )
+            else:
+                self.assertEqual(params, params_cuda)
+                self.assertEqual(optimizer.state_dict(), optimizer_cuda.state_dict())
 
 
 TestOptimRenewed.test_state_dict_with_cuda_params = _test_state_dict_with_cuda_params

--- a/test/xpu/test_optim_xpu.py
+++ b/test/xpu/test_optim_xpu.py
@@ -258,7 +258,7 @@ def _test_state_dict_with_cuda_params(self, device, dtype, optim_info):
             self.assertEqual(
                 optimizer.state_dict(),
                 optimizer_cuda.state_dict(),
-                atol=1.9e-5,
+                atol=2e-5,
                 rtol=1.3e-6,
             )
 

--- a/test/xpu/test_optim_xpu.py
+++ b/test/xpu/test_optim_xpu.py
@@ -254,8 +254,13 @@ def _test_state_dict_with_cuda_params(self, device, dtype, optim_info):
         for _ in range(5):
             optimizer.step(closure)
             optimizer_cuda.step(closure)
-            self.assertEqual(params, params_cuda)
-            self.assertEqual(optimizer.state_dict(), optimizer_cuda.state_dict())
+            self.assertEqual(params, params_cuda, atol=2e-5, rtol=1.3e-6)
+            self.assertEqual(
+                optimizer.state_dict(),
+                optimizer_cuda.state_dict(),
+                atol=1.9e-5,
+                rtol=1.3e-6,
+            )
 
 
 TestOptimRenewed.test_state_dict_with_cuda_params = _test_state_dict_with_cuda_params


### PR DESCRIPTION
Fixes:
https://github.com/intel/torch-xpu-ops/issues/1973

Slightly relax the XPU Muon state_dict test tolerance to account for small float32 CPU-XPU numerical