### PR TITLE
[BE] Upgrade oneAPI XPU bundle to 2026.0.0

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -69,30 +69,31 @@ if [ -n "${ONEDNN_COMMIT:-}" ] && [ "${ONEDNN_COMMIT,,}" != "pinned" ]; then
 fi
 
 python -m pip install -r requirements.txt
-python -m pip install mkl-static==2025.2.0 mkl-include==2025.2.0
+python -m pip install mkl-static==2026.0.0 mkl-include==2026.0.0
 export USE_STATIC_MKL=1
 if [ "${XPU_ONEAPI_PATH}" == "" ];then
     export PYTORCH_EXTRA_INSTALL_REQUIREMENTS=" \
-        intel-cmplr-lib-rt==2025.3.2 | \
-        intel-cmplr-lib-ur==2025.3.2 | \
-        intel-cmplr-lic-rt==2025.3.2 | \
-        intel-sycl-rt==2025.3.2 | \
-        oneccl-devel==2021.17.2 | \
-        oneccl==2021.17.2 | \
-        impi-rt==2021.17.2 | \
-        onemkl-sycl-blas==2025.3.1 | \
-        onemkl-sycl-dft==2025.3.1 | \
-        onemkl-sycl-lapack==2025.3.1 | \
-        onemkl-sycl-rng==2025.3.1 | \
-        onemkl-sycl-sparse==2025.3.1 | \
-        dpcpp-cpp-rt==2025.3.2 | \
-        intel-opencl-rt==2025.3.2 | \
-        mkl==2025.3.1 | \
-        intel-openmp==2025.3.2 | \
-        tbb==2022.3.1 | \
-        tcmlib==1.4.1 | \
-        umf==1.0.3 | \
-        intel-pti==0.16.0
+        intel-cmplr-lib-rt==2026.0.0 | \
+        intel-cmplr-lib-ur==2026.0.0 | \
+        intel-cmplr-lic-rt==2026.0.0 | \
+        intel-sycl-rt==2026.0.0 | \
+        oneccl-devel==2022.0.0 | \
+        oneccl==2022.0.0 | \
+        impi-rt==2021.18.0 | \
+        onemkl-license==2026.0.0 | \
+        onemkl-sycl-blas==2026.0.0 | \
+        onemkl-sycl-dft==2026.0.0 | \
+        onemkl-sycl-lapack==2026.0.0 | \
+        onemkl-sycl-rng==2026.0.0 | \
+        onemkl-sycl-sparse==2026.0.0 | \
+        dpcpp-cpp-rt==2026.0.0 | \
+        intel-opencl-rt==2026.0.0 | \
+        mkl==2026.0.0 | \
+        intel-openmp==2026.0.0 | \
+        tbb==2023.0.0 | \
+        tcmlib==1.5.0 | \
+        umf==1.1.0 | \
+        intel-pti==0.17.0
     "
 fi
 

--- a/.github/scripts/install_xpu.bat
+++ b/.github/scripts/install_xpu.bat
@@ -3,9 +3,9 @@ REM Description: Install Intel Support Packages on Windows
 REM BKM reference: https://www.intel.com/content/www/us/en/developer/articles/tool/pytorch-prerequisites-for-intel-gpus.html
 
 set XPU_BUNDLE_PARENT_DIR=C:\Program Files (x86)\Intel\oneAPI
-set XPU_BUNDLE_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/24751ead-ddc5-4479-b9e6-f9fe2ff8b9f2/intel-deep-learning-essentials-2025.2.1.25_offline.exe
+set XPU_BUNDLE_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/e5a5ada1-6bce-45ed-ac6e-e3b79d7a847e/intel-deep-learning-essentials-2025.3.2.35_offline.exe
 set XPU_BUNDLE_PRODUCT_NAME=intel.oneapi.win.deep-learning-essentials.product
-set XPU_BUNDLE_VERSION=2025.2.1+20
+set XPU_BUNDLE_VERSION=2025.3.2+34
 set XPU_BUNDLE_INSTALLED=0
 set XPU_BUNDLE_UNINSTALL=0
 set XPU_EXTRA_URL=NULL
@@ -14,9 +14,9 @@ set XPU_EXTRA_VERSION=2025.0.1+1226
 set XPU_EXTRA_INSTALLED=0
 set XPU_EXTRA_UNINSTALL=0
 
