### PR TITLE
Adjust local test copies to upstream.

### DIFF
--- a/test/xpu/dynamo/test_ctx_manager_xpu.py
+++ b/test/xpu/dynamo/test_ctx_manager_xpu.py
@@ -572,7 +572,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         res = opt_fn(x)
         self.assertEqual(ref, res)
         self.assertEqual(cnts.frame_count, 1)
-        self.assertExpectedInline(str(cnts.op_count), """16""")
+        self.assertExpectedInline(str(cnts.op_count), """17""")
 
     @unittest.skipIf(not requires_gpu, "requires cuda or xpu")
     def test_cuda_device(self):

--- a/test/xpu/functorch/test_aot_joint_with_descriptors_xpu.py
+++ b/test/xpu/functorch/test_aot_joint_with_descriptors_xpu.py
@@ -1248,11 +1248,11 @@ class inner_f(torch.nn.Module):
             """\
 ('get_attr', 'repeated_subgraph0', {'mod_name': 'my_mod'})
 [('placeholder', 'arg0_1', {'mod_name': 'my_mod'}), ('call_function', 'sin', {'mod_name': 'bar'}), ('call_function', 'mul', {'mod_name': 'bar'}), ('output', 'output', {'mod_name': 'my_mod'})]
-('call_function', 'invoke_subgraph', {'mod_name': 'my_mod'})
+('call_function', 'invoke_subgraph', {'mod_name': 'my_mod', 'call_id': 1})
 ('call_function', 'getitem', {'mod_name': 'my_mod'})
 ('get_attr', 'repeated_subgraph1', {'mod_name': 'my_mod'})
 [('placeholder', 'arg0_1', {'mod_name': 'my_mod'}), ('placeholder', 'arg1_1', {'mod_name': 'my_mod'}), ('call_function', 'sin', {'mod_name': 'bar'}), ('call_function', 'mul', {'mod_name': 'bar'}), ('call_function', 'mul_1', {'mod_name': 'bar'}), ('call_function', 'cos', {'mod_name': 'bar'}), ('call_function', 'mul_2', {'mod_name': 'bar'}), ('output', 'output', {'mod_name': 'my_mod'})]
-('call_function', 'invoke_subgraph_1', {'mod_name': 'my_mod'})
+('call_function', 'invoke_subgraph_1', {'call_id': 1, 'mod_name': 'my_mod'})
 ('call_function', 'getitem_1', {'mod_name': 'my_mod'})""",
         )
 

--- a/test/xpu/functorch/test_eager_transforms_xpu.py
+++ b/test/xpu/functorch/test_eager_transforms_xpu.py
@@ -1218,7 +1218,7 @@ class TestAutogradFunction(TestCase):
         def fn(x):
             return A.apply(x.clone())
 
-        err_msg = "A input that has been returned as-is"
+        err_msg = "An input that has been returned as-is"
 
         a = torch.tensor(2.0, device=device, requires_grad=inner_requires_grad)
         a_t = torch.tensor(2.0, device=device, requires_grad=inner_requires_grad)

--- a/test/xpu/higher_order_ops/test_invoke_subgraph_xpu.py
+++ b/test/xpu/higher_order_ops/test_invoke_subgraph_xpu.py
@@ -1822,7 +1822,9 @@ class GraphModule(torch.nn.Module):
 class GraphModule(torch.nn.Module):
     def forward(self, primals_1: "f32[8, 8]"):
         partitioned_fw_subgraph_0_0 = self.partitioned_fw_subgraph_0_0
+
         invoke_subgraph_2 = torch.ops.higher_order.invoke_subgraph(partitioned_fw_subgraph_0_0, 'partitioned_fw_subgraph_0_0', primals_1);  partitioned_fw_subgraph_0_0 = primals_1 = None
+
         getitem: "f32[8, 8]" = invoke_subgraph_2[0]
         getitem_1: "f32[8, 8]" = invoke_subgraph_2[1];  invoke_subgraph_2 = None
 
