### PR TITLE
Fix maxpool2d backward accuracy with acc_type

### DIFF
--- a/src/ATen/native/xpu/sycl/DilatedMaxPool2d.cpp
+++ b/src/ATen/native/xpu/sycl/DilatedMaxPool2d.cpp
@@ -416,7 +416,11 @@ struct MaxPool2dBackwardKernelFunctor {
   BatchKernelConfig cfg_;
 };
 
-template <typename scalar_t, bool is_channels_last, typename index_t = int>
+template <
+    typename scalar_t,
+    typename accscalar_t,
+    bool is_channels_last,
+    typename index_t = int>
 struct MaxPool2dBackwardDeterministicKernelFunctor {
   void operator()(sycl::nd_item<2> item) const {
     auto desc = cfg_.get_item_desc(item);
@@ -441,14 +445,14 @@ struct MaxPool2dBackwardDeterministicKernelFunctor {
         int pwstart =
             p_start(inputW, pad_w_, kernel_w_, dilation_w_, stride_w_);
         int pwend = p_end(inputW, pad_w_, gradOutputSizeW_, stride_w_);
-        scalar_t grad = 0;
+        accscalar_t grad = accscalar_t(0);
         if constexpr (is_channels_last) {
           index_t offset = batch * out_n_stride_ + plane;
           for (int ph = phstart; ph < phend; ++ph) {
             for (int pw = pwstart; pw < pwend; ++pw) {
               if (indices_[offset + (ph * gradOutputSizeW_ + pw) * numPlane_] ==
                   input_hw_index) {
-                grad += static_cast<scalar_t>(
+                grad += static_cast<accscalar_t>(
                     gradOutput_
                         [offset + (ph * gradOutputSizeW_ + pw) * numPlane_]);
               }
@@ -460,13 +464,13 @@ struct MaxPool2dBackwardDeterministicKernelFunctor {
             for (int pw = pwstart; pw < pwend; ++pw) {
               if (indices_[offset + ph * gradOutputSizeW_ + pw] ==
                   input_hw_index) {
-                grad += static_cast<scalar_t>(
+                grad += static_cast<accscalar_t>(
                     gradOutput_[offset + ph * gradOutputSizeW_ + pw]);
               }
             }
           }
         }
-        gradInput_[inputIndex] = grad;
+        gradInput_[inputIndex] = static_cast<scalar_t>(grad);
       }
     } while (cfg_.next(item, desc));
   }
@@ -543,6 +547,7 @@ struct MaxPool2dBackwardDeterministicKernelFunctor {
 
 template <
     typename scalar_t,
+    typename accscalar_t,
     typename vec_t,
     int vec_size,
     typename index_t = int>
@@ -566,10 +571,10 @@ struct MaxPool2dBackwardChannelLastVec {
       int phend = p_end(inputH, pad_h_, gradOutputSizeH_, stride_h_);
       int pwstart = p_start(inputW, pad_w_, kernel_w_, dilation_w_, stride_w_);
       int pwend = p_end(inputW, pad_w_, gradOutputSizeW_, stride_w_);
-      vec_t grad_vec;
+      accscalar_t grad_acc[vec_size];
 #pragma unroll
       for (int i = 0; i < vec_size; i++) {
-        grad_vec[i] = 0;
+        grad_acc[i] = accscalar_t(0);
       }
 
       int offset = batch * out_n_stride_ / vec_size + plane;
@@ -582,13 +587,17 @@ struct MaxPool2dBackwardChannelLastVec {
 #pragma unroll
           for (int i = 0; i < vec_size; i++) {
             if (indices_[load_offset * vec_size + i] == input_hw_index) {
-              grad_vec[i] = static_cast<scalar_t>(grad_vec[i]) +
-                  static_cast<scalar_t>(gout_val_vec[i]);
+              grad_acc[i] += static_cast<accscalar_t>(gout_val_vec[i]);
             }
           }
         }
       }
 
+      vec_t grad_vec;
+#pragma unroll
+      for (int i = 0; i < vec_size; i++) {
+        grad_vec[i] = static_cast<scalar_t>(grad_acc[i]);
+      }
       gradInput_[inputIndex] = grad_vec;
     }
   }
@@ -890,30 +899,35 @@ void launch_max_pool2d_kernel(
     dilation_h,                                                                \
     dilation_w)                                                                \
   {                                                                            \
+    using accscalar_t = at::acc_type_device<scalar_t, kXPU>;                   \
     using vec_t = memory::aligned_vector<scalar_t, vec_size>;                  \
     const vec_t* grad_output_vec = reinterpret_cast<const vec_t*>(gradOutput); \
     vec_t* grad_input_vec = reinterpret_cast<vec_t*>(gradInput);               \
-    auto kfn =                                                                 \
-        MaxPool2dBackwardChannelLastVec<scalar_t, vec_t, vec_size, index_t>(   \
-            grad_input_vec,                                                    \
-            grad_output_vec,                                                   \
-            indices,                                                           \
-            numPlane,                                                          \
-            gradInputSizeH,                                                    \
-            gradInputSizeW,                                                    \
-            gradOutputSizeH,                                                   \
-            gradOutputSizeW,                                                   \
-            gradInputSize,                                                     \
-            out_n_stride,                                                      \
-            in_n_stride,                                                       \
-            kernel_h,                                                          \
-            kernel_w,                                                          \
-            stride_h,                                                          \
-            stride_w,                                                          \
-            pad_h,                                                             \
-            pad_w,                                                             \
-            dilation_h,                                                        \
-            dilation_w);                                                       \
+    auto kfn = MaxPool2dBackwardChannelLastVec<                                \
+        scalar_t,                                                              \
+        accscalar_t,                                                           \
+        vec_t,                                                                 \
+        vec_size,                                                              \
+        index_t>(                                                              \
+        grad_input_vec,                                                        \
+        grad_output_vec,                                                       \
+        indices,                                                               \
+        numPlane,                                                              \
+        gradInputSizeH,                                                        \
+        gradInputSizeW,                                                        \
+        gradOutputSizeH,                                                       \
+        gradOutputSizeW,                                                       \
+        gradInputSize,                                                         \
+        out_n_stride,                                                          \
+        in_n_stride,                                                           \
+        kernel_h,                                                              \
+        kernel_w,                                                              \
+        stride_h,                                                              \
+        stride_w,                                                              \
+        pad_h,                                                                 \
+        pad_w,                                                                 \
+        dilation_h,                                                            \
+        dilation_w);                                                           \
     sycl_kernel_submit(num_wg* wg_size, wg_size, queue, kfn);                  \
   }
 
@@ -1064,8 +1078,10 @@ void launch_max_pool2d_backward_kernel(
         break;
     };
   }
+  using accscalar_t = at::acc_type_device<scalar_t, kXPU>;
   using KernelClass = MaxPool2dBackwardDeterministicKernelFunctor<
       scalar_t,
+      accscalar_t,
       is_channels_last,
       index_t>;
   BatchKernelConfig cfg = BatchKernelConfig::make_config<KernelClass>(

--- a/test/regressions/test_max_pool2d_bwd.py
+++ b/test/regressions/test_max_pool2d_bwd.py
@@ -1,0 +1,47 @@
+# Copyright 2020-2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Owner(s): ["module: intel"]
+import torch
+from torch.testing._internal.common_utils import TestCase
+
+aten = torch.ops.aten
+
+
+class TestMaxPool2dBwd(TestCase):
+    def test_max_pool2d_bwd_fp16(self):
+        # Regression test: verify correctness under float16 (lowp) inputs.
+        # The large window size (13x13) causes window_size > 25, so the lowering
+        # falls back to the aten kernel rather than generating a Triton kernel.
+        # Reference is computed in float32 (upcast), then downcast to float16 for
+        # comparison, matching the behavior of check_model with reference_in_float=True.
+        def fn(a, b, c):
+            return aten.max_pool2d_with_indices_backward(
+                a, b, [13, 13], [1, 1], [2, 2], [1, 1], False, c
+            )
+
+        x_fp16 = torch.randn([2, 64, 20, 20], dtype=torch.half, device="xpu")
+        result, indices = aten.max_pool2d_with_indices(
+            x_fp16,
+            [13, 13],
+            [1, 1],
+            2,
+            1,
+            False,
+        )
+        grad_output_fp16 = torch.randn_like(result)
+
+        # fp32 reference
+        x_fp32 = x_fp16.float()
+        grad_output_fp32 = grad_output_fp16.float()
+        expected_fp32 = fn(grad_output_fp32, x_fp32, indices)
+        expected = expected_fp32.half()
+
+        actual = fn(grad_output_fp16, x_fp16, indices)
+
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
# Motivation
Fix https://github.com/pytorch/pytorch/issues/184539
The reason is that XPU doesn't use fp32 as an acc type for fp16. 