### PR TITLE
Skip test_leaky_relu_observed_output_xpu

### DIFF
--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -27,6 +27,11 @@ skip_dict = {
         "test_add_scalar_relu_xpu",
         # AssertionError: Tensor-likes are not close!
         "test_cat_nhwc_xpu",
+        # AssertionError: Quantized tensor-likes are not close!
+        # Rounding mismatch at quantization midpoint due to hypothesis
+        # derandomize seed difference from _xpu suffix.
+        # https://github.com/intel/torch-xpu-ops/issues/3482
+        "test_leaky_relu_observed_output_xpu",
         # QuantizedXPU is deprecated https://github.com/pytorch/pytorch/pull/173923
         "test_max_pool2d_cudnn_xpu",
         "test_qgelu_xpu",


### PR DESCRIPTION
Fixes: https://github.com/intel/torch-xpu-ops/issues/3482

Skipping test_leaky_relu_observed_output_xpu as it is a CPU test and failure is caused by the fact that CI is run with
```
hypothesis.settings.register_profile(
        "pytorch_ci",
        settings(
            derandomize=True,
            suppress_health_check=[hypothesis.HealthCheck.too_slow],
            database=None,
            max_examples=50,
            verbosity=hypothesis.Verbosity.normal))
```
`specifically derandomize=True` causes the seed used to be based on the test function hash: https://hypothesis.readthedocs.io/en/latest/reference/api.html#hypothesis.settings.derandomize
in our case the added _xpu causes the hash to change and we get an unlucky seed either way it is a CPU issue and once we are upstreamed it won't be a problem seeing as this test does not accept `device` as a a param.