@@ -1843,7 +1845,9 @@ class GraphModule(torch.nn.Module):
 class GraphModule(torch.nn.Module):
     def forward(self, tangents_1: "f32[8, 8]"):
         partitioned_bw_subgraph_0_0 = self.partitioned_bw_subgraph_0_0
+
         invoke_subgraph_3 = torch.ops.higher_order.invoke_subgraph(partitioned_bw_subgraph_0_0, 'partitioned_bw_subgraph_0_0', tangents_1, tangents_1);  partitioned_bw_subgraph_0_0 = tangents_1 = None
+
         getitem_2: "f32[8, 8]" = invoke_subgraph_3[0];  invoke_subgraph_3 = None
         return (getitem_2,)
 
@@ -2015,10 +2019,12 @@ class GraphModule(torch.nn.Module):
 class GraphModule(torch.nn.Module):
     def forward(self, primals_1: "f32[8, 8]", primals_2: "f32[8, 8]"):
         partitioned_fw_subgraph_0_0 = self.partitioned_fw_subgraph_0_0
+
         invoke_subgraph_2 = torch.ops.higher_order.invoke_subgraph(partitioned_fw_subgraph_0_0, 'partitioned_fw_subgraph_0_0', primals_1, primals_2);  partitioned_fw_subgraph_0_0 = primals_1 = primals_2 = None
         getitem_6: "f32[8, 8]" = invoke_subgraph_2[3]
         getitem_5: "f32[8, 8]" = invoke_subgraph_2[2]
         getitem_4: "f32[8, 8]" = invoke_subgraph_2[1]
+
         getitem: "f32[8, 8]" = invoke_subgraph_2[0];  invoke_subgraph_2 = None
         sin: "f32[8, 8]" = torch.ops.aten.sin.default(getitem)
         cos: "f32[8, 8]" = torch.ops.aten.cos.default(getitem);  getitem = None
@@ -2043,7 +2049,9 @@ class GraphModule(torch.nn.Module):
     def forward(self, getitem_6: "f32[8, 8]", getitem_5: "f32[8, 8]", getitem_4: "f32[8, 8]", cos: "f32[8, 8]", tangents_1: "f32[8, 8]"):
         mul: "f32[8, 8]" = torch.ops.aten.mul.Tensor(tangents_1, cos);  tangents_1 = cos = None
         partitioned_bw_subgraph_0_0 = self.partitioned_bw_subgraph_0_0
+
         invoke_subgraph_3 = torch.ops.higher_order.invoke_subgraph(partitioned_bw_subgraph_0_0, 'partitioned_bw_subgraph_0_0', getitem_4, getitem_5, getitem_6, mul);  partitioned_bw_subgraph_0_0 = getitem_4 = getitem_5 = getitem_6 = mul = None
+
         getitem_1: "f32[8, 8]" = invoke_subgraph_3[0]
         getitem_2: "f32[8, 8]" = invoke_subgraph_3[1];  invoke_subgraph_3 = None
         return (getitem_1, getitem_2)


### PR DESCRIPTION
Fix for: #3584 
Fix for: #3583 
Fix for: #3588 

## Summary

The test cases from mentioned issues started failing as the upstream test files were adjusted to newest changes, but local torch-xpu-ops test files were not adjusted.
The local and upstream test files diverged and that made the test cases to fail.

## Solution

This PR simply synchronizes the local test files related to linked issues with the upstream.
The exact commits that changed the test files in PyTorch are here:
#3584 : [COMMIT](https://github.com/pytorch/pytorch/commit/fa294df4dd9c050d7839faf62b84ca93f699b7e6)
#3583 : [COMMIT](https://github.com/pytorch/pytorch/commit/9746a7c845b9a94d8020a1a46e4e4057e8d21032)
#3588 : [COMMIT](https://github.com/pytorch/pytorch/commit/b268f757816f760ecf4d765b9aec73e40ecdb163)