### PR TITLE
[sparse][xpu] Fix test_gradcheck_mm error message regex for XPU and remove spurious skipTest

### DIFF
--- a/test/xpu/test_sparse_xpu.py
+++ b/test/xpu/test_sparse_xpu.py
@@ -6711,10 +6711,9 @@ class TestSparseAny(TestCase):
         if layout is torch.sparse_bsr and not masked or layout is torch.sparse_bsc:
             with self.assertRaisesRegex(
                 RuntimeError,
-                r"addmm: computation on (CPU|CUDA) is not implemented for Strided \+ Sparse(Bsr|Bsc) @ Strided",
+                r"addmm: computation on (CPU|CUDA|XPU) is not implemented for Strided \+ Sparse(Bsr|Bsc) @ Strided",
             ):
                 torch.autograd.gradcheck(mm, (x, y), fast_mode=fast_mode, masked=masked)
-            self.skipTest("NOT IMPL")
         elif (
             layout in {torch.sparse_csc, torch.sparse_bsr, torch.sparse_bsc} and masked
         ):
@@ -6722,11 +6721,10 @@ class TestSparseAny(TestCase):
                 RuntimeError,
                 r"(sparse_addmm_sparse_backward: unsupported combination of layouts,"
                 r" grad: Strided, mat1: Sparse(Csc|Bsr|Bsc), mat2: Strided"
-                r"|addmm: computation on (CPU|CUDA) is not implemented for "
+                r"|addmm: computation on (CPU|CUDA|XPU) is not implemented for "
                 r"Strided \+ Sparse(Csc|Bsr|Bsc) @ Strided without MKL)",
             ):
                 torch.autograd.gradcheck(mm, (x, y), fast_mode=fast_mode, masked=masked)
-            self.skipTest("NOT IMPL")
         else:
             torch.autograd.gradcheck(mm, (x, y), fast_mode=fast_mode, masked=masked)
 


### PR DESCRIPTION
 **XPU raises the same "not implemented" error as CPU/CUDA for BSR/BSC**

Decription:
1. Fix **Regex mismatch**: The `assertRaisesRegex` patterns used `(CPU|CUDA)` but
   XPU raises errors with the device name "XPU". Added `XPU` to both patterns
   so the assertion matches the actual error on XPU hardware.

2. Remove **Spurious skipTest** called `self.skipTest("NOT IMPL")`.

To solve #2214 