### PR TITLE
Fix test_scaled_mm_deepseek_error_messages for XPU

### DIFF
--- a/test/xpu/test_scaled_matmul_cuda_xpu.py
+++ b/test/xpu/test_scaled_matmul_cuda_xpu.py
@@ -9,6 +9,7 @@
 # Owner(s): ["module: intel"]
 
 import torch
+from torch.nn.functional import ScalingType
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import parametrize, run_tests
 
@@ -22,6 +23,7 @@ with XPUPatchForImport(False):
         e4m3_type,
         e5m2_type,
         scaled_mm_wrap,
+        tensor_to_scale_block,
         TestFP8Matmul,
     )
 
@@ -79,11 +81,69 @@ TestFP8Matmul.test_float8_rowwise_scaling_sanity = parametrize(
 )(_xpu_test_float8_rowwise_scaling_sanity)
 
 
-# NOTE: test_scaled_mm_deepseek_error_messages_* is left at upstream's CUDA-12.9 skip:
-# overriding the body works (skip bypassed), but the asserted error pattern
-# (NotImplementedError "DeepSeek...only supported in CUDA for SM90") is CUDA-specific.
-# XPU's scaled_mm raises ValueError("Invalid scaling configuration") for blockwise scales,
-# so the upstream assertRaisesRegex cannot pass on XPU without changing what it asserts.
+# Override test_scaled_mm_deepseek_error_messages: upstream gates with @onlyCUDA and a
+# CUDA-12.9 skip that trivially evaluates true on XPU (_get_torch_cuda_version() returns
+# (0, 0)).  XPU's _scaled_mm_v2 raises ValueError("Invalid scaling configuration...")
+# for unsupported blockwise scales, so we add an XPU branch alongside the existing
+# CUDA / ROCm ones.
+@parametrize("output_dtype", [torch.bfloat16])
+@parametrize("lhs_block,rhs_block", [(1, 1), (128, 1), (1, 128)])
+@parametrize("M,N,K", [(256, 256, 256), (256, 256, 512)])
+def _xpu_test_scaled_mm_deepseek_error_messages(
+    self, output_dtype, lhs_block, rhs_block, M, N, K, device
+):
+    torch.manual_seed(42)
+
+    x = torch.randn(M, K, device=device, dtype=output_dtype).pow(3)
+    y = torch.randn(N, K, device=device, dtype=output_dtype).pow(3)
+
+    x_fp8, x_scales = tensor_to_scale_block(x, e4m3_type, lhs_block, 128)
+    y_fp8, y_scales = tensor_to_scale_block(y, e4m3_type, rhs_block, 128)
+
+    # 1x128 blocks need scales to be outer-dim-major
+    if lhs_block == 1:
+        x_scales = x_scales.t().contiguous().t()
+        lhs_recipe = ScalingType.BlockWise1x128
+    else:
+        lhs_recipe = ScalingType.BlockWise128x128
+
+    if rhs_block == 1:
+        y_scales = y_scales.t().contiguous().t()
+        rhs_recipe = ScalingType.BlockWise1x128
+    else:
+        rhs_recipe = ScalingType.BlockWise128x128
+
+    # Verify that actual F8 mm raises expected error
+    if torch.version.hip:
+        # ROCm does not yet support DeepSeek-style blockwise scaling
+        expected_error = NotImplementedError
+        expected_pattern = "1x128 and 128x128 scaling not available with ROCm"
+    elif self.device_type == "xpu":
+        # XPU does not support DeepSeek-style blockwise scaling
+        expected_error = ValueError
+        expected_pattern = "Invalid scaling configuration"
+    else:
+        # CUDA non-SM90 should raise NotImplementedError
+        expected_error = NotImplementedError
+        expected_pattern = ".*DeepSeek.*scaling.*only supported in CUDA for SM90.*"
+    with self.assertRaisesRegex(
+        expected_error,
+        expected_pattern,
+    ):
+        scaled_mm_wrap(
+            x_fp8,
+            y_fp8.t(),
+            scale_a=x_scales,
+            scale_recipe_a=lhs_recipe,
+            scale_b=y_scales.t(),
+            scale_recipe_b=rhs_recipe,
+            out_dtype=output_dtype,
+        )
+
+
+TestFP8Matmul.test_scaled_mm_deepseek_error_messages = (
+    _xpu_test_scaled_mm_deepseek_error_messages
+)
 
 
 instantiate_device_type_tests(TestFP8Matmul, globals(), only_for="xpu", allow_xpu=True)


### PR DESCRIPTION
Override `test_scaled_mm_deepseek_error_messages` to handle the XPU-specific error. XPU's `_scaled_mm_v2` does not support DeepSeek-style block-wise scaling and raises `ValueError("Invalid scaling configuration...")` rather than the `NotImplementedError` expected by the upstream CUDA/ROCm paths.

The override keeps all three backend branches (ROCm, XPU, CUDA) so the change can be easily integrated back upstream.

Previously these 6 parametrized cases were accidentally skipped because `_get_torch_cuda_version()` returns `(0, 0)` on XPU, trivially satisfying the `< (12, 9)` skip condition. The override removes that stale skip and properly validates XPU's error behavior.