### PR TITLE
Fixed test_override_fake test problem by adjusting RuntimeError message

### DIFF
--- a/test/xpu/test_custom_ops_xpu.py
+++ b/test/xpu/test_custom_ops_xpu.py
@@ -2268,7 +2268,7 @@ Dynamic shape operator
         def foo_impl2(x):
             return torch.cat([x, x])
 
-        with self.assertRaisesRegex(RuntimeError, "already has an fake impl"):
+        with self.assertRaisesRegex(RuntimeError, "already has a fake impl"):
             torch.library.register_fake(op_name, foo_impl2, lib=lib)
 
         # Override fake kernel to foo_impl2


### PR DESCRIPTION
This patch fixes #3624.
Test `test_override_fake` was failing due to error: `AssertionError: "already has an fake impl" does not match "register_fake(...): the operator _test_custom_op::foo already has a fake impl registered`.
The fix was to update the error message which was updated in https://github.com/pytorch/pytorch/commit/bdfe60ce2d77e62d2bf0572e2dd6c6897d5c7cd3