### PR TITLE
[1/N][SymmetricMemory] implement torch.distributed._symmetric_memory for XCCL backend

### DIFF
--- a/src/xccl/CMakeLists.txt
+++ b/src/xccl/CMakeLists.txt
@@ -11,9 +11,11 @@
 file(GLOB xccl_h "*.hpp")
 file(GLOB xccl_cpp "*.cpp")
 list(REMOVE_ITEM xccl_cpp "${CMAKE_CURRENT_SOURCE_DIR}/NanCheck_XPU.cpp")
+list(REMOVE_ITEM xccl_cpp "${CMAKE_CURRENT_SOURCE_DIR}/Signal.cpp")
 
 list(APPEND ATen_XPU_XCCL_SRCS ${xccl_cpp})
 list(APPEND ATen_XPU_SYCL_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/NanCheck_XPU.cpp")
+list(APPEND ATen_XPU_SYCL_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/Signal.cpp")
 
 set(ATen_XPU_XCCL_SRCS ${ATen_XPU_XCCL_SRCS} PARENT_SCOPE)
 set(ATen_XPU_SYCL_SRCS ${ATen_XPU_SYCL_SRCS} PARENT_SCOPE)

--- a/src/xccl/Signal.cpp
+++ b/src/xccl/Signal.cpp
@@ -1,0 +1,201 @@
+#include <ATen/xpu/XPUContext.h>
+#include <comm/SYCLContext.h>
+#include <xccl/Signal.hpp>
+#include <chrono>
+
+namespace c10d::symmetric_memory {
+
+struct barrierKernel {
+  void operator()(sycl::nd_item<1> item) const {
+    auto thread_id = item.get_local_id(0);
+
+    if (thread_id < world_size) {
+      auto target_rank = thread_id;
+      if (target_rank == rank) {
+        return;
+      }
+      auto put_success = try_put_signal_device<std::memory_order_release>(
+          signal_pads[target_rank] + world_size * channel + rank, 10000000);
+        if (!put_success) {
+          SYCL_KERNEL_ASSERT(false);
+        }
+
+      auto wait_success = try_wait_signal_device<std::memory_order_acquire>(
+          signal_pads[rank] + world_size * channel + target_rank, 10000000);
+        if (!wait_success) {
+          SYCL_KERNEL_ASSERT(false);
+        }
+    }
+  }
+
+  barrierKernel(
+      uint32_t** signal_pads,
+      int channel,
+      int rank,
+      int world_size,
+      size_t timeout_ms)
+      : signal_pads(signal_pads),
+        channel(channel),
+        rank(rank),
+        world_size(world_size),
+        timeout_ms(timeout_ms) {}
+
+ private:
+  uint32_t** signal_pads;
+  int channel;
+  int rank;
+  int world_size;
+  size_t timeout_ms;
+};
+
+void barrier_impl_xpu(
+    uint32_t** signal_pads,
+    int channel,
+    int rank,
+    int world_size,
+    size_t timeout_ms,
+    at::xpu::XPUStream& stream) {
+  int64_t maxNumThreadsPerBlock = syclMaxWorkGroupSize<barrierKernel>();
+  const size_t numThreadsPerBlock =
+      std::min<size_t>(maxNumThreadsPerBlock, std::max(32, world_size));
+
+  if (!(numThreadsPerBlock > 0)) {
+    return;
+  }
+  int64_t numBlocks = 1;
+  auto global_range = numBlocks * numThreadsPerBlock;
+  auto local_range = numThreadsPerBlock;
+
+  using Kernel = barrierKernel;
+  auto kfn = Kernel(signal_pads, channel, rank, world_size, timeout_ms);
+
+  sycl_kernel_submit(global_range, local_range, stream.queue(), kfn);
+}
+
+struct putSignalKernel {
+  void operator()(sycl::nd_item<1> item) const {
+    auto thread_id = item.get_local_id(0);
+
+    if (thread_id == 0) {
+      auto put_success = try_put_signal_device<std::memory_order_release>(
+          signal_pads[dst_rank] + world_size * channel + rank, 10000000);
+        if (!put_success) {
+          SYCL_KERNEL_ASSERT(false);
+        }
+    }
+  }
+
+  putSignalKernel(
+      uint32_t** signal_pads,
+      int dst_rank,
+      int channel,
+      int rank,
+      int world_size,
+      size_t timeout_ms)
+      : signal_pads(signal_pads),
+        dst_rank(dst_rank),
+        channel(channel),
+        rank(rank),
+        world_size(world_size),
+        timeout_ms(timeout_ms) {}
+
+ private:
+  uint32_t** signal_pads;
+  int dst_rank;
+  int channel;
+  int rank;
+  int world_size;
+  size_t timeout_ms;
+};
+
+void put_signal_impl_xpu(
+    uint32_t** signal_pads,
+    int dst_rank,
+    int channel,
+    int rank,
+    int world_size,
+    size_t timeout_ms,
+    at::xpu::XPUStream& stream) {
+  int64_t maxNumThreadsPerBlock = syclMaxWorkGroupSize<putSignalKernel>();
+  const size_t numThreadsPerBlock = std::min<size_t>(maxNumThreadsPerBlock, 32);
+
+  if (!(numThreadsPerBlock > 0)) {
+    return;
+  }
+
+  int64_t numBlocks = 1;
+  auto global_range = numBlocks * numThreadsPerBlock;
+  auto local_range = numThreadsPerBlock;
+
+  using Kernel = putSignalKernel;
+  auto kfn =
+      Kernel(signal_pads, dst_rank, channel, rank, world_size, timeout_ms);
+
+  sycl_kernel_submit(global_range, local_range, stream.queue(), kfn);
+}
+
+struct waitSignalKernel {
+  void operator()(sycl::nd_item<1> item) const {
+    auto thread_id = item.get_local_id(0);
+
+    if (thread_id == 0) {
+      auto wait_success = try_wait_signal_device<std::memory_order_acquire>(
+          signal_pads[rank] + world_size * channel + src_rank, 10000000);
+        if (!wait_success) {
+          SYCL_KERNEL_ASSERT(false);
+        }
+
+      sycl::atomic_fence(sycl::memory_order_seq_cst, sycl::memory_scope_system);
+    }
+  }
+
+  waitSignalKernel(
+      uint32_t** signal_pads,
+      int src_rank,
+      int channel,
+      int rank,
+      int world_size,
+      size_t timeout_ms)
+      : signal_pads(signal_pads),
+        src_rank(src_rank),
+        channel(channel),
+        rank(rank),
+        world_size(world_size),
+        timeout_ms(timeout_ms) {}
+
+ private:
+  uint32_t** signal_pads;
+  int src_rank;
+  int channel;
+  int rank;
+  int world_size;
+  size_t timeout_ms;
+};
+
+void wait_signal_impl_xpu(
+    uint32_t** signal_pads,
+    int src_rank,
+    int channel,
+    int rank,
+    int world_size,
+    size_t timeout_ms,
+    at::xpu::XPUStream& stream) {
+  int64_t maxNumThreadsPerBlock = syclMaxWorkGroupSize<waitSignalKernel>();
+  const size_t numThreadsPerBlock = std::min<size_t>(maxNumThreadsPerBlock, 32);
+
+  if (!(numThreadsPerBlock > 0)) {
+    return;
+  }
+
+  int64_t numBlocks = 1;
+  auto global_range = numBlocks * numThreadsPerBlock;
+  auto local_range = numThreadsPerBlock;
+
+  using Kernel = waitSignalKernel;
+  auto kfn =
+      Kernel(signal_pads, src_rank, channel, rank, world_size, timeout_ms);
+
+  sycl_kernel_submit(global_range, local_range, stream.queue(), kfn);
+}
+
+} // namespace c10d::symmetric_memory

--- a/src/xccl/Signal.cpp
+++ b/src/xccl/Signal.cpp
@@ -16,15 +16,15 @@ struct barrierKernel {
       }
       auto put_success = try_put_signal_device<std::memory_order_release>(
           signal_pads[target_rank] + world_size * channel + rank, 10000000);
-        if (!put_success) {
-          SYCL_KERNEL_ASSERT(false);
-        }
+      if (!put_success) {
+        SYCL_KERNEL_ASSERT(false);
+      }
 
       auto wait_success = try_wait_signal_device<std::memory_order_acquire>(
           signal_pads[rank] + world_size * channel + target_rank, 10000000);
-        if (!wait_success) {
-          SYCL_KERNEL_ASSERT(false);
-        }
+      if (!wait_success) {
+        SYCL_KERNEL_ASSERT(false);
+      }
     }
   }
 
