### PR TITLE
Add proper skip for device with index :0 suffix

### DIFF
--- a/test/xpu/test_custom_ops_xpu.py
+++ b/test/xpu/test_custom_ops_xpu.py
@@ -457,7 +457,7 @@ class TestCustomOpTesting(CustomOpTestCaseBase):
             torch.library.opcheck(op.op, args, kwargs)
 
     def test_opcheck_fails_basic(self, device):
-        if device == "xpu":
+        if device.startswith("xpu"):
             self.skipTest(
                 "XPU schema error path for this opcheck case is not supported"
             )


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/3630
Test should be skipped but as device is `xpu:0` and it doesn't satisfy `== "xpu"` condition