### PR TITLE
Replace Euclid's algorithm with optimized std::gcd

### DIFF
--- a/src/ATen/native/xpu/sycl/Reduce.h
+++ b/src/ATen/native/xpu/sycl/Reduce.h
@@ -200,23 +200,10 @@ inline int last_pow2(int n) {
   return std::max(1, n - (n >> 1));
 }
 
-// Warning: 64-bit integer loop inside device
 static void reduce_fraction(size_t& numerator, size_t& denominator) {
-  // get GCD of num and denom using Euclid's algorithm.
-  // Can replace this with std::gcd if we ever support c++17.
-  size_t a = denominator;
-  size_t b = numerator;
-  while (b != 0) {
-    a %= b;
-    // swap(a, b)
-    size_t tmp = a;
-    a = b;
-    b = tmp;
-  }
-
-  // a is now the GCD
-  numerator /= a;
-  denominator /= a;
+  auto gcd = std::gcd(numerator, denominator);
+  numerator /= gcd;
+  denominator /= gcd;
 }
 
 struct ReduceConfig {

--- a/src/ATen/native/xpu/sycl/Reduce.h
+++ b/src/ATen/native/xpu/sycl/Reduce.h
@@ -26,6 +26,7 @@
 #include <comm/xpu_aten.h>
 #include <functional>
 #include <iosfwd>
+#include <numeric>
 #include <type_traits>
 #include <utility>
 


### PR DESCRIPTION
Simplified `reduce_fraction` by replacing the hand-written Euclidean GCD loop with `std::gcd` (as PyTorch defaults to C++20), reducing the body to three lines and boosting performance.