### PR TITLE
[CI] Automatically label PRs created by AI with `ai_generated` label

### DIFF
--- a/.github/workflows/label-ai-prs.yml
+++ b/.github/workflows/label-ai-prs.yml
@@ -9,6 +9,7 @@ jobs:
     if: github.event.pull_request.user.login == 'copilot[bot]'
     runs-on: ubuntu-latest
     permissions:
+      issues: write
       pull-requests: write
     steps:
       - uses: actions/github-script@v7

--- a/.github/workflows/label-ai-prs.yml
+++ b/.github/workflows/label-ai-prs.yml
@@ -1,0 +1,22 @@
+name: Label AI-generated PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-label:
+    if: github.event.pull_request.user.login == 'copilot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['ai_generated']
+            });


### PR DESCRIPTION
We found that when we assigned copilot to fix, it doesn't label the PR, so it won't trigger the reproducer running CI. This PR is to ensure the label be marked, even if it doesn't have the reproducer.