@@ -79,9 +79,9 @@ struct putSignalKernel {
     if (thread_id == 0) {
       auto put_success = try_put_signal_device<std::memory_order_release>(
           signal_pads[dst_rank] + world_size * channel + rank, 10000000);
-        if (!put_success) {
-          SYCL_KERNEL_ASSERT(false);
-        }
+      if (!put_success) {
+        SYCL_KERNEL_ASSERT(false);
+      }
     }
   }
 
@@ -141,9 +141,9 @@ struct waitSignalKernel {
     if (thread_id == 0) {
       auto wait_success = try_wait_signal_device<std::memory_order_acquire>(
           signal_pads[rank] + world_size * channel + src_rank, 10000000);
-        if (!wait_success) {
-          SYCL_KERNEL_ASSERT(false);
-        }
+      if (!wait_success) {
+        SYCL_KERNEL_ASSERT(false);
+      }
 
       sycl::atomic_fence(sycl::memory_order_seq_cst, sycl::memory_scope_system);
     }

--- a/src/xccl/Signal.hpp
+++ b/src/xccl/Signal.hpp
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <atomic>
+
+#include <ATen/native/xpu/sycl/MemoryAccess.h>
+#include <comm/SYCLContext.h>
+
+namespace c10d::symmetric_memory {
+
+using at::native::memory::get_alignment;
+
+// =============================================================================
+// Signal primitives using store/load + atomic_fence
+// (sycl::atomic_ref is not supported, use explicit fence instead)
+// =============================================================================
+
+// Store value with release fence (for put_signal)
+// Order: store first, then release fence to flush the store
+inline void store_release(uint32_t* addr, uint32_t val) {
+  *addr = val;
+  sycl::atomic_fence(sycl::memory_order::release, sycl::memory_scope::system);
+}
+
+// Load value with acquire fence (for get_signal/wait_signal)
+// Order: acquire fence first, then load to see the latest value
+inline uint32_t load_acquire(uint32_t* addr) {
+  sycl::atomic_fence(sycl::memory_order::acquire, sycl::memory_scope::system);
+  uint32_t val = *addr;
+  return val;
+}
+
+// =============================================================================
+// Put signal: wait until addr == 0, then set to 1 (release semantics)
+// =============================================================================
+
+// Device-compatible version using iteration count
+template <std::memory_order Sem>
+bool try_put_signal_device(uint32_t* addr, size_t max_iterations = 1000) {
+  size_t iterations = 0;
+  // Wait until the slot is free (value == 0)
+  while (load_acquire(addr) != 0) {
+    if (max_iterations != 0 && iterations++ > max_iterations) {
+      return false;
+    }
+  }
+  // Set signal to 1 with release semantics
+  store_release(addr, 1);
+  return true;
+}
+
+// =============================================================================
+// Wait signal: wait until addr == 1, then set to 0 (acquire semantics)
+// =============================================================================
+
+// Device-compatible version using iteration count
+template <std::memory_order Sem>
+bool try_wait_signal_device(uint32_t* addr, size_t max_iterations = 1000) {
+  (void)max_iterations;
+  // Wait until signal is set (value == 1)
+  while (load_acquire(addr) != 1) {
+    // Spin wait (no timeout check to avoid early exit)
+    continue;
+  }
+  // Clear signal to 0 with release semantics
+  store_release(addr, 0);
+  return true;
+}
+
+void barrier_impl_xpu(
+    uint32_t** signal_pads,
+    int channel,
+    int rank,
+    int world_size,
+    size_t timeout_ms,
+    at::xpu::XPUStream& stream);
+
+void put_signal_impl_xpu(
+    uint32_t** signal_pads,
+    int dst_rank,
+    int channel,
+    int rank,
+    int world_size,
+    size_t timeout_ms,
+    at::xpu::XPUStream& stream);
+
+void wait_signal_impl_xpu(
+    uint32_t** signal_pads,
+    int src_rank,
+    int channel,
+    int rank,
+    int world_size,
+    size_t timeout_ms,
+    at::xpu::XPUStream& stream);
+} // namespace c10d::symmetric_memory

--- a/src/xccl/XPUSymmetricMemory.cpp
+++ b/src/xccl/XPUSymmetricMemory.cpp
@@ -1,0 +1,525 @@
+#include <xccl/ProcessGroupXCCL.hpp>
+#include <xccl/XPUSymmetricMemory.hpp>
+#include <xccl/XPUSymmetricMemoryUtils.hpp>
+
+#include <ATen/ceil_div.h>
+#include <ATen/xpu/XPUContext.h>
+#include <c10/core/DeviceGuard.h>
+#include <c10/util/error.h>
+#include <c10/xpu/XPUCachingAllocator.h>
+#include <torch/csrc/distributed/c10d/GroupRegistry.hpp>
+
+#include <sycl/ext/oneapi/experimental/ipc_memory.hpp>
+
+#include <cstdlib>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace c10d {
+namespace symmetric_memory {
+
+static StoreExchange storeExchange = StoreExchange("XPUSymmetricMemory");
+
+namespace {
+
+bool use_signal_barrier_enabled() {
+  static const bool cached_value = []() {
+    const char* env = std::getenv("USE_SIGNAL_BARRIER");
+    return env != nullptr && std::string(env) == "1";
+  }();
+  return cached_value;
+}
+
+} // namespace
+
+AllocationRef::AllocationRef(
+    void* ptr,
+    HandleType handle,
+    size_t block_size,
+    int device_idx,
+    bool local_allocation)
+    : ptr(ptr),
+      handle(handle),
+      block_size(block_size),
+      device_idx(device_idx),
+      local_allocation(local_allocation) {}
+
+AllocationRef::~AllocationRef() {
+  if (is_finalizing()) {
+    return;
+  }
+  // Currently, we cannot free virtual memory exchanged from other device.
+  // (SYCL `ipc_memory::close` is available but calling it during teardown
+  // has been observed to hang on this stack; match the original L0 path
+  // which also skips remote unmap.)
+  if (!local_allocation) {
+    return;
+  }
+  c10::Device local_device(c10::DeviceType::XPU, device_idx);
+  c10::DeviceGuard guard(local_device);
+  c10::xpu::syncStreamsOnDevice();
+  auto stream = at::xpu::getCurrentXPUStream();
+  sycl::free(ptr, stream);
+}
+
+XPUSymmetricMemory::XPUSymmetricMemory(
+    std::vector<c10::intrusive_ptr<AllocationRef>> alloc_refs,
+    std::vector<void*> buffers,
+    std::vector<void*> signal_pads,
+    HandleType mc_handle,
+    void* mc_addr,
+    size_t buffer_size,
+    int local_device_idx,
+    int rank,
+    int world_size)
+    : alloc_refs_(std::move(alloc_refs)),
+      buffers_(std::move(buffers)),
+      signal_pads_(std::move(signal_pads)),
+      mc_handle_(mc_handle),
+      mc_addr_(mc_addr),
+      buffer_size_(buffer_size),
+      local_device_idx_(local_device_idx),
+      rank_(rank),
+      world_size_(world_size) {
+  const size_t arr_size = sizeof(void*) * world_size_;
+  buffers_dev_ = reinterpret_cast<void**>(
+      c10::xpu::XPUCachingAllocator::raw_alloc(arr_size));
+  signal_pads_dev_ = reinterpret_cast<void**>(
+      c10::xpu::XPUCachingAllocator::raw_alloc(arr_size));
+
+  c10::Device local_device(c10::DeviceType::XPU, local_device_idx);
+  c10::DeviceGuard guard(local_device);
+
+  at::xpu::getCurrentXPUStream().queue().memcpy(
+      buffers_dev_, buffers_.data(), arr_size);
+  at::xpu::getCurrentXPUStream().queue().memcpy(
+      signal_pads_dev_, signal_pads_.data(), arr_size);
+}
+
+std::vector<void*> XPUSymmetricMemory::get_buffer_ptrs() {
+  return buffers_;
+}
+
+std::vector<void*> XPUSymmetricMemory::get_signal_pad_ptrs() {
+  return signal_pads_;
+}
+
+void** XPUSymmetricMemory::get_buffer_ptrs_dev() {
+  return buffers_dev_;
+}
+
+void** XPUSymmetricMemory::get_signal_pad_ptrs_dev() {
+  return signal_pads_dev_;
+}
+
+size_t XPUSymmetricMemory::get_buffer_size() {
+  return buffer_size_;
+}
+
+size_t XPUSymmetricMemory::get_offset() {
+  return 0;
+}
+
+bool XPUSymmetricMemory::has_multicast_support() {
+  return false;
+}
+
+void* XPUSymmetricMemory::get_multicast_ptr() {
+  return nullptr;
+}
+
+at::Tensor XPUSymmetricMemory::get_buffer(
+    int rank,
+    c10::IntArrayRef sizes,
+    c10::ScalarType dtype,
+    int64_t storage_offset) {
+  const size_t numel = std::accumulate(
+      sizes.begin(),
+      sizes.end(),
+      static_cast<size_t>(1),
+      std::multiplies<size_t>());
+  const auto element_size = c10::elementSize(dtype);
+  const auto req_size = (numel + storage_offset) * element_size;
+  TORCH_CHECK(
+      req_size <= buffer_size_,
+      "XPUSymmetricMemory::get_buffer: the requested size (",
+      req_size,
+      " bytes) exceeds the allocated size (",
+      buffer_size_,
+      " bytes)");
+  auto data_ptr = reinterpret_cast<uint8_t*>(buffers_[rank]) +
+      storage_offset * element_size;
+  // check the device of this device buffer
+  auto ptr_to_device_id = c10::xpu::get_device_idx_from_pointer(data_ptr);
+  auto device = c10::Device(c10::DeviceType::XPU, ptr_to_device_id);
+  auto options = at::TensorOptions().dtype(dtype).device(device);
+
+  return at::for_blob(data_ptr, sizes)
+      .options(options)
+      .target_device(device)
+      .make_tensor();
+}
+
+void check_channel(int channel, int world_size) {
+  TORCH_CHECK(
+      channel >= 0,
+      "channel for barrier(), put_signal() and wait_signal() ",
+      "must be greater than 0 (got ",
+      channel,
+      ")");
+  const size_t num_channels =
+      get_signal_pad_size() / sizeof(uint32_t) * world_size;
+  TORCH_CHECK(
+      static_cast<size_t>(channel) < num_channels,
+      "The maximum supported channel for barrier(), put_signal() and wait_signal() is ",
+      num_channels - 1,
+      " (got ",
+      channel,
+      ")");
+}
+
+void XPUSymmetricMemory::barrier(int channel, size_t timeout_ms) {
+  check_channel(channel, world_size_);
+
+  c10::Device local_device(c10::DeviceType::XPU, local_device_idx_);
+  c10::DeviceGuard guard(local_device);
+  if (use_signal_barrier_enabled()) {
+    auto stream = at::xpu::getCurrentXPUStream();
+    barrier_impl_xpu(
+        reinterpret_cast<uint32_t**>(signal_pads_dev_),
+        channel,
+        rank_,
+        world_size_,
+        timeout_ms,
+        stream);
+    return;
+  }
+
+  auto group = c10d::resolve_process_group(group_name_);
+  TORCH_CHECK(
+      group != nullptr,
+      "Process group '",
+      group_name_,
+      "' not found, please init process group first before calling "
+      "SymmetricMemory");
+
+  auto backend = group->getBackend(c10::DeviceType::XPU);
+
+  static thread_local at::Tensor barrier_tensor;
+  if (!barrier_tensor.defined() || barrier_tensor.device() != local_device) {
+    barrier_tensor = at::zeros(
+        {1}, at::TensorOptions().device(local_device).dtype(at::kFloat));
+  } else {
+    barrier_tensor.zero_();
+  }
+
+  c10d::AllreduceOptions arOpts;
+  arOpts.asyncOp = false;
+  std::vector<at::Tensor> tensors = {barrier_tensor};
+  auto work = backend->allreduce(tensors, arOpts);
+
+  if (work) {
+    bool success = work->wait(std::chrono::milliseconds(timeout_ms));
+    TORCH_CHECK(
+        success,
+        "Barrier timeout after ",
+        timeout_ms,
+        " ms for group '",
+        group_name_,
+        "'");
+  }
+}
+
+void XPUSymmetricMemory::put_signal(
+    int dst_rank,
+    int channel,
+    size_t timeout_ms) {
+  check_channel(channel, world_size_);
+
+  c10::Device local_device(c10::DeviceType::XPU, local_device_idx_);
+  c10::DeviceGuard guard(local_device);
+  auto stream = at::xpu::getCurrentXPUStream();
+
+  put_signal_impl_xpu(
+      reinterpret_cast<uint32_t**>(signal_pads_dev_),
+      dst_rank,
+      channel,
+      rank_,
+      world_size_,
+      timeout_ms,
+      stream);
+}
+
+void XPUSymmetricMemory::wait_signal(
+    int src_rank,
+    int channel,
+    size_t timeout_ms) {
+  check_channel(channel, world_size_);
+
+  c10::Device local_device(c10::DeviceType::XPU, local_device_idx_);
+  c10::DeviceGuard guard(local_device);
+  auto stream = at::xpu::getCurrentXPUStream();
+
+  wait_signal_impl_xpu(
+      reinterpret_cast<uint32_t**>(signal_pads_dev_),
+      src_rank,
+      channel,
+      rank_,
+      world_size_,
+      timeout_ms,
+      stream);
+}
+
+int XPUSymmetricMemory::get_rank() {
+  return rank_;
+}
+
+int XPUSymmetricMemory::get_world_size() {
+  return world_size_;
+}
+
+c10::Device XPUSymmetricMemory::get_device() {
+  return c10::Device(c10::DeviceType::XPU, local_device_idx_);
+}
+
+Block::Block(
+    c10::intrusive_ptr<AllocationRef> alloc_ref,
+    int device_idx,
+    size_t block_size,
+    size_t buffer_size,
+    size_t signal_pad_offset,
+    const std::optional<std::string>& group_name)
+    : alloc_ref(std::move(alloc_ref)),
+      device_idx(device_idx),
+      block_size(block_size),
+      buffer_size(buffer_size),
+      signal_pad_offset(signal_pad_offset),
+      default_group_name(std::move(group_name)) {}
+
+void* XPUSymmetricMemoryAllocator::alloc(
+    size_t size,
+    int device_idx,
+    const std::optional<std::string>& group_name) {
+  size_t signal_pad_offset = at::round_up(size, 16UL);
+  size_t block_size = signal_pad_offset + get_signal_pad_size();
+
+  sycl::queue current_queue = at::xpu::getCurrentXPUStream().queue();
+  void* ptr = sycl::malloc_device(block_size, current_queue);
+  current_queue.memset(ptr, 0, block_size);
+  auto alloc_ref = c10::make_intrusive<AllocationRef>(
+      ptr, ptr, block_size, device_idx, true);
+  auto block = c10::make_intrusive<Block>(
+      std::move(alloc_ref),
+      device_idx,
+      block_size,
+      size,
+      signal_pad_offset,
+      group_name);
+
+  {
+    std::unique_lock lock(mutex_);
+    ptr_to_block_.emplace(ptr, std::move(block));
+  }
+  return ptr;
+}
+
+void XPUSymmetricMemoryAllocator::free(void* ptr) {
+  std::unique_lock lock(mutex_);
+  ptr_to_block_.erase(ptr);
+}
+
+size_t XPUSymmetricMemoryAllocator::get_alloc_size(void* ptr) {
+  auto block = find_block(ptr);
+  TORCH_CHECK(
+      block != nullptr,
+      "XPUSymmetricMemoryAllocator::get_alloc_size: input must be allocated ",
+      "via XPUSymmetricMemoryAllocator::alloc");
+  return block->buffer_size;
+}
+
+struct RendezvousRequest {
+  int device_idx;
+  int pid;
+  size_t block_size;
+  size_t buffer_size;
+  size_t signal_pad_offset;
+  bool has_multicast_support;
+};
+
+void validate_rendezvous_requests(
+    const std::vector<RendezvousRequest>& reqs,
+    int world_size) {
+  TORCH_CHECK(reqs.size() == (size_t)world_size);
+
+  std::unordered_set<int> device_indices;
+  device_indices.reserve(world_size);
+  for (auto req : reqs) {
+    device_indices.insert(req.device_idx);
+  }
+
+  for (int r = 1; r < world_size; ++r) {
+    TORCH_CHECK(reqs[r].block_size == reqs[0].block_size);
+    TORCH_CHECK(reqs[r].buffer_size == reqs[0].buffer_size);
+    TORCH_CHECK(reqs[r].signal_pad_offset == reqs[0].signal_pad_offset);
+  }
+}
+
+c10::intrusive_ptr<SymmetricMemory> XPUSymmetricMemoryAllocator::rendezvous(
+    void* ptr,
+    const std::optional<std::string>& group_name) {
+  auto block = find_block(ptr);
+  if (block == nullptr) {
+    return nullptr;
+  }
+
+  // The group_name passed to rendezvous() takes precedence over
+  // the default group_name specified during allocation.
+  std::string group_name_;
+  // Treat empty string and std::nullopt the same as empty string seems to be
+  // implicitly used that way
+  if (group_name.has_value() && group_name != "") {
+    group_name_ = *group_name;
+  } else {
+    if (!block->default_group_name.has_value()) {
+      TORCH_CHECK(
+          false,
+          "XPUSymmetricMemory::rendezvous: `group_name` is neither "
+          "specified during allocation nor passed to rendezvous().");
+    }
+    group_name_ = *block->default_group_name;
+  }
+
+  auto it = block->symm_mems.find(group_name_);
+  if (it != block->symm_mems.end()) {
+    return it->second;
+  }
+
+  c10::Device local_device(c10::DeviceType::XPU, block->device_idx);
+  c10::DeviceGuard guard(local_device);
+
+  auto group = resolve_process_group(group_name_);
+  auto rank = group->getRank();
+  auto world_size = group->getSize();
+  auto store = group->getStore();
+  sycl::queue current_queue = at::xpu::getCurrentXPUStream().queue();
+
+  auto local_req = RendezvousRequest{
+      .device_idx = block->device_idx,
+      .pid = getpid(),
+      .block_size = block->block_size,
+      .buffer_size = block->buffer_size,
+      .signal_pad_offset = block->signal_pad_offset,
+      .has_multicast_support = false};
+  auto reqs = storeExchange.all_gather(store, rank, world_size, local_req);
+  validate_rendezvous_requests(reqs, world_size);
+
+  // Step 1: Get SYCL experimental IPC handle from the allocation base.
+  // `ptr` is always a base pointer here: alloc() stores ptr_to_block_[ptr]
+  // keyed by the malloc_device return value, and find_block() does an exact
+  // lookup, so by the time rendezvous() is called we already have the base.
+  sycl::context ctx = current_queue.get_context();
+  sycl::device dev = current_queue.get_device();
+
+  namespace syclexp = sycl::ext::oneapi::experimental;
+  syclexp::ipc_memory::handle local_handle =
+      syclexp::ipc_memory::get(ptr, ctx);
+  syclexp::ipc_memory::handle_data_t local_handle_bytes = local_handle.data();
+  std::vector<uint8_t> local_payload(
+      reinterpret_cast<const uint8_t*>(local_handle_bytes.data()),
+      reinterpret_cast<const uint8_t*>(local_handle_bytes.data()) +
+          local_handle_bytes.size());
+
+  // Step 2: Exchange IPC-handle bytes via store (variable-length payload).
+  auto peer_handle_payloads =
+      storeExchange.all_gather_bytes(store, rank, world_size, local_payload);
+
+  // Step 3: Open peer IPC handles via SYCL API.
+  std::vector<HandleType> handles(world_size);
+  std::vector<void*> buffers(world_size, nullptr);
+  std::vector<void*> signal_pads(world_size, nullptr);
+
+  for (int r = 0; r < world_size; ++r) {
+    if (r == rank) {
+      handles[r] = ptr;
+      buffers[r] = ptr;
+      signal_pads[r] = (void*)((uintptr_t)ptr + block->signal_pad_offset);
+      continue;
+    }
+
+    const auto& payload = peer_handle_payloads[r];
+    syclexp::ipc_memory::handle_data_t peer_bytes(
+        reinterpret_cast<const std::byte*>(payload.data()),
+        reinterpret_cast<const std::byte*>(payload.data()) + payload.size());
+    void* remote_base = syclexp::ipc_memory::open(peer_bytes, ctx, dev);
+
+    handles[r] = remote_base;
+    buffers[r] = remote_base;
+    signal_pads[r] =
+        (void*)((uintptr_t)remote_base + block->signal_pad_offset);
+  }
+  storeExchange.barrier(store, rank, world_size);
+
+  HandleType mc_handle{};
+  void* mc_addr = nullptr;
+
+  std::vector<c10::intrusive_ptr<AllocationRef>> alloc_refs;
+  for (int r = 0; r < world_size; ++r) {
+    if (r == rank) {
+      alloc_refs.emplace_back(block->alloc_ref);
+      continue;
+    }
+    alloc_refs.push_back(c10::make_intrusive<AllocationRef>(
+        buffers[r], handles[r], block->block_size, block->device_idx, false));
+  }
+
+  auto symm_mem = c10::make_intrusive<XPUSymmetricMemory>(
+      std::move(alloc_refs),
+      std::move(buffers),
+      std::move(signal_pads),
+      mc_handle,
+      mc_addr,
+      block->buffer_size,
+      block->device_idx,
+      rank,
+      world_size);
+  symm_mem->set_group_name(group_name_);
+  block->symm_mems[group_name_] = symm_mem;
+  return symm_mem;
+}
+
+bool XPUSymmetricMemoryAllocator::has_multicast_support(int device_idx) {
+  return false;
+}
+
+c10::DeviceType XPUSymmetricMemoryAllocator::supported_device_type() {
+  return c10::DeviceType::XPU;
+}
+
+std::string XPUSymmetricMemoryAllocator::name() {
+  return "XPU";
+}
+
+c10::intrusive_ptr<Block> XPUSymmetricMemoryAllocator::find_block(void* ptr) {
+  std::shared_lock lock(mutex_);
+  auto it = ptr_to_block_.find(ptr);
+  if (it == ptr_to_block_.end()) {
+    return nullptr;
+  }
+  return it->second;
+}
+
+struct RegisterXPUSymmetricMemoryAllocator {
+  RegisterXPUSymmetricMemoryAllocator() {
+    auto allocator = c10::make_intrusive<XPUSymmetricMemoryAllocator>();
+    // Always register availability to support dynamic backend switching
+    register_availability("XPU", allocator);
+    // If this is the preferred backend, also set it as default
+    if (getSymmMemBackendXPU() == "XPU") {
+      register_allocator(c10::DeviceType::XPU, allocator);
+    }
+  }
+};
+static RegisterXPUSymmetricMemoryAllocator register_allocator_;
+
+} // namespace symmetric_memory
+} // namespace c10d

