### PR TITLE
Adapt SDPA diagnostics to OptionalRef

### DIFF
--- a/src/ATen/native/transformers/SDPUtils.cpp
+++ b/src/ATen/native/transformers/SDPUtils.cpp
@@ -16,6 +16,96 @@ namespace sdp {
 
 using c10::array_of;
 
+#ifdef TORCH_XPU_OPS_USE_SDPA_OPTIONALREF_DIAGNOSTICS
+bool check_all_tensors_on_device(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics) {
+  // Check that all tensors are on the GPU device
+  // This should be handled by the stub dispatch, but whe call
+  // can_use_*_attention directly from python we need to ensure that the tensors
+  // are on cuda
+  if (params.query.device().type() != at::DeviceType::XPU) {
+    report_failure(
+        diagnostics,
+        "All tensors need to be on cuda device. Got query on device: ",
+        params.query.device(),
+        ", key on device: ",
+        params.key.device(),
+        ", value on device: ",
+        params.value.device());
+    return false;
+  }
+  return true;
+}
+
+inline bool check_head_dim(
+    sdp_params const& params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics) {
+  if (params.query.sym_size(-1) > 512) {
+    report_failure(
+        diagnostics,
+        "Mem efficient attention on XPU requires head dimension to be no more than 512.");
+    return false;
+  }
+  return true;
+}
+
+bool can_use_mem_efficient_attention(
+    sdp::sdp_params params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics) {
+  //  Define gate functions that determine if a flash kernel can be ran
+  constexpr auto general_constraints =
+      array_of<bool (*)(sdp_params const&, c10::OptionalRef<SDPDiagnostics>)>(
+          sdp::check_runtime_disabled_mem_efficient,
+          check_all_tensors_on_device,
+          sdp::check_tensor_shapes,
+          check_head_dim);
+  for (auto& constraint : general_constraints) {
+    if (!constraint(params, diagnostics)) {
+      return false;
+    }
+  }
+
+  if (has_for_nested_inputs(params)) {
+    constexpr auto nested_constraints =
+        array_of<bool (*)(sdp_params const&, c10::OptionalRef<SDPDiagnostics>)>(
+            sdp::check_requires_grad_and_nested,
+            sdp::check_batch_size_nested,
+            sdp::check_for_seq_len_0_nested_tensor);
+    for (auto& constraint : nested_constraints) {
+      if (!constraint(params, diagnostics)) {
+        return false;
+      }
+    }
+  }
+
+  if (has_only_dense_inputs(params)) {
+    constexpr auto dense_constraints =
+        array_of<bool (*)(sdp_params const&, c10::OptionalRef<SDPDiagnostics>)>(
+            sdp::check_nonzero_sequence_lengths_dense,
+            sdp::check_last_dim_stride_equals_1_dense<
+                false /*ignore_singleton_dim=*/>,
+            sdp::check_batch_size_and_num_heads_dense<
+                false /*supports_grouped_query_attention=*/>);
+    for (auto& constraint : dense_constraints) {
+      if (!constraint(params, diagnostics)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+bool can_use_mem_efficient_attention(sdp::sdp_params params, bool debug) {
+  if (!debug) {
+    return can_use_mem_efficient_attention(
+        params, c10::OptionalRef<SDPDiagnostics>{});
+  }
+  SDPDiagnostics diagnostics(true);
+  return can_use_mem_efficient_attention(params, diagnostics);
+}
+#else
 bool check_all_tensors_on_device(sdp_params const& params, bool debug) {
   // Check that all tensors are on the GPU device
   // This should be handled by the stub dispatch, but whe call
@@ -87,5 +177,6 @@ bool can_use_mem_efficient_attention(sdp::sdp_params params, bool debug) {
 
   return true;
 }
+#endif
 
 } // namespace sdp

--- a/src/ATen/native/transformers/SDPUtils.h
+++ b/src/ATen/native/transformers/SDPUtils.h
@@ -14,6 +14,11 @@
 
 namespace sdp {
 
+#ifdef TORCH_XPU_OPS_USE_SDPA_OPTIONALREF_DIAGNOSTICS
+bool can_use_mem_efficient_attention(
+    sdp::sdp_params params,
+    c10::OptionalRef<SDPDiagnostics> diagnostics);
+#endif
 bool can_use_mem_efficient_attention(sdp::sdp_params params, bool debug);
 
 } // namespace sdp


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/pull/184307

PyTorch PR #184307 updates SDPA backend diagnostics to pass c10::OptionalRef<sdp::SDPDiagnostics> through backend constraint checks instead of bool debug flags. Stage the XPU mem-efficient SDPA helper behind TORCH_XPU_OPS_USE_SDPA_OPTIONALREF_DIAGNOSTICS so current PyTorch builds keep using the bool-debug path while the PyTorch PR can opt into the new diagnostics plumbing. The bool-debug wrapper remains available for compatibility.

Test: none (build compatibility fix for PyTorch PR #184307; validated both current PyTorch-main bool path and macro-enabled OptionalRef path with compile-only checks against local PyTorch checkouts)