### PR TITLE
Implement XPU queue_push torchbind kernel

### DIFF
--- a/src/ATen/native/xpu/TorchScriptTesting.cpp
+++ b/src/ATen/native/xpu/TorchScriptTesting.cpp
@@ -1,0 +1,48 @@
+#include <ATen/core/class_type.h>
+#include <ATen/core/ivalue.h>
+#include <torch/library.h>
+
+namespace at::native::xpu {
+namespace {
+
+void queue_push_boxed(
+    const c10::OperatorHandle& op,
+    c10::DispatchKeySet ks,
+    c10::Stack* stack) {
+  (void)op;
+  (void)ks;
+
+  auto x = torch::jit::pop(*stack).toTensor();
+  auto tq = torch::jit::pop(*stack);
+
+  TORCH_CHECK(
+      tq.isObject(),
+      "Expected _TorchScriptTesting::queue_push first argument to be a TorchBind object");
+
+  auto class_type = tq.type()->cast<c10::ClassType>();
+  TORCH_CHECK(
+      class_type != nullptr,
+      "Expected _TorchScriptTesting::queue_push first argument to have ClassType");
+  TORCH_CHECK(
+      class_type->hasMethod("push"),
+      "Expected _TorchScriptTesting::queue_push object to implement method 'push'");
+
+  // Match CPU implementation in test_custom_class_registrations.cpp.
+  class_type->getMethod("push")({std::move(tq), x.clone()});
+}
+
+} // namespace
+
+TORCH_LIBRARY_IMPL(_TorchScriptTesting, XPU, m) {
+  m.impl(
+      "queue_push",
+      torch::CppFunction::makeFromBoxedFunction<&queue_push_boxed>());
+}
+
+TORCH_LIBRARY_IMPL(_TorchScriptTesting, AutocastXPU, m) {
+    m.impl(
+            "queue_push",
+            torch::CppFunction::makeFromBoxedFunction<&queue_push_boxed>());
+}
+
+} // namespace at::native::xpu

--- a/src/ATen/native/xpu/TorchScriptTesting.cpp
+++ b/src/ATen/native/xpu/TorchScriptTesting.cpp
@@ -40,9 +40,9 @@ TORCH_LIBRARY_IMPL(_TorchScriptTesting, XPU, m) {
 }
 
 TORCH_LIBRARY_IMPL(_TorchScriptTesting, AutocastXPU, m) {
-    m.impl(
-            "queue_push",
-            torch::CppFunction::makeFromBoxedFunction<&queue_push_boxed>());
+  m.impl(
+      "queue_push",
+      torch::CppFunction::makeFromBoxedFunction<&queue_push_boxed>());
 }
 
 } // namespace at::native::xpu

--- a/test/xpu/export/test_torchbind_xpu.py
+++ b/test/xpu/export/test_torchbind_xpu.py
@@ -38,7 +38,6 @@ from torch.testing._internal.torchbind_impls import (
     init_torchbind_implementations,
 )
 
-
 requires_cuda_or_xpu = unittest.skipIf(
     not (
         torch.cuda.is_available()

--- a/test/xpu/export/test_torchbind_xpu.py
+++ b/test/xpu/export/test_torchbind_xpu.py
@@ -13,6 +13,7 @@
 # Owner(s): ["module: intel"]
 
 import copy
+import unittest
 
 import torch
 import torch.utils._pytree as pytree
@@ -36,7 +37,15 @@ from torch.testing._internal.torchbind_impls import (
     _empty_tensor_queue,
     init_torchbind_implementations,
 )
-from torch.testing._internal.triton_utils import requires_gpu
+
+
+requires_cuda_or_xpu = unittest.skipIf(
+    not (
+        torch.cuda.is_available()
+        or (hasattr(torch, "xpu") and torch.xpu.is_available())
+    ),
+    "requires cuda or xpu",
+)
 
 
 def _assertEqualSkipScriptObject(test_case, exp, actual):
@@ -1573,7 +1582,7 @@ def forward(self, token, obj, x):
             self, f(_empty_tensor_queue(), x), opt_f(_empty_tensor_queue(), x)
         )
 
-    @requires_gpu
+    @requires_cuda_or_xpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("backend", ["eager", "aot_eager", "inductor"])
     def test_compile_obj_torchbind_op_with_autocast(self, backend, device):
@@ -1591,7 +1600,7 @@ def forward(self, token, obj, x):
             self, f(_empty_tensor_queue(), x), opt_f(_empty_tensor_queue(), x)
         )
 
-    @requires_gpu
+    @requires_cuda_or_xpu
     @parametrize("device", ["cpu", GPU_TYPE])
     def test_export_obj_torchbind_op_with_autocast(self, device):
         class Mod(torch.nn.Module):


### PR DESCRIPTION
Add a native boxed implementation for _TorchScriptTesting::queue_push on XPU
and register it for both XPU and AutocastXPU dispatch keys.

The new kernel mirrors CPU behavior by validating the TorchBind object,
calling its push method, and cloning the tensor before enqueueing to avoid
aliasing issues.

Fix  for: [#3477](https://github.com/intel/torch-xpu-ops/issues/3477)