### PR TITLE
Update reset_counters() call in test_cudagraph_bisect_max

### DIFF
--- a/test/xpu/dynamo/test_compiler_bisector_xpu.py
+++ b/test/xpu/dynamo/test_compiler_bisector_xpu.py
@@ -332,7 +332,7 @@ class TestCompilerBisector(TestCase):
         from unittest.mock import patch
 
         from torch._dynamo.utils import counters
-        from torch._inductor.compiler_bisector import get_env_val, reset_counters
+        from torch._inductor.compiler_bisector import get_env_val
 
         def foo(x):
             return x + 1
@@ -348,7 +348,7 @@ class TestCompilerBisector(TestCase):
 
         with patch.dict(os.environ, env):
             get_env_val.cache_clear()
-            reset_counters()
+            CompilerBisector.reset_counters()
             torch._dynamo.reset()
             counters.clear()
             CompilerBisector.bisection_enabled = True


### PR DESCRIPTION
Fixes: https://github.com/intel/torch-xpu-ops/issues/3594

In PyTorch https://github.com/pytorch/pytorch/pull/181452 reset_counters() method was transformed from a regular method into a class method. Test_cudagraph_bisect_max failed, as used previous syntax.
Same change was done in upstream test/dynamo/test_compiler_bisector.py