### PR TITLE
[agent] Add skills for issue triaging

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,7 +39,7 @@ memory. The contents of these files are authoritative.
 
 | When you are about to... | Read this file first |
 |--------------------------|---------------------|
-| Fix or triaging an issue | `.github/skills/xpu-issues-triaging/SKILL.md` |
+| Fix or triage an issue | `.github/skills/xpu-issues-triaging/SKILL.md` |
 | Open a pull request, push a branch, or write a PR body | `.github/skills/xpu-ops-pr-creation/SKILL.md` |
 | Review a pull request | `.github/skills/xpu-ops-pr-review/SKILL.md` |
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 ---
 name: copilot-instructions
 description: The overall hot memory that should be loaded in all LLM agents when developing on torch-xpu-ops.
-license: MIT
+license: Apache-2.0
 ---
 
 # Copilot Instructions — Torch XPU Ops Repository
@@ -57,7 +57,7 @@ interactions within this repository.
 
 <!-- Guidelines below adapted from https://github.com/forrestchang/andrej-karpathy-skills (MIT License) -->
 
-# Guidelines
+## Guidelines
 
 ## 1. Think Before Coding
 
@@ -114,5 +114,3 @@ For multi-step tasks, state a brief plan:
 ```
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
-
-

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,9 @@
+---
+name: copilot-instructions
+description: The overall hot memory that should be loaded in all LLM agents when developing on torch-xpu-ops.
+license: MIT
+---
+
 # Copilot Instructions — Torch XPU Ops Repository
 
 This repository implements Torch XPU Operators for Intel GPU support.
@@ -33,6 +39,7 @@ memory. The contents of these files are authoritative.
 
 | When you are about to... | Read this file first |
 |--------------------------|---------------------|
+| Fix or triaging an issue | `.github/skills/xpu-issues-triaging/SKILL.md` |
 | Open a pull request, push a branch, or write a PR body | `.github/skills/xpu-ops-pr-creation/SKILL.md` |
 | Review a pull request | `.github/skills/xpu-ops-pr-review/SKILL.md` |
 
@@ -47,3 +54,65 @@ State explicitly in your response which skill file(s) you read.
 
 This file provides repository-wide context and applies to all Copilot
 interactions within this repository.
+
+<!-- Guidelines below adapted from https://github.com/forrestchang/andrej-karpathy-skills (MIT License) -->
+
+# Guidelines
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+

--- a/.github/skills/xpu-issues-triaging/SKILL.md
+++ b/.github/skills/xpu-issues-triaging/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: issue-triaging
+name: xpu-issues-triaging
 description: >
   Instructions for issue triaging. Works for both pytorch and torch-xpu-ops repos.
 ---
@@ -49,7 +49,7 @@ on the PyTorch **main** branch:
 - If the root cause is in **device-agnostic / framework code** (e.g.,
   `torch/`, `aten/src/ATen/`, `c10/`), the fix belongs in **pytorch**, not
   torch-xpu-ops. Do NOT submit a PR to torch-xpu-ops for such issues.
-  Comment on the original issue. Or create an empty PR indicating the logic.
+  Comment on the original issue to explain the root cause and where the fix belongs.
 - If the root cause is in **XPU-specific kernel or dispatch code** (e.g.,
   `src/ATen/native/xpu/`), the fix belongs in **torch-xpu-ops**.
 

--- a/.github/skills/xpu-issues-triaging/SKILL.md
+++ b/.github/skills/xpu-issues-triaging/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: issue-fix
+description: >
+  Propose for issue fix. Works for both pytorch and torch-xpu-ops repos.
+---
+
+# Fix XPU Issue
+
+## Step 0: Triage the Issue
+
+1. **Check issue labels.** If the issue has the label **"task"**, it is a
+   tracking issue — do NOT make any code changes or create a PR. Simply
+   acknowledge the task and stop. Then leave the comment in the issue on why you stopped (e.g., "This is a tracking issue, so no code changes will be made.").
+
+2. **Classify the issue type.** Determine which category the issue falls into:
+   - **A) XPU kernel / operator bug** — failure in XPU-specific operator code.
+   - **B) PyTorch core bug** — failure in device-agnostic or framework code
+     that happens to surface on XPU.
+   - **C) CUDA UT porting issue** — a test originally written for CUDA was
+     ported to XPU and fails due to porting gaps (see [Step 1b](#step-1b-cuda-ut-porting-issues)).
+
+3. **Obtain PyTorch source for cross-reference.** If you are in the
+   `torch-xpu-ops` repo, clone or fetch the PyTorch repo so you can inspect
+   the upstream code:
+   ```bash
+   git clone --depth 1 https://github.com/pytorch/pytorch.git /tmp/pytorch
+   ```
+   Use this checkout to compare CUDA kernels, check upstream fixes, and
+   verify device-agnostic code paths. Reference files from `/tmp/pytorch/`
+   throughout the remaining steps.
+
+4. **Check which repo you're in:** `basename $(git rev-parse --show-toplevel)`
+   - `torch-xpu-ops` → XPU kernel/operator code (files under `src/`)
+   - `pytorch` → PyTorch core code (files under `torch/`, `aten/`, `test/`, `c10/`)
+
+## Step 1: Investigate Before Coding
+
+### Check if already fixed upstream
+Before writing any fix, check whether the issue has already been resolved
+on the PyTorch **main** branch:
+
+1. Search the PyTorch repo for recent commits touching the relevant file(s)
+   or function(s).
+2. Search PyTorch GitHub issues / PRs for the same error message or test name.
+3. If a fix already exists on PyTorch main, report that in your summary and
+   **do not duplicate the fix** in torch-xpu-ops.
+
+### Decide the right repo for the fix
+- If the root cause is in **device-agnostic / framework code** (e.g.,
+  `torch/`, `aten/src/ATen/`, `c10/`), the fix belongs in **pytorch**, not
+  torch-xpu-ops. Do NOT submit a PR to torch-xpu-ops for such issues.
+- If the root cause is in **XPU-specific kernel or dispatch code** (e.g.,
+  `src/ATen/native/xpu/`), the fix belongs in **torch-xpu-ops**.
+
+### Construct a reproducer
+Extract the reproducer from the issue description. If absent, construct one
+from the failed test name and error context. The reproducer should be a
+standalone Python script or pytest command. Do NOT run the reproducer locally
+(no XPU hardware is available in this environment).
+
+### Step 1b: CUDA UT Porting Issues
+
+If the issue is caused by a **CUDA unit test ported to XPU**, follow this
+dedicated workflow:
+
+1. **Locate the original CUDA test** — find the corresponding test in the
+   PyTorch repo (usually under `test/`). Identify the CUDA-specific
+   assertions, tolerances, dtypes, or device assumptions.
+2. **Create a proper reproducer** — write a minimal reproducer that mirrors
+   the CUDA test's logic but targets `device="xpu"`. Include the same
+   inputs, dtypes, and expected outputs as the CUDA version.
+3. **Diff CUDA vs XPU behavior** — compare what the CUDA test expects with
+   what XPU produces. Note differences in:
+   - Supported dtypes
+   - Numerical tolerances (`atol` / `rtol`)
+   - Operator dispatch paths
+   - Device-specific decorators or skip conditions in the test
+4. **Root cause** — determine whether the failure is due to:
+   - Missing XPU kernel implementation → fix in `src/`
+   - Incorrect test porting (wrong tolerance, missing dtype) → fix in
+     `test/` (pytorch repo)
+   - Genuine behavioral difference requiring XPU-specific handling
+5. Continue to Step 2 with the root cause.
+
+## Step 2: Implement the Fix
+
+Follow the **Proposed Fix Strategy** from the issue. This is **issue-driven
+development** — the fix must address the root cause described in the issue,
+not merely make a single reproducer pass.
+
+Key principles:
+
+- **Minimal changes** — fix only what's broken.
+- **Align with CUDA** — when the feature does not depend on hardware-specific
+  information (e.g., warp size, shared memory layout), the XPU kernel
+  implementation should match the CUDA implementation's logic, tolerances,
+  and behavior. Use the CUDA kernel as the reference.
+- **Never skip tests** — no `@skipIfXpu`, `@skip`, `unittest.skip`.
+- **Stay in your repo** — if in pytorch, don't modify `third_party/*`; if in
+  torch-xpu-ops, only modify files in torch-xpu-ops.
+- **Never modify unrelated files.**
+- **Issue-driven, not reproducer-driven** — ensure the fix addresses the
+  underlying issue. A reproducer passing is necessary but not sufficient;
+  verify that the root cause is resolved and related code paths are correct.
+
+
+## HARD RULES
+- NEVER make code changes or create PRs for issues labeled **"task"**.
+- NEVER submit a torch-xpu-ops PR for a bug whose root cause is in pytorch.
+- NEVER add skip decorators. FIX the test.
+- NEVER modify files outside your repo scope.
+- NEVER modify unrelated files.
+
+## Output
+At the end, output:
+```
+### Agent Summary
+- **Issue type:** <kernel bug / pytorch core bug / CUDA UT porting / task>
+- **Fix repo:** <pytorch / torch-xpu-ops / N/A (already fixed or task)>
+- **What I found:** <root cause in one sentence>
+- **What I changed:** <bullet list of files, or "None" for task issues>
+- **CUDA alignment:** <how the fix aligns with CUDA, or "N/A">
+- **Open questions / risks:** <concerns or "None">
+```

--- a/.github/skills/xpu-issues-triaging/SKILL.md
+++ b/.github/skills/xpu-issues-triaging/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: issue-triaging
 description: >
-  Propose for issue triaging. Works for both pytorch and torch-xpu-ops repos.
+  Instructions for issue triaging. Works for both pytorch and torch-xpu-ops repos.
 ---
 
-# Fix XPU Issue
+# Triage & Fix XPU Issue
 
 ## Step 0: Triage the Issue
 

--- a/.github/skills/xpu-issues-triaging/SKILL.md
+++ b/.github/skills/xpu-issues-triaging/SKILL.md
@@ -1,7 +1,7 @@
 ---
-name: issue-fix
+name: issue-triaging
 description: >
-  Propose for issue fix. Works for both pytorch and torch-xpu-ops repos.
+  Propose for issue triaging. Works for both pytorch and torch-xpu-ops repos.
 ---
 
 # Fix XPU Issue
@@ -82,10 +82,9 @@ dedicated workflow:
    - Genuine behavioral difference requiring XPU-specific handling
 5. Continue to Step 2 with the root cause.
 
-## Step 2: Implement the Fix
+## Step 2: Propose the Fix
 
-Follow the **Proposed Fix Strategy** from the issue. This is **issue-driven
-development** — the fix must address the root cause described in the issue,
+This is **issue-driven development** — the fix must address the root cause described in the issue,
 not merely make a single reproducer pass.
 
 Key principles:

--- a/.github/skills/xpu-issues-triaging/SKILL.md
+++ b/.github/skills/xpu-issues-triaging/SKILL.md
@@ -49,6 +49,7 @@ on the PyTorch **main** branch:
 - If the root cause is in **device-agnostic / framework code** (e.g.,
   `torch/`, `aten/src/ATen/`, `c10/`), the fix belongs in **pytorch**, not
   torch-xpu-ops. Do NOT submit a PR to torch-xpu-ops for such issues.
+  Comment on the original issue. Or create an empty PR indicating the logic.
 - If the root cause is in **XPU-specific kernel or dispatch code** (e.g.,
   `src/ATen/native/xpu/`), the fix belongs in **torch-xpu-ops**.
 

--- a/.github/skills/xpu-ops-pr-creation/SKILL.md
+++ b/.github/skills/xpu-ops-pr-creation/SKILL.md
@@ -13,8 +13,8 @@ placeholders:
 
 # PR Creation — torch-xpu-ops
 
-Read `.github/copilot-instructions.md` for full repo context before starting.
-
+- Read `.github/copilot-instructions.md` for full repo context before starting.
+- Read `.github/skills/xpu-issues-triaging` for issue triaging before actually do PR. BE SURE to triage and understand the root cause first, then create PR.
 ---
 
 ## Step 1: Verify your branch

--- a/.github/skills/xpu-ops-pr-creation/SKILL.md
+++ b/.github/skills/xpu-ops-pr-creation/SKILL.md
@@ -14,7 +14,7 @@ placeholders:
 # PR Creation — torch-xpu-ops
 
 - Read `.github/copilot-instructions.md` for full repo context before starting.
-- Read `.github/skills/xpu-issues-triaging` for issue triaging before actually do PR. BE SURE to triage and understand the root cause first, then create PR.
+- Read `.github/skills/xpu-issues-triaging/SKILL.md` for issue triaging before creating a PR. BE SURE to triage and understand the root cause first, then create PR.
 ---
 
 ## Step 1: Verify your branch

--- a/.github/skills/xpu-ops-pr-creation/SKILL.md
+++ b/.github/skills/xpu-ops-pr-creation/SKILL.md
@@ -50,6 +50,7 @@ must name existing tests that validate the change.
 Use this exact template:
 
 ```
+Fixes <original_issue_link>
 <description of what the PR does and why>
 
 Test: <one of the three forms below>


### PR DESCRIPTION
This PR does the following:
1. Add instructions to triage issue and skip the fixes like task issues.
2. Port rules from karpathy skills