### PR TITLE
Fix typo and remove CUDA test

### DIFF
--- a/test/xpu/functorch/test_control_flow_xpu.py
+++ b/test/xpu/functorch/test_control_flow_xpu.py
@@ -2982,7 +2982,7 @@ class GraphModule(torch.nn.Module):
         "triton requires CUDA with SM>=7.0",
     )
     @parametrize("layers", [1, 2, 3])
-    @parametrize("device", ["cpu", "cuda", "xpu"])
+    @parametrize("device", ["cpu", "xpu"])
     @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_scan_multiple_layers_gradient(self, layers, device):
         import torch.nn as nn
@@ -5386,7 +5386,7 @@ class GraphModule(torch.nn.Module):
 
         with self.assertRaisesRegex(
             AssertionError,
-            "Combin_fn received wrong number of arguments.*",
+            "Combine_fn received wrong number of arguments.*",
         ):
             associative_scan(fct_wrong_pytree, inp, 0, combine_mode="generic")
 


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/2767

Failing because test tries to run on CUDA backend
```
op_ut,third_party.torch-xpu-ops.test.xpu.functorch.test_control_flow_xpu.TestControlFlow,test_scan_multiple_layers_gradient_layers_1_device_cuda
op_ut,third_party.torch-xpu-ops.test.xpu.functorch.test_control_flow_xpu.TestControlFlow,test_scan_multiple_layers_gradient_layers_2_device_cuda
op_ut,third_party.torch-xpu-ops.test.xpu.functorch.test_control_flow_xpu.TestControlFlow,test_scan_multiple_layers_gradient_layers_3_device_cuda
```

Fails because of typo in assert
```
op_ut,third_party.torch-xpu-ops.test.xpu.functorch.test_control_flow_xpu.AssociativeScanTests,test_associative_scan_wrong_pytree
```