### PR TITLE
Remove _flash_attention_forward from XPU CPU fallback list

### DIFF
--- a/src/ATen/native/xpu/XPUFallback.template
+++ b/src/ATen/native/xpu/XPUFallback.template
@@ -230,7 +230,6 @@ TORCH_LIBRARY_IMPL(aten, XPU, m) {
     "cholesky_inverse.out",
     "_cholesky_solve_helper",
     "_efficient_attention_forward",
-    "_flash_attention_forward",
     "geqrf",
     "geqrf.a",
     "hash_tensor.out",


### PR DESCRIPTION
Fixes:
https://github.com/intel/torch-xpu-ops/issues/3698

This PR removes aten::_flash_attention_forward from the XPU CPU fallback list, so XPU can use the native XPU implementation path instead of being forced to CPU fallback.

This change is required together with PyTorch PR https://github.com/pytorch/pytorch/pull/184724, which adds/enables the XPU-side flash attention forward implementation.