--- a/src/xccl/XPUSymmetricMemory.cpp
+++ b/src/xccl/XPUSymmetricMemory.cpp
@@ -11,9 +11,9 @@
 
 #include <sycl/ext/oneapi/experimental/ipc_memory.hpp>
 
-#include <cstdlib>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <cstdlib>
 
 namespace c10d {
 namespace symmetric_memory {
@@ -421,8 +421,7 @@ c10::intrusive_ptr<SymmetricMemory> XPUSymmetricMemoryAllocator::rendezvous(
   sycl::device dev = current_queue.get_device();
 
   namespace syclexp = sycl::ext::oneapi::experimental;
-  syclexp::ipc_memory::handle local_handle =
-      syclexp::ipc_memory::get(ptr, ctx);
+  syclexp::ipc_memory::handle local_handle = syclexp::ipc_memory::get(ptr, ctx);
   syclexp::ipc_memory::handle_data_t local_handle_bytes = local_handle.data();
   std::vector<uint8_t> local_payload(
       reinterpret_cast<const uint8_t*>(local_handle_bytes.data()),
@@ -454,8 +453,7 @@ c10::intrusive_ptr<SymmetricMemory> XPUSymmetricMemoryAllocator::rendezvous(
 
     handles[r] = remote_base;
     buffers[r] = remote_base;
-    signal_pads[r] =
-        (void*)((uintptr_t)remote_base + block->signal_pad_offset);
+    signal_pads[r] = (void*)((uintptr_t)remote_base + block->signal_pad_offset);
   }
   storeExchange.barrier(store, rank, world_size);
 

--- a/src/xccl/XPUSymmetricMemory.hpp
+++ b/src/xccl/XPUSymmetricMemory.hpp
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <xccl/Signal.hpp>
+
+#include <ATen/ATen.h>
+#include <sycl/sycl.hpp>
+#include <torch/csrc/distributed/c10d/Store.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
+#include <xccl/XPUSymmetricMemoryTypes.hpp>
+
+#include <shared_mutex>
+
+namespace c10d::symmetric_memory {
+
+// Resource wrapper that owns a (vaddr, allocation handle) pair. Upon
+// destruction, it unmaps the vaddr and releases the allocation handle.
+struct AllocationRef : public c10::intrusive_ptr_target {
+  void* ptr;
+  HandleType handle;
+  size_t block_size;
+  int device_idx;
+  bool local_allocation;
+
+  AllocationRef(
+      void* ptr,
+      HandleType handle,
+      size_t block_size,
+      int device_idx,
+      bool local_allocation);
+
+  ~AllocationRef();
+};
+
+class XPUSymmetricMemory : public SymmetricMemory {
+ public:
+  XPUSymmetricMemory(
+      std::vector<c10::intrusive_ptr<AllocationRef>> alloc_refs,
+      std::vector<void*> buffers,
+      std::vector<void*> signal_pads,
+      HandleType mc_handle,
+      void* mc_addr,
+      size_t buffer_size,
+      int local_device_idx,
+      int rank,
+      int world_size);
+
+  ~XPUSymmetricMemory() override{};
+
+  std::vector<void*> get_buffer_ptrs() override;
+  std::vector<void*> get_signal_pad_ptrs() override;
+  void** get_buffer_ptrs_dev() override;
+  void** get_signal_pad_ptrs_dev() override;
+  size_t get_buffer_size() override;
+
+  size_t get_offset() override;
+
+  bool has_multicast_support() override;
+  void* get_multicast_ptr() override;
+
+  at::Tensor get_buffer(
+      int rank,
+      c10::IntArrayRef sizes,
+      c10::ScalarType dtype,
+      int64_t storage_offset);
+
+  void barrier(int channel, size_t timeout_ms) override;
+  void put_signal(int dst_rank, int channel, size_t timeout_ms) override;
+  void wait_signal(int src_rank, int channel, size_t timeout_ms) override;
+
+  int get_rank() override;
+  int get_world_size() override;
+  c10::Device get_device() override;
+
+  void set_group_name(const std::string& group_name) {
+    group_name_ = group_name;
+  }
+
+ private:
+  std::vector<c10::intrusive_ptr<AllocationRef>> alloc_refs_;
+  std::vector<void*> buffers_;
+  std::vector<void*> signal_pads_;
+  HandleType mc_handle_;
+  void* mc_addr_;
+  size_t buffer_size_;
+  int local_device_idx_;
+  int rank_;
+  int world_size_;
+  void** buffers_dev_;
+  void** signal_pads_dev_;
+  std::string group_name_;
+};
+
+struct Block : public c10::intrusive_ptr_target {
+  c10::intrusive_ptr<AllocationRef> alloc_ref;
+  int device_idx;
+  size_t block_size;
+  size_t buffer_size;
+  size_t signal_pad_offset;
+  std::optional<std::string> default_group_name;
+  std::map<std::string, c10::intrusive_ptr<XPUSymmetricMemory>> symm_mems;
+
+  Block(
+      c10::intrusive_ptr<AllocationRef> alloc_ref,
+      int device_idx,
+      size_t block_size,
+      size_t buffer_size,
+      size_t signal_pad_offset,
+      const std::optional<std::string>& group_name);
+};
+
+class XPUSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
+ public:
+  void* alloc(
+      size_t size,
+      int device_idx,
+      const std::optional<std::string>& group_name) override;
+
+  void free(void* ptr) override;
+  size_t get_alloc_size(void* ptr) override;
+  c10::intrusive_ptr<SymmetricMemory> rendezvous(
+      void* ptr,
+      const std::optional<std::string>& group_name) override;
+  bool has_multicast_support(int device_idx) override;
+  //  void exchange_peer_ipc_mem(sycl::queue& queue, void* ptr);
+  c10::DeviceType supported_device_type() override;
+  std::string name() override;
+
+ private:
+  c10::intrusive_ptr<Block> find_block(void* ptr);
+
+  std::shared_mutex mutex_;
+  std::unordered_map<void*, c10::intrusive_ptr<Block>> ptr_to_block_;
+};
+
+} // namespace c10d::symmetric_memory

--- a/src/xccl/XPUSymmetricMemoryTypes.hpp
+++ b/src/xccl/XPUSymmetricMemoryTypes.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace c10d::symmetric_memory {
+
+constexpr size_t signal_pad_size = 2048;
+using HandleType = void*;
+
+} // namespace c10d::symmetric_memory

--- a/src/xccl/XPUSymmetricMemoryUtils.cpp
+++ b/src/xccl/XPUSymmetricMemoryUtils.cpp
@@ -1,0 +1,223 @@
+#include <xccl/XPUSymmetricMemoryUtils.hpp>
+
+#include <sys/socket.h>
+#include <sys/syscall.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <c10/util/error.h>
+
+namespace c10d::symmetric_memory {
+
+std::string getSymmMemBackendXPU() {
+  // TORCH_SYMMMEM environment variable can be used to indicate the preferred
+  // backend.
+  static auto val = c10::utils::get_env("TORCH_SYMMMEM");
+  if (val.has_value()) {
+    TORCH_CHECK(
+        val.value() == "XPU",
+        "TORCH_SYMMMEM environment variable must be 'XPU'.")
+    return val.value();
+  }
+  return "XPU";
+}
+
+IpcChannel::IpcChannel()
+    : socket_name_(get_socket_name(getpid())),
+      socket_(socket(AF_UNIX, SOCK_DGRAM, 0)) {
+  // On success, a file descriptor for the new socket is returned.
+  //  On error, -1 is returned, and errno is set to indicate the error.
+  TORCH_CHECK(
+      socket_ != -1, "Failed to create socket: ", c10::utils::str_error(errno));
+
+  struct sockaddr_un addr = {.sun_family = AF_UNIX};
+  std::copy(socket_name_.begin(), socket_name_.end(), addr.sun_path);
+
+  TORCH_CHECK(
+      bind(socket_, (struct sockaddr*)&addr, SUN_LEN(&addr)) == 0,
+      "Failed to bind socket: ",
+      c10::utils::str_error(errno));
+}
+
+IpcChannel::~IpcChannel() {
+  close(socket_);
+  unlink(socket_name_.c_str());
+}
+
+void IpcChannel::send_fd(int dst_pid, int fd) {
+  // Because file descriptors are process-local kernel objects, and we can’t
+  // pass them via normal socket payloads (like write() or send()).  Unix domain
+  // sockets provide a mechanism to pass actual FDs via sendmsg()/recvmsg().
+  // Define destination socket address
+  struct sockaddr_un addr = {.sun_family = AF_UNIX};
+  auto socket_name = get_socket_name(dst_pid);
+  std::copy(socket_name.begin(), socket_name.end(), addr.sun_path);
+
+  // Prepare data to send
+  // Data being sent is "fd", the value of fd will be sent as auxiliary data
+  // (control message)
+  struct iovec io = {.iov_base = (void*)("fd"), .iov_len = 2};
+
+  // Prepare control message data buffer and zero it out
+  // NOLINTNEXTLINE(*array*)
+  char cbuf[CMSG_SPACE(sizeof(int))];
+  memset(cbuf, 0, sizeof(cbuf));
+
+  // Create message header
+  struct msghdr msg {
+    // destination socket address and size of it
+    // message content in msg_iov and number of such structs (1 in our case)
+    // auxiliary data with the value of fd and size of it
+    .msg_name = (void*)&addr, .msg_namelen = sizeof(struct sockaddr_un),
+    .msg_iov = &io, .msg_iovlen = 1, .msg_control = cbuf,
+    .msg_controllen = sizeof(cbuf)
+  };
+
+  // This points to the first control message header
+  // With SCM_RIGHTS we let the kernel know that we are passing file
+  // descriptors.
+  auto cmsg = CMSG_FIRSTHDR(&msg);
+  cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+  // Specify socket level message
+  cmsg->cmsg_level = SOL_SOCKET;
+  // SCM_RIGHTS is the type used to pass file descriptors
+  cmsg->cmsg_type = SCM_RIGHTS;
+
+  if (fd != -1) {
+    std::copy(
+        reinterpret_cast<const char*>(&fd),
+        reinterpret_cast<const char*>(&fd) + sizeof(fd),
+        reinterpret_cast<char*>(CMSG_DATA(cmsg)));
+  } else {
+    msg.msg_controllen = 0;
+  }
+
+  // Retry sending with exponential backoff (wait for destination socket to be
+  // ready)
+  const int max_retries = 100;
+  int retry = 0;
+  ssize_t result = -1;
+
+  while (retry < max_retries) {
+    result = sendmsg(socket_, &msg, 0);
+    if (result > 0) {
+      return; // Success
+    }
+
+    // Check if error is because destination doesn't exist yet
+    if (errno == ENOENT || errno == ECONNREFUSED) {
+      // Exponential backoff: 1ms, 2ms, 4ms, ..., up to 100ms
+      int sleep_ms = std::min(1 << retry, 100);
+      usleep(sleep_ms * 1000);
+      retry++;
+      continue;
+    }
+
+    // Other errors should fail immediately
+    break;
+  }
+
+  // Finally check if we succeeded or report error
+  TORCH_CHECK(
+      result > 0,
+      "Failed to send fd after ",
+      retry,
+      " retries: ",
+      c10::utils::str_error(errno));
+}
+
+int IpcChannel::recv_fd() {
+  // Prepare buffer for regular message "fd"
+  // NOLINTNEXTLINE(*array*)
+  char buf[2];
+  memset(&buf, 0, sizeof(buf));
+  struct iovec io = {.iov_base = (void*)buf, .iov_len = sizeof(buf)};
+
+  // Prepare buffer for control message and zero it out
+  // NOLINTNEXTLINE(*array*)
+  char cbuf[CMSG_SPACE(sizeof(int))];
+  memset(cbuf, 0, sizeof(cbuf));
+
+  // Define socket address to receive on: family AF_UNIX means unix domain
+  // socket
+  struct sockaddr_un addr = {.sun_family = AF_UNIX};
+  std::copy(socket_name_.begin(), socket_name_.end(), addr.sun_path);
+
+  // Prepare message header
+  struct msghdr msg = {
+      .msg_name = (void*)&addr,
+      .msg_namelen = sizeof(struct sockaddr_un),
+      .msg_iov = &io,
+      .msg_iovlen = 1,
+      .msg_control = cbuf,
+      .msg_controllen = sizeof(cbuf)};
+
+  // Receive message on socket_
+  TORCH_CHECK(
+      recvmsg(socket_, &msg, 0) > 0,
+      "Failed to receive fd: ",
+      c10::utils::str_error(errno));
+
+  if (msg.msg_controllen == 0) {
+    return -1;
+  }
+
+  // Extract control message and validate its content
+  auto cmsg = CMSG_FIRSTHDR(&msg);
+  TORCH_CHECK(cmsg != nullptr);
+  TORCH_CHECK(cmsg->cmsg_len == CMSG_LEN(sizeof(int)));
+  TORCH_CHECK(cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS);
+  return *reinterpret_cast<int*>(CMSG_DATA(cmsg));
+}
+
+std::vector<int> IpcChannel::all_gather_fds(
+    int rank,
+    const std::vector<int>& pids,
+    int fd) {
+  int world_size = static_cast<int>(pids.size());
+  std::vector<int> fds(pids.size());
+  fds[rank] = fd;
+
+  int dst_rank = (rank + 1) % world_size;
+  for (int step = 1; step < world_size; ++step) {
+    int src_rank = (rank + world_size - step) % world_size;
+    send_fd(pids[dst_rank], fd);
+    fd = recv_fd();
+    fds[src_rank] = fd;
+  }
+  return fds;
+}
+
+int IpcChannel::broadcast_fds(
+    int rank,
+    int src_rank,
+    const std::vector<int>& pids,
+    int fd) {
+  int world_size = static_cast<int>(pids.size());
+
+  if (rank == src_rank) {
+    for (int dst_rank = 0; dst_rank < world_size; ++dst_rank) {
+      if (dst_rank == rank) {
+        continue;
+      }
+      send_fd(pids[dst_rank], fd);
+    }
+    return fd;
+  }
+  return recv_fd();
+}
+
+std::string IpcChannel::get_socket_name(int pid) {
+  const char* tmp_dir = "/tmp";
+  for (const char* env_var : {"TMPDIR", "TMP", "TEMP", "TEMPDIR"}) {
+    if (const char* path = getenv(env_var)) {
+      tmp_dir = path;
+      break;
+    }
+  }
+  std::ostringstream oss;
+  oss << tmp_dir << "/symm_mem-" << pid;
+  return oss.str();
+}
+
+} // namespace c10d::symmetric_memory

--- a/src/xccl/XPUSymmetricMemoryUtils.hpp
+++ b/src/xccl/XPUSymmetricMemoryUtils.hpp
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <torch/csrc/distributed/c10d/Store.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
+#include <xccl/XPUSymmetricMemoryTypes.hpp>
+
+#include <sys/socket.h>
+#include <sys/syscall.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <c10/util/error.h>
+
+#include <torch/csrc/distributed/c10d/Store.hpp>
+
+namespace c10d {
+namespace symmetric_memory {
+
+std::string getSymmMemBackendXPU();
+
+class IpcChannel {
+ public:
+  IpcChannel();
+  ~IpcChannel();
+
+  void send_fd(int dst_pid, int fd);
+  int recv_fd();
+
+  std::vector<int> all_gather_fds(
+      int rank,
+      const std::vector<int>& pids,
+      int fd);
+
+  int broadcast_fds(
+      int rank,
+      int src_rank,
+      const std::vector<int>& pids,
+      int fd);
+
+ private:
+  static std::string get_socket_name(int pid);
+
+  std::string socket_name_;
+  int socket_;
+};
+
+class StoreExchange {
+ public:
+  StoreExchange(const std::string& store_prefix)
+      : store_prefix_(store_prefix) {}
+
+  // Put template function in header file so that compiler can easily access it.
+  template <typename T>
+  std::vector<T> all_gather(
+      const c10::intrusive_ptr<c10d::Store>& store,
+      int rank,
+      int world_size,
+      T val) {
+    static_assert(std::is_trivially_copyable_v<T>);
+
+    std::vector<std::string> peer_keys;
+    peer_keys.reserve(world_size);
+    for (int r = 0; r < world_size; ++r) {
+      std::ostringstream oss;
+      oss << store_prefix_ << "/" << seq_id_ << "/" << r;
+      peer_keys.push_back(oss.str());
+    }
+    ++seq_id_;
+
+    {
+      std::vector<uint8_t> payload(
+          reinterpret_cast<uint8_t*>(&val),
+          reinterpret_cast<uint8_t*>(&val) + sizeof(T));
+      store->set(peer_keys[rank], payload);
+    }
+
+    std::vector<T> peer_vals;
+    peer_vals.reserve(world_size);
+    for (int r = 0; r < world_size; ++r) {
+      if (r == rank) {
+        peer_vals.push_back(val);
+        continue;
+      }
+      store->wait({peer_keys[r]});
+      auto payload = store->get(peer_keys[r]);
+      TORCH_CHECK(payload.size() == sizeof(T));
+      T peer_val{};
+      std::memcpy(&peer_val, payload.data(), sizeof(T));
+      peer_vals.push_back(peer_val);
+    }
+    return peer_vals;
+  }
+
+  void barrier(
+      const c10::intrusive_ptr<c10d::Store>& store,
+      int rank,
+      int world_size) {
+    // TODO: implement an efficient one?
+    all_gather(store, rank, world_size, 0);
+  }
+
+  // Variable-length byte all_gather (used to exchange SYCL IPC handles, whose
+  // serialized size is opaque and may differ from platform to platform).
+  std::vector<std::vector<uint8_t>> all_gather_bytes(
+      const c10::intrusive_ptr<c10d::Store>& store,
+      int rank,
+      int world_size,
+      const std::vector<uint8_t>& payload) {
+    std::vector<std::string> peer_keys;
+    peer_keys.reserve(world_size);
+    for (int r = 0; r < world_size; ++r) {
+      std::ostringstream oss;
+      oss << store_prefix_ << "/bytes/" << seq_id_ << "/" << r;
+      peer_keys.push_back(oss.str());
+    }
+    ++seq_id_;
+
+    store->set(peer_keys[rank], payload);
+
+    std::vector<std::vector<uint8_t>> peer_vals(world_size);
+    peer_vals[rank] = payload;
+    for (int r = 0; r < world_size; ++r) {
+      if (r == rank) {
+        continue;
+      }
+      store->wait({peer_keys[r]});
+      peer_vals[r] = store->get(peer_keys[r]);
+    }
+    return peer_vals;
+  }
+
+ private:
+  const std::string store_prefix_;
+  size_t seq_id_ = 0;
+};
+
+} // namespace symmetric_memory
+} // namespace c10d

--- a/test/xpu/distributed/test_c10d_xccl.py
+++ b/test/xpu/distributed/test_c10d_xccl.py
@@ -29,15 +29,19 @@ from unittest import mock
 import torch
 import torch._C._distributed_c10d
 import torch.distributed as c10d
-import torch.distributed._functional_collectives as _functional_collectives
-
-if not c10d.is_available() or not c10d.is_xccl_available():
-    print("c10d XCCL not available, skipping tests", file=sys.stderr)
-    sys.exit(0)
-
 import torch.distributed as dist
+import torch.distributed._functional_collectives as _functional_collectives
+import torch.distributed._symmetric_memory as symm_mem
+from torch._C._distributed_c10d import _SymmetricMemory
+from torch.distributed._symmetric_memory import (
+    _fused_all_gather_matmul_fallback,
+    _fused_matmul_reduce_scatter_fallback,
+)
 import torch.testing._internal.common_utils as common
-from torch.testing._internal.common_distributed import MultiProcessTestCase
+from torch.testing._internal.common_distributed import (
+    MultiProcContinuousTest,
+    MultiProcessTestCase,
+)
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_SANDCASTLE,
@@ -1348,14 +1352,159 @@ class XCCLTraceTest(XCCLTraceTestBase):
             self.assertTrue("duration_ms" not in t["entries"][0])
 
 
+# ------------------------------------------------------------------
+# XPU SymmetricMemory tests (SYCL IPC backend)
+# ------------------------------------------------------------------
+
+# Use the SYCL signal-pad kernel for barrier / put_signal / wait_signal.
+os.environ.setdefault("USE_SIGNAL_BARRIER", "1")
+# XPU does not support multicast.
+os.environ["TORCH_SYMM_MEM_DISABLE_MULTICAST"] = "1"
+
+device_type = "xpu"
+
+
+@instantiate_parametrized_tests
+class SymmetricMemoryTest(MultiProcContinuousTest):
+    """XPU SymmetricMemory tests (SYCL IPC backend)."""
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("xpu", self.rank)
+
+    def _init_process(self):
+        torch.xpu.set_device(self.device)
+        torch.manual_seed(42 + self.rank)
+
+    @requires_xccl()
+    @skip_if_lt_x_gpu(2)
+    def test_rendezvous_basic(self) -> None:
+        """Smoke-test the SYCL IPC rendezvous path: allocate → rendezvous →
+        write → barrier → read peer buffer."""
+        self._init_process()
+
+        numel = 1024
+        t = symm_mem.empty(numel, dtype=torch.float32, device=self.device)
+        hdl = symm_mem.rendezvous(t, group=dist.group.WORLD)
+
+        self.assertEqual(hdl.rank, self.rank)
+        self.assertEqual(hdl.world_size, self.world_size)
+        self.assertEqual(len(hdl.buffer_ptrs), self.world_size)
+
+        t.fill_(float(self.rank))
+        hdl.barrier()
+
+        for r in range(self.world_size):
+            buf = hdl.get_buffer(r, (numel,), torch.float32)
+            self.assertTrue(
+                buf.eq(float(r)).all().item(),
+                f"peer {r} buffer != {r} (seen from rank {self.rank})",
+            )
+
+    @requires_xccl()
+    @skip_if_lt_x_gpu(2)
+    def test_get_signal_pad(self) -> None:
+        """Verify that signal-pad views (dtype, numel, data_ptr) match the
+        handle's metadata, and that buffer writes do not corrupt the pad."""
+        self._init_process()
+
+        t = symm_mem.empty(1, device="xpu")
+        hdl = symm_mem.rendezvous(t, group=dist.group.WORLD)
+        peer = (self.rank + 1) % self.world_size
+
+        # Local pad pointer must match what the handle advertises.
+        local_pad = hdl.get_signal_pad(self.rank)
+        self.assertEqual(local_pad.data_ptr(), hdl.signal_pad_ptrs[hdl.rank])
+
+        # Default: uint32, signal_pad_size // 4 elements.
+        pad = hdl.get_signal_pad(peer)
+        self.assertEqual(pad.dtype, torch.uint32)
+        self.assertEqual(pad.numel(), hdl.signal_pad_size // 4)
+
+        # Sizes only.
+        pad = hdl.get_signal_pad(peer, (8, 8))
+        self.assertEqual(pad.dtype, torch.uint32)
+        self.assertEqual(pad.numel(), 64)
+
+        # dtype only.
+        pad = hdl.get_signal_pad(peer, dtype=torch.uint64)
+        self.assertEqual(pad.dtype, torch.uint64)
+        self.assertEqual(pad.numel(), hdl.signal_pad_size // 8)
+
+        # Sizes + dtype.
+        pad = hdl.get_signal_pad(peer, (8, 8), dtype=torch.uint64)
+        self.assertEqual(pad.dtype, torch.uint64)
+        self.assertEqual(pad.numel(), 64)
+
+        # Writes to buffer must not corrupt the signal pad.
+        t2 = symm_mem.empty(1, device="xpu")
+        hdl2 = symm_mem.rendezvous(t2, group=dist.group.WORLD)
+        local_pad2 = hdl2.get_signal_pad(self.rank)
+        local_pad2.fill_(42)
+        t2.fill_(0)
+        self.assertTrue(local_pad2.eq(42).all().item())
+
+    @requires_xccl()
+    @skip_if_lt_x_gpu(4)
+    def test_subgroup(self) -> None:
+        """Two disjoint subgroups rendezvous on the same tensor; each can
+        observe its peers correctly via the SYCL IPC mapping."""
+        self._init_process()
+
+        ranks = list(range(self.world_size))
+        subgroup_0 = dist.new_group(ranks[: len(ranks) // 2])
+        subgroup_1 = dist.new_group(ranks[len(ranks) // 2 :])
+
+        world = dist.group.WORLD
+        subgroup = subgroup_0 if world.rank() < world.size() // 2 else subgroup_1
+
+        t = symm_mem.empty(64, device="xpu")
+        sm_world = symm_mem.rendezvous(t, group=world)
+        sm_sub = symm_mem.rendezvous(t, group=subgroup)
+
+        self.assertEqual(sm_world.world_size, world.size())
+        self.assertEqual(sm_world.rank, world.rank())
+        self.assertEqual(sm_sub.world_size, world.size() // 2)
+        self.assertEqual(sm_sub.rank, world.rank() % subgroup.size())
+
+        t.fill_(world.rank())
+        sm_world.barrier()
+
+        peer = (world.rank() + 1) % world.size()
+        buf = sm_world.get_buffer(peer, (64,), torch.float32)
+        self.assertTrue(buf.eq(peer).all().item())
+
+        peer_sub = (subgroup.rank() + 1) % subgroup.size()
+        buf = sm_sub.get_buffer(peer_sub, (64,), torch.float32)
+        if world.rank() < world.size() // 2:
+            self.assertTrue(buf.eq(peer_sub).all().item())
+        else:
+            self.assertTrue(
+                buf.eq(peer_sub + world.size() // 2).all().item()
+            )
+
+    @requires_xccl()
+    @skip_if_lt_x_gpu(2)
+    def test_put_wait_signal(self) -> None:
+        """Verify put_signal / wait_signal over the SYCL IPC peer mapping."""
+        self._init_process()
+
+        t = symm_mem.empty(1, device="xpu")
+        hdl = symm_mem.rendezvous(t, group=dist.group.WORLD)
+
+        # Ring: each rank sends a signal to its right neighbor and waits for
+        # a signal from its left neighbor.
+        dst = (self.rank + 1) % self.world_size
+        src = (self.rank - 1) % self.world_size
+        hdl.put_signal(dst_rank=dst, channel=0, timeout_ms=10_000)
+        hdl.wait_signal(src_rank=src, channel=0, timeout_ms=10_000)
+
 instantiate_parametrized_tests(XCCLTraceTest)
 instantiate_parametrized_tests(ProcessGroupXCCLTest)
-
 
 class SetDeviceMethod(Enum):
     TORCH_XPU_SET = auto()  # torch.xpu.set_device
     COLLECTIVE_ARGUMENT = auto()  # broadcast_object_list(device=)
-
 
 if __name__ == "__main__":
     run_tests()

--- a/test/xpu/distributed/test_c10d_xccl.py
+++ b/test/xpu/distributed/test_c10d_xccl.py
@@ -32,11 +32,6 @@ import torch.distributed as c10d
 import torch.distributed as dist
 import torch.distributed._functional_collectives as _functional_collectives
 import torch.distributed._symmetric_memory as symm_mem
-from torch._C._distributed_c10d import _SymmetricMemory
-from torch.distributed._symmetric_memory import (
-    _fused_all_gather_matmul_fallback,
-    _fused_matmul_reduce_scatter_fallback,
-)
 import torch.testing._internal.common_utils as common
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
@@ -1479,9 +1474,7 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         if world.rank() < world.size() // 2:
             self.assertTrue(buf.eq(peer_sub).all().item())
         else:
-            self.assertTrue(
-                buf.eq(peer_sub + world.size() // 2).all().item()
-            )
+            self.assertTrue(buf.eq(peer_sub + world.size() // 2).all().item())
 
     @requires_xccl()
     @skip_if_lt_x_gpu(2)
@@ -1499,12 +1492,15 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         hdl.put_signal(dst_rank=dst, channel=0, timeout_ms=10_000)
         hdl.wait_signal(src_rank=src, channel=0, timeout_ms=10_000)
 
+
 instantiate_parametrized_tests(XCCLTraceTest)
 instantiate_parametrized_tests(ProcessGroupXCCLTest)
+
 
 class SetDeviceMethod(Enum):
     TORCH_XPU_SET = auto()  # torch.xpu.set_device
     COLLECTIVE_ARGUMENT = auto()  # broadcast_object_list(device=)
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Use SYCL `ext::oneapi::experimental::ipc_memory` API implement symmetric memory

Know issue(WA): sycl::atomic_ref not support on BMG platform, implemented `put/wait/barrier` using `atomic_fence` to guarantee semaphore ordering(USE_SIGNAL_BARRIER=1), but the system may still hang on BMG. As a fallback solution, the default path uses a oneCCL `allreduce` to submit an additional kernel, ensuring that all preceding kernels have completed execution.

Next step:
1. signal barrier as default and implement https://github.com/pytorch/pytorch/blob/944d779fe3a58a34c2d646d067d2925dcf18ff01/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.cuh#L60-L69 by using `__spirv_ReadClockKHR(1)`
2. Upstream torch symm frontend to support AsyncTP for XPU
3. Align cuda `SymmetricMemory` base class interface.
4. Add `ishmem` as new symm backend.
5. Refactor as `CUDAPeerAllocInfo` style.
6. More symm op like `one_shot_all_reduce_xpu` `two_shot_all_reduce_out`