### PR TITLE
fix: check full device (incl. index) in XPU fallback consistency check

### DIFF
--- a/src/ATen/native/xpu/XPUFallback.template
+++ b/src/ATen/native/xpu/XPUFallback.template
@@ -6,20 +6,21 @@ namespace at {
 static bool DEBUG_XPU_FALLBACK = false;
 
 /*
- * Verifies that all input tensors reside on the same device type.
+ * Verifies that all input tensors reside on the same device
+ * (including device index, e.g., xpu:0 vs xpu:1).
  * The first defined tensor establishes the reference device;
  * all subsequent tensors must match it.
- * Raises an error if a mismatch (e.g., CPU vs. XPU) is detected.
+ * Raises an error if a mismatch (e.g., CPU vs. XPU, or xpu:0 vs. xpu:1) is detected.
  */
 static void check_device_consistency(
     const torch::jit::Stack* stack,
     const c10::OperatorHandle& op) {
-  std::optional<c10::DeviceType> reference_device;
+  std::optional<c10::Device> reference_device;
 
   auto check_tensor = [&](const at::Tensor& t) {
     if (!t.defined()) return;
 
-    auto cur_device = t.device().type();
+    auto cur_device = t.device();
     if (!reference_device) {
       reference_device = cur_device;
       return;


### PR DESCRIPTION
## Root Cause

`check_device_consistency()` in `XPUFallback.template` compared only `DeviceType` (e.g., XPU) ignoring device index (e.g., 0 vs 1). When tensors were on `xpu:0` and `xpu:1`, the check passed because both are `DeviceType::XPU`. But subsequent `cpu_fallback()` triggered a different error message format (`device of crow_indices (=xpu:0) must match device of col_indices (=xpu:1)`) that did not match the test expectation (`Expected all tensors to be on the same device, but found at least two devices, xpu:0 and xpu:1!`).

## Fix

Compare full `c10::Device` (type + index) instead of just `DeviceType` in `check_device_consistency()`. Now `xpu:0` vs `xpu:1` correctly triggers the expected error message.

Change:
- `std::optional<c10::DeviceType> reference_device` → `std::optional<c10::Device> reference_device`
- `t.device().type()` → `t.device()`

## CUDA Reference

`aten/src/ATen/native/cuda/ValidateCompressedIndicesKernel.cu` — CUDA implements `_validate_compressed_sparse_indices` natively, so this issue does not affect CUDA.

## Reproducer

```python
import torch
crow = torch.tensor([0, 1], dtype=torch.int32, device="xpu:0")
col = torch.tensor([0], dtype=torch.int32, device="xpu:1")
val = torch.tensor([1.0], device="xpu:0")
torch._validate_compressed_sparse_indices(crow, col, val, (2, 1), torch.sparse_csr)
# Before: RuntimeError: device of crow_indices (=xpu:0) must match device of col_indices (=xpu:1)
# After:  RuntimeError: Expected all tensors to be on the same device, but found at least two devices, xpu:0 and xpu:1!
```

## Self-Review

- [x] fix_location_correct: `check_device_consistency` is the right place
- [x] cuda_semantics_matched: CUDA natively implements this op; device comparison semantics are the same
- [x] minimal_change: 3 lines changed (type, assignment, comment)
- [x] no_cuda_dependency: Pure c10 change, no CUDA-specific APIs
- [x] test_coverage: Covered by `test_sparse_csr_xpu.py::test_invalid_input`
- [x] no_unrelated_changes: Only `check_device_consistency` changed
- [x] no_perf_impact: Same number of comparisons, just more precise
- [x] clear_description: Title and body describe exact root cause and fix

Fixes: #2229