-if not [%XPU_VERSION%]==[] if [%XPU_VERSION%]==[2025.3] (
-    set XPU_BUNDLE_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/e5a5ada1-6bce-45ed-ac6e-e3b79d7a847e/intel-deep-learning-essentials-2025.3.2.35_offline.exe
-    set XPU_BUNDLE_VERSION=2025.3.2+34
+if not [%XPU_VERSION%]==[] if [%XPU_VERSION%]==[2026.0] (
+    set XPU_BUNDLE_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/d2148e15-b3c4-4313-afa9-a2373318b0b5/intel-deep-learning-essentials-2026.0.0.613_offline.exe
+    set XPU_BUNDLE_VERSION=2026.0.0+611
 )
 
 :: Check if XPU bundle is target version or already installed

--- a/.github/workflows/_linux_build.yml
+++ b/.github/workflows/_linux_build.yml
@@ -90,7 +90,6 @@ jobs:
           bash oneapi.sh -a -s --eula accept --action remove || true
           rm -rf /opt/intel/oneapi
           bash oneapi.sh -a -s --eula accept --action install --install-dir /opt/intel/oneapi
-          echo "XPU_ONEAPI_PATH=/opt/intel/oneapi" >> "${GITHUB_ENV}"
           rm -f oneapi.sh
           source /opt/intel/oneapi/setvars.sh --force
           # verify oneAPI installation

--- a/.github/workflows/_linux_build.yml
+++ b/.github/workflows/_linux_build.yml
@@ -42,7 +42,6 @@ defaults:
     shell: bash -xe {0}
 env:
   DOCKER_REGISTRY_AUTH_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
-  ONEAPI_DLE_INSTALLER_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/8170208e-86db-4faa-a0d6-1ecf62699574/intel-deep-learning-essentials-2026.0.0.624_offline.sh
 
 jobs:
   build:
@@ -84,16 +83,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: torch-xpu-ops
-      - name: Install oneAPI 2026.0.0
-        run: |
-          wget -q -O oneapi.sh "${ONEAPI_DLE_INSTALLER_URL}"
-          bash oneapi.sh -a -s --eula accept --action remove || true
-          rm -rf /opt/intel/oneapi
-          bash oneapi.sh -a -s --eula accept --action install --install-dir /opt/intel/oneapi
-          rm -f oneapi.sh
-          source /opt/intel/oneapi/setvars.sh --force
-          # verify oneAPI installation
-          icpx --version
       - name: Snapshot open skipped issues at build start
         run: |
           touch known_issue_static.log issues_snapshot.log

--- a/.github/workflows/_linux_build.yml
+++ b/.github/workflows/_linux_build.yml
@@ -42,6 +42,7 @@ defaults:
     shell: bash -xe {0}
 env:
   DOCKER_REGISTRY_AUTH_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+  ONEAPI_DLE_INSTALLER_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/8170208e-86db-4faa-a0d6-1ecf62699574/intel-deep-learning-essentials-2026.0.0.624_offline.sh
 
 jobs:
   build:
@@ -83,6 +84,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: torch-xpu-ops
+      - name: Install oneAPI 2026.0.0
+        run: |
+          wget -q -O oneapi.sh "${ONEAPI_DLE_INSTALLER_URL}"
+          bash oneapi.sh -a -s --eula accept --action remove || true
+          rm -rf /opt/intel/oneapi
+          bash oneapi.sh -a -s --eula accept --action install --install-dir /opt/intel/oneapi
+          echo "XPU_ONEAPI_PATH=/opt/intel/oneapi" >> "${GITHUB_ENV}"
+          rm -f oneapi.sh
+          source /opt/intel/oneapi/setvars.sh --force
+          # verify oneAPI installation
+          icpx --version
       - name: Snapshot open skipped issues at build start
         run: |
           touch known_issue_static.log issues_snapshot.log

--- a/.github/workflows/_windows_build.yml
+++ b/.github/workflows/_windows_build.yml
@@ -26,32 +26,32 @@ on:
       xpu_version:
         required: false
         type: string
-        default: '2025.3'
+        default: '2026.0'
         description: XPU version
 
 permissions: read-all
 
 env: 
-    USE_XPU: 1
-    PYTORCH_EXTRA_INSTALL_REQUIREMENTS: >-
-      intel-cmplr-lib-rt==2025.3.2 | 
-      intel-cmplr-lib-ur==2025.3.2 | 
-      intel-cmplr-lic-rt==2025.3.2 | 
-      intel-sycl-rt==2025.3.2 | 
-      onemkl-license==2025.3.1 | 
-      onemkl-sycl-blas==2025.3.1 | 
-      onemkl-sycl-dft==2025.3.1 | 
-      onemkl-sycl-lapack==2025.3.1 | 
-      onemkl-sycl-rng==2025.3.1 | 
-      onemkl-sycl-sparse==2025.3.1 | 
-      dpcpp-cpp-rt==2025.3.2 | 
-      intel-opencl-rt==2025.3.2 | 
-      mkl==2025.3.1 | 
-      intel-openmp==2025.3.2 | 
-      tbb==2022.3.1 | 
-      tcmlib==1.4.1 | 
-      umf==1.0.3 | 
-      intel-pti==0.16.0
+  USE_XPU: 1
+  PYTORCH_EXTRA_INSTALL_REQUIREMENTS: >-
+    intel-cmplr-lib-rt==2026.0.0 |
+    intel-cmplr-lib-ur==2026.0.0 |
+    intel-cmplr-lic-rt==2026.0.0 |
+    intel-sycl-rt==2026.0.0 |
+    onemkl-license==2026.0.0 |
+    onemkl-sycl-blas==2026.0.0 |
+    onemkl-sycl-dft==2026.0.0 |
+    onemkl-sycl-lapack==2026.0.0 |
+    onemkl-sycl-rng==2026.0.0 |
+    onemkl-sycl-sparse==2026.0.0 |
+    dpcpp-cpp-rt==2026.0.0 |
+    intel-opencl-rt==2026.0.0 |
+    mkl==2026.0.0 |
+    intel-openmp==2026.0.0 |
+    tbb==2023.0.0 |
+    tcmlib==1.5.0 |
+    umf==1.1.0 |
+    intel-pti==0.17.0
 
 jobs:
   build:
@@ -175,7 +175,7 @@ jobs:
           cd ../pytorch
           python -m pip install -r requirements.txt
           python -m pip install cmake setuptools clang-format
-          python -m pip install mkl-static mkl-include
+          python -m pip install mkl-static==2026.0.0 mkl-include==2026.0.0
           set USE_STATIC_MKL=1
           copy "%CONDA_PREFIX%\Library\bin\libiomp*5md.dll" .\torch\lib
           copy "%CONDA_PREFIX%\Library\bin\uv.dll" .\torch\lib

--- a/.github/workflows/_windows_ut.yml
+++ b/.github/workflows/_windows_ut.yml
@@ -127,9 +127,6 @@ jobs:
           call "C:\ProgramData\miniforge3\Scripts\activate.bat"
           call conda activate windows_ut
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-          call "C:\Program Files (x86)\Intel\oneAPI\compiler\latest\env\vars.bat"
-          call "C:\Program Files (x86)\Intel\oneAPI\ocloc\latest\env\vars.bat"
-          call "C:\Program Files (x86)\Intel\oneAPI\pti\latest\env\vars.bat"
           
           for /r "%GITHUB_WORKSPACE%\wheel_artifact" %%f in (*.whl) do set "TORCH_WHL=%%f"
           python -m pip install "%TORCH_WHL%"
@@ -164,9 +161,6 @@ jobs:
         run: |
           call "C:\ProgramData\miniforge3\Scripts\activate.bat"
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-          call "C:\Program Files (x86)\Intel\oneAPI\compiler\latest\env\vars.bat"
-          call "C:\Program Files (x86)\Intel\oneAPI\ocloc\latest\env\vars.bat"
-          call "C:\Program Files (x86)\Intel\oneAPI\pti\latest\env\vars.bat"
           call conda activate windows_ut
           cd ../pytorch/third_party/torch-xpu-ops/test/xpu/
           python -m pytest test_cpp_extensions_aot_xpu.py -v --junit-xml=test_cpp_extensions_aot_xpu.xml

--- a/.github/workflows/_windows_ut.yml
+++ b/.github/workflows/_windows_ut.yml
@@ -26,8 +26,12 @@ on:
       runner:
         required: true
         type: string
-        default: 'Windows_CI'
         description: Runner label
+      xpu_version:
+        required: false
+        type: string
+        default: '2026.0'
+        description: XPU version
 
 permissions: read-all
 
@@ -47,6 +51,12 @@ jobs:
         with:
           pattern: Torch-XPU-Windows-Binary-${{ github.event.pull_request.number || github.sha }}-*
           path: ${{ github.workspace }}/wheel_artifact
+      - name: Install oneAPI (for UT runtime)
+        shell: cmd
+        run: |
+          set XPU_VERSION=${{ inputs.xpu_version }}
+          call .github\scripts\install_xpu.bat
+          if errorlevel 1 exit /b 1
       - name: Setup Python Environment
         shell: cmd
         run: |
@@ -126,8 +136,6 @@ jobs:
         run: |
           call "C:\ProgramData\miniforge3\Scripts\activate.bat"
           call conda activate windows_ut
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-          
           for /r "%GITHUB_WORKSPACE%\wheel_artifact" %%f in (*.whl) do set "TORCH_WHL=%%f"
           python -m pip install "%TORCH_WHL%"
           cd %GITHUB_WORKSPACE%\..\pytorch
@@ -161,6 +169,9 @@ jobs:
         run: |
           call "C:\ProgramData\miniforge3\Scripts\activate.bat"
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+          call "C:\Program Files (x86)\Intel\oneAPI\compiler\latest\env\vars.bat"
+          call "C:\Program Files (x86)\Intel\oneAPI\ocloc\latest\env\vars.bat"
+          call "C:\Program Files (x86)\Intel\oneAPI\pti\latest\env\vars.bat"
           call conda activate windows_ut
           cd ../pytorch/third_party/torch-xpu-ops/test/xpu/
           python -m pytest test_cpp_extensions_aot_xpu.py -v --junit-xml=test_cpp_extensions_aot_xpu.xml

--- a/.github/workflows/_windows_ut.yml
+++ b/.github/workflows/_windows_ut.yml
@@ -28,35 +28,8 @@ on:
         type: string
         default: 'Windows_CI'
         description: Runner label
-      xpu_version:
-        required: false
-        type: string
-        default: '2025.3'
-        description: XPU version
 
 permissions: read-all
-
-env: 
-    USE_XPU: 1
-    PYTORCH_EXTRA_INSTALL_REQUIREMENTS: >-
-      intel-cmplr-lib-rt==2025.3.2 | 
-      intel-cmplr-lib-ur==2025.3.2 | 
-      intel-cmplr-lic-rt==2025.3.2 | 
-      intel-sycl-rt==2025.3.2 | 
-      onemkl-license==2025.3.1 | 
-      onemkl-sycl-blas==2025.3.1 | 
-      onemkl-sycl-dft==2025.3.1 | 
-      onemkl-sycl-lapack==2025.3.1 | 
-      onemkl-sycl-rng==2025.3.1 | 
-      onemkl-sycl-sparse==2025.3.1 | 
-      dpcpp-cpp-rt==2025.3.2 | 
-      intel-opencl-rt==2025.3.2 | 
-      mkl==2025.3.1 | 
-      intel-openmp==2025.3.2 | 
-      tbb==2022.3.1 | 
-      tcmlib==1.4.1 | 
-      umf==1.0.3 | 
-      intel-pti==0.16.0
 
 jobs:
   ut_test:
@@ -74,12 +47,6 @@ jobs:
         with:
           pattern: Torch-XPU-Windows-Binary-${{ github.event.pull_request.number || github.sha }}-*
           path: ${{ github.workspace }}/wheel_artifact
-      - name: Install oneAPI (for UT runtime)
-        shell: cmd
-        run: |
-          set XPU_VERSION=${{ inputs.xpu_version }}
-          call .github\scripts\install_xpu.bat
-          if errorlevel 1 exit /b 1
       - name: Setup Python Environment
         shell: cmd
         run: |


### PR DESCRIPTION
## Summary
- upgrade Linux XPU package pins to the 2026.0.0 support stack
- upgrade Windows build package pins and installer defaults to 2026.0.0
- add Linux oneAPI 2026.0.0 offline installer setup in the build workflow
- pin Windows mkl-static and mkl-include to 2026.0.0

## Dependency
- depends on https://github.com/pytorch/pytorch/pull/182003

## Validation
- checked workflow/script diagnostics in the workspace
- validated edited workflow files report no errors