### PR TITLE
Improve CI workflows: lint, triggers, reproducer and build status checks

### DIFF
--- a/.github/workflows/_linux_build.yml
+++ b/.github/workflows/_linux_build.yml
@@ -35,29 +35,10 @@ env:
   DOCKER_REGISTRY_AUTH_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
 
 jobs:
-  runner:
-    runs-on: ${{ inputs.runner }}
-    name: get-runner
-    outputs:
-      runner_id: ${{ steps.runner-info.outputs.runner_id }}
-      user_id: ${{ steps.runner-info.outputs.user_id }}
-      render_id: ${{ steps.runner-info.outputs.render_id }}
-      hostname: ${{ steps.runner-info.outputs.hostname }}
-    steps:
-      - name: Cleanup workspace
-        run: |
-          sudo find ./ |grep -v "^\./$" |xargs sudo rm -rf
-      - name: Checkout torch-xpu-ops
-        uses: actions/checkout@v4
-      - name: Get runner
-        id: runner-info
-        uses: ./.github/actions/get-runner
-
   build:
     name: ${{ inputs.pytorch }}
-    needs: runner
     if: ${{ ! endsWith(inputs.pytorch, '_wheel') }}
-    runs-on: ${{ needs.runner.outputs.runner_id }}
+    runs-on: ${{ inputs.runner }}
     container:
       image: 'pytorch/manylinux2_28-builder:xpu-main'
       volumes:
@@ -106,7 +87,7 @@ jobs:
           path: |
             known_issue_static.log
             issues_snapshot.log
-      - name: Build Pytorch on ${{ needs.runner.outputs.hostname }}
+      - name: Build Pytorch
         run: |
           export USE_XCCL=1
           export IS_XPU_CI=1
@@ -232,3 +213,24 @@ jobs:
         if: ${{ always() }}
         run: |
           chmod 777 /__w /github ./ -R
+
+  build-status-check:
+    needs: [build]
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check build result
+        run: |
+          result="${{ needs.build.result }}"
+          echo "build result: $result"
+          if [ "$result" = "skipped" ]; then
+            echo "build was skipped, marking as pass"
+            exit 0
+          elif [ "$result" = "success" ]; then
+            echo "build passed"
+            exit 0
+          else
+            echo "build failed with result: $result"
+            exit 1
+          fi

--- a/.github/workflows/_linux_reproducer.yml
+++ b/.github/workflows/_linux_reproducer.yml
@@ -35,6 +35,7 @@ env:
 
 jobs:
   runner:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ai_generated') }}
     runs-on: ${{ inputs.runner }}
     name: get-runner
     outputs:
@@ -198,3 +199,24 @@ jobs:
               issue_number: prNumber,
               body: body
             });
+
+  reproducer-status-check:
+    needs: [reproducer-test]
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check reproducer-test result
+        run: |
+          result="${{ needs.reproducer-test.result }}"
+          echo "reproducer-test result: $result"
+          if [ "$result" = "skipped" ]; then
+            echo "reproducer-test was skipped, marking as pass"
+            exit 0
+          elif [ "$result" = "success" ]; then
+            echo "reproducer-test passed"
+            exit 0
+          else
+            echo "reproducer-test failed with result: $result"
+            exit 1
+          fi

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -75,7 +75,6 @@ jobs:
             fi
           fi
           JOB_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           printf -v COMMENT_BODY '%s\n' \
             "@copilot The ${FAILED_STEPS} check failed. Please fix the lint errors in this PR." \
             "" \
@@ -200,7 +199,6 @@ jobs:
 
   reproducer-test:
     needs: [linux-build, preci-lint-check]
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ai_generated') }}
     secrets: inherit
     permissions:
       contents: read
@@ -213,29 +211,8 @@ jobs:
       torch_xpu_ops: ${{ contains(github.event.pull_request.labels.*.name, 'disable_build') && 'pinned' || 'main' }}
       pr_body_cmd: ${{ needs.preci-lint-check.outputs.pr_body_cmd }}
 
-  reproducer-status-check:
-    needs: [reproducer-test]
-    if: ${{ always() }}
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    steps:
-      - name: Check reproducer-test result
-        run: |
-          result="${{ needs.reproducer-test.result }}"
-          echo "reproducer-test result: $result"
-          if [ "$result" = "skipped" ]; then
-            echo "reproducer-test was skipped, marking as pass"
-            exit 0
-          elif [ "$result" = "success" ]; then
-            echo "reproducer-test passed"
-            exit 0
-          else
-            echo "reproducer-test failed with result: $result"
-            exit 1
-          fi
-
   linux-ut:
-    needs: [linux-build,reproducer-status-check]
+    needs: [linux-build,reproducer-test]
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'disable_ut') }}
     secrets: inherit
     permissions:
