### PR TITLE
Refine layer_norm_wg_size_select to reduce tree-reduce barrier cost

### DIFF
--- a/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
@@ -589,11 +589,34 @@ struct VectorizedLayerNormKernelFunctor
   sycl_local_acc_t<T_ACC> buf_;
 };
 
-int64_t layer_norm_wg_size_select(int64_t max_wg_size, int n) {
-  while (max_wg_size > n && max_wg_size > SIMD) {
-    max_wg_size >>= 1;
+int64_t layer_norm_wg_size_select(
+    const int64_t max_wg_size,
+    const int64_t M,
+    const int n) {
+  if (n > max_wg_size)
+    return max_wg_size;
+
+  int64_t wg_size = max_wg_size;
+  while (wg_size > n && wg_size > SIMD) {
+    wg_size >>= 1;
   }
-  return max_wg_size;
+
+  // To reduce the barrier overhead during tree-reduce
+  // with 4 subgroups per workgroup
+  constexpr int64_t threads_per_wg = 4;
+  constexpr int64_t preferred_wg_size = SIMD * threads_per_wg;
+
+  // keep wg_size when n is not large enough to utilize preferred_wg_size
+  if (wg_size <= preferred_wg_size)
+    return wg_size;
+
+  // (XeCore count * EUs per XeCore) * HW threads per EU
+  int64_t total_hw_threads = syclGpuEuCount() * syclGpuHWThreadsPerEU();
+  // Only use preferred_wg_size when less than 50% HW threads would be left idle
+  if (M * threads_per_wg > total_hw_threads / 2)
+    return preferred_wg_size;
+
+  return wg_size;
 }
 
 template <typename T, typename T_ACC, bool rms_norm>
@@ -609,7 +632,7 @@ void launch_vectorized_layer_norm_kernel(
     T_ACC* rstd_data) {
   using KernelClass = VectorizedLayerNormKernelFunctor<T, T_ACC, rms_norm>;
   auto wg_size = layer_norm_wg_size_select(
-      syclMaxWorkGroupSize<KernelClass>(), N / vec_size);
+      syclMaxWorkGroupSize<KernelClass>(), M, N / vec_size);
   KernelClass kfn(
       N,
       eps,


### PR DESCRIPTION
This PR is to set `wg_size` to `SIMD * 4` for the vectorized LayerNorm kernel when `N / vec_size <= max_wg_size`.

Motivation:
The vectorized LayerNorm kernel uses inter-subgroup tree-reduce in `compute_stats()`. For `wg_size = 1024` and `SIMD32`, the inter-subgroup tree-reduce requires 5 rounds of reduction, where average subgroup utilization during reduce is only ~19.4%. Stall sampling shows barrier synchronization as the biggest stall source (~31.5% of all stalls). Reducing `wg_size / SIMD` to 4 cuts tree-reduce to 2 rounds, eliminates ~92% of sync stalls.

Why gate on `N / vec_size <= max_wg_size`:
Smaller `wg_size / SIMD` means more concurrent workgroups per Xe-core, increasing L1 pressure. The Pass2 of vectorized LayerNorm kernel has a working set that scales as: 
`W_L1 = concurrent_WGs × N × element_size`
when `W_L1` exceeds the LSC cache capacity, Pass2 degrades from L1 hit to L3 hit, offsetting the barrier reduction gains. Since LSC cache sizes vary across platforms and cannot be queried at runtime, we need a platform-independent guard.