### PR TITLE
Add single task for sycl_kernel_submit and refine it

### DIFF
--- a/src/ATen/native/sparse/xpu/sycl/SparseCsrTensorMathKernels.cpp
+++ b/src/ATen/native/sparse/xpu/sycl/SparseCsrTensorMathKernels.cpp
@@ -181,7 +181,7 @@ Tensor reduce_sparse_csr_dim0_xpu_template(
 
 template <typename index_t>
 struct ReduceCrowIndicesDim1KernelFunctor {
-  void operator()(sycl::nd_item<1> item) const {
+  void operator()() const {
     int64_t nnz = 0;
     new_crow_indices[0] = 0;
     for (int64_t i = 0; i < nrows; i++) {
@@ -291,8 +291,7 @@ Tensor reduce_sparse_csr_dim1_xpu_template(
         index_t* row_map_ptr = row_map.data_ptr<index_t>();
         ReduceCrowIndicesDim1KernelFunctor<index_t> kfn_crow(
             new_crow_indices_ptr, row_map_ptr, crow_indices_ptr, nrows);
-        sycl_kernel_submit(
-            sycl::range<1>(1), sycl::range<1>(1), queue, kfn_crow);
+        sycl_kernel_submit(sycl_single_task, queue, kfn_crow);
 
         index_t new_nnz = new_crow_indices[-1].item<index_t>();
         new_col_indices.resize_(new_nnz);

--- a/src/ATen/native/xpu/sycl/AmpKernels.cpp
+++ b/src/ATen/native/xpu/sycl/AmpKernels.cpp
@@ -116,11 +116,7 @@ void amp_foreach_non_finite_check_and_unscale_kernel(
 }
 
 struct AmpUpdateScaleKernelFunctor {
-  void operator()(sycl::nd_item<1> item) const {
-    // There is only single item/task scheduled.
-    if (item.get_global_linear_id() != 0)
-      return;
-
+  void operator()() const {
     if (*found_inf_) {
       *current_scale_ *= backoff_factor_;
       *growth_tracker_ = 0;
@@ -176,8 +172,7 @@ Tensor& amp_update_scale_kernel(
       growth_factor,
       backoff_factor,
       growth_interval);
-  sycl_kernel_submit(
-      sycl::range<1>(1), sycl::range<1>(1), getCurrentSYCLQueue(), kfn);
+  sycl_kernel_submit(sycl_single_task, getCurrentSYCLQueue(), kfn);
 
   return current_scale;
 }

--- a/src/ATen/native/xpu/sycl/Indexing.cpp
+++ b/src/ATen/native/xpu/sycl/Indexing.cpp
@@ -787,7 +787,7 @@ struct MaskedScatterElementwiseFunctor {
 };
 
 struct MaskedScatterSizeCheckFunctor {
-  void operator()(sycl::nd_item<1> item) const {
+  void operator()() const {
     const auto totalElements = *mask_exclusive_sum_ + *mask_;
     SYCL_KERNEL_ASSERT(totalElements <= srcSize_);
   }
@@ -828,7 +828,7 @@ void masked_scatter_kernel(
   // must be <= the number of elements available in `src`.
   auto caller = MaskedScatterSizeCheckFunctor(
       &maskPrefixSum_data[mask_numel - 1], &mask_data[mask_numel - 1], srcSize);
-  sycl_kernel_submit((size_t)1, (size_t)1, getCurrentSYCLQueue(), caller);
+  sycl_kernel_submit(sycl_single_task, getCurrentSYCLQueue(), caller);
 
   // We are getting elements from `src` based on an offset from
   // `maskPrefixSum`, so that should be made contiguous too

--- a/src/ATen/native/xpu/sycl/LossNLL2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LossNLL2dKernels.cpp
@@ -171,7 +171,7 @@ struct NllLoss2dForwardKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
 
 template <typename scalar_t>
 struct NllLoss2dForwardAverageKernelFunctor {
-  void operator()(sycl::nd_item<1> item) const {
+  void operator()() const {
     *output_ /= *total_weight_;
   }
 
@@ -310,7 +310,8 @@ void nll_loss2d_forward_kernel(
                 NllLoss2dForwardAverageKernelFunctor kfn_average(
                     output.mutable_data_ptr<scalar_t>(),
                     total_weight.const_data_ptr<scalar_t>());
-                sycl_kernel_submit(1, 1, getCurrentSYCLQueue(), kfn_average);
+                sycl_kernel_submit(
+                    sycl_single_task, getCurrentSYCLQueue(), kfn_average);
               }
             });
       });

--- a/src/ATen/native/xpu/sycl/LossNLLKernel.cpp
+++ b/src/ATen/native/xpu/sycl/LossNLLKernel.cpp
@@ -85,9 +85,7 @@ struct NllLossForwardNoReduceKernelFunctor {
 
 template <typename scalar_t, typename index_t>
 struct NllLossForwardReduce1DKernelFunctor {
-  void operator()(sycl::nd_item<1> item) const {
-    SYCL_KERNEL_ASSERT(item.get_local_id(0) == 0 && item.get_group(0) == 0);
-
+  void operator()() const {
     const index_t t = *target;
     if (t != ignore_index) {
       CHECK_INDEX_IN_CLASS(t, n_classes);
@@ -269,8 +267,7 @@ struct NllLossBackwardNoReduceKernelFunctor {
 
 template <typename scalar_t, typename index_t>
 struct NllLossBackwardReduce1DKernelFunctor {
-  void operator()(sycl::nd_item<1> item) const {
-    SYCL_KERNEL_ASSERT(item.get_local_id(0) == 0 && item.get_group(0) == 0);
+  void operator()() const {
     const index_t t = *target;
     if (t != ignore_index) {
       CHECK_INDEX_IN_CLASS(t, n_classes);
@@ -489,7 +486,8 @@ void nll_loss_forward_kernel(
                         reduction == at::Reduction::Mean,
                         n_classes,
                         ignore_index);
-                sycl_kernel_submit(1, 1, getCurrentSYCLQueue(), kfn);
+                sycl_kernel_submit(
+                    sycl_single_task, getCurrentSYCLQueue(), kfn);
               });
         });
 
@@ -612,10 +610,7 @@ void nll_loss_backward_kernel(
                         n_classes,
                         ignore_index);
                 sycl_kernel_submit(
-                    sycl::range<1>(1),
-                    sycl::range<1>(1),
-                    getCurrentSYCLQueue(),
-                    kfn);
+                    sycl_single_task, getCurrentSYCLQueue(), kfn);
               });
         });
   } else {

--- a/src/ATen/native/xpu/sycl/TensorCompareKernels.cpp
+++ b/src/ATen/native/xpu/sycl/TensorCompareKernels.cpp
@@ -176,7 +176,7 @@ struct Msg {
 // SYCL_KERNEL_ASSERT_MSG is not ready
 template <typename scalar_t>
 struct AssertAsyncKernelFunctor1 {
-  void operator()(sycl::nd_item<1> item) const {
+  void operator()() const {
     SYCL_KERNEL_ASSERT(input_[0] != 0);
   }
   AssertAsyncKernelFunctor1(const scalar_t* input, Msg msg)
@@ -188,7 +188,7 @@ struct AssertAsyncKernelFunctor1 {
 };
 
 struct AssertAsyncKernelFunctor2 {
-  void operator()(sycl::nd_item<1> item) const {
+  void operator()() const {
     SYCL_KERNEL_ASSERT(input_[0] != c10::complex<float>(0, 0));
   }
   AssertAsyncKernelFunctor2(const c10::complex<float>* input, Msg msg)
@@ -200,7 +200,7 @@ struct AssertAsyncKernelFunctor2 {
 };
 
 struct AssertAsyncKernelFunctor3 {
-  void operator()(sycl::nd_item<1> item) const {
+  void operator()() const {
     SYCL_KERNEL_ASSERT(input_[0] != c10::complex<double>(0, 0));
   }
   AssertAsyncKernelFunctor3(const c10::complex<double>* input, Msg msg)
@@ -214,19 +214,19 @@ struct AssertAsyncKernelFunctor3 {
 template <typename scalar_t>
 void launch_assert_async_kernel(const scalar_t* input, Msg msg) {
   AssertAsyncKernelFunctor1<scalar_t> kfn(input, msg);
-  sycl_kernel_submit(1, 1, getCurrentSYCLQueue(), kfn);
+  sycl_kernel_submit(sycl_single_task, getCurrentSYCLQueue(), kfn);
 }
 
 template <>
 void launch_assert_async_kernel(const c10::complex<float>* input, Msg msg) {
   AssertAsyncKernelFunctor2 kfn(input, msg);
-  sycl_kernel_submit(1, 1, getCurrentSYCLQueue(), kfn);
+  sycl_kernel_submit(sycl_single_task, getCurrentSYCLQueue(), kfn);
 }
 
 template <>
 void launch_assert_async_kernel(const c10::complex<double>* input, Msg msg) {
   AssertAsyncKernelFunctor3 kfn(input, msg);
-  sycl_kernel_submit(1, 1, getCurrentSYCLQueue(), kfn);
+  sycl_kernel_submit(sycl_single_task, getCurrentSYCLQueue(), kfn);
 }
 
 void _assert_async_msg_kernel(

--- a/src/ATen/native/xpu/sycl/pstl/PSTLFunctions.h
+++ b/src/ATen/native/xpu/sycl/pstl/PSTLFunctions.h
@@ -79,9 +79,9 @@ struct LSFunctor {
 };
 
 template <class T, class InputIt>
-struct GetItemFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
-  void operator()(sycl::item<1> item_id) const {
-    d_first_[item_id] = first_[item_id];
+struct GetItemFunctor {
+  void operator()() const {
+    d_first_[0] = first_[index_];
   }
   GetItemFunctor(InputIt first, T index, InputIt d_first)
       : first_(first), index_(index), d_first_(d_first) {}
@@ -96,19 +96,18 @@ template <class T, class InputIt>
 static inline T get_item(InputIt first, InputIt last, T index) {
   RECORD_FUNCTION("get_item_xpu", {});
   const auto N = std::distance(first, last);
-  auto& q = getCurrentSYCLQueue();
 
   T res = -1;
   if (index >= N)
     return res;
 
   auto options = map_options<T>();
-  Tensor d_tensor = at::empty({N}, options);
+  Tensor d_tensor = at::empty({1}, options);
   T* d_tensor_ptr = d_tensor.data_ptr<T>();
 
   GetItemFunctor<T, InputIt> kfn1(first, index, d_tensor_ptr);
-  sycl_kernel_submit(sycl::range<1>(N), q, kfn1);
-  res = d_tensor[index].template item<T>();
+  sycl_kernel_submit(sycl_single_task, getCurrentSYCLQueue(), kfn1);
+  res = d_tensor[0].template item<T>();
 
   return res;
 }

--- a/src/comm/SYCLHelpers.h
+++ b/src/comm/SYCLHelpers.h
@@ -54,14 +54,9 @@ template <typename T>
 using sycl_atomic_ref_rlx_dev_global_t =
     sycl::atomic_ref<T, sycl_mem_odr_rlx, sycl_mem_scp_dev, sycl_global_space>;
 
-template <typename ker_t, int dim>
-static inline void sycl_kernel_submit(
-    ::sycl::range<dim> range,
-    ::sycl::queue q,
-    ker_t ker) {
-  auto cgf = [&](::sycl::handler& cgh) { cgh.parallel_for<ker_t>(range, ker); };
-  q.submit(cgf);
-}
+// Tag type to select the single_task overload of sycl_kernel_submit.
+struct sycl_single_task_t {};
+inline constexpr sycl_single_task_t sycl_single_task{};
 
 // Additional convention of SYCL kernel configuration. Besides construct kernel
 // functor, SYCL has some additional conventions to be called during setuping
@@ -78,33 +73,44 @@ static inline void sycl_kernel_submit(
 // compilation.
 struct __SYCL_KER_CONFIG_CONVENTION__ {};
 
-template <typename ker_t, int dim>
-static inline typename std::enable_if<
-    std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
-    void>::type
-sycl_kernel_submit(
-    ::sycl::range<dim> global_range,
-    ::sycl::range<dim> local_range,
+template <typename ker_t>
+static inline void sycl_kernel_submit(
+    sycl_single_task_t,
     ::sycl::queue q,
     ker_t ker) {
   auto cgf = [&](::sycl::handler& cgh) {
-    ker.sycl_ker_config_convention(cgh);
-    cgh.parallel_for<ker_t>(
-        ::sycl::nd_range<dim>(global_range, local_range), ker);
+    if constexpr (std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>) {
+      ker.sycl_ker_config_convention(cgh);
+    }
+    cgh.single_task<ker_t>(ker);
   };
   q.submit(cgf);
 }
 
 template <typename ker_t, int dim>
-static inline typename std::enable_if<
-    !std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
-    void>::type
-sycl_kernel_submit(
+static inline void sycl_kernel_submit(
+    ::sycl::range<dim> range,
+    ::sycl::queue q,
+    ker_t ker) {
+  auto cgf = [&](::sycl::handler& cgh) {
+    if constexpr (std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>) {
+      ker.sycl_ker_config_convention(cgh);
+    }
+    cgh.parallel_for<ker_t>(range, ker);
+  };
+  q.submit(cgf);
+}
+
+template <typename ker_t, int dim>
+static inline void sycl_kernel_submit(
     ::sycl::range<dim> global_range,
     ::sycl::range<dim> local_range,
     ::sycl::queue q,
     ker_t ker) {
   auto cgf = [&](::sycl::handler& cgh) {
+    if constexpr (std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>) {
+      ker.sycl_ker_config_convention(cgh);
+    }
     cgh.parallel_for<ker_t>(
         ::sycl::nd_range<dim>(global_range, local_range), ker);
   };
@@ -112,40 +118,13 @@ sycl_kernel_submit(
 }
 
 template <typename ker_t>
-static inline typename std::enable_if<
-    std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
-    void>::type
-sycl_kernel_submit(
+static inline void sycl_kernel_submit(
     int64_t global_range,
     int64_t local_range,
     ::sycl::queue q,
     ker_t ker) {
-  auto cgf = [&](::sycl::handler& cgh) {
-    ker.sycl_ker_config_convention(cgh);
-    cgh.parallel_for<ker_t>(
-        ::sycl::nd_range<1>(
-            ::sycl::range<1>(global_range), ::sycl::range<1>(local_range)),
-        ker);
-  };
-  q.submit(cgf);
-}
-
-template <typename ker_t>
-static inline typename std::enable_if<
-    !std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
-    void>::type
-sycl_kernel_submit(
-    int64_t global_range,
-    int64_t local_range,
-    ::sycl::queue q,
-    ker_t ker) {
-  auto cgf = [&](::sycl::handler& cgh) {
-    cgh.parallel_for<ker_t>(
-        ::sycl::nd_range<1>(
-            ::sycl::range<1>(global_range), ::sycl::range<1>(local_range)),
-        ker);
-  };
-  q.submit(cgf);
+  sycl_kernel_submit(
+      ::sycl::range<1>(global_range), ::sycl::range<1>(local_range), q, ker);
 }
 
 // Overloads accepting kernel properties (e.g., sub_group_size, grf_size).
@@ -169,10 +148,7 @@ struct __SyclKernelWithProps__ {
 };
 
 template <typename ker_t, typename Props, int dim>
-static inline typename std::enable_if<
-    std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
-    void>::type
-sycl_kernel_submit(
+static inline void sycl_kernel_submit(
     ::sycl::range<dim> global_range,
     ::sycl::range<dim> local_range,
     ::sycl::queue q,
@@ -180,26 +156,9 @@ sycl_kernel_submit(
     ker_t ker) {
   (void)properties;
   auto cgf = [&](::sycl::handler& cgh) {
-    ker.sycl_ker_config_convention(cgh);
-    __SyclKernelWithProps__<ker_t, Props> wrapped{ker};
-    cgh.parallel_for<ker_t>(
-        ::sycl::nd_range<dim>(global_range, local_range), wrapped);
-  };
-  q.submit(cgf);
-}
-
-template <typename ker_t, typename Props, int dim>
-static inline typename std::enable_if<
-    !std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
-    void>::type
-sycl_kernel_submit(
-    ::sycl::range<dim> global_range,
-    ::sycl::range<dim> local_range,
-    ::sycl::queue q,
-    Props properties,
-    ker_t ker) {
-  (void)properties;
-  auto cgf = [&](::sycl::handler& cgh) {
+    if constexpr (std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>) {
+      ker.sycl_ker_config_convention(cgh);
+    }
     __SyclKernelWithProps__<ker_t, Props> wrapped{ker};
     cgh.parallel_for<ker_t>(
         ::sycl::nd_range<dim>(global_range, local_range), wrapped);
@@ -208,46 +167,18 @@ sycl_kernel_submit(
 }
 
 template <typename ker_t, typename Props>
-static inline typename std::enable_if<
-    std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
-    void>::type
-sycl_kernel_submit(
+static inline void sycl_kernel_submit(
     int64_t global_range,
     int64_t local_range,
     ::sycl::queue q,
     Props properties,
     ker_t ker) {
-  (void)properties;
-  auto cgf = [&](::sycl::handler& cgh) {
-    ker.sycl_ker_config_convention(cgh);
-    __SyclKernelWithProps__<ker_t, Props> wrapped{ker};
-    cgh.parallel_for<ker_t>(
-        ::sycl::nd_range<1>(
-            ::sycl::range<1>(global_range), ::sycl::range<1>(local_range)),
-        wrapped);
-  };
-  q.submit(cgf);
-}
-
-template <typename ker_t, typename Props>
-static inline typename std::enable_if<
-    !std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
-    void>::type
-sycl_kernel_submit(
-    int64_t global_range,
-    int64_t local_range,
-    ::sycl::queue q,
-    Props properties,
-    ker_t ker) {
-  (void)properties;
-  auto cgf = [&](::sycl::handler& cgh) {
-    __SyclKernelWithProps__<ker_t, Props> wrapped{ker};
-    cgh.parallel_for<ker_t>(
-        ::sycl::nd_range<1>(
-            ::sycl::range<1>(global_range), ::sycl::range<1>(local_range)),
-        wrapped);
-  };
-  q.submit(cgf);
+  sycl_kernel_submit(
+      ::sycl::range<1>(global_range),
+      ::sycl::range<1>(local_range),
+      q,
+      properties,
+      ker);
 }
 
 #ifdef __SYCL_DEVICE_ONLY__


### PR DESCRIPTION
# Motivation
Use `single_task` for single-item kernels. Several kernels (e.g., `NllLossForwardAverage`, `assert_async`) only need to execute a single work-item. Previously they were submitted as `sycl_kernel_submit(1, 1, queue, ker)`, which goes through `parallel_for` with an `nd_range<1>({1}, {1})`. Using `cgh.single_task<ker_t>(ker)` instead expresses the intent directly and avoids unnecessary overhead such as range/boundary checks in `parallel_for`. A tag type `sycl_single_task` is introduced for this overload.

Simplify `sycl_kernel_submit` overloads with `if constexpr`. The `__SYCL_KER_CONFIG_CONVENTION__` dispatch previously required paired `enable_if` overloads -- one for kernels that inherit from `__SYCL_KER_CONFIG_CONVENTION__` and one for those that don't -- with identical signatures and nearly identical bodies. Replacing each pair with a single function using `if constexpr` eliminates the duplication. The `int64_t` convenience overloads are further reduced to one-line forwarding to the `sycl::range<1>` versions. This reduces the template count from 12 overloads (9 originally existing overloads + 2 missing `single_task` overload + 1 missing single `range<dim>` with `__SYCL_KER_CONFIG_CONVENTION__` overload) to 6 with no change in behavior.