@@ -253,7 +230,7 @@ jobs:
       ut: ${{ matrix.ut_name }}
 
   linux-distributed:
-    needs: [linux-build, reproducer-status-check]
+    needs: [linux-build, reproducer-test]
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'disable_distributed') }}
     secrets: inherit
     permissions:
@@ -274,7 +251,7 @@ jobs:
     name: linux-e2e
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'disable_e2e') }}
     secrets: inherit
-    needs: [linux-build, reproducer-status-check]
+    needs: [linux-build, reproducer-test]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           export ADDITIONAL_LINTRUNNER_ARGS="--skip CLANGTIDY,CLANGFORMAT,MERGE_CONFLICTLESS_CSV --all-files"
           cd ./torch-xpu-ops
-          bash .github/scripts/lintrunner.sh
+          bash .github/scripts/lintrunner.sh 2>&1 | tee ${{ github.workspace }}/lint_python_errors.log
       - name: Checkout PyTorch (for headers)
         uses: actions/checkout@v4
         with:
@@ -56,11 +56,10 @@ jobs:
         run: |
           cd ./torch-xpu-ops
           export ADDITIONAL_LINTRUNNER_ARGS="--take CLANGFORMAT,CLANGTIDY --all-files"
-          bash .github/scripts/lintrunner.sh
+          bash .github/scripts/lintrunner.sh 2>&1 | tee ${{ github.workspace }}/lint_clang_errors.log
       - name: Comment on lint failure for AI-generated PR
         if: >-
-          ${{ (steps.lint-python.outcome == 'failure' || steps.lint-clang.outcome == 'failure')
-          && contains(github.event.pull_request.labels.*.name, 'ai_generated') }}
+          ${{ (steps.lint-python.outcome == 'failure' || steps.lint-clang.outcome == 'failure') }}
         env:
           GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
         run: |
@@ -89,7 +88,15 @@ jobs:
       - name: Fail if lint failed
         if: ${{ steps.lint-python.outcome == 'failure' || steps.lint-clang.outcome == 'failure' }}
         run: |
-          echo "::error::Lint check failed"
+          echo "::error::Lint check failed. Error details below:"
+          if [ "${{ steps.lint-python.outcome }}" = "failure" ]; then
+            echo "=== Python lint (flake8/ruff) errors ==="
+            cat ${{ github.workspace }}/lint_python_errors.log
+          fi
+          if [ "${{ steps.lint-clang.outcome }}" = "failure" ]; then
+            echo "=== Clang format/tidy errors ==="
+            cat ${{ github.workspace }}/lint_clang_errors.log
+          fi
           exit 1
       - name: Check reproducer exists for AI-generated PR
         if: ${{ contains(github.event.pull_request.labels.*.name, 'ai_generated') }}
@@ -190,8 +197,44 @@ jobs:
       runner: pvc_rolling
       pytorch: ${{ contains(github.event.pull_request.labels.*.name, 'disable_build') && 'nightly_wheel' || github.base_ref }}
 
+  reproducer-test:
+    needs: [linux-build, preci-lint-check]
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ai_generated') }}
+    secrets: inherit
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    uses: ./.github/workflows/_linux_reproducer.yml
+    with:
+      runner: pvc_rolling
+      pytorch: ${{ contains(github.event.pull_request.labels.*.name, 'disable_build') && 'nightly_wheel' || github.base_ref }}
+      torch_xpu_ops: ${{ contains(github.event.pull_request.labels.*.name, 'disable_build') && 'pinned' || 'main' }}
+      pr_body_cmd: ${{ needs.preci-lint-check.outputs.pr_body_cmd }}
+
+  reproducer-status-check:
+    needs: [reproducer-test]
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check reproducer-test result
+        run: |
+          result="${{ needs.reproducer-test.result }}"
+          echo "reproducer-test result: $result"
+          if [ "$result" = "skipped" ]; then
+            echo "reproducer-test was skipped, marking as pass"
+            exit 0
+          elif [ "$result" = "success" ]; then
+            echo "reproducer-test passed"
+            exit 0
+          else
+            echo "reproducer-test failed with result: $result"
+            exit 1
+          fi
+
   linux-ut:
-    needs: [linux-build]
+    needs: [reproducer-status-check]
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'disable_ut') }}
     secrets: inherit
     permissions:
@@ -209,7 +252,7 @@ jobs:
       ut: ${{ matrix.ut_name }}
 
   linux-distributed:
-    needs: [linux-build]
+    needs: [reproducer-status-check]
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'disable_distributed') }}
     secrets: inherit
     permissions:
@@ -230,7 +273,7 @@ jobs:
     name: linux-e2e
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'disable_e2e') }}
     secrets: inherit
-    needs: [linux-build]
+    needs: [reproducer-status-check]
     strategy:
       fail-fast: false
       matrix:
@@ -253,21 +296,6 @@ jobs:
     uses: ./.github/workflows/_linux_e2e_summary.yml
     with:
       test_type: ${{ contains(github.event.pull_request.labels.*.name, 'disable_build') && 'wheel-cicd' || 'build-cicd' }}
-
-  reproducer-test:
-    needs: [linux-build, preci-lint-check]
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ai_generated') }}
-    secrets: inherit
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
-    uses: ./.github/workflows/_linux_reproducer.yml
-    with:
-      runner: pvc_rolling
-      pytorch: ${{ contains(github.event.pull_request.labels.*.name, 'disable_build') && 'nightly_wheel' || github.base_ref }}
-      torch_xpu_ops: ${{ contains(github.event.pull_request.labels.*.name, 'disable_build') && 'pinned' || 'main' }}
-      pr_body_cmd: ${{ needs.preci-lint-check.outputs.pr_body_cmd }}
 
   windows-build:
     name: windows-build

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -79,7 +79,7 @@ jobs:
           JOB_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           printf -v COMMENT_BODY '%s\n' \
-            "@${PR_AUTHOR} The ${FAILED_STEPS} check failed. Please fix the lint errors in this PR." \
+            "@copilot The ${FAILED_STEPS} check failed. Please fix the lint errors in this PR." \
             "" \
             "Lint job log: ${JOB_URL}" \
             "" \

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -7,8 +7,6 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-      - labeled
-      - unlabeled
     branches:
       - main
       - release/*

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -234,7 +234,7 @@ jobs:
           fi
 
   linux-ut:
-    needs: [reproducer-status-check]
+    needs: [linux-build,reproducer-status-check]
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'disable_ut') }}
     secrets: inherit
     permissions:
@@ -252,7 +252,7 @@ jobs:
       ut: ${{ matrix.ut_name }}
 
   linux-distributed:
-    needs: [reproducer-status-check]
+    needs: [linux-build, reproducer-status-check]
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'disable_distributed') }}
     secrets: inherit
     permissions:
@@ -273,7 +273,7 @@ jobs:
     name: linux-e2e
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'disable_e2e') }}
     secrets: inherit
-    needs: [reproducer-status-check]
+    needs: [linux-build, reproducer-status-check]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           export ADDITIONAL_LINTRUNNER_ARGS="--skip CLANGTIDY,CLANGFORMAT,MERGE_CONFLICTLESS_CSV --all-files"
           cd ./torch-xpu-ops
+          set -o pipefail
           bash .github/scripts/lintrunner.sh 2>&1 | tee ${{ github.workspace }}/lint_python_errors.log
       - name: Checkout PyTorch (for headers)
         uses: actions/checkout@v4
@@ -56,8 +57,9 @@ jobs:
         run: |
           cd ./torch-xpu-ops
           export ADDITIONAL_LINTRUNNER_ARGS="--take CLANGFORMAT,CLANGTIDY --all-files"
+          set -o pipefail
           bash .github/scripts/lintrunner.sh 2>&1 | tee ${{ github.workspace }}/lint_clang_errors.log
-      - name: Comment on lint failure for AI-generated PR
+      - name: Comment on lint failure
         if: >-
           ${{ (steps.lint-python.outcome == 'failure' || steps.lint-clang.outcome == 'failure') }}
         env:
@@ -75,8 +77,9 @@ jobs:
             fi
           fi
           JOB_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           printf -v COMMENT_BODY '%s\n' \
-            "@copilot The ${FAILED_STEPS} check failed. Please fix the lint errors in this PR." \
+            "@${PR_AUTHOR} The ${FAILED_STEPS} check failed. Please fix the lint errors in this PR." \
             "" \
             "Lint job log: ${JOB_URL}" \
             "" \


### PR DESCRIPTION
## Summary

### pull.yml
- Remove `labeled`/`unlabeled` triggers to avoid redundant CI runs; label changes take effect on next push
- Add `set -o pipefail` before `tee` pipelines to preserve lint script exit code
- Save lint check output to log files and print error details in "Fail if lint failed" step
- Remove `ai_generated` label restriction from lint failure comment step (now triggers for all PRs)
- Move `reproducer-test` job after `linux-build`, remove `if` condition (gate moved into reusable workflow)
- Make `linux-ut`, `linux-e2e`, and `linux-distributed` depend on `reproducer-test`

### _linux_reproducer.yml
- Add `if: ai_generated` condition on internal `runner` job
- Add `reproducer-status-check` job to convert skip to success for non-AI PRs

### _linux_build.yml
- Remove `get-runner` job, `build` job directly uses `inputs.runner`
- Add `build-status-check` job to convert skip to success when build is disabled, preventing downstream jobs from being skipped