### PR TITLE
Restrict @copilot auto-comment to AI-generated PRs only

### DIFF
--- a/.github/workflows/_linux_ut.yml
+++ b/.github/workflows/_linux_ut.yml
@@ -260,7 +260,12 @@ jobs:
           path: ${{ github.workspace }}/ut_log
           overwrite: true
       - name: Comment on PR for new failures
-        if: ${{ ! cancelled() && github.event_name == 'pull_request' && steps.new-failures.outputs.has_new_failures == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: >-
+          ${{ ! cancelled() && github.event_name == 'pull_request'
+          && steps.new-failures.outputs.has_new_failures == 'true'
+          && github.event.pull_request.head.repo.full_name == github.repository
+          && (contains(github.event.pull_request.labels.*.name, 'ai_generated')
+              || github.event.pull_request.user.login == 'copilot[bot]') }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.MERGE_TOKEN }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -60,7 +60,9 @@ jobs:
       - name: Comment on lint failure
         if: >-
           ${{ (steps.lint-python.outcome == 'failure' || steps.lint-clang.outcome == 'failure')
-          && github.event.pull_request.head.repo.full_name == github.repository }}
+          && github.event.pull_request.head.repo.full_name == github.repository
+          && (contains(github.event.pull_request.labels.*.name, 'ai_generated')
+              || github.event.pull_request.user.login == 'copilot[bot]') }}
         env:
           GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary
- Restrict `@copilot` auto-comment steps in `pull.yml` (lint failure) and `_linux_ut.yml` (new UT failures) to only trigger when the PR has the `ai_generated` label or the PR author is `copilot[bot]`.
- This avoids unnecessary `@copilot` comment noise on human-authored PRs.