### PR TITLE
Support at::xpu::sleep on XPU

### DIFF
--- a/src/ATen/CMakeLists.txt
+++ b/src/ATen/CMakeLists.txt
@@ -11,13 +11,14 @@
 file(GLOB xpu_native_cpp "native/xpu/*.cpp" "native/sparse/*.cpp" "native/sparse/xpu/*.cpp" "native/nested/*.cpp" "native/nested/xpu/*.cpp" "native/transformers/*.cpp" "native/quantized/*.cpp" "native/transformers/xpu/flash_attn/*.cpp")
 file(GLOB xpu_sycl "native/xpu/sycl/*.cpp" "native/sparse/xpu/sycl/*.cpp" "native/nested/xpu/sycl/*.cpp" "native/transformers/sycl/*.cpp" "native/quantized/sycl/*.cpp")
 file(GLOB xpu_sycltla "native/transformers/xpu/flash_attn/sycltla/*.cpp")
+file(GLOB xpu_sleep "xpu/Sleep.cpp")
 
 if(USE_ONEMKL_XPU)
   file(GLOB xpu_mkl "native/xpu/mkl/*.cpp")
   list(APPEND ATen_XPU_MKL_SRCS ${xpu_mkl})
 endif()
 list(APPEND ATen_XPU_NATIVE_CPP_SRCS ${xpu_native_cpp})
-list(APPEND ATen_XPU_SYCL_SRCS ${xpu_sycl})
+list(APPEND ATen_XPU_SYCL_SRCS ${xpu_sycl} ${xpu_sleep})
 list(APPEND ATen_XPU_SYCLTLA_SRCS ${xpu_sycltla})
 
 set(ATen_XPU_MKL_SRCS ${ATen_XPU_MKL_SRCS} PARENT_SCOPE)
@@ -34,6 +35,7 @@ macro(install_xpu_headers subdir)
   endif()
 endmacro()
 
+install_xpu_headers("xpu")
 install_xpu_headers("native/xpu")
 install_xpu_headers("native/xpu/sycl")
 install_xpu_headers("native/xpu/mkl")

--- a/src/ATen/xpu/Sleep.cpp
+++ b/src/ATen/xpu/Sleep.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include <ATen/xpu/Sleep.h>
+#include <c10/xpu/XPUStream.h>
+#include <comm/SYCLContext.h>
+
+namespace at::xpu {
+
+void sleep(uint64_t cycles) {
+#if SYCL_COMPILER_VERSION >= 20260000
+  // SYCL free-function kernel compiled at runtime via the online-compilation
+  // extension (sycl_ext_oneapi_kernel_compiler).
+  static const std::string source = R"""(
+    #include <sycl/sycl.hpp>
+
+    namespace syclex = sycl::ext::oneapi::experimental;
+
+    extern "C"
+    SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclex::single_task_kernel))
+    void spin_kernel(uint64_t cycles) {
+      uint64_t start = syclex::clock<syclex::clock_scope::device>();
+      while (syclex::clock<syclex::clock_scope::device>() - start < cycles) {}
+    }
+  )""";
+
+  namespace syclex = sycl::ext::oneapi::experimental;
+  // TODO: PVC does not expose sycl_ext_oneapi_device_clock because its bundled
+  // IGC (Intel Graphics Compiler) is too old, and enabling the extension breaks
+  // AOT builds on PVC. Online compilation is used here as a workaround. Once
+  // the driver ships a newer IGC, migrate to a functor-based implementation.
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      c10::xpu::get_raw_device(c10::xpu::current_device())
+          .has(sycl::aspect::ext_oneapi_device_clock),
+      "Requires the sycl_ext_oneapi_device_clock extension, "
+      "which is not supported on this device. ",
+      "Please upgrade to a newer driver.");
+  auto& queue = getCurrentSYCLQueue();
+
+  // All XPU queues in a process share the same SYCL context, so compile once
+  // and reuse the kernel object across calls.
+  static sycl::kernel spin_kernel = [&]() {
+    auto kb_src = syclex::create_kernel_bundle_from_source(
+        c10::xpu::get_device_context(), syclex::source_language::sycl, source);
+    auto kb_exe = syclex::build(kb_src);
+    return kb_exe.ext_oneapi_get_kernel("spin_kernel");
+  }();
+
+  queue.submit([&](sycl::handler& cgh) {
+    cgh.set_args(cycles);
+    cgh.single_task(spin_kernel);
+  });
+#else
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      false,
+      "sleep is not supported for the current SYCL compiler version. ",
+      "Please upgrade to SYCL compiler version 2026.0 or newer.");
+#endif
+}
+
+} // namespace at::xpu

--- a/src/ATen/xpu/Sleep.h
+++ b/src/ATen/xpu/Sleep.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <c10/macros/Export.h>
+#include <cstdint>
+
+namespace at::xpu {
+
+// Enqueues a kernel that spins for the specified number of cycles
+TORCH_XPU_API void sleep(uint64_t cycles);
+
+} // namespace at::xpu

--- a/tools/fixheaders/pytorch.yaml
+++ b/tools/fixheaders/pytorch.yaml
@@ -9,6 +9,8 @@
 exclude:
   - "tools/linter/adapters/README.md" # Original README file (unmodified)
   - ".cmakelintrc"
+  # These files will be installed into PyTorch
+  - "src/ATen/xpu/Sleep.h"
   # Test files copied from PyTorch — do not add Intel headers
   # (these will be upstreamed back to PyTorch)
   - "test/xpu/dynamo/test_ctx_manager_xpu.py"


### PR DESCRIPTION
# Motivation
This PR implements `at::xpu::sleep`, which backs `torch.xpu._sleep`.

The header `ATen/xpu/Sleep.h` is aligned to `ATen/cuda/Sleep.h`.

We use online compilation as a workaround because PVC does not expose `sycl_ext_oneapi_device_clock`; the bundled Intel Graphics Compiler (IGC) is too old, and enabling this extension would break AOT builds on PVC. Once the driver ships with a newer IGC that supports this extension, we plan to migrate to a functor-based implementation.

# Additional Context
online compilation refers to [sycl_ext_oneapi_kernel_compiler](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_compiler.asciidoc)
device clock refers to [sycl_ext_oneapi_clock](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_clock.asciidoc)