### PR TITLE
Refactor Memory.h and simply the API

### DIFF
--- a/src/ATen/native/sparse/xpu/sycl/SparseCsrTensorAddKernels.cpp
+++ b/src/ATen/native/sparse/xpu/sycl/SparseCsrTensorAddKernels.cpp
@@ -23,6 +23,7 @@
 
 #include <ATen/native/sparse/xpu/sycl/SparseCsrTensorAddKernels.h>
 #include <ATen/native/xpu/sycl/pstl/PSTLFunctions.h>
+#include <comm/Memory.h>
 #include <comm/SYCLContext.h>
 
 namespace at::native::xpu {
@@ -238,13 +239,12 @@ void add_out_sparse_csr_kernel(
               // Set out_crow[0] = 0 on device (no wait needed; the
               // in-order queue guarantees this completes before the
               // memcpy below).
-              getCurrentSYCLQueue().memset(out_crow_ptr, 0, sizeof(index_t));
+              ::xpu::sycl::memsetAsync(out_crow_ptr, 0, sizeof(index_t));
 
               // Read total nnz from device.
               index_t total_nnz = 0;
-              getCurrentSYCLQueue()
-                  .memcpy(&total_nnz, out_crow_ptr + nrows, sizeof(index_t))
-                  .wait();
+              ::xpu::sycl::memcpyAndSync(
+                  &total_nnz, out_crow_ptr + nrows, sizeof(index_t));
 
               // Allocate output col_indices and values.
               Tensor out_col = at::empty({total_nnz}, dense_idx_options);

--- a/src/ATen/native/xpu/Copy.cpp
+++ b/src/ATen/native/xpu/Copy.cpp
@@ -26,11 +26,12 @@ DISABLE_SYCL_DEPRECATED_WARNING_BEGIN
 DISABLE_SYCL_DEPRECATED_WARNING_END
 #include <c10/core/ScalarType.h>
 #include <c10/xpu/XPUStream.h>
-#include <comm/xpu_aten.h>
 
 #include <ATen/native/xpu/sycl/CopyKernel.h>
 #include <ATen/native/xpu/sycl/UnaryComplexKernels.h>
+#include <comm/Memory.h>
 #include <comm/SYCLContext.h>
+#include <comm/xpu_aten.h>
 
 #include <ATen/ops/empty_like.h>
 
@@ -86,18 +87,17 @@ void memcpyAsync(
   if (dst_device != src_device) {
     TORCH_INTERNAL_ASSERT(p2p_enabled == true);
   }
-  auto q = copy_stream.queue();
-  auto dev = q.get_device();
+  auto dev = copy_stream.queue().get_device();
   if (dev.ext_oneapi_architecture_is(
           sycl::ext::oneapi::experimental::architecture::intel_gpu_pvc) ||
       dev.ext_oneapi_architecture_is(
           sycl::ext::oneapi::experimental::architecture::intel_gpu_pvc_vg)) {
     copy_kernel(iter);
   } else {
-    auto dst = (char*)iter.data_ptr(0);
-    auto src = (char*)iter.data_ptr(1);
+    auto dst = iter.data_ptr(0);
+    auto src = iter.data_ptr(1);
     size_t size = iter.numel() * iter.element_size(0);
-    q.copy(src, dst, size);
+    ::xpu::sycl::memcpyAsync(dst, src, size);
   }
 }
 
@@ -259,47 +259,16 @@ void _copy_xpu(TensorIterator& iter, bool non_blocking) {
   void* src = iter.data_ptr(1);
   int64_t nbytes = iter.numel() * iter.element_size(0);
 
-  auto q = getCurrentSYCLQueue();
   if (non_blocking) {
     if (copy_kind == _H2D_) {
-      if (at::detail::getXPUHooks().isPinnedPtr(src)) {
-        q.memcpy(dst, src, nbytes);
-        at::getHostAllocator(at::kXPU)->record_event(
-            const_cast<void*>(src),
-            iter.tensor(1).storage().data_ptr().get_context(),
-            at::xpu::getCurrentXPUStream());
-      } else {
-        // Using stage memory for async copy to avoid incorrect
-        // free of src host memory before async H2D copy. E.g. memory allocated
-        // by CPU tensor factory won't be cached in CPU allocator. When host
-        // memory is freed with CPU tensor dtor at the end of train main loop,
-        // but the corresponding H2D copy might not have been executed yet.
-        auto stage_mem_dptr = at::getHostAllocator(at::kXPU)->allocate(nbytes);
-        void* stage_mem = stage_mem_dptr.get();
-        if (!stage_mem) {
-          throw std::runtime_error(
-              "Fail to allocate host memory from XPU HostAllocator");
-        }
-
-        std::memcpy(stage_mem, src, nbytes);
-        q.memcpy(dst, stage_mem, nbytes);
-        at::getHostAllocator(at::kXPU)->record_event(
-            const_cast<void*>(stage_mem),
-            stage_mem_dptr.get_context(),
-            at::xpu::getCurrentXPUStream());
-      }
+      ::xpu::sycl::memcpyHostToDeviceAsync(
+          dst, src, nbytes, iter.tensor(1).storage().data_ptr().get_context());
     } else {
-      q.memcpy(dst, src, nbytes);
-      if (at::detail::getXPUHooks().isPinnedPtr(dst)) {
-        at::getHostAllocator(at::kXPU)->record_event(
-            const_cast<void*>(dst),
-            iter.tensor(0).storage().data_ptr().get_context(),
-            at::xpu::getCurrentXPUStream());
-      }
+      ::xpu::sycl::memcpyDeviceToHostAsync(
+          dst, src, nbytes, iter.tensor(0).storage().data_ptr().get_context());
     }
   } else {
-    auto e = q.memcpy(dst, src, nbytes);
-    e.wait();
+    ::xpu::sycl::memcpyAndSync(dst, src, nbytes);
   }
 
   if (iter.tensor(0).is_conj() != iter.tensor(1).is_conj()) {

--- a/src/ATen/native/xpu/XPUScalar.cpp
+++ b/src/ATen/native/xpu/XPUScalar.cpp
@@ -13,7 +13,7 @@
 #include <ATen/EmptyTensor.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/ops/_local_scalar_dense_native.h>
-#include <comm/SYCLContext.h>
+#include <comm/Memory.h>
 
 namespace at::native {
 
@@ -34,12 +34,8 @@ Scalar _local_scalar_dense_xpu(const Tensor& self) {
             std::nullopt /* memory format */
         );
 
-        auto queue = at::xpu::getCurrentSYCLQueue();
-        auto e = queue.memcpy(
-            (void*)value.const_data_ptr<scalar_t>(),
-            self.const_data_ptr<scalar_t>(),
-            sizeof(scalar_t));
-        e.wait();
+        ::xpu::sycl::memcpyAndSync(
+            value.mutable_data_ptr(), self.const_data_ptr(), sizeof(scalar_t));
 
         r = Scalar(*value.const_data_ptr<scalar_t>());
       }),

--- a/src/ATen/native/xpu/sycl/ForeachReduceKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ForeachReduceKernels.cpp
@@ -16,6 +16,7 @@
 #include <ATen/native/xpu/sycl/ForeachFunctors.h>
 #include <ATen/native/xpu/sycl/MultiTensorApply.h>
 #include <ATen/xpu/EmptyTensor.h>
+#include <comm/Memory.h>
 #include <comm/SYCLContext.h>
 
 #include <ATen/native/xpu/sycl/ForeachReduceKernels.h>
@@ -246,7 +247,6 @@ std::vector<Tensor> foreach_norm_kernel(
   for (int i = 0; i < ntensors; i++) {
     ret_per_tensor.push_back(at::empty({}, res_option));
   }
-  auto& q = getCurrentSYCLQueue();
   auto addressStorage =
       at::empty({(int)(sizeof(void*) * ntensors)}, options.dtype(at::kByte));
   auto metaAddress = static_cast<void**>(addressStorage.mutable_data_ptr());
@@ -305,15 +305,11 @@ std::vector<Tensor> foreach_norm_kernel(
                   tensor_list_addresses[i] =
                       ret_per_tensor[i].mutable_data_ptr<out_t>();
                 }
-                q.memcpy(
+                ::xpu::sycl::memcpyPinnedHostToDeviceAsync(
                     (void*)metaAddress,
                     (void*)tensor_list_addresses,
-                    sizeof(void*) * ntensors);
-
-                at::getHostAllocator(at::kXPU)->record_event(
-                    (void*)tensor_list_addresses,
-                    tensor_list_addresses_dptr.get_context(),
-                    at::xpu::getCurrentXPUStream());
+                    sizeof(void*) * ntensors,
+                    tensor_list_addresses_dptr.get_context());
                 if (simd == SIMD32) {
                   launch_lpnorm_chunk_reduce_kernel<
                       out_t,
@@ -374,15 +370,11 @@ std::vector<Tensor> foreach_norm_kernel(
                   tensor_list_addresses[i] =
                       ret_per_tensor[i].mutable_data_ptr<out_t>();
                 }
-                q.memcpy(
+                ::xpu::sycl::memcpyPinnedHostToDeviceAsync(
                     (void*)metaAddress,
                     (void*)tensor_list_addresses,
-                    sizeof(void*) * ntensors);
-
-                at::getHostAllocator(at::kXPU)->record_event(
-                    (void*)tensor_list_addresses,
-                    tensor_list_addresses_dptr.get_context(),
-                    at::xpu::getCurrentXPUStream());
+                    sizeof(void*) * ntensors,
+                    tensor_list_addresses_dptr.get_context());
                 if (simd == SIMD32) {
                   launch_lpnorm_chunk_reduce_kernel<
                       out_t,
@@ -443,15 +435,11 @@ std::vector<Tensor> foreach_norm_kernel(
                   tensor_list_addresses[i] =
                       ret_per_tensor[i].mutable_data_ptr<out_t>();
                 }
-                q.memcpy(
+                ::xpu::sycl::memcpyPinnedHostToDeviceAsync(
                     (void*)metaAddress,
                     (void*)tensor_list_addresses,
-                    sizeof(void*) * ntensors);
-
-                at::getHostAllocator(at::kXPU)->record_event(
-                    (void*)tensor_list_addresses,
-                    tensor_list_addresses_dptr.get_context(),
-                    at::xpu::getCurrentXPUStream());
+                    sizeof(void*) * ntensors,
+                    tensor_list_addresses_dptr.get_context());
                 if (simd == SIMD32) {
                   launch_lpnorm_chunk_reduce_kernel<
                       out_t,
@@ -632,7 +620,6 @@ std::vector<Tensor> foreach_max_kernel(TensorList tensors) {
   const size_t ntensors = tensors.size();
   const auto options = tensors[0].options();
 
-  auto& q = getCurrentSYCLQueue();
   // Store output address for each tensor
   auto addressStorage =
       at::empty({(int)(sizeof(void*) * ntensors)}, options.dtype(at::kByte));
@@ -708,20 +695,16 @@ std::vector<Tensor> foreach_max_kernel(TensorList tensors) {
         for (int i = 0; i < ntensors; i++) {
           tensor_list_addresses[i] = vec_res[i].mutable_data_ptr<scalar_t>();
         }
-        q.memcpy(
+        ::xpu::sycl::memcpyPinnedHostToDeviceAsync(
             (void*)metaAddress,
             (void*)tensor_list_addresses,
-            sizeof(void*) * ntensors);
-        at::getHostAllocator(at::kXPU)->record_event(
-            (void*)tensor_list_addresses,
-            tensor_list_addresses_dptr.get_context(),
-            at::xpu::getCurrentXPUStream());
-        q.memcpy(
-            (void*)metaCounts, (void*)thunk_counts, sizeof(int) * ntensors);
-        at::getHostAllocator(at::kXPU)->record_event(
+            sizeof(void*) * ntensors,
+            tensor_list_addresses_dptr.get_context());
+        ::xpu::sycl::memcpyPinnedHostToDeviceAsync(
+            (void*)metaCounts,
             (void*)thunk_counts,
-            thunk_counts_dptr.get_context(),
-            at::xpu::getCurrentXPUStream());
+            sizeof(int) * ntensors,
+            thunk_counts_dptr.get_context());
         if (simd == SIMD32) {
           launch_lpmax_chunk_reduce_kernel<scalar_t, SIMD32>(
               output_per_tensor.mutable_data_ptr<scalar_t>(),

--- a/src/ATen/native/xpu/sycl/MultiTensorApply.h
+++ b/src/ATen/native/xpu/sycl/MultiTensorApply.h
@@ -16,6 +16,7 @@
 #include <ATen/native/xpu/sycl/GroupReduceUtils.h>
 #include <ATen/native/xpu/sycl/MemoryAccessUtils.h>
 #include <ATen/xpu/CachingHostAllocator.h>
+#include <comm/Memory.h>
 #include <comm/SYCLContext.h>
 
 namespace at::native::xpu {
@@ -165,7 +166,6 @@ void multi_tensor_apply(
       "Number of tensor lists has to match he depth");
   size_t n_tensors = tensor_lists[0].size();
 
-  auto& q = getCurrentSYCLQueue();
   int64_t simd = syclMaxSubGroupSize();
   int64_t kChunkSize = multi_tensor_apply_kernel_get_chunk_size(simd);
 
@@ -194,14 +194,11 @@ void multi_tensor_apply(
     }
   }
 
-  q.memcpy(
+  ::xpu::sycl::memcpyPinnedHostToDeviceAsync(
       (void*)metaAddressInput,
       (void*)tlAddress,
-      sizeof(TLMetaForAddressScalar<scalar_vals_t, depth>) * n_tensors);
-  at::getHostAllocator(at::kXPU)->record_event(
-      (void*)tlAddress,
-      tlAddress_dptr.get_context(),
-      at::xpu::getCurrentXPUStream());
+      sizeof(TLMetaForAddressScalar<scalar_vals_t, depth>) * n_tensors,
+      tlAddress_dptr.get_context());
 
   auto wgMetaStorage = at::empty(
       {(int)(sizeof(TLMetaForWG) * totalWG)},
@@ -227,11 +224,11 @@ void multi_tensor_apply(
       posWG == totalWG,
       "Work group index dose not equal to the allocated memory size, segment fault might occur");
 
-  q.memcpy((void*)metaWGInput, (void*)tlWGMeta, sizeof(TLMetaForWG) * totalWG);
-  at::getHostAllocator(at::kXPU)->record_event(
+  ::xpu::sycl::memcpyPinnedHostToDeviceAsync(
+      (void*)metaWGInput,
       (void*)tlWGMeta,
-      tlWGMeta_dptr.get_context(),
-      at::xpu::getCurrentXPUStream());
+      sizeof(TLMetaForWG) * totalWG,
+      tlWGMeta_dptr.get_context());
 
   launch_multi_tensor_apply_kernel<false>(
       metaAddressInput, metaWGInput, callable, totalWG, args...);
@@ -247,7 +244,6 @@ void multi_tensor_apply(
       "Number of tensor lists has to match he depth");
   size_t n_tensors = tensor_lists[0].size();
 
-  auto& q = getCurrentSYCLQueue();
   int64_t simd = syclMaxSubGroupSize();
   int64_t kChunkSize = multi_tensor_apply_kernel_get_chunk_size(simd);
 
@@ -273,14 +269,11 @@ void multi_tensor_apply(
     }
   }
 
-  q.memcpy(
+  ::xpu::sycl::memcpyPinnedHostToDeviceAsync(
       (void*)metaAddressInput,
       (void*)tlAddress,
-      sizeof(TLMetaForAddress<depth>) * n_tensors);
-  at::getHostAllocator(at::kXPU)->record_event(
-      (void*)tlAddress,
-      tlAddress_dptr.get_context(),
-      at::xpu::getCurrentXPUStream());
+      sizeof(TLMetaForAddress<depth>) * n_tensors,
+      tlAddress_dptr.get_context());
 
   auto wgMetaStorage = at::empty(
       {(int)(sizeof(TLMetaForWG) * totalWG)},
@@ -306,11 +299,11 @@ void multi_tensor_apply(
       posWG == totalWG,
       "Work group index dose not equal to the allocated memory size, segment fault might occur");
 
-  q.memcpy((void*)metaWGInput, (void*)tlWGMeta, sizeof(TLMetaForWG) * totalWG);
-  at::getHostAllocator(at::kXPU)->record_event(
+  ::xpu::sycl::memcpyPinnedHostToDeviceAsync(
+      (void*)metaWGInput,
       (void*)tlWGMeta,
-      tlWGMeta_dptr.get_context(),
-      at::xpu::getCurrentXPUStream());
+      sizeof(TLMetaForWG) * totalWG,
+      tlWGMeta_dptr.get_context());
 
   launch_multi_tensor_apply_kernel<false>(
       metaAddressInput, metaWGInput, callable, totalWG, args...);
@@ -327,7 +320,6 @@ void multi_tensor_apply_for_fused_optimizer(
       "Number of tensor lists has to match the depth");
   const auto n_tensors = tensor_lists[0].size();
 
-  auto& q = getCurrentSYCLQueue();
   int64_t kChunkSize = multi_tensor_apply_fused_kernel_get_chunk_size();
 
   auto addressStorage = at::empty(
@@ -353,14 +345,11 @@ void multi_tensor_apply_for_fused_optimizer(
     }
   }
 
-  q.memcpy(
+  ::xpu::sycl::memcpyPinnedHostToDeviceAsync(
       (void*)metaFusedAddressInput,
       (void*)tlAddress,
-      sizeof(TLFusedMetaForAddress<depth>) * n_tensors);
-  at::getHostAllocator(at::kXPU)->record_event(
-      (void*)tlAddress,
-      tlAddress_dptr.get_context(),
-      at::xpu::getCurrentXPUStream());
+      sizeof(TLFusedMetaForAddress<depth>) * n_tensors,
+      tlAddress_dptr.get_context());
 
   auto wgMetaStorage = at::empty(
       {(int)(sizeof(TLMetaForWG) * totalWG)},
@@ -386,11 +375,11 @@ void multi_tensor_apply_for_fused_optimizer(
       posWG == totalWG,
       "Work group index dose not equal to the allocated memory size, segment fault might occur");
 
-  q.memcpy((void*)metaWGInput, (void*)tlWGMeta, sizeof(TLMetaForWG) * totalWG);
-  at::getHostAllocator(at::kXPU)->record_event(
+  ::xpu::sycl::memcpyPinnedHostToDeviceAsync(
+      (void*)metaWGInput,
       (void*)tlWGMeta,
-      tlWGMeta_dptr.get_context(),
-      at::xpu::getCurrentXPUStream());
+      sizeof(TLMetaForWG) * totalWG,
+      tlWGMeta_dptr.get_context());
 
   launch_multi_tensor_apply_kernel<true>(
       metaFusedAddressInput, metaWGInput, callable, totalWG, args...);

--- a/src/ATen/native/xpu/sycl/ResizeKernel.cpp
+++ b/src/ATen/native/xpu/sycl/ResizeKernel.cpp
@@ -14,7 +14,7 @@
 
 #include <ATen/EmptyTensor.h>
 #include <ATen/native/ResizeCommon.h>
-#include <comm/SYCLContext.h>
+#include <comm/Memory.h>
 
 #include <ATen/native/xpu/sycl/ResizeKernel.h>
 
@@ -40,8 +40,7 @@ void resize_bytes_xpu(StorageImpl* storage, size_t size_bytes) {
   if (storage->data_ptr()) {
     at::globalContext().lazyInitDevice(c10::DeviceType::XPU);
 
-    auto q = at::xpu::getCurrentSYCLQueue();
-    q.memcpy(
+    ::xpu::sycl::memcpyAsync(
         data.get(), storage->data(), std::min(storage->nbytes(), size_bytes));
   }
 

--- a/src/comm/Memory.h
+++ b/src/comm/Memory.h
@@ -8,6 +8,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#pragma once
 #include <ATen/core/Tensor.h>
 #include <ATen/detail/XPUHooksInterface.h>
 #include <ATen/native/xpu/sycl/MemoryAccessUtils.h>
@@ -17,159 +18,114 @@
 
 using namespace at;
 
-namespace xpu {
-namespace sycl {
+namespace xpu::sycl {
 
-inline void memcpyHostToDevice(
-    void* dst,
-    const void* src,
-    size_t n_bytes,
-    bool async,
-    const void* hctx,
-    bool is_pinned = false) {
-  if (n_bytes == 0)
+// Synchronous memory copy via the current SYCL queue. At least one of `dst` or
+// `src` must reside on the device. If both are on device, they must be on the
+// same device or P2P access must be enabled.
+inline void memcpyAndSync(void* dst, const void* src, size_t n_bytes) {
+  if (n_bytes == 0) {
     return;
-
-  auto& queue = getCurrentSYCLQueue();
-  auto e = queue.memcpy(dst, src, n_bytes);
-  if (!async) {
-    e.wait();
-  } else {
-    if (is_pinned) {
-      at::getHostAllocator(at::kXPU)->record_event(
-          const_cast<void*>(src),
-          const_cast<void*>(hctx),
-          at::xpu::getCurrentXPUStream());
-    } else {
-      // Using stage memory for async copy to avoid incorrect free of src host
-      // memory before async H2D copy. E.g. memory allocated by CPU tensor
-      // factory won't be cached in CPU allocator. When host memory is freed
-      // with CPU tensor dtor at the end of train main loop, but the
-      // corresponding H2D copy might not have been executed yet.
-      auto stage_mem_dptr = at::getHostAllocator(at::kXPU)->allocate(n_bytes);
-      void* stage_mem = stage_mem_dptr.get();
-      TORCH_CHECK(
-          stage_mem, "Fail to allocate host memory from XPU HostAllocator");
-      std::memcpy(stage_mem, src, n_bytes);
-      e = queue.memcpy(dst, stage_mem, n_bytes);
-      at::getHostAllocator(at::kXPU)->record_event(
-          stage_mem,
-          stage_mem_dptr.get_context(),
-          at::xpu::getCurrentXPUStream());
-    }
   }
+
+  getCurrentXPUStream().queue().memcpy(dst, src, n_bytes).wait();
 }
 
-inline void memcpyDeviceToHost(
+// Asynchronous memory copy via the current SYCL queue. Same placement rules
+// as memcpyAndSync. Caller must ensure both `dst` and `src` remain valid until
+// the copy completes (e.g. via event recording or pinned memory).
+inline void memcpyAsync(void* dst, const void* src, size_t n_bytes) {
+  if (n_bytes == 0) {
+    return;
+  }
+
+  getCurrentXPUStream().queue().memcpy(dst, src, n_bytes);
+}
+
+// Asynchronous host-to-device copy for known-pinned `src`. Skips the
+// `isPinnedPtr` check, suitable for hot paths where `src` is guaranteed pinned.
+// `hctx` is the allocator context associated with `src`, used for event
+// recording.
+inline void memcpyPinnedHostToDeviceAsync(
     void* dst,
     const void* src,
     size_t n_bytes,
-    bool async,
-    const void* hctx,
-    bool is_pinned = false) {
-  if (n_bytes == 0)
+    const void* hctx) {
+  if (n_bytes == 0) {
     return;
+  }
 
-  auto& queue = getCurrentSYCLQueue();
-  auto e = queue.memcpy(dst, src, n_bytes);
+  memcpyAsync(dst, src, n_bytes);
+  at::getHostAllocator(at::kXPU)->record_event(
+      const_cast<void*>(src), const_cast<void*>(hctx), getCurrentXPUStream());
+}
 
-  if (!async) {
-    e.wait();
-  } else if (is_pinned) {
+// Asynchronous host-to-device memory copy. For pinned `src`, record an event
+// directly. For non-pinned `src`, stage through pinned memory so the source
+// remains valid until the copy completes. `hctx` is the allocator context
+// associated with `src`, used for event recording.
+inline void memcpyHostToDeviceAsync(
+    void* dst,
+    const void* src,
+    size_t n_bytes,
+    const void* hctx) {
+  if (n_bytes == 0) {
+    return;
+  }
+
+  if (at::detail::getXPUHooks().isPinnedPtr(src)) {
+    memcpyPinnedHostToDeviceAsync(dst, src, n_bytes, hctx);
+    return;
+  }
+
+  // Non-pinned host memory may be freed before the async copy completes.
+  // Stage through pinned memory to keep the data alive.
+  auto stage_mem_dptr = at::getHostAllocator(at::kXPU)->allocate(n_bytes);
+  void* stage_mem = stage_mem_dptr.get();
+  TORCH_CHECK(stage_mem, "Fail to allocate host memory from XPU HostAllocator");
+  std::memcpy(stage_mem, src, n_bytes);
+  memcpyAsync(dst, stage_mem, n_bytes);
+  at::getHostAllocator(at::kXPU)->record_event(
+      stage_mem, stage_mem_dptr.get_context(), getCurrentXPUStream());
+}
+
+// Asynchronous device-to-host memory copy. Record an event if `dst` is pinned
+// to ensure the memory won't be reused until the copy completes. `hctx` is the
+// allocator context associated with `dst`, used for event recording.
+inline void memcpyDeviceToHostAsync(
+    void* dst,
+    const void* src,
+    size_t n_bytes,
+    const void* hctx) {
+  if (n_bytes == 0) {
+    return;
+  }
+
+  memcpyAsync(dst, src, n_bytes);
+  if (at::detail::getXPUHooks().isPinnedPtr(dst)) {
     at::getHostAllocator(at::kXPU)->record_event(
-        dst, const_cast<void*>(hctx), at::xpu::getCurrentXPUStream());
+        dst, const_cast<void*>(hctx), getCurrentXPUStream());
   }
 }
 
-inline void memcpyDeviceToDevice(
-    void* dst,
-    const void* src,
-    size_t n_bytes,
-    bool async) {
-  if (n_bytes == 0)
+// Synchronous memset on device memory. Caller must ensure `dst` is on the
+// current device.
+inline void memsetAndSync(void* dst, int value, size_t n_bytes) {
+  if (n_bytes == 0) {
     return;
-
-  auto& queue = getCurrentSYCLQueue();
-  auto e = queue.memcpy(dst, src, n_bytes);
-
-  if (!async) {
-    e.wait();
   }
+
+  getCurrentXPUStream().queue().memset(dst, value, n_bytes).wait();
 }
 
-inline void memsetDevice(void* dst, int value, size_t n_bytes, bool async) {
-  auto& queue = getCurrentSYCLQueue();
-  auto e = queue.memset(dst, value, n_bytes);
-
-  if (!async) {
-    e.wait();
+// Asynchronous memset on device memory. Caller must ensure `dst` is on the
+// current device.
+inline void memsetAsync(void* dst, int value, size_t n_bytes) {
+  if (n_bytes == 0) {
+    return;
   }
+
+  getCurrentXPUStream().queue().memset(dst, value, n_bytes);
 }
 
-enum syclMemcpyKind { HostToDevice, DeviceToHost, DeviceToDevice };
-
-inline void syclMemcpy(
-    void* dst,
-    const void* src,
-    size_t n_bytes,
-    syclMemcpyKind kind) {
-  switch (kind) {
-    case HostToDevice:
-      // for synchronous copy, the context of host data pointer is unnecessary.
-      memcpyHostToDevice(dst, src, n_bytes, false, nullptr);
-      break;
-    case DeviceToHost:
-      // for synchronous copy, the context of host data pointer is unnecessary.
-      memcpyDeviceToHost(dst, src, n_bytes, false, nullptr);
-      break;
-    case DeviceToDevice:
-      memcpyDeviceToDevice(dst, src, n_bytes, false);
-      break;
-    default:
-      TORCH_CHECK(false, "Unknown sycl memory kind");
-  }
-}
-
-inline void syclMemcpyAsync(
-    void* dst,
-    const void* src,
-    size_t n_bytes,
-    syclMemcpyKind kind,
-    const void* hctx = nullptr) {
-  switch (kind) {
-    case HostToDevice:
-      memcpyHostToDevice(
-          dst,
-          src,
-          n_bytes,
-          true,
-          hctx,
-          at::detail::getXPUHooks().isPinnedPtr(src));
-      break;
-    case DeviceToHost:
-      memcpyDeviceToHost(
-          dst,
-          src,
-          n_bytes,
-          true,
-          hctx,
-          at::detail::getXPUHooks().isPinnedPtr(dst));
-      break;
-    case DeviceToDevice:
-      memcpyDeviceToDevice(dst, src, n_bytes, true);
-      break;
-    default:
-      TORCH_CHECK(false, "Unknown sycl memory kind");
-  }
-}
-
-inline void syclMemset(void* data, int value, size_t n_bytes) {
-  memsetDevice(data, value, n_bytes, false);
-}
-
-inline void syclMemsetAsync(void* data, int value, size_t n_bytes) {
-  memsetDevice(data, value, n_bytes, true);
-}
-
-} // namespace sycl
-} // namespace xpu
+} // namespace xpu::sycl


### PR DESCRIPTION
# Motivation
Centralize XPU memory copy/set operations into `comm/Memory.h`. Previously, all APIs defined in `Memory.h` are unused. I refactor it and provide some APIs could be reused in code.

Raw `queue.memcpy()` + `record_event()` pairs were scattered across the codebase, making it easy to miss event recording and leak pinned memory lifetime bugs. This introduces a small set of typed wrappers that encapsulate the correct synchronization and event-recording protocol, then migrates all callsites to use them.

Benefits: correctness by construction (can't forget record_event), single point of maintenance.