### PR TITLE
[SYCLTLA] Enable dropout for FlashAttention

### DIFF
--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_epilogue.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_epilogue.h
@@ -91,9 +91,11 @@ class FMHAFwdEpilogue {
   using TiledCopyO =
       conditional_t<is_void_v<TiledCopyO_>, DefaultTiledCopyO, TiledCopyO_>;
 
-  // Stateless design -- no arguments or parameters.
-  struct Arguments {};
-  struct Params {};
+  struct Arguments {
+    float rp_dropout;
+  };
+
+  using Params = Arguments;
 
   // Shared memory storage
   // Note sum/max tiles are padded to 16 elements, due to limitations in CuTe
@@ -115,13 +117,14 @@ class FMHAFwdEpilogue {
       SharedStorageNone>;
 
  private:
+  Params params;
   SharedStorage& shared;
 
  public:
   static constexpr Params to_underlying_arguments(
       Arguments const& args,
       void* /* workspace */) {
-    return {};
+    return args;
   }
 
   CUTLASS_HOST_DEVICE static bool can_implement(Arguments const&) {
@@ -129,7 +132,8 @@ class FMHAFwdEpilogue {
   }
 
   CUTLASS_HOST_DEVICE
-  FMHAFwdEpilogue(Params const&, SharedStorage& shared_) : shared(shared_) {}
+  FMHAFwdEpilogue(Params const& params_, SharedStorage& shared_)
+      : params(params_), shared(shared_) {}
 
   template <typename QVCoord>
   CUTLASS_DEVICE void operator()(
@@ -141,7 +145,8 @@ class FMHAFwdEpilogue {
       int thr_id, // Work-item ID
       float* pLSE, // Global LSE Ptr
       const std::tuple<int, int, int, int, int, int, int>&
-          metadata_for_lse // Metadata for LSE to calculate offset
+          metadata_for_lse, // Metadata for LSE to calculate offset
+      bool is_dropout // Whether dropout is enabled
   ) {
     using namespace cute;
     using ElementA = typename FragA::element_type;
@@ -162,6 +167,8 @@ class FMHAFwdEpilogue {
     CUTLASS_PRAGMA_UNROLL
     for (int i = 0; i < rA.size(); i++) {
       rA(i) *= broadcast<0>(rA_sum, rA, i);
+      if (is_dropout)
+        rA(i) *= params.rp_dropout;
       if (std::isnan(rA(i))) {
         rA(i) =
             0; // Handle the -nan when the whole sequence is completely masked

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_mainloop.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_mainloop.h
@@ -20,6 +20,8 @@
 
 #include <flash_attention_v2/collective/fmha_fusion.hpp>
 
+#include <sycltla/dropout.h>
+
 namespace cutlass::fmha {
 
 template <int Stages>
@@ -142,7 +144,18 @@ struct FMHAFwdMainloop<
 
   // User-facing arguments
   struct Arguments {
+    // Softmax scale factor.
     ElementS const scale;
+    // Random state for dropout.
+    at::PhiloxXpuState philox_args;
+    // Pointer to the RNG seed and offset.
+    uint64_t* rng_seed;
+    uint64_t* rng_offset;
+    // The dropout probability (probability of keeping an activation).
+    float p_dropout;
+    uint16_t p_dropout_in_uint16_t;
+    // Storing dropout mask for debug accuracy.
+    float* p_ptr;
   };
 
   // Kernel-facing parameters
@@ -164,7 +177,14 @@ struct FMHAFwdMainloop<
       void* /* workspace */) {
     constexpr double kLog2e = 1.4426950408889634074; // log_2(e)
     ElementS val = args.scale * static_cast<ElementS>(kLog2e);
-    return Params{val};
+    return Params{
+        val,
+        args.philox_args,
+        args.rng_seed,
+        args.rng_offset,
+        args.p_dropout,
+        args.p_dropout_in_uint16_t,
+        args.p_ptr};
   }
 
   CUTLASS_HOST_DEVICE static bool can_implement(Arguments const&) {
@@ -188,8 +208,12 @@ struct FMHAFwdMainloop<
       int seq_len_qo,
       int seq_len_kv,
       int l_coord,
+      // For LSE
       int& tile_row_idx,
-      const int& rows_of_maxima) {
+      const int& rows_of_maxima,
+      // For dropout
+      bool is_dropout,
+      FLASH_NAMESPACE::Dropout& dropout) {
     using namespace sycl::ext::oneapi::this_work_item;
 
     // Short dimension names:
@@ -367,6 +391,47 @@ struct FMHAFwdMainloop<
       /* Apply softmax and scaling (tA rescaling fused into GEMM2 VTile loop) */
       auto rescale = softmax(K == blk_k0, tSrS, tA_max, tA_sum);
 
+      /* Apply Dropout on S
+       *
+       * The Philox PRNG produces 4x uint32 per call, reinterpretable as
+       * 8x uint16 — exactly enough for the 8 elements each lane holds in
+       * one m8×n16 MMA atomic block (subgroup_size = 16).
+       *
+       * To guarantee identical dropout masks in forward and backward
+       * regardless of TiledMMA tile size or subgroup layout, we treat
+       * the m8×n16 mma atomic block as the fundamental unit of dropout:
+       *
+       *   Philox(seed,
+       *          offset  = f(batch_id, head_id, lane_id),
+       *          subseq  = f(block_row_id, block_col_id))
+       *
+       * where block_row/col_id is the atomic block's position in the
+       * global S matrix.  Because both forward and backward use the
+       * same XE_DPAS m8×n16 atomic block, each lane owns the same 8 elements
+       * within a given atomic block, so the generated mask matches.
+       */
+      static_assert(size<0>(typename TiledMMAQK::AtomShape_MNK{}) == 8);
+      int block_row_id = get<0>(cS_thread(0)) / 8;
+      int block_col_id = get<1>(cS_thread(0)) / intel::sg_size;
+      if (params.p_ptr != nullptr) {
+        // Store the S matrix for debug purposes.
+        auto rP_drop = make_fragment_like(tSrS);
+        cute::copy(tSrS, rP_drop);
+        dropout.template apply_dropout</*encode_dropout_in_sign_bit=*/true>(
+            rP_drop, block_row_id, block_col_id);
+        float* p_ptr = params.p_ptr;
+        for (int i = 0; i < rP_drop.size(); ++i) {
+          auto row_idx = get<0>(cS_thread(i));
+          auto col_idx = get<1>(cS_thread(i));
+          int idx = row_idx * seq_len_kv + col_idx;
+          p_ptr[idx] = rP_drop(i);
+        }
+      }
+
+      if (is_dropout) {
+        dropout.apply_dropout(tSrS, block_row_id, block_col_id);
+      }
+
       reorder(tSrS, tArP);
 
       /* Apply softmax and scaling (tA rescaling fused into GEMM2 VTile loop) */
@@ -377,7 +442,7 @@ struct FMHAFwdMainloop<
         if (K != blk_k0) {
           CUTLASS_PRAGMA_UNROLL
           for (int i = 0; i < tArA.size() / VTiles; i++)
-            tArA(_,_,_,VV)(i) *= broadcast<0>(rescale, tArA, i);
+            tArA(_, _, _, VV)(i) *= broadcast<0>(rescale, tArA, i);
         }
         cute::gemm(mma_pv, tArP, tArV, tArA(_, _, _, VV));
       }
@@ -426,7 +491,7 @@ struct FMHAFwdMainloop<
       bool first_block, // First softmax block?
       FragS& tS, // Softmax src/dst block
       FragSRow& tS_max, // Softmax row-wise max accumulator
-      FragSRow& tS_sum  // Softmax row-wise sum accumulator
+      FragSRow& tS_sum // Softmax row-wise sum accumulator
   ) {
     /* Compute row-wise maxima for this block */
     auto tS_bmax = reduce<1>(tS, sycl::maximum{});

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_mainloop.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_mainloop.h
@@ -423,8 +423,10 @@ struct FMHAFwdMainloop<
         for (int i = 0; i < rP_drop.size(); ++i) {
           auto row_idx = get<0>(cS_thread(i));
           auto col_idx = get<1>(cS_thread(i));
-          int idx = row_idx * seq_len_kv + col_idx;
-          p_ptr[idx] = rP_drop(i);
+          if (row_idx < seq_len_qo && col_idx < seq_len_kv) {
+            int idx = row_idx * seq_len_kv + col_idx;
+            p_ptr[idx] = rP_drop(i);
+          }
         }
       }
 

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_mainloop.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_mainloop.h
@@ -364,15 +364,21 @@ struct FMHAFwdMainloop<
         }
       }
 
-      /* Apply softmax and scaling */
-      softmax(K == blk_k0, tSrS, tA_max, tA_sum, tArA);
+      /* Apply softmax and scaling (tA rescaling fused into GEMM2 VTile loop) */
+      auto rescale = softmax(K == blk_k0, tSrS, tA_max, tA_sum);
+
       reorder(tSrS, tArP);
 
-      /* GEMM 2: A += P * V, split in v dimension */
+      /* Apply softmax and scaling (tA rescaling fused into GEMM2 VTile loop) */
       CUTLASS_PRAGMA_UNROLL
       for (int VV = 0; VV < VTiles; VV++) {
         copy(copy_v, tVgV(_, _, _, VV, K), tVrV);
         reorder(tVrV, tArV);
+        if (K != blk_k0) {
+          CUTLASS_PRAGMA_UNROLL
+          for (int i = 0; i < tArA.size() / VTiles; i++)
+            tArA(_,_,_,VV)(i) *= broadcast<0>(rescale, tArA, i);
+        }
         cute::gemm(mma_pv, tArP, tArV, tArA(_, _, _, VV));
       }
 
@@ -416,19 +422,17 @@ struct FMHAFwdMainloop<
 
   // Single step of blocked softmax.
   CUTLASS_DEVICE
-  void softmax(
+  FragSRow softmax(
       bool first_block, // First softmax block?
       FragS& tS, // Softmax src/dst block
       FragSRow& tS_max, // Softmax row-wise max accumulator
-      FragSRow& tS_sum, // Softmax row-wise sum accumulator
-      FragA& tA // O accumulator (for rescaling)
+      FragSRow& tS_sum  // Softmax row-wise sum accumulator
   ) {
     /* Compute row-wise maxima for this block */
     auto tS_bmax = reduce<1>(tS, sycl::maximum{});
 
     /* Update (scaled) maxima */
     FragSRow rescale;
-    auto tS_prev_max = tS_max;
     CUTLASS_PRAGMA_UNROLL
     for (int i = 0; i < tS_max.size(); i++) {
       ElementS new_max = sycl::max(tS_max(i), params.scale * tS_bmax(i));
@@ -443,23 +447,20 @@ struct FMHAFwdMainloop<
           params.scale * tS(i) -
           broadcast<0>(tS_max, tS, i)); // Local exponentials
 
-    /* Rescale existing S sums and O accumulator */
+    /* Rescale existing S sums */
     if (!first_block) {
       CUTLASS_PRAGMA_UNROLL
       for (int i = 0; i < tS_max.size(); i++) {
-        rescale(i) = sycl::native::exp2(tS_prev_max(i) - tS_max(i)); //
         tS_sum(i) *= rescale(i);
       }
-
-      CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < tA.size(); i++)
-        tA(i) *= broadcast<0>(rescale, tA, i);
     }
 
     /* Update sums */
     auto tS_bsum = reduce<1>(tS, sycl::plus<void>{}); // local sum
     for (int i = 0; i < tS_sum.size(); i++) // Add for each row
       tS_sum(i) += tS_bsum(i);
+
+    return rescale;
   }
 };
 

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/dropout.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/dropout.h
@@ -51,9 +51,9 @@ struct Dropout {
 #pragma unroll
     for (int m = 0; m < size<1>(tensor); ++m, block_row_start += 1) {
 #pragma unroll
-      for (int n = 0; n < size<2>(tensor); ++n, block_col_start += 1) {
+      for (int n = 0; n < size<2>(tensor); ++n) {
         uint64_t rowcol =
-            (uint64_t(block_row_start) << 32) | uint64_t(block_col_start);
+            (uint64_t(block_row_start) << 32) | uint64_t(block_col_start + n);
         uint4 random_uint4 = FLASH_NAMESPACE::philox(seed, rowcol, offset);
         uint16_t(&rnd_16)[8] = reinterpret_cast<uint16_t(&)[8]>(random_uint4);
 #pragma unroll

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/dropout.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/dropout.h
@@ -54,7 +54,7 @@ struct Dropout {
       for (int n = 0; n < size<2>(tensor); ++n) {
         uint64_t rowcol =
             (uint64_t(block_row_start) << 32) | uint64_t(block_col_start + n);
-        uint4 random_uint4 = FLASH_NAMESPACE::philox(seed, rowcol, offset);
+        at::native::xpu::uint4 random_uint4 = FLASH_NAMESPACE::philox(seed, rowcol, offset);
         uint16_t(&rnd_16)[8] = reinterpret_cast<uint16_t(&)[8]>(random_uint4);
 #pragma unroll
         for (int i = 0; i < 8; i++) {

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/dropout.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/dropout.h
@@ -54,7 +54,8 @@ struct Dropout {
       for (int n = 0; n < size<2>(tensor); ++n) {
         uint64_t rowcol =
             (uint64_t(block_row_start) << 32) | uint64_t(block_col_start + n);
-        at::native::xpu::uint4 random_uint4 = FLASH_NAMESPACE::philox(seed, rowcol, offset);
+        at::native::xpu::uint4 random_uint4 =
+            FLASH_NAMESPACE::philox(seed, rowcol, offset);
         uint16_t(&rnd_16)[8] = reinterpret_cast<uint16_t(&)[8]>(random_uint4);
 #pragma unroll
         for (int i = 0; i < 8; i++) {

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/dropout.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/dropout.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#pragma once
+
+#include <sycltla/mha_common.h>
+#include <sycltla/philox.h>
+
+namespace FLASH_NAMESPACE {
+
+struct Dropout {
+  const uint64_t seed, offset;
+  const uint16_t p_dropout_in_uint16_t;
+
+  Dropout(
+      const uint64_t seed,
+      const uint64_t offset,
+      const uint16_t p_dropout_in_uint16_t,
+      const int bid,
+      const int hid,
+      const int tid,
+      const int nheads)
+      : seed(seed),
+        offset(
+            offset + (bid * nheads + hid) * kSubgroupSize +
+            tid % kSubgroupSize),
+        p_dropout_in_uint16_t(p_dropout_in_uint16_t) {}
+
+  template <
+      bool encode_dropout_in_sign_bit = false,
+      typename Engine,
+      typename Layout>
+  inline void apply_dropout(
+      cute::Tensor<Engine, Layout>& tensor,
+      int block_row_start,
+      int block_col_start) {
+    // tensor should have shape (8, MMA_M, MMA_N)
+    static_assert(decltype(rank(tensor.layout()))::value == 3);
+    static_assert(decltype(size<0>(tensor.layout()))::value == 8);
+    using T = typename Engine::value_type;
+    auto encode_dropout = [](bool keep, T val) {
+      return keep ? val : (encode_dropout_in_sign_bit ? -val : T(0));
+    };
+#pragma unroll
+    for (int m = 0; m < size<1>(tensor); ++m, block_row_start += 1) {
+#pragma unroll
+      for (int n = 0; n < size<2>(tensor); ++n, block_col_start += 1) {
+        uint64_t rowcol =
+            (uint64_t(block_row_start) << 32) | uint64_t(block_col_start);
+        uint4 random_uint4 = FLASH_NAMESPACE::philox(seed, rowcol, offset);
+        uint16_t(&rnd_16)[8] = reinterpret_cast<uint16_t(&)[8]>(random_uint4);
+#pragma unroll
+        for (int i = 0; i < 8; i++) {
+          tensor(i, m, n) = encode_dropout(
+              rnd_16[i] <= p_dropout_in_uint16_t, tensor(i, m, n));
+        }
+      }
+    }
+  }
+};
+
+} // namespace FLASH_NAMESPACE

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/kernel/xe_fmha_fwd_kernel.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/kernel/xe_fmha_fwd_kernel.h
@@ -228,11 +228,21 @@ class XeFMHAFwdKernel {
 
     SharedStorage& shared_storage = *reinterpret_cast<SharedStorage*>(smem_buf);
 
+    int thr_id = int(ThreadIdxX());
+
+    bool is_dropout = params.mainloop.p_dropout < 1.0f;
+    auto seed_offset = at::xpu::philox::unpack(params.mainloop.philox_args);
+    // Save seed and offset for backward, before any early exiting. Otherwise
+    // the 0-th thread block might exit early and no one saves the rng states.
+    if (is_dropout && BlockIdxX() == 0 && BlockIdxY() == 0 &&
+        BlockIdxZ() == 0 && thr_id == 0) {
+      params.mainloop.rng_seed[0] = std::get<0>(seed_offset);
+      params.mainloop.rng_offset[0] = std::get<1>(seed_offset);
+    }
+
     auto& p = params.kernel;
     ProblemShape const& s = p.shape;
     int head_group_q = s.num_heads_q / s.num_heads_kv;
-
-    int thr_id = int(ThreadIdxX());
     int q_sg_tile = get<0>(shape_div(TileShapeQK{}, shape(SubgroupLayoutQK{})));
 
     auto cS = make_identity_tensor(take<0, 2>(TiledMMAQK{}.tile_mnk()));
@@ -249,6 +259,15 @@ class XeFMHAFwdKernel {
           tile_scheduler.get_block_coord(); // (Q,V,h,b)
       auto blk_qv = make_coord(blk_q, blk_v);
       int head = head_q / head_group_q;
+
+      FLASH_NAMESPACE::Dropout dropout(
+          std::get<0>(seed_offset),
+          std::get<1>(seed_offset),
+          params.mainloop.p_dropout_in_uint16_t,
+          idx_b,
+          head_q,
+          thr_id,
+          s.num_heads_q);
 
       auto [seq_len_qo, seq_len_kv] = get_sequence_length_shape(s, idx_b);
       if (blk_q * get<0>(TileShapeQK{}) >= seq_len_qo)
@@ -333,6 +352,9 @@ class XeFMHAFwdKernel {
       // Main loop
       int l_coord = is_var_len ? 0 : idx_b;
       CollectiveMainloop mainloop(params.mainloop, shared_storage.mainloop);
+      if (mainloop.params.p_ptr)
+        mainloop.params.p_ptr +=
+            (l_coord * s.num_heads_q + head_q) * seq_len_qo * seq_len_kv;
       mainloop(
           Q(_, _, head_q, l_coord),
           K(_, _, head, l_coord),
@@ -350,7 +372,9 @@ class XeFMHAFwdKernel {
           seq_len_kv,
           idx_b,
           tile_row_idx,
-          rows_of_maxima);
+          rows_of_maxima,
+          is_dropout,
+          dropout);
 
       if constexpr (
           !is_empty_v<MainloopSharedStorage> &&
@@ -376,7 +400,8 @@ class XeFMHAFwdKernel {
           blk_qv,
           thr_id,
           dpLSE,
-          metadata_for_lse);
+          metadata_for_lse,
+          is_dropout);
     }
   }
 };

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.cpp
@@ -18,34 +18,12 @@ namespace cute {
 template <typename T, int Headdim, bool is_causal>
 void run_mha_bwd_(sycl::queue& queue, FLASH_BWD_params& params);
 
-template <typename T, bool is_causal>
-void run_mha_bwd_(sycl::queue& queue, FLASH_BWD_params& params) {
-  const int headdim = params.head_size_vo;
-
-  if (headdim <= 32) {
-    run_mha_bwd_<T, 32, is_causal>(queue, params);
-  } else if (headdim <= 64) {
-    run_mha_bwd_<T, 64, is_causal>(queue, params);
-  } else if (headdim <= 96) {
-    run_mha_bwd_<T, 96, is_causal>(queue, params);
-  } else if (headdim <= 128) {
-    run_mha_bwd_<T, 128, is_causal>(queue, params);
-  } else if (headdim <= 192) {
-    run_mha_bwd_<T, 192, is_causal>(queue, params);
-  } else if (headdim <= 256) {
-    run_mha_bwd_<T, 256, is_causal>(queue, params);
-  } else {
-    TORCH_CHECK(
-        false,
-        "FlashAttentionBackwardXPU only support headdim up to 256, got ",
-        headdim);
-  }
-}
-
 void run_mha_bwd(sycl::queue& queue, FLASH_BWD_params& params) {
   FP16_SWITCH(params.is_fp16, [&] {
     BOOL_SWITCH(params.is_causal, IS_CAUSAL, [&] {
-      run_mha_bwd_<elem_type, IS_CAUSAL>(queue, params);
+      HEADDIM_SWITCH(params.head_size_vo, [&] {
+        run_mha_bwd_<elem_type, Headdim, IS_CAUSAL>(queue, params);
+      });
     });
   });
 }
@@ -78,8 +56,6 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_bwd(
     const bool deterministic,
     const at::Tensor philox_seed,
     const at::Tensor philox_offset) {
-  TORCH_CHECK(
-      p_dropout == 0.0, "mha_bwd on xpu does not support dropout > 0.0 yet");
   TORCH_CHECK(
       !alibi_slopes_.has_value(),
       "mha_bwd on xpu does not support alibi slopes yet");
@@ -321,7 +297,11 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_bwd(
       tensor_dqaccum,
       tensor_pbuff,
       softmax_scale,
+      p_dropout,
       is_causal);
+
+  params.rng_seed = reinterpret_cast<uint64_t*>(philox_seed.data_ptr());
+  params.rng_offset = reinterpret_cast<uint64_t*>(philox_offset.data_ptr());
 
   if (seqlen_qo > 0) {
     cute::run_mha_bwd(sycl_queue, params);

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
@@ -70,7 +70,7 @@ struct FAKernel {
       Layout<Shape<Int<AtomLayoutNdKV>, Int<kNSGs / AtomLayoutNdKV>, _1>>;
   using SubgroupLayoutdQ =
       Layout<Shape<Int<AtomLayoutMdQ>, Int<kNSGs / AtomLayoutMdQ>, _1>>;
-  using TileShapeSdP = Layout<Shape<Int<kBlockN>, Int<kBlockM>, _K>>;
+  using TileShapeSdP = Layout<Shape<Int<kBlockM>, Int<kBlockN>, _K>>;
   using TileShapedKV = Layout<Shape<Int<kBlockN>, Int<kHeadDim>, _K>>;
   using TileShapedQ = Layout<Shape<Int<kBlockM>, Int<kHeadDim>, _K>>;
 

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
@@ -28,6 +28,7 @@
 #include <cute/util/compat.hpp>
 #include <cutlass/numeric_conversion.h>
 #include <sycl/sycl.hpp>
+#include <sycltla/dropout.h>
 #include <sycltla/mha_common.h>
 
 #pragma clang diagnostic pop
@@ -92,6 +93,10 @@ struct FAKernel {
   static constexpr int SubgroupSize = 16;
   static constexpr int smem_size = 0;
 
+  static_assert(
+      SubgroupSize == kSubgroupSize,
+      "Subgroup size must be consistent with the one used in mha_common.h");
+
   FAKernel() {}
 };
 
@@ -106,27 +111,37 @@ struct Param {
       const T* k,
       const T* v,
       const float* lse,
+      const uint64_t* rng_seed,
+      const uint64_t* rng_offset,
       float* odo,
       float* dqaccum,
       T* dq,
       T* dk,
       T* dv,
       T* pb,
-      const float softmax_scale)
+      const float softmax_scale,
+      const float p_dropout,
+      const uint16_t p_dropout_in_uint16_t,
+      const float rp_dropout)
       : do_ptr(dO),
         o_ptr(o),
         q_ptr(q),
         k_ptr(k),
         v_ptr(v),
         lse_ptr(lse),
-        scale_softmax(softmax_scale),
-        scale_softmax_log2(softmax_scale * M_LOG2E),
+        rng_seed(rng_seed),
+        rng_offset(rng_offset),
         odo_ptr(odo),
         dqaccum_ptr(dqaccum),
         dq_ptr(dq),
         dk_ptr(dk),
         dv_ptr(dv),
-        pb_ptr(pb) {}
+        pb_ptr(pb),
+        scale_softmax(softmax_scale),
+        scale_softmax_log2(softmax_scale * M_LOG2E),
+        p_dropout(p_dropout),
+        p_dropout_in_uint16_t(p_dropout_in_uint16_t),
+        rp_dropout(rp_dropout) {}
   // read only
   const T* do_ptr;
   const T* o_ptr;
@@ -134,8 +149,9 @@ struct Param {
   const T* k_ptr;
   const T* v_ptr;
   const float* lse_ptr;
-  const float scale_softmax;
-  const float scale_softmax_log2;
+  const uint64_t* rng_seed;
+  const uint64_t* rng_offset;
+
   // write
   float* odo_ptr;
   float* dqaccum_ptr;
@@ -159,6 +175,13 @@ struct Param {
   int tail_m;
   int num_qh_per_kvh;
   int num_nb_per_blk;
+
+  // other params
+  const float scale_softmax;
+  const float scale_softmax_log2;
+  const float p_dropout;
+  const uint16_t p_dropout_in_uint16_t;
+  const float rp_dropout;
 
   // strides
   index_t q_r_stride;

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
@@ -25,7 +25,7 @@ template <typename T, int Headdim, bool is_causal>
 void run_mha_bwd_(sycl::queue& queue, FLASH_BWD_params& params);
 
 template <bool Is_even_M, class T>
-void compute_o_dot_do(
+CUTLASS_DEVICE void compute_o_dot_do(
     T& trait,
     Param<typename T::DType>& param,
     const int m_block,
@@ -179,7 +179,7 @@ void mha_dot_do_o(T trait, Param<typename T::DType> param) {
 }
 
 template <typename Layout>
-auto convert_layout_2d_layout(Layout layout) {
+CUTLASS_DEVICE auto convert_layout_2d_layout(Layout layout) {
   auto l =
       make_layout(make_layout(get<0>(layout), get<1>(layout)), get<2>(layout));
   return l;
@@ -196,7 +196,7 @@ CUTLASS_DEVICE auto convert_layout_acc_layout(Layout acc_layout) {
 }
 
 template <typename T, class Trait, class MTensor, class TiledMMA>
-auto create_reg(
+CUTLASS_DEVICE auto create_reg(
     Trait const& trait,
     MTensor const& C,
     TiledMMA const& tiled_mma) {
@@ -229,7 +229,7 @@ template <
     class Layout2,
     class TVLayout2,
     class TiledMMA>
-void gemm_kernel(
+CUTLASS_DEVICE void gemm_kernel(
     Trait& trait,
     Tensor<Engine0, Layout0> const& A,
     Tensor<Engine1, Layout1> const& B,
@@ -315,7 +315,7 @@ template <
     class Layout2,
     class TVLayout2,
     class TiledMMA>
-void gemm_SdP(
+CUTLASS_DEVICE void gemm_SdP(
     Trait& trait,
     Tensor<Engine0, Layout0> const& A,
     Tensor<Engine1, Layout1> const& B,
@@ -334,7 +334,7 @@ template <
     class Layout2,
     class TVLayout2,
     class TiledMMA>
-void gemm_dKV(
+CUTLASS_DEVICE void gemm_dKV(
     Trait& trait,
     Tensor<Engine0, Layout0> const& A,
     Tensor<Engine1, Layout1> const& B,
@@ -352,7 +352,7 @@ template <
     class Engine2,
     class Layout2,
     class TiledMMA>
-void gemm_dQ(
+CUTLASS_DEVICE void gemm_dQ(
     Trait& trait,
     Tensor<Engine0, Layout0> const& A,
     Tensor<Engine1, Layout1> const& B,
@@ -502,7 +502,7 @@ CUTLASS_DEVICE void softmax_backward(
 }
 
 template <typename Engine, typename Layout>
-void apply_dropout_on_signed_P(
+CUTLASS_DEVICE void apply_dropout_on_signed_P(
     Tensor<Engine, Layout>& P,
     const float& rp_dropout) {
   CUTLASS_PRAGMA_UNROLL
@@ -519,7 +519,7 @@ template <
     class TVLayout0,
     class Engine1,
     class Layout1>
-void mha_copy(
+CUTLASS_DEVICE void mha_copy(
     Trait& trait,
     TiledMma& tiled_mma,
     SubgroupTensor<Engine0, Layout0, TVLayout0>& r,
@@ -545,7 +545,7 @@ template <
     class TVLayout0,
     class Engine1,
     class Layout1>
-void mha_reorder_copy(
+CUTLASS_DEVICE void mha_reorder_copy(
     Trait& trait,
     TiledMma& tiled_mma,
     SubgroupTensor<Engine0, Layout0, TVLayout0>& r,
@@ -556,7 +556,7 @@ void mha_reorder_copy(
 }
 
 template <bool Is_even_N, bool is_dropout, class Trait>
-void dq_dk_dv_1colblock(
+CUTLASS_DEVICE void dq_dk_dv_1colblock(
     Trait& trait,
     Param<typename Trait::DType>& param,
     const int bidb,
@@ -863,7 +863,7 @@ CUTLASS_DEVICE void convert_type(
 }
 
 template <bool Is_even_M, class T>
-void convert_dq(
+CUTLASS_DEVICE void convert_dq(
     T& trait,
     Param<typename T::DType>& param,
     int m_block,

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
@@ -201,8 +201,8 @@ CUTLASS_DEVICE void apply_mask_causal(
   for (int n = 0; n < size<1>(tensor); ++n) {
     CUTLASS_PRAGMA_UNROLL
     for (int m = 0; m < size<0>(tensor); ++m) {
-      int y = m_offset + get<1>(rC_2d(m, n)) + diagonal_offset;
-      int x = n_offset + get<0>(rC_2d(m, n));
+      int y = m_offset + get<0>(rC_2d(m, n)) + diagonal_offset;
+      int x = n_offset + get<1>(rC_2d(m, n));
       if (x > y) {
         tensor(m, n) = -INFINITY;
       }
@@ -485,22 +485,22 @@ CUTLASS_DEVICE void scale_apply_exp2(
   Tensor rC_2d = make_tensor(rC.data(), convert_layout_2d_layout(rC.layout()));
   if constexpr (Is_even_M) {
     CUTLASS_PRAGMA_UNROLL
-    for (int ni = 0; ni < size<1>(tensor); ++ni) {
-      int n = get<1>(rC_2d(0, ni));
-      const float max_scaled = max(n) == -INFINITY ? 0.f : max(n) * M_LOG2E;
+    for (int mi = 0; mi < size<0>(tensor); ++mi) {
+      int m = get<0>(rC_2d(mi, 0));
+      const float max_scaled = max(m) == -INFINITY ? 0.f : max(m) * M_LOG2E;
       CUTLASS_PRAGMA_UNROLL
-      for (int mi = 0; mi < size<0>(tensor); ++mi) {
+      for (int ni = 0; ni < size<1>(tensor); ++ni) {
         tensor(mi, ni) = exp2f(tensor(mi, ni) * scale - max_scaled);
       }
     }
   } else {
     CUTLASS_PRAGMA_UNROLL
-    for (int ni = 0; ni < size<1>(tensor); ++ni) {
-      int n = get<1>(rC_2d(0, ni));
+    for (int mi = 0; mi < size<0>(tensor); ++mi) {
+      int m = get<0>(rC_2d(mi, 0));
       const float max_scaled =
-          ((n >= tail_m) || (max(n) == -INFINITY)) ? 0.f : max(n) * M_LOG2E;
+          ((m >= tail_m) || (max(m) == -INFINITY)) ? 0.f : max(m) * M_LOG2E;
       CUTLASS_PRAGMA_UNROLL
-      for (int mi = 0; mi < size<0>(tensor); ++mi) {
+      for (int ni = 0; ni < size<1>(tensor); ++ni) {
         tensor(mi, ni) = exp2f(tensor(mi, ni) * scale - max_scaled);
       }
     }
@@ -527,22 +527,22 @@ CUTLASS_DEVICE void softmax_backward(
   Tensor rC_2d = make_tensor(rC.data(), convert_layout_2d_layout(rC.layout()));
   if constexpr (Is_even_M) {
     CUTLASS_PRAGMA_UNROLL
-    for (int ni = 0; ni < size<1>(dP); ++ni) {
-      int n = get<1>(rC_2d(0, ni));
-      const float neg_dpsum_scaled = -(dP_sum(n) * scale);
+    for (int mi = 0; mi < size<0>(dP); ++mi) {
+      int m = get<0>(rC_2d(mi, 0));
+      const float neg_dpsum_scaled = -(dP_sum(m) * scale);
       CUTLASS_PRAGMA_UNROLL
-      for (int mi = 0; mi < size<0>(dP); ++mi) {
+      for (int ni = 0; ni < size<1>(dP); ++ni) {
         dP(mi, ni) = P(mi, ni) * fmaf(dP(mi, ni), scale, neg_dpsum_scaled);
       }
     }
   } else {
     CUTLASS_PRAGMA_UNROLL
-    for (int ni = 0; ni < size<1>(dP); ++ni) {
-      int n = get<1>(rC_2d(0, ni));
-      if (n < tail_m) {
-        const float neg_dpsum_scaled = -(dP_sum(n) * scale);
+    for (int mi = 0; mi < size<0>(dP); ++mi) {
+      int m = get<0>(rC_2d(mi, 0));
+      if (m < tail_m) {
+        const float neg_dpsum_scaled = -(dP_sum(m) * scale);
         CUTLASS_PRAGMA_UNROLL
-        for (int mi = 0; mi < size<0>(dP); ++mi) {
+        for (int ni = 0; ni < size<1>(dP); ++ni) {
           dP(mi, ni) = P(mi, ni) * fmaf(dP(mi, ni), scale, neg_dpsum_scaled);
         }
       }
@@ -585,54 +585,80 @@ void dq_dk_dv_1colblock(
       2;
   const index_t dsb_offset = pb_offset + kBlockN * kBlockM;
 
-  const auto block_n_dim = tail_n == 0 ? Int<kBlockN>{} : ((tail_n + 1) & ~1);
-  auto shapeO = make_shape(kBlockM, Int<kHeadDim>{});
-  auto shapeQtOt = make_shape(Int<kHeadDim>{}, kBlockM);
-  auto shapeSPt = make_shape(Int<kBlockN>{}, kBlockM);
-  auto shapeSP = make_shape(kBlockM, block_n_dim);
+  // P = S = Q * K^t
+  auto shapeSP = make_shape(Int<kBlockM>{}, Int<kBlockN>{});
+  Tensor mP = make_tensor(
+      make_gmem_ptr(param.pb_ptr + pb_offset),
+      make_layout(shapeSP, make_stride(Int<kBlockN>{}, _1{})));
 
-  using Shape1 =
-      Shape<std::conditional_t<Is_even_N, Int<kBlockN>, int>, Int<kHeadDim>>;
-  using Shape2 =
-      Shape<Int<kHeadDim>, std::conditional_t<Is_even_N, Int<kBlockN>, int>>;
   auto shapeQ = make_shape(kBlockM, Int<kHeadDim>{});
-  auto shapedQ = Shape<Int<kBlockM>, Int<kHeadDim>>{};
-  Shape1 shapeKtVt;
-  Shape2 shapeKV;
-  if constexpr (Is_even_N) {
-    shapeKtVt = make_shape(Int<kBlockN>{}, Int<kHeadDim>{});
-    shapeKV = make_shape(Int<kHeadDim>{}, Int<kBlockN>{});
-  } else {
-    shapeKtVt = make_shape(tail_n, Int<kHeadDim>{});
-    shapeKV = make_shape(Int<kHeadDim>{}, tail_n);
-  }
   Tensor mQ = make_tensor(
       make_gmem_ptr(param.q_ptr + q_offset),
       make_layout(shapeQ, make_stride(param.q_r_stride, _1{})));
+  using ShapeKtVt_t =
+      Shape<std::conditional_t<Is_even_N, Int<kBlockN>, int>, Int<kHeadDim>>;
+  ShapeKtVt_t shapeKtVt;
+  if constexpr (Is_even_N) {
+    shapeKtVt = make_shape(Int<kBlockN>{}, Int<kHeadDim>{});
+  } else {
+    shapeKtVt = make_shape(tail_n, Int<kHeadDim>{});
+  }
   Tensor mKt = make_tensor(
       make_gmem_ptr(param.k_ptr + k_offset),
       make_layout(shapeKtVt, make_stride(param.k_r_stride, _1{})));
+
+  // dP = dO * V^t
+  Tensor mdP = make_tensor(
+      make_gmem_ptr(param.pb_ptr + dsb_offset),
+      make_layout(shapeSP, make_stride(Int<kBlockN>{}, _1{})));
+  auto shapedO = make_shape(kBlockM, Int<kHeadDim>{});
   Tensor mdO = make_tensor(
       make_gmem_ptr(param.do_ptr + do_offset),
-      make_layout(shapeO, make_stride(param.do_r_stride, _1{})));
+      make_layout(shapedO, make_stride(param.do_r_stride, _1{})));
   Tensor mVt = make_tensor(
       make_gmem_ptr(param.v_ptr + v_offset),
       make_layout(shapeKtVt, make_stride(param.v_r_stride, _1{})));
+
+  // dV = P^t * dO
+  Tensor mdV = make_tensor(
+      make_gmem_ptr(param.dv_ptr + dv_offset),
+      make_layout(shapeKtVt, make_stride(param.dv_r_stride, _1{})));
+  auto shapeSPt = make_shape(Int<kBlockN>{}, Int<kBlockM>{});
   Tensor mPt = make_tensor(
       make_gmem_ptr(param.pb_ptr + pb_offset),
-      make_layout(shapeSPt, make_stride(Int<kBlockM>{}, _1{})));
+      make_layout(shapeSPt, make_stride(_1{}, Int<kBlockN>{})));
+  auto shapeQtOt = make_shape(Int<kHeadDim>{}, kBlockM);
   Tensor mdOt = make_tensor(
       make_gmem_ptr(param.do_ptr + do_offset),
       make_layout(shapeQtOt, make_stride(_1{}, param.do_r_stride)));
-  Tensor mK = make_tensor(
-      make_gmem_ptr(param.k_ptr + k_offset),
-      make_layout(shapeKV, make_stride(_1{}, param.k_r_stride)));
+
+  // dK = (dP)^t * Q
+  Tensor mdK = make_tensor(
+      make_gmem_ptr(param.dk_ptr + dk_offset),
+      make_layout(shapeKtVt, make_stride(param.dk_r_stride, _1{})));
   Tensor mdPt = make_tensor(
       make_gmem_ptr(param.pb_ptr + dsb_offset),
-      make_layout(shapeSPt, make_stride(Int<kBlockM>{}, _1{})));
+      make_layout(shapeSPt, make_stride(_1{}, Int<kBlockN>{})));
   Tensor mQt = make_tensor(
       make_gmem_ptr(param.q_ptr + q_offset),
       make_layout(shapeQtOt, make_stride(_1{}, param.q_r_stride)));
+
+  // dQ = dP * K
+  auto shapedQ = Shape<Int<kBlockM>, Int<kHeadDim>>{};
+  Tensor mdQaccum = make_tensor(
+      make_gmem_ptr(param.dqaccum_ptr + dqaccum_offset),
+      make_layout(shapedQ, make_stride(param.head_dim, _1{})));
+  using ShapeK_t =
+      Shape<Int<kHeadDim>, std::conditional_t<Is_even_N, Int<kBlockN>, int>>;
+  ShapeK_t shapeK;
+  if constexpr (Is_even_N) {
+    shapeK = make_shape(Int<kHeadDim>{}, Int<kBlockN>{});
+  } else {
+    shapeK = make_shape(Int<kHeadDim>{}, tail_n);
+  }
+  Tensor mK = make_tensor(
+      make_gmem_ptr(param.k_ptr + k_offset),
+      make_layout(shapeK, make_stride(_1{}, param.k_r_stride)));
 
   Tensor mLSE = make_tensor(
       make_gmem_ptr(param.lse_ptr + lse_offset),
@@ -641,28 +667,15 @@ void dq_dk_dv_1colblock(
       make_gmem_ptr(param.odo_ptr + lse_offset),
       make_layout(Shape<Int<kBlockM>>{}, Stride<_1>{}));
 
-  Tensor mdV = make_tensor(
-      make_gmem_ptr(param.dv_ptr + dv_offset),
-      make_layout(shapeKtVt, make_stride(param.dv_r_stride, _1{})));
-  Tensor mdP = make_tensor(
-      make_gmem_ptr(param.pb_ptr + dsb_offset),
-      make_layout(shapeSP, make_stride(_1{}, Int<kBlockM>{})));
-  Tensor mdQaccum = make_tensor(
-      make_gmem_ptr(param.dqaccum_ptr + dqaccum_offset),
-      make_layout(shapedQ, make_stride(param.head_dim, _1{})));
-  Tensor mdK = make_tensor(
-      make_gmem_ptr(param.dk_ptr + dk_offset),
-      make_layout(shapeKtVt, make_stride(param.dk_r_stride, _1{})));
-
   typename Trait::TiledMmaSdP tiled_mma_sdp;
   typename Trait::TiledMmadKV tiled_mma_dkv;
   typename Trait::TiledMmadQ tiled_mma_dq;
 
   auto thr_mma_sdp = tiled_mma_sdp.get_slice(local_id);
 
-  Tensor caccSt = make_identity_tensor(Shape<Int<kBlockN>, Int<kBlockM>>{});
-  Tensor taccScSt = thr_mma_sdp.partition_C(caccSt);
-  Tensor taccScS_rt = logical_divide(taccScSt, Shape<_1>{});
+  Tensor caccS = make_identity_tensor(Shape<Int<kBlockM>, Int<kBlockN>>{});
+  Tensor taccScS = thr_mma_sdp.partition_C(caccS);
+  Tensor taccScS_rt = logical_divide(taccScS, Shape<_1>{});
 
   const int max_m_block = ceil_div(param.seq_len_q, kBlockM);
   const int tail_m = param.seq_len_q % kBlockM;
@@ -674,7 +687,6 @@ void dq_dk_dv_1colblock(
   for (int m_block = 0; m_block < max_m_block; ++m_block) {
     const bool Is_even_M = not((m_block == max_m_block - 1) and (tail_m != 0));
     if (not Is_even_M) {
-      const int block_m_dim = ((tail_m + 1) & ~1);
       mQ = make_tensor(
           make_gmem_ptr(mQ.data()),
           make_layout(
@@ -685,29 +697,11 @@ void dq_dk_dv_1colblock(
           make_layout(
               make_shape(tail_m, Int<kHeadDim>{}),
               make_stride(param.do_r_stride, _1{})));
-      mPt = make_tensor(
-          make_gmem_ptr(mPt.data()),
-          make_layout(
-              make_shape(Int<kBlockN>{}, block_m_dim),
-              make_stride(Int<kBlockM>{}, _1{})));
       mdOt = make_tensor(
           make_gmem_ptr(mdOt.data()),
           make_layout(
               make_shape(Int<kHeadDim>{}, tail_m),
               make_stride(_1{}, param.do_r_stride)));
-      mdPt = make_tensor(
-          make_gmem_ptr(mdPt.data()),
-          make_layout(
-              make_shape(Int<kBlockN>{}, block_m_dim),
-              make_stride(Int<kBlockM>{}, _1{})));
-      mdP = make_tensor(
-          make_gmem_ptr(mdP.data()),
-          make_layout(
-              make_shape(block_m_dim, block_n_dim),
-              make_stride(_1{}, Int<kBlockM>{})));
-      mdQaccum = make_tensor(
-          make_gmem_ptr(mdQaccum.data()),
-          make_layout(shapedQ, make_stride(param.head_dim, _1{})));
       mQt = make_tensor(
           make_gmem_ptr(mQt.data()),
           make_layout(
@@ -715,8 +709,8 @@ void dq_dk_dv_1colblock(
               make_stride(_1{}, param.q_r_stride)));
     }
     {
-      auto rS = create_reg<V>(trait, mPt, tiled_mma_sdp);
-      gemm_SdP(trait, mKt, mQ, rS, tiled_mma_sdp);
+      auto rS = create_reg<V>(trait, mP, tiled_mma_sdp);
+      gemm_SdP(trait, mQ, mKt, rS, tiled_mma_sdp);
       Tensor scores =
           make_tensor(rS.data(), convert_layout_acc_layout(rS.layout()));
       if constexpr (is_causal) {
@@ -734,8 +728,8 @@ void dq_dk_dv_1colblock(
         scale_apply_exp2<false>(
             scores, mLSE, taccScS_rt, param.scale_softmax_log2, tail_m);
       }
-      auto rdP = create_reg<V>(trait, mdPt, tiled_mma_sdp);
-      gemm_SdP(trait, mVt, mdO, rdP, tiled_mma_sdp);
+      auto rdP = create_reg<V>(trait, mdP, tiled_mma_sdp);
+      gemm_SdP(trait, mdO, mVt, rdP, tiled_mma_sdp);
       Tensor dS = make_tensor(rdP.data(), scores.layout());
       if (Is_even_M) {
         softmax_backward<true>(
@@ -744,8 +738,8 @@ void dq_dk_dv_1colblock(
         softmax_backward<false>(
             scores, mdPsum, dS, taccScS_rt, param.scale_softmax, tail_m);
       }
-      mha_reorder_copy(trait, tiled_mma_sdp, rS, mPt);
-      mha_reorder_copy(trait, tiled_mma_sdp, rdP, mdPt);
+      mha_reorder_copy(trait, tiled_mma_sdp, rS, mP);
+      mha_reorder_copy(trait, tiled_mma_sdp, rdP, mdP);
     }
     sycl::group_barrier(group);
     gemm_dKV(trait, mPt, mdOt, rdV, tiled_mma_dkv);
@@ -754,8 +748,8 @@ void dq_dk_dv_1colblock(
     mQ.data() = mQ.data() + int(kBlockM * param.q_r_stride);
     mdO.data() = mdO.data() + int(kBlockM * param.do_r_stride);
     mdOt.data() = mdOt.data() + int(kBlockM * param.do_r_stride);
-    mdQaccum.data() = mdQaccum.data() + int(kBlockM * param.head_dim);
     mQt.data() = mQt.data() + int(kBlockM * param.q_r_stride);
+    mdQaccum.data() = mdQaccum.data() + int(kBlockM * param.head_dim);
     mLSE.data() = mLSE.data() + int(kBlockM);
     mdPsum.data() = mdPsum.data() + int(kBlockM);
   }
@@ -774,8 +768,7 @@ void mha_backward_seq(T trait, Param<typename T::DType> param) {
       dq_dk_dv_1colblock<false>(
           trait, param, bidb, bidhq, bidhkv, param.n_block - 1, param.tail_n);
     else
-      dq_dk_dv_1colblock<true>(
-          trait, param, bidb, bidhq, bidhkv, n_block);
+      dq_dk_dv_1colblock<true>(trait, param, bidb, bidhq, bidhkv, n_block);
   }
 }
 

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
@@ -24,13 +24,6 @@ namespace cute {
 template <typename T, int Headdim, bool is_causal>
 void run_mha_bwd_(sycl::queue& queue, FLASH_BWD_params& params);
 
-template <typename Layout>
-auto convert_layout_2d_layout(Layout layout) {
-  auto l =
-      make_layout(make_layout(get<0>(layout), get<1>(layout)), get<2>(layout));
-  return l;
-}
-
 template <bool Is_even_M, class T>
 void compute_o_dot_do(
     T& trait,
@@ -185,30 +178,21 @@ void mha_dot_do_o(T trait, Param<typename T::DType> param) {
   }
 }
 
-template <
-    typename Engine0,
-    typename Layout0,
-    typename Engine1,
-    typename Layout1>
-CUTLASS_DEVICE void apply_mask_causal(
-    Tensor<Engine0, Layout0>& tensor,
-    Tensor<Engine1, Layout1>& rC,
-    int m_offset,
-    int n_offset,
-    int diagonal_offset = 0) {
-  Tensor rC_2d = make_tensor(rC.data(), convert_layout_2d_layout(rC.layout()));
-  CUTLASS_PRAGMA_UNROLL
-  for (int n = 0; n < size<1>(tensor); ++n) {
-    CUTLASS_PRAGMA_UNROLL
-    for (int m = 0; m < size<0>(tensor); ++m) {
-      int y = m_offset + get<0>(rC_2d(m, n)) + diagonal_offset;
-      int x = n_offset + get<1>(rC_2d(m, n));
-      if (x > y) {
-        tensor(m, n) = -INFINITY;
-      }
-    }
-  }
-  return;
+template <typename Layout>
+auto convert_layout_2d_layout(Layout layout) {
+  auto l =
+      make_layout(make_layout(get<0>(layout), get<1>(layout)), get<2>(layout));
+  return l;
+}
+
+template <typename Layout>
+CUTLASS_DEVICE auto convert_layout_acc_layout(Layout acc_layout) {
+  static_assert(decltype(size<0>(acc_layout))::value == 8);
+  static_assert(decltype(rank(acc_layout))::value == 3);
+  auto l = logical_divide(acc_layout, Shape<_1>{});
+  auto l2 =
+      make_layout(make_layout(get<0, 1>(l), get<1>(l)), make_layout(get<2>(l)));
+  return l2;
 }
 
 template <typename T, class Trait, class MTensor, class TiledMMA>
@@ -392,78 +376,29 @@ void gemm_dQ(
 }
 
 template <
-    class Trait,
-    class TiledMma,
-    class Engine0,
-    class Layout0,
-    class TVLayout0,
-    class Engine1,
-    class Layout1>
-void mha_copy(
-    Trait& trait,
-    TiledMma& tiled_mma,
-    SubgroupTensor<Engine0, Layout0, TVLayout0>& r,
-    Tensor<Engine1, Layout1>& m,
-    int m_block = 0,
-    int n_block = 0) {
-  auto local_id = int(compat::get_nd_item<1>().get_local_id(0));
-  auto copy_c = make_block_2d_copy_D(tiled_mma, m);
-  auto thr_copy_c = copy_c.get_slice(local_id);
-  auto tile_mnk = tiled_mma.tile_mnk();
-  Tensor cC = make_identity_tensor(m.shape());
-  Tensor gC =
-      local_tile(cC, select<0, 1>(tile_mnk), make_coord(m_block, n_block));
-  Tensor tCgC = thr_copy_c.partition_D(gC);
-  copy(copy_c, r, tCgC);
-}
-
-template <
-    class Trait,
-    class TiledMma,
-    class Engine0,
-    class Layout0,
-    class TVLayout0,
-    class Engine1,
-    class Layout1>
-void mha_reorder_copy(
-    Trait& trait,
-    TiledMma& tiled_mma,
-    SubgroupTensor<Engine0, Layout0, TVLayout0>& r,
-    Tensor<Engine1, Layout1>& m) {
-  auto r16 = create_reg<typename Trait::DType>(trait, m, tiled_mma);
-  reorder(r, r16);
-  mha_copy(trait, tiled_mma, r16, m);
-}
-
-template <bool Is_even_M, class Tensor0, class Tensor1, class Tensor2>
-CUTLASS_DEVICE void load_1colvec(
-    Tensor0& reg,
-    Tensor1& mT,
-    Tensor2& coord_row,
-    int tail_m = 0) {
-  if constexpr (Is_even_M) {
+    typename Engine0,
+    typename Layout0,
+    typename Engine1,
+    typename Layout1>
+CUTLASS_DEVICE void apply_mask_causal(
+    Tensor<Engine0, Layout0>& tensor,
+    Tensor<Engine1, Layout1>& rC,
+    int m_offset,
+    int n_offset,
+    int diagonal_offset = 0) {
+  Tensor rC_2d = make_tensor(rC.data(), convert_layout_2d_layout(rC.layout()));
+  CUTLASS_PRAGMA_UNROLL
+  for (int n = 0; n < size<1>(tensor); ++n) {
     CUTLASS_PRAGMA_UNROLL
-    for (int mi = 0; mi < size(reg); ++mi) {
-      reg(mi) = mT(get<0>(coord_row(mi)));
-    }
-  } else {
-    for (int mi = 0; mi < size(reg); ++mi) {
-      int row = get<0>(coord_row(mi));
-      if (row < tail_m) {
-        reg(mi) = mT(row);
+    for (int m = 0; m < size<0>(tensor); ++m) {
+      int y = m_offset + get<0>(rC_2d(m, n)) + diagonal_offset;
+      int x = n_offset + get<1>(rC_2d(m, n));
+      if (x > y) {
+        tensor(m, n) = -INFINITY;
       }
     }
   }
-}
-
-template <typename Layout>
-CUTLASS_DEVICE auto convert_layout_acc_layout(Layout acc_layout) {
-  static_assert(decltype(size<0>(acc_layout))::value == 8);
-  static_assert(decltype(rank(acc_layout))::value == 3);
-  auto l = logical_divide(acc_layout, Shape<_1>{});
-  auto l2 =
-      make_layout(make_layout(get<0, 1>(l), get<1>(l)), make_layout(get<2>(l)));
-  return l2;
+  return;
 }
 
 template <
@@ -522,17 +457,23 @@ CUTLASS_DEVICE void softmax_backward(
     Tensor<Engine1, Layout1>& dP_sum,
     Tensor<Engine2, Layout2>& dP,
     Tensor<Engine3, Layout3>& rC,
+    const int tail_m,
     const float scale,
-    const int tail_m = 0) {
+    const bool is_dropout = false,
+    const float rp_dropout = 1.0f) {
   Tensor rC_2d = make_tensor(rC.data(), convert_layout_2d_layout(rC.layout()));
+  auto pointwise_mult = [is_dropout, scale, rp_dropout](
+                            float p, float dp, float d) {
+    return scale * p * (!is_dropout || p >= 0 ? dp * rp_dropout - d : d);
+  };
   if constexpr (Is_even_M) {
     CUTLASS_PRAGMA_UNROLL
     for (int mi = 0; mi < size<0>(dP); ++mi) {
       int m = get<0>(rC_2d(mi, 0));
-      const float neg_dpsum_scaled = -(dP_sum(m) * scale);
+      const float dpsum = dP_sum(m);
       CUTLASS_PRAGMA_UNROLL
       for (int ni = 0; ni < size<1>(dP); ++ni) {
-        dP(mi, ni) = P(mi, ni) * fmaf(dP(mi, ni), scale, neg_dpsum_scaled);
+        dP(mi, ni) = pointwise_mult(P(mi, ni), dP(mi, ni), dpsum);
       }
     }
   } else {
@@ -540,14 +481,68 @@ CUTLASS_DEVICE void softmax_backward(
     for (int mi = 0; mi < size<0>(dP); ++mi) {
       int m = get<0>(rC_2d(mi, 0));
       if (m < tail_m) {
-        const float neg_dpsum_scaled = -(dP_sum(m) * scale);
+        const float dpsum = dP_sum(m);
         CUTLASS_PRAGMA_UNROLL
         for (int ni = 0; ni < size<1>(dP); ++ni) {
-          dP(mi, ni) = P(mi, ni) * fmaf(dP(mi, ni), scale, neg_dpsum_scaled);
+        dP(mi, ni) = pointwise_mult(P(mi, ni), dP(mi, ni), dpsum);
         }
       }
     }
   }
+}
+
+template <typename Engine, typename Layout>
+void apply_dropout_on_signed_P(
+    Tensor<Engine, Layout>& P,
+    const float& rp_dropout) {
+  CUTLASS_PRAGMA_UNROLL
+  for (int i = 0; i < size(P); ++i) {
+    P(i) = P(i) >= 0 ? P(i) * rp_dropout : 0;
+  }
+}
+
+template <
+    class Trait,
+    class TiledMma,
+    class Engine0,
+    class Layout0,
+    class TVLayout0,
+    class Engine1,
+    class Layout1>
+void mha_copy(
+    Trait& trait,
+    TiledMma& tiled_mma,
+    SubgroupTensor<Engine0, Layout0, TVLayout0>& r,
+    Tensor<Engine1, Layout1>& m,
+    int m_block = 0,
+    int n_block = 0) {
+  auto local_id = int(compat::get_nd_item<1>().get_local_id(0));
+  auto copy_c = make_block_2d_copy_D(tiled_mma, m);
+  auto thr_copy_c = copy_c.get_slice(local_id);
+  auto tile_mnk = tiled_mma.tile_mnk();
+  Tensor cC = make_identity_tensor(m.shape());
+  Tensor gC =
+      local_tile(cC, select<0, 1>(tile_mnk), make_coord(m_block, n_block));
+  Tensor tCgC = thr_copy_c.partition_D(gC);
+  copy(copy_c, r, tCgC);
+}
+
+template <
+    class Trait,
+    class TiledMma,
+    class Engine0,
+    class Layout0,
+    class TVLayout0,
+    class Engine1,
+    class Layout1>
+void mha_reorder_copy(
+    Trait& trait,
+    TiledMma& tiled_mma,
+    SubgroupTensor<Engine0, Layout0, TVLayout0>& r,
+    Tensor<Engine1, Layout1>& m) {
+  auto r16 = create_reg<typename Trait::DType>(trait, m, tiled_mma);
+  reorder(r, r16);
+  mha_copy(trait, tiled_mma, r16, m);
 }
 
 template <bool Is_even_N, class Trait>
@@ -570,6 +565,16 @@ void dq_dk_dv_1colblock(
   auto local_id = int(compat::get_nd_item<1>().get_local_id(0));
   auto group = compat::get_nd_item<1>().get_group();
   auto bofst = Boffset(param);
+
+  FLASH_NAMESPACE::Dropout dropout(
+      param.rng_seed[0],
+      param.rng_offset[1],
+      param.p_dropout_in_uint16_t,
+      bidb,
+      bidh,
+      local_id,
+      param.num_head_q);
+  bool is_dropout = param.p_dropout < 1.0f;
 
   const index_t q_offset = bofst.q_offset(bidb, bidh, 0);
   const index_t k_offset = bofst.k_offset(bidb, bidhkv, n_block * kBlockN);
@@ -721,6 +726,7 @@ void dq_dk_dv_1colblock(
             n_block * kBlockN,
             param.seq_len_kv - param.seq_len_q);
       }
+
       if (Is_even_M) {
         scale_apply_exp2<true>(
             scores, mLSE, taccScS_rt, param.scale_softmax_log2);
@@ -728,15 +734,45 @@ void dq_dk_dv_1colblock(
         scale_apply_exp2<false>(
             scores, mLSE, taccScS_rt, param.scale_softmax_log2, tail_m);
       }
+
+      if (is_dropout) {
+        static_assert(
+            decltype(size<0>(
+                typename Trait::TiledMmaSdP::AtomShape_MNK{}))::value == 8);
+        int block_row_id = (m_block * kBlockM + get<0>(taccScS(0))) / 8;
+        int block_col_id =
+            (n_block * kBlockN + get<1>(taccScS(0))) / intel::sg_size;
+        dropout.apply_dropout</*encode_dropout_in_sign_bit=*/true>(
+            rS, block_row_id, block_col_id);
+      }
+
       auto rdP = create_reg<V>(trait, mdP, tiled_mma_sdp);
       gemm_SdP(trait, mdO, mVt, rdP, tiled_mma_sdp);
       Tensor dS = make_tensor(rdP.data(), scores.layout());
       if (Is_even_M) {
         softmax_backward<true>(
-            scores, mdPsum, dS, taccScS_rt, param.scale_softmax);
+            scores,
+            mdPsum,
+            dS,
+            taccScS_rt,
+            0,
+            param.scale_softmax,
+            is_dropout,
+            param.rp_dropout);
       } else {
         softmax_backward<false>(
-            scores, mdPsum, dS, taccScS_rt, param.scale_softmax, tail_m);
+            scores,
+            mdPsum,
+            dS,
+            taccScS_rt,
+            tail_m,
+            param.scale_softmax,
+            is_dropout,
+            param.rp_dropout);
+      }
+
+      if (is_dropout) {
+        apply_dropout_on_signed_P(rS, param.rp_dropout);
       }
       mha_reorder_copy(trait, tiled_mma_sdp, rS, mP);
       mha_reorder_copy(trait, tiled_mma_sdp, rdP, mdP);
@@ -951,13 +987,18 @@ void run_mha_bwd_specialized(
       static_cast<const T*>(flash_bwd_params.k_ptr),
       static_cast<const T*>(flash_bwd_params.v_ptr),
       static_cast<const float*>(flash_bwd_params.lse_ptr),
+      static_cast<const uint64_t*>(flash_bwd_params.rng_seed),
+      static_cast<const uint64_t*>(flash_bwd_params.rng_offset),
       static_cast<float*>(flash_bwd_params.odo_ptr),
       static_cast<float*>(flash_bwd_params.dqaccum_ptr),
       static_cast<T*>(flash_bwd_params.dq_ptr),
       static_cast<T*>(flash_bwd_params.dk_ptr),
       static_cast<T*>(flash_bwd_params.dv_ptr),
       static_cast<T*>(flash_bwd_params.pb_ptr),
-      flash_bwd_params.scale);
+      flash_bwd_params.scale,
+      flash_bwd_params.p_dropout,
+      flash_bwd_params.p_dropout_in_uint16_t,
+      flash_bwd_params.rp_dropout);
   param.batch = BATCH;
   param.num_head_q = NUM_HEAD_Q;
   param.num_head_kv = NUM_HEAD_KV;

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
@@ -550,7 +550,7 @@ CUTLASS_DEVICE void softmax_backward(
   }
 }
 
-template <bool Is_even_N, bool Seq_parallel, class Trait>
+template <bool Is_even_N, class Trait>
 void dq_dk_dv_1colblock(
     Trait& trait,
     Param<typename Trait::DType>& param,
@@ -771,10 +771,10 @@ void mha_backward_seq(T trait, Param<typename T::DType> param) {
   const int bidhkv = bidhq / param.num_qh_per_kvh;
   for (int n_block = bidnblk; n_block < param.n_block; n_block += GridDimX()) {
     if (param.tail_n > 0 and n_block == param.n_block - 1)
-      dq_dk_dv_1colblock<false, false>(
+      dq_dk_dv_1colblock<false>(
           trait, param, bidb, bidhq, bidhkv, param.n_block - 1, param.tail_n);
     else
-      dq_dk_dv_1colblock<true, false>(
+      dq_dk_dv_1colblock<true>(
           trait, param, bidb, bidhq, bidhkv, n_block);
   }
 }

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
@@ -376,25 +376,37 @@ void gemm_dQ(
 }
 
 template <
+    bool is_causal,
     typename Engine0,
     typename Layout0,
     typename Engine1,
     typename Layout1>
-CUTLASS_DEVICE void apply_mask_causal(
+CUTLASS_DEVICE void apply_mask(
     Tensor<Engine0, Layout0>& tensor,
     Tensor<Engine1, Layout1>& rC,
     int m_offset,
     int n_offset,
+    int m_size,
+    int n_size,
     int diagonal_offset = 0) {
   Tensor rC_2d = make_tensor(rC.data(), convert_layout_2d_layout(rC.layout()));
   CUTLASS_PRAGMA_UNROLL
   for (int n = 0; n < size<1>(tensor); ++n) {
     CUTLASS_PRAGMA_UNROLL
     for (int m = 0; m < size<0>(tensor); ++m) {
-      int y = m_offset + get<0>(rC_2d(m, n)) + diagonal_offset;
+      int y = m_offset + get<0>(rC_2d(m, n));
       int x = n_offset + get<1>(rC_2d(m, n));
-      if (x > y) {
+      // mask out of bound positions with -inf, so that after softmax they
+      // become 0 and do not contribute to the output
+      if (y >= m_size || x >= n_size) {
         tensor(m, n) = -INFINITY;
+      }
+
+      // apply bottom-right causal mask
+      if constexpr (is_causal) {
+        if (x > y + diagonal_offset) {
+          tensor(m, n) = -INFINITY;
+        }
       }
     }
   }
@@ -413,7 +425,7 @@ CUTLASS_DEVICE void scale_apply_exp2(
     Tensor<Engine0, Layout0>& tensor,
     Tensor<Engine1, Layout1>& max,
     Tensor<Engine2, Layout2>& rC,
-    const float scale,
+    const float scale_softmax_log2,
     const int tail_m = 0) {
   static_assert(Layout0::rank == 2, "Only support 2D Tensor");
   static_assert(Layout1::rank == 1, "Only support 1D Tensor");
@@ -422,21 +434,30 @@ CUTLASS_DEVICE void scale_apply_exp2(
     CUTLASS_PRAGMA_UNROLL
     for (int mi = 0; mi < size<0>(tensor); ++mi) {
       int m = get<0>(rC_2d(mi, 0));
-      const float max_scaled = max(m) == -INFINITY ? 0.f : max(m) * M_LOG2E;
+      const bool max_is_inf = max(m) == -INFINITY;
       CUTLASS_PRAGMA_UNROLL
       for (int ni = 0; ni < size<1>(tensor); ++ni) {
-        tensor(mi, ni) = exp2f(tensor(mi, ni) * scale - max_scaled);
+        if (max_is_inf) {
+          tensor(mi, ni) = 0.f;
+        } else {
+          tensor(mi, ni) =
+              exp2f(tensor(mi, ni) * scale_softmax_log2 - max(m) * M_LOG2E);
+        }
       }
     }
   } else {
     CUTLASS_PRAGMA_UNROLL
     for (int mi = 0; mi < size<0>(tensor); ++mi) {
       int m = get<0>(rC_2d(mi, 0));
-      const float max_scaled =
-          ((m >= tail_m) || (max(m) == -INFINITY)) ? 0.f : max(m) * M_LOG2E;
+      const bool max_is_inf = m >= tail_m || max(m) == -INFINITY;
       CUTLASS_PRAGMA_UNROLL
       for (int ni = 0; ni < size<1>(tensor); ++ni) {
-        tensor(mi, ni) = exp2f(tensor(mi, ni) * scale - max_scaled);
+        if (max_is_inf) {
+          tensor(mi, ni) = 0.f;
+        } else {
+          tensor(mi, ni) =
+              exp2f(tensor(mi, ni) * scale_softmax_log2 - max(m) * M_LOG2E);
+        }
       }
     }
   }
@@ -484,7 +505,7 @@ CUTLASS_DEVICE void softmax_backward(
         const float dpsum = dP_sum(m);
         CUTLASS_PRAGMA_UNROLL
         for (int ni = 0; ni < size<1>(dP); ++ni) {
-        dP(mi, ni) = pointwise_mult(P(mi, ni), dP(mi, ni), dpsum);
+          dP(mi, ni) = pointwise_mult(P(mi, ni), dP(mi, ni), dpsum);
         }
       }
     }
@@ -568,7 +589,7 @@ void dq_dk_dv_1colblock(
 
   FLASH_NAMESPACE::Dropout dropout(
       param.rng_seed[0],
-      param.rng_offset[1],
+      param.rng_offset[0],
       param.p_dropout_in_uint16_t,
       bidb,
       bidh,
@@ -718,14 +739,15 @@ void dq_dk_dv_1colblock(
       gemm_SdP(trait, mQ, mKt, rS, tiled_mma_sdp);
       Tensor scores =
           make_tensor(rS.data(), convert_layout_acc_layout(rS.layout()));
-      if constexpr (is_causal) {
-        apply_mask_causal(
-            scores,
-            taccScS_rt,
-            m_block * kBlockM,
-            n_block * kBlockN,
-            param.seq_len_kv - param.seq_len_q);
-      }
+
+      apply_mask<is_causal>(
+          scores,
+          taccScS_rt,
+          m_block * kBlockM,
+          n_block * kBlockN,
+          param.seq_len_q,
+          param.seq_len_kv,
+          param.seq_len_kv - param.seq_len_q);
 
       if (Is_even_M) {
         scale_apply_exp2<true>(

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
@@ -377,6 +377,8 @@ void gemm_dQ(
 
 template <
     bool is_causal,
+    bool Is_even_N = false,
+    bool Is_even_M = false,
     typename Engine0,
     typename Layout0,
     typename Engine1,
@@ -389,6 +391,12 @@ CUTLASS_DEVICE void apply_mask(
     int m_size,
     int n_size,
     int diagonal_offset = 0) {
+  // When both M and N dimensions are even (no tail), all positions are
+  // in bounds -- skip the OOB position mask entirely.
+  constexpr bool skip_pos_mask = Is_even_N && Is_even_M;
+  if constexpr (!is_causal && skip_pos_mask) {
+    return;
+  }
   Tensor rC_2d = make_tensor(rC.data(), convert_layout_2d_layout(rC.layout()));
   CUTLASS_PRAGMA_UNROLL
   for (int n = 0; n < size<1>(tensor); ++n) {
@@ -398,8 +406,10 @@ CUTLASS_DEVICE void apply_mask(
       int x = n_offset + get<1>(rC_2d(m, n));
       // mask out of bound positions with -inf, so that after softmax they
       // become 0 and do not contribute to the output
-      if (y >= m_size || x >= n_size) {
-        tensor(m, n) = -INFINITY;
+      if constexpr (!skip_pos_mask) {
+        if (y >= m_size || x >= n_size) {
+          tensor(m, n) = -INFINITY;
+        }
       }
 
       // apply bottom-right causal mask
@@ -430,41 +440,29 @@ CUTLASS_DEVICE void scale_apply_exp2(
   static_assert(Layout0::rank == 2, "Only support 2D Tensor");
   static_assert(Layout1::rank == 1, "Only support 1D Tensor");
   Tensor rC_2d = make_tensor(rC.data(), convert_layout_2d_layout(rC.layout()));
-  if constexpr (Is_even_M) {
-    CUTLASS_PRAGMA_UNROLL
-    for (int mi = 0; mi < size<0>(tensor); ++mi) {
-      int m = get<0>(rC_2d(mi, 0));
-      const bool max_is_inf = max(m) == -INFINITY;
-      CUTLASS_PRAGMA_UNROLL
-      for (int ni = 0; ni < size<1>(tensor); ++ni) {
-        if (max_is_inf) {
-          tensor(mi, ni) = 0.f;
-        } else {
-          tensor(mi, ni) =
-              exp2f(tensor(mi, ni) * scale_softmax_log2 - max(m) * M_LOG2E);
+  CUTLASS_PRAGMA_UNROLL
+  for (int mi = 0; mi < size<0>(tensor); ++mi) {
+    int m = get<0>(rC_2d(mi, 0));
+    if constexpr (!Is_even_M) {
+      if (m >= tail_m) {
+        CUTLASS_PRAGMA_UNROLL
+        for (int ni = 0; ni < size<1>(tensor); ++ni) {
+          tensor(mi, ni) = 0.0f;
         }
+        continue;
       }
     }
-  } else {
+    const float max_scaled = max(m) == -INFINITY ? 0.f : max(m) * M_LOG2E;
     CUTLASS_PRAGMA_UNROLL
-    for (int mi = 0; mi < size<0>(tensor); ++mi) {
-      int m = get<0>(rC_2d(mi, 0));
-      const bool max_is_inf = m >= tail_m || max(m) == -INFINITY;
-      CUTLASS_PRAGMA_UNROLL
-      for (int ni = 0; ni < size<1>(tensor); ++ni) {
-        if (max_is_inf) {
-          tensor(mi, ni) = 0.f;
-        } else {
-          tensor(mi, ni) =
-              exp2f(tensor(mi, ni) * scale_softmax_log2 - max(m) * M_LOG2E);
-        }
-      }
+    for (int ni = 0; ni < size<1>(tensor); ++ni) {
+      tensor(mi, ni) = exp2f(tensor(mi, ni) * scale_softmax_log2 - max_scaled);
     }
   }
 }
 
 template <
     bool Is_even_M,
+    bool is_dropout,
     class Engine0,
     class Layout0,
     class Engine1,
@@ -480,33 +478,24 @@ CUTLASS_DEVICE void softmax_backward(
     Tensor<Engine3, Layout3>& rC,
     const int tail_m,
     const float scale,
-    const bool is_dropout = false,
     const float rp_dropout = 1.0f) {
   Tensor rC_2d = make_tensor(rC.data(), convert_layout_2d_layout(rC.layout()));
-  auto pointwise_mult = [is_dropout, scale, rp_dropout](
-                            float p, float dp, float d) {
-    return scale * p * (!is_dropout || p >= 0 ? dp * rp_dropout - d : d);
-  };
-  if constexpr (Is_even_M) {
-    CUTLASS_PRAGMA_UNROLL
-    for (int mi = 0; mi < size<0>(dP); ++mi) {
-      int m = get<0>(rC_2d(mi, 0));
-      const float dpsum = dP_sum(m);
-      CUTLASS_PRAGMA_UNROLL
-      for (int ni = 0; ni < size<1>(dP); ++ni) {
-        dP(mi, ni) = pointwise_mult(P(mi, ni), dP(mi, ni), dpsum);
-      }
+  CUTLASS_PRAGMA_UNROLL
+  for (int mi = 0; mi < size<0>(dP); ++mi) {
+    int m = get<0>(rC_2d(mi, 0));
+    if constexpr (!Is_even_M) {
+      if (m >= tail_m)
+        continue;
     }
-  } else {
+    const float dpsum = dP_sum(m);
     CUTLASS_PRAGMA_UNROLL
-    for (int mi = 0; mi < size<0>(dP); ++mi) {
-      int m = get<0>(rC_2d(mi, 0));
-      if (m < tail_m) {
-        const float dpsum = dP_sum(m);
-        CUTLASS_PRAGMA_UNROLL
-        for (int ni = 0; ni < size<1>(dP); ++ni) {
-          dP(mi, ni) = pointwise_mult(P(mi, ni), dP(mi, ni), dpsum);
-        }
+    for (int ni = 0; ni < size<1>(dP); ++ni) {
+      if constexpr (is_dropout) {
+        float p = P(mi, ni);
+        dP(mi, ni) =
+            scale * p * (p >= 0 ? dP(mi, ni) * rp_dropout - dpsum : dpsum);
+      } else {
+        dP(mi, ni) = scale * P(mi, ni) * (dP(mi, ni) - dpsum);
       }
     }
   }
@@ -566,7 +555,7 @@ void mha_reorder_copy(
   mha_copy(trait, tiled_mma, r16, m);
 }
 
-template <bool Is_even_N, class Trait>
+template <bool Is_even_N, bool is_dropout, class Trait>
 void dq_dk_dv_1colblock(
     Trait& trait,
     Param<typename Trait::DType>& param,
@@ -586,16 +575,6 @@ void dq_dk_dv_1colblock(
   auto local_id = int(compat::get_nd_item<1>().get_local_id(0));
   auto group = compat::get_nd_item<1>().get_group();
   auto bofst = Boffset(param);
-
-  FLASH_NAMESPACE::Dropout dropout(
-      param.rng_seed[0],
-      param.rng_offset[0],
-      param.p_dropout_in_uint16_t,
-      bidb,
-      bidh,
-      local_id,
-      param.num_head_q);
-  bool is_dropout = param.p_dropout < 1.0f;
 
   const index_t q_offset = bofst.q_offset(bidb, bidh, 0);
   const index_t k_offset = bofst.k_offset(bidb, bidhkv, n_block * kBlockN);
@@ -740,14 +719,25 @@ void dq_dk_dv_1colblock(
       Tensor scores =
           make_tensor(rS.data(), convert_layout_acc_layout(rS.layout()));
 
-      apply_mask<is_causal>(
-          scores,
-          taccScS_rt,
-          m_block * kBlockM,
-          n_block * kBlockN,
-          param.seq_len_q,
-          param.seq_len_kv,
-          param.seq_len_kv - param.seq_len_q);
+      if (Is_even_M) {
+        apply_mask<is_causal, Is_even_N, true>(
+            scores,
+            taccScS_rt,
+            m_block * kBlockM,
+            n_block * kBlockN,
+            param.seq_len_q,
+            param.seq_len_kv,
+            param.seq_len_kv - param.seq_len_q);
+      } else {
+        apply_mask<is_causal, Is_even_N, false>(
+            scores,
+            taccScS_rt,
+            m_block * kBlockM,
+            n_block * kBlockN,
+            param.seq_len_q,
+            param.seq_len_kv,
+            param.seq_len_kv - param.seq_len_q);
+      }
 
       if (Is_even_M) {
         scale_apply_exp2<true>(
@@ -757,13 +747,21 @@ void dq_dk_dv_1colblock(
             scores, mLSE, taccScS_rt, param.scale_softmax_log2, tail_m);
       }
 
-      if (is_dropout) {
+      if constexpr (is_dropout) {
         static_assert(
             decltype(size<0>(
                 typename Trait::TiledMmaSdP::AtomShape_MNK{}))::value == 8);
         int block_row_id = (m_block * kBlockM + get<0>(taccScS(0))) / 8;
         int block_col_id =
             (n_block * kBlockN + get<1>(taccScS(0))) / intel::sg_size;
+        FLASH_NAMESPACE::Dropout dropout(
+            param.rng_seed[0],
+            param.rng_offset[0],
+            param.p_dropout_in_uint16_t,
+            bidb,
+            bidh,
+            local_id,
+            param.num_head_q);
         dropout.apply_dropout</*encode_dropout_in_sign_bit=*/true>(
             rS, block_row_id, block_col_id);
       }
@@ -772,28 +770,26 @@ void dq_dk_dv_1colblock(
       gemm_SdP(trait, mdO, mVt, rdP, tiled_mma_sdp);
       Tensor dS = make_tensor(rdP.data(), scores.layout());
       if (Is_even_M) {
-        softmax_backward<true>(
+        softmax_backward<true, is_dropout>(
             scores,
             mdPsum,
             dS,
             taccScS_rt,
             0,
             param.scale_softmax,
-            is_dropout,
             param.rp_dropout);
       } else {
-        softmax_backward<false>(
+        softmax_backward<false, is_dropout>(
             scores,
             mdPsum,
             dS,
             taccScS_rt,
             tail_m,
             param.scale_softmax,
-            is_dropout,
             param.rp_dropout);
       }
 
-      if (is_dropout) {
+      if constexpr (is_dropout) {
         apply_dropout_on_signed_P(rS, param.rp_dropout);
       }
       mha_reorder_copy(trait, tiled_mma_sdp, rS, mP);
@@ -821,12 +817,23 @@ void mha_backward_seq(T trait, Param<typename T::DType> param) {
   const int bidhq = BlockIdxY();
   const int bidnblk = BlockIdxX();
   const int bidhkv = bidhq / param.num_qh_per_kvh;
+  const bool is_dropout = param.p_dropout < 1.0f;
   for (int n_block = bidnblk; n_block < param.n_block; n_block += GridDimX()) {
-    if (param.tail_n > 0 and n_block == param.n_block - 1)
-      dq_dk_dv_1colblock<false>(
-          trait, param, bidb, bidhq, bidhkv, param.n_block - 1, param.tail_n);
-    else
-      dq_dk_dv_1colblock<true>(trait, param, bidb, bidhq, bidhkv, n_block);
+    if (param.tail_n > 0 and n_block == param.n_block - 1) {
+      if (is_dropout)
+        dq_dk_dv_1colblock<false, true>(
+            trait, param, bidb, bidhq, bidhkv, param.n_block - 1, param.tail_n);
+      else
+        dq_dk_dv_1colblock<false, false>(
+            trait, param, bidb, bidhq, bidhkv, param.n_block - 1, param.tail_n);
+    } else {
+      if (is_dropout)
+        dq_dk_dv_1colblock<true, true>(
+            trait, param, bidb, bidhq, bidhkv, n_block);
+      else
+        dq_dk_dv_1colblock<true, false>(
+            trait, param, bidb, bidhq, bidhkv, n_block);
+    }
   }
 }
 

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_common.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_common.h
@@ -12,6 +12,7 @@
 #include <cassert>
 
 #include <ATen/xpu/XPUContext.h>
+#include <ATen/xpu/XPUGeneratorImpl.h>
 
 #include <ATen/native/transformers/xpu/flash_attn/flash_api.h>
 #include <ATen/native/transformers/xpu/flash_attn/sycltla/flash_api.h>
@@ -59,6 +60,31 @@
     }                                     \
   }()
 
+#define HEADDIM_SWITCH(HEADDIM, ...)      \
+  [&] {                                   \
+    if (HEADDIM <= 32) {                  \
+      constexpr static int Headdim = 32;  \
+      return __VA_ARGS__();               \
+    } else if (HEADDIM <= 64) {           \
+      constexpr static int Headdim = 64;  \
+      return __VA_ARGS__();               \
+    } else if (HEADDIM <= 96) {           \
+      constexpr static int Headdim = 96;  \
+      return __VA_ARGS__();               \
+    } else if (HEADDIM <= 128) {          \
+      constexpr static int Headdim = 128; \
+      return __VA_ARGS__();               \
+    } else if (HEADDIM <= 192) {          \
+      constexpr static int Headdim = 192; \
+      return __VA_ARGS__();               \
+    } else if (HEADDIM <= 256) {          \
+      constexpr static int Headdim = 256; \
+      return __VA_ARGS__();               \
+    }                                     \
+  }()
+
+#define DROPOUT_SWITCH BOOL_SWITCH
+
 struct QKV_params {
   using index_t = int64_t;
   // The QKV matrices.
@@ -90,6 +116,9 @@ struct FLASH_FWD_params : public QKV_params {
   // The pointer to the softmax logsumexp.
   void* lse_ptr;
 
+  // The pointer to the P matrix.
+  void* p_ptr;
+
   // The dimensions of the problem.
   int batch_size;
   int num_heads_qo;
@@ -103,6 +132,19 @@ struct FLASH_FWD_params : public QKV_params {
 
   bool is_causal;
   float scale;
+  // The dropout probability (probability of keeping an activation).
+  float p_dropout;
+  uint16_t p_dropout_in_uint16_t;
+  // Scale factor of 1 / (1 - p_dropout).
+  float rp_dropout;
+
+  // Random state.
+  at::PhiloxXpuState philox_args;
+
+  // Pointer to the RNG seed and offset.
+  void* rng_seed;
+  void* rng_offset;
+
   bool is_fp16;
 };
 
@@ -155,7 +197,9 @@ inline void set_params_fprop(
     const at::Tensor& v,
     at::Tensor& out,
     at::Tensor& logsumexp,
+    std::optional<at::Tensor> p,
     float scale,
+    float p_dropout,
     bool is_causal) {
   // Reset the parameters
   params = {};
@@ -168,6 +212,7 @@ inline void set_params_fprop(
   params.v_ptr = v.data_ptr();
   params.o_ptr = out.data_ptr();
   params.lse_ptr = logsumexp.data_ptr();
+  params.p_ptr = p.has_value() ? p->data_ptr() : nullptr;
   // All stride are in elements, not bytes.
   params.q_batch_stride = q.stride(0);
   params.k_batch_stride = k.stride(0);
@@ -196,6 +241,12 @@ inline void set_params_fprop(
   // Other params
   params.is_causal = is_causal;
   params.scale = scale;
+  // Set this to probability of keeping an element to simplify things.
+  TORCH_CHECK(p_dropout < 1.0f);
+  params.p_dropout = 1.f - p_dropout;
+  params.p_dropout_in_uint16_t =
+      uint16_t(std::floor(params.p_dropout * 65535.0));
+  params.rp_dropout = 1.f / params.p_dropout;
 }
 
 inline void set_params_dgrad(
@@ -226,6 +277,7 @@ inline void set_params_dgrad(
     at::Tensor& tensor_pbuff,
     // other params
     float scale,
+    float p_dropout,
     bool is_causal) {
   params = {};
   set_params_fprop(
@@ -244,7 +296,9 @@ inline void set_params_dgrad(
       v,
       const_cast<at::Tensor&>(out),
       const_cast<at::Tensor&>(logsumexp),
+      std::nullopt, // p is not needed for backward
       scale,
+      p_dropout,
       is_causal);
 
   params.do_ptr = grad_out.data_ptr();
@@ -273,6 +327,9 @@ inline void set_params_dgrad(
 // Backward kernel padding constants.
 constexpr int kBwdMPad = 128;
 constexpr int kBwdNPad = 128;
+
+// same as subgroup size used in the kernel, which is 16 for Xe.
+constexpr int kSubgroupSize = 16;
 
 // block 2D restrictions:
 //

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_common.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_common.h
@@ -60,27 +60,29 @@
     }                                     \
   }()
 
-#define HEADDIM_SWITCH(HEADDIM, ...)      \
-  [&] {                                   \
-    if (HEADDIM <= 32) {                  \
-      constexpr static int Headdim = 32;  \
-      return __VA_ARGS__();               \
-    } else if (HEADDIM <= 64) {           \
-      constexpr static int Headdim = 64;  \
-      return __VA_ARGS__();               \
-    } else if (HEADDIM <= 96) {           \
-      constexpr static int Headdim = 96;  \
-      return __VA_ARGS__();               \
-    } else if (HEADDIM <= 128) {          \
-      constexpr static int Headdim = 128; \
-      return __VA_ARGS__();               \
-    } else if (HEADDIM <= 192) {          \
-      constexpr static int Headdim = 192; \
-      return __VA_ARGS__();               \
-    } else if (HEADDIM <= 256) {          \
-      constexpr static int Headdim = 256; \
-      return __VA_ARGS__();               \
-    }                                     \
+#define HEADDIM_SWITCH(HEADDIM, ...)                        \
+  [&] {                                                     \
+    if (HEADDIM <= 32) {                                    \
+      constexpr static int Headdim = 32;                    \
+      return __VA_ARGS__();                                 \
+    } else if (HEADDIM <= 64) {                             \
+      constexpr static int Headdim = 64;                    \
+      return __VA_ARGS__();                                 \
+    } else if (HEADDIM <= 96) {                             \
+      constexpr static int Headdim = 96;                    \
+      return __VA_ARGS__();                                 \
+    } else if (HEADDIM <= 128) {                            \
+      constexpr static int Headdim = 128;                   \
+      return __VA_ARGS__();                                 \
+    } else if (HEADDIM <= 192) {                            \
+      constexpr static int Headdim = 192;                   \
+      return __VA_ARGS__();                                 \
+    } else if (HEADDIM <= 256) {                            \
+      constexpr static int Headdim = 256;                   \
+      return __VA_ARGS__();                                 \
+    } else {                                                \
+      TORCH_CHECK(false, "Unsupported headdim: ", HEADDIM); \
+    }                                                       \
   }()
 
 struct QKV_params {

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_common.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_common.h
@@ -83,8 +83,6 @@
     }                                     \
   }()
 
-#define DROPOUT_SWITCH BOOL_SWITCH
-
 struct QKV_params {
   using index_t = int64_t;
   // The QKV matrices.
@@ -242,7 +240,7 @@ inline void set_params_fprop(
   params.is_causal = is_causal;
   params.scale = scale;
   // Set this to probability of keeping an element to simplify things.
-  TORCH_CHECK(p_dropout < 1.0f);
+  TORCH_CHECK(p_dropout >= 0.0f && p_dropout < 1.0f);
   params.p_dropout = 1.f - p_dropout;
   params.p_dropout_in_uint16_t =
       uint16_t(std::floor(params.p_dropout * 65535.0));

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.cpp
@@ -86,17 +86,12 @@ mha_fwd(
     const bool return_softmax,
     std::optional<at::Generator> gen_) {
   TORCH_CHECK(
-      p_dropout == 0.0, "mha_fwd on xpu does not support p_dropout > 0.0 yet");
-  TORCH_CHECK(
       alibi_slopes_.has_value() == false,
       "mha_fwd on xpu does not support alibi_slopes yet");
   TORCH_CHECK(
       window_size_left == -1 && window_size_right == -1,
       "mha_fwd on xpu does not support window_size yet");
   TORCH_CHECK(softcap == 0.0, "mha_fwd on xpu does not support softcap yet");
-  TORCH_CHECK(
-      return_softmax == false,
-      "mha_fwd on xpu does not support return_softmax yet");
   TORCH_CHECK(
       !gen_.has_value(),
       "mha_fwd on xpu does not support custom generator yet");
@@ -257,7 +252,10 @@ mha_fwd(
     TORCH_CHECK(
         p_dropout > 0.0f,
         "return_softmax is only supported when p_dropout > 0.0");
-    p = at::empty({batch_size, numhead_qo, seqlen_qo, seqlen_kv}, opts);
+    p = at::full(
+        {batch_size, numhead_qo, seqlen_qo, seqlen_kv},
+        -1.f,
+        opts.dtype(at::kFloat));
   } else {
     p = at::empty({0}, opts);
   }

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.cpp
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.cpp
@@ -47,34 +47,12 @@ namespace cute {
 template <typename T, int Headdim, bool IS_CAUSAL>
 void run_mha_fwd_(sycl::queue& queue, FLASH_FWD_params& params);
 
-template <typename T, bool IS_CAUSAL>
-void run_mha_fwd_(sycl::queue& queue, FLASH_FWD_params& params) {
-  const int headdim = params.head_size_vo;
-
-  if (headdim <= 32) {
-    run_mha_fwd_<T, 32, IS_CAUSAL>(queue, params);
-  } else if (headdim <= 64) {
-    run_mha_fwd_<T, 64, IS_CAUSAL>(queue, params);
-  } else if (headdim <= 96) {
-    run_mha_fwd_<T, 96, IS_CAUSAL>(queue, params);
-  } else if (headdim <= 128) {
-    run_mha_fwd_<T, 128, IS_CAUSAL>(queue, params);
-  } else if (headdim <= 192) {
-    run_mha_fwd_<T, 192, IS_CAUSAL>(queue, params);
-  } else if (headdim <= 256) {
-    run_mha_fwd_<T, 256, IS_CAUSAL>(queue, params);
-  } else {
-    TORCH_CHECK(
-        false,
-        "FlashAttentionForwardXPU only support headdim up to 256, got ",
-        headdim);
-  }
-}
-
 void run_mha_fwd(sycl::queue& queue, FLASH_FWD_params& params) {
   FP16_SWITCH(params.is_fp16, [&] {
     BOOL_SWITCH(params.is_causal, IS_CAUSAL, [&] {
-      run_mha_fwd_<elem_type, IS_CAUSAL>(queue, params);
+      HEADDIM_SWITCH(params.head_size_vo, [&] {
+        run_mha_fwd_<elem_type, Headdim, IS_CAUSAL>(queue, params);
+      });
     });
   });
 }
@@ -274,7 +252,15 @@ mha_fwd(
   at::Tensor logsumexp =
       at::empty({batch_size, numhead_qo, seqlen_qo}, opts.dtype(at::kFloat));
 
-  at::Tensor p = at::empty({0}, opts);
+  at::Tensor p;
+  if (return_softmax) {
+    TORCH_CHECK(
+        p_dropout > 0.0f,
+        "return_softmax is only supported when p_dropout > 0.0");
+    p = at::empty({batch_size, numhead_qo, seqlen_qo, seqlen_kv}, opts);
+  } else {
+    p = at::empty({0}, opts);
+  }
 
   FLASH_FWD_params params;
   set_params_fprop(
@@ -293,13 +279,35 @@ mha_fwd(
       v_padded,
       out_padded,
       logsumexp,
+      return_softmax ? std::optional<at::Tensor>(p) : std::nullopt,
       softmax_scale,
+      p_dropout,
       is_causal);
 
   at::Tensor philox_seed =
       at::empty({}, at::dtype(c10::kLong).device(at::kXPU));
   at::Tensor philox_offset =
       at::empty({}, at::dtype(c10::kLong).device(at::kXPU));
+  if (p_dropout > 0.0) {
+    auto gen = at::get_generator_or_default<at::XPUGeneratorImpl>(
+        std::nullopt, at::xpu::detail::getDefaultXPUGenerator());
+    // Advance the Philox counter so that successive kernel launches
+    // draw non-overlapping random sequences.
+    //
+    // Our dropout scheme assigns each (batch, head, subgroup_lane_id) triple a
+    // unique Philox offset, and uses (block_row_id, block_col_id)
+    // as the subsequence to generate 8×uint16 for the 8 elements
+    // each lane holds in one m8×n16 MMA atomic block.
+    //
+    // Total unique offsets = batch_size × nheads × subgroup_size.
+    int64_t counter_offset =
+        params.batch_size * params.num_heads_qo * kSubgroupSize;
+    std::lock_guard<std::mutex> lock(gen->mutex_);
+    at::PhiloxXpuState philox_state = gen->philox_xpu_state(counter_offset);
+    params.rng_seed = reinterpret_cast<uint64_t*>(philox_seed.data_ptr());
+    params.rng_offset = reinterpret_cast<uint64_t*>(philox_offset.data_ptr());
+    params.philox_args = philox_state;
+  }
 
   if (seqlen_kv > 0) {
     cute::run_mha_fwd(sycl_queue, params);

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd_launch.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd_launch.h
@@ -75,6 +75,9 @@ struct FA2Runner {
     compat::experimental::launch_properties launch_props{
         syclex::work_group_scratch_size(smem_size),
     };
+    static_assert(
+        kSubgroupSize == cute::intel::sg_size,
+        "Subgroup size must be consistent with the one used in mha_common.h");
     compat::experimental::kernel_properties kernel_props{
         syclex::sub_group_size<cute::intel::sg_size>, intelex::grf_size<256>};
     compat::experimental::launch_policy policy{
@@ -110,6 +113,9 @@ struct FA2Runner {
     const ElementV* v_ptr = static_cast<const ElementV*>(params.v_ptr);
     ElementO* o_ptr = static_cast<ElementO*>(params.o_ptr);
     float* lse_ptr = static_cast<float*>(params.lse_ptr);
+    float* p_ptr = static_cast<float*>(params.p_ptr);
+    uint64_t* rng_seed = static_cast<uint64_t*>(params.rng_seed);
+    uint64_t* rng_offset = static_cast<uint64_t*>(params.rng_offset);
     float softmax_scale = params.scale;
 
     typename FMHAPrefillKernel::Arguments arguments{
@@ -133,8 +139,14 @@ struct FA2Runner {
             params.o_row_stride,
             lse_ptr,
         },
-        {softmax_scale},
-        {},
+        {softmax_scale,
+         params.philox_args,
+         rng_seed,
+         rng_offset,
+         params.p_dropout,
+         params.p_dropout_in_uint16_t,
+         p_ptr},
+        {params.rp_dropout},
         hw_info};
 
     size_t workspace_size = FMHAPrefillKernel::get_workspace_size(arguments);
@@ -296,7 +308,7 @@ void run_mha_fwd_hdim64(sycl::queue& queue, FLASH_FWD_params& params) {
     using TileShapeQK = Shape<_64, _64, _32>;
     using TileShapePV = Shape<_64, _32, _64>;
     using TileShapeOutPut = Shape<_64, _64>;
-    using SubgroupLayoutQK = Layout<Shape<_16, _1, _1>>;
+    using SubgroupLayoutQK = Layout<Shape<_8, _1, _1>>;
     run_mha_fwd_specialized(
         TileShapeQK,
         TileShapePV,

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/philox.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/philox.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace FLASH_NAMESPACE {
+
+struct uint2 {
+  uint32_t x;
+  uint32_t y;
+};
+
+struct uint4 {
+  uint32_t x;
+  uint32_t y;
+  uint32_t z;
+  uint32_t w;
+};
+
+inline uint2 mulhilo32(uint32_t a, uint32_t b) {
+  uint64_t product = static_cast<uint64_t>(a) * static_cast<uint64_t>(b);
+  return {static_cast<uint32_t>(product), static_cast<uint32_t>(product >> 32)};
+}
+
+inline uint4 philox_single_round(const uint4 ctr, const uint2 key) {
+  constexpr uint32_t kPhiloxSA = 0xD2511F53;
+  constexpr uint32_t kPhiloxSB = 0xCD9E8D57;
+  uint2 res0 = mulhilo32(kPhiloxSA, ctr.x);
+  uint2 res1 = mulhilo32(kPhiloxSB, ctr.z);
+  return {res1.y ^ ctr.y ^ key.x, res1.x, res0.y ^ ctr.w ^ key.y, res0.x};
+}
+
+inline uint4 philox(uint64_t seed, uint64_t subsequence, uint64_t offset) {
+  constexpr uint32_t kPhilox10A = 0x9E3779B9;
+  constexpr uint32_t kPhilox10B = 0xBB67AE85;
+  uint2 key;
+  key.x = static_cast<uint32_t>(seed);
+  key.y = static_cast<uint32_t>(seed >> 32);
+  uint4 counter;
+  counter.x = static_cast<uint32_t>(offset);
+  counter.y = static_cast<uint32_t>(offset >> 32);
+  counter.z = static_cast<uint32_t>(subsequence);
+  counter.w = static_cast<uint32_t>(subsequence >> 32);
+#pragma unroll
+  for (int i = 0; i < 6; i++) {
+    counter = philox_single_round(counter, key);
+    key.x += kPhilox10A;
+    key.y += kPhilox10B;
+  }
+  return philox_single_round(counter, key);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/philox.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/philox.h
@@ -10,53 +10,24 @@
 
 #pragma once
 
+#include <ATen/native/xpu/sycl/Philox4x32.h>
 #include <cstdint>
 
 namespace FLASH_NAMESPACE {
 
-struct uint2 {
-  uint32_t x;
-  uint32_t y;
-};
-
-struct uint4 {
-  uint32_t x;
-  uint32_t y;
-  uint32_t z;
-  uint32_t w;
-};
-
-inline uint2 mulhilo32(uint32_t a, uint32_t b) {
-  uint64_t product = static_cast<uint64_t>(a) * static_cast<uint64_t>(b);
-  return {static_cast<uint32_t>(product), static_cast<uint32_t>(product >> 32)};
-}
-
-inline uint4 philox_single_round(const uint4 ctr, const uint2 key) {
-  constexpr uint32_t kPhiloxSA = 0xD2511F53;
-  constexpr uint32_t kPhiloxSB = 0xCD9E8D57;
-  uint2 res0 = mulhilo32(kPhiloxSA, ctr.x);
-  uint2 res1 = mulhilo32(kPhiloxSB, ctr.z);
-  return {res1.y ^ ctr.y ^ key.x, res1.x, res0.y ^ ctr.w ^ key.y, res0.x};
-}
-
-inline uint4 philox(uint64_t seed, uint64_t subsequence, uint64_t offset) {
-  constexpr uint32_t kPhilox10A = 0x9E3779B9;
-  constexpr uint32_t kPhilox10B = 0xBB67AE85;
-  uint2 key;
-  key.x = static_cast<uint32_t>(seed);
-  key.y = static_cast<uint32_t>(seed >> 32);
-  uint4 counter;
-  counter.x = static_cast<uint32_t>(offset);
-  counter.y = static_cast<uint32_t>(offset >> 32);
-  counter.z = static_cast<uint32_t>(subsequence);
-  counter.w = static_cast<uint32_t>(subsequence >> 32);
-#pragma unroll
-  for (int i = 0; i < 6; i++) {
-    counter = philox_single_round(counter, key);
-    key.x += kPhilox10A;
-    key.y += kPhilox10B;
-  }
-  return philox_single_round(counter, key);
+inline at::native::xpu::uint4 philox(
+    uint64_t seed,
+    uint64_t subsequence,
+    uint64_t offset) {
+  at::native::xpu::uint2 key{
+      static_cast<uint32_t>(seed), static_cast<uint32_t>(seed >> 32)};
+  at::native::xpu::uint4 counter{
+      static_cast<uint32_t>(offset),
+      static_cast<uint32_t>(offset >> 32),
+      static_cast<uint32_t>(subsequence),
+      static_cast<uint32_t>(subsequence >> 32)};
+  auto result = at::native::xpu::philox4x32_rounds(counter, key, 7);
+  return {result.x, result.y, result.z, result.w};
 }
 
 } // namespace FLASH_NAMESPACE


### PR DESCRIPTION
# Flash Attention Dropout Implementation Summary

## Forward

### Mathematical Definition

$$S = QK^T, \quad P = \text{softmax}(S), \quad \tilde{P} = \frac{1}{1-p} P \odot M, \quad O = \tilde{P} V$$

where $M$ is a 0/1 dropout mask, $p$ is the drop probability, and $\frac{1}{1-p}$ is the rescale factor.

### Implementation Key Points

1. **No mask storage**: Only the RNG state (two integers) is saved; the backward pass regenerates the exact same mask using the same RNG state.
2. **Dropout applied after softmax**: Applied to $P$ (softmax output), not to $S$ (raw scores).
3. **Rescale**: Multiply by $\frac{1}{1-p}$ to keep the expected value unchanged.

### Philox RNG Implementation (philox.cuh)

FlashAttention uses the Philox4x32-7 (7 rounds) counter-based random number generator.

#### Core Primitive

```
output(4×uint32) = philox(key(2×uint32), counter(4×uint32))
```

#### Parameter Mapping

| User Level | Philox Internal | Bit Width |
|-----------|----------------|-----------|
| seed | key | 64 bit (2×uint32) |
| offset | counter[0:1] | 64 bit (low 64 bits) |
| subsequence | counter[2:3] | 64 bit (high 64 bits) |

#### Key Functions

- **`mulhilo32(a, b)`**: Uses PTX `mul.wide.u32` to compute the full-width multiplication of two uint32 values, returning (lo, hi).
- **`philox_single_round(ctr, key)`**: Single-round permutation, performing multiplication + XOR mixing on both halves of the counter.
- **`philox(seed, subsequence, offset)`**: Main function, executes 7 rounds (6 loop iterations + 1 tail round). After each round, the key is incremented by Weyl sequence constants `(0x9E3779B9, 0xBB67AE85)`, producing 4 uint32 random numbers.


#### Dropout Mask Generation Strategy

##### Core Design Principle

A single Philox invocation produces 4×uint32 random numbers (reinterpretable as 8×uint16 or 16×uint8). To fully amortize the computational cost of each Philox call, each thread/lane should process an equal number of S matrix elements per call.

To ensure **fwd/bwd generate exactly the same dropout mask regardless of different TiledMMA tile sizes and thread layouts**, the S matrix is partitioned into fixed-size **MMA atomic blocks** as the fundamental dropout unit. For each atomic block:

```
Philox(seed,
       offset      = f(batch_id, head_id, lane_id),   
       subsequence = f(block_row_id, block_col_id))      
```

offset and subsequence occupy different dimensions of the 128-bit counter (low/high 64 bits), **orthogonal and non-overlapping**. Given (seed, batch, head, lane, block position), fwd/bwd will necessarily produce the same random numbers for the same set of elements, thus generating an identical mask.

##### CUDA FA vs Intel XPU FA Comparison

|  | CUDA FA (Tri Dao) | Intel XPU FA (SyclTLA) |
|---|---|---|
| MMA atom | m16×n8 | m8×n16 |
| Thread group | warp = 32 threads | subgroup = 16 lanes |
| Elements per thread/lane per atom | 4 | 8 |
| Dropout basic block | (16, 32) = 4 m16n8 atoms | (8, 16) = 1 m8×n16 atom |
| Elements per Philox call | 4 atoms × 4 elements = 16 elements | 1 atom × 8 elements = 8 elements |
| Random number reinterpretation | 4×uint32 → 16×uint8 | 4×uint32 → 8×uint16 |
| Comparison precision | uint8 (256 levels) | uint16 (65536 levels) |

**CUDA FA Details**: Each thread in an m16n8 atom holds only 4 elements, but Philox produces 16 uint8 values. Therefore, a (16, 32) block (= 4 m16n8 atoms, 1×M 4×N) is used as the basic unit, and one Philox call covers all 4×4 = 16 elements held by the current thread within that block:

```cpp
for (int j = 0; j < 2; j++) {          // 2 groups, each with 2 n-atoms
    for (int i = 0; i < 8; i++) {       // 8 elements per group
        tensor(i, m, n * 2 + j) = encode_dropout(rnd_8[j * 8 + i] <= threshold, ...);
    }
}
```

**Intel XPU FA Details**: Each lane in an m8×n16 atom holds 8 elements, which exactly matches 8×uint16. One Philox call covers a complete atomic block without needing to combine across atoms.

##### Offset Increment

After each forward kernel invocation, the global Philox offset increases by `batch × heads × lane_count`:

- CUDA: `batch × heads × 32` (warp size)
- XPU: `batch × heads × 16` (subgroup size)

---

### Dropout Flow in Forward Kernel

Mathematically $O = \frac{1}{1-p}(P \odot M) V$, but the kernel **defers rescaling to the epilogue**:

**Mainloop** (each K block iteration):
1. $S = Q K^T$ (GEMM1)
2. $P = \text{softmax}(S)$ (online softmax)
3. **Apply dropout mask**: Generate mask $M$ using Philox, **zero out** dropped elements: $\tilde{P} = P \odot M$
4. $O_{acc} += \tilde{P} \cdot V$ (GEMM2, accumulate to output registers)

**Epilogue**:
5. **Dropout rescale**: $O = \frac{1}{1-p} \cdot O_{acc}$

Deferring the $\frac{1}{1-p}$ multiplication to the epilogue avoids scaling $\tilde{P}$ before each GEMM2, reducing intermediate computation. The final result is equivalent to $O = \frac{1}{1-p}(P \odot M) V$.

## Backward

### Mathematical Derivation

Need to compute $dV, dK, dQ$. Dropout propagates to all gradients through the chain rule.

**Key Equations:**

- $d\tilde{P} = dO \cdot V^T$ (gradient w.r.t. dropout output)
- $dP = \frac{M}{1-p} \odot d\tilde{P}$ (backprop through dropout)
- $D_i = \sum_j P_{ij} \cdot dP_{ij} = dO_i \cdot O_i$ (normalization term gradient inside softmax)
- $dS = P \odot (dP - D)$ (softmax backward)
- $dV = \tilde{P}^T \cdot dO, \quad dK = scale \cdot dS^T \cdot Q, \quad dQ = scale \cdot dS \cdot K$

### CUDA Code Implementation

The code employs a **sign-bit encoding + deferred scaling** strategy, avoiding explicit mask storage and reducing extra computation.

#### 1. RNG Reconstruction (No Mask Storage Needed)

```cpp
FLASH_NAMESPACE::Dropout dropout(params.rng_state[0], params.rng_state[1],
    params.p_dropout_in_uint8_t, bidb, bidh, tidx, params.h);
```

Uses the RNG state saved during forward to regenerate the exact same dropout pattern.

#### 2. Sign-Bit Encoding of Mask

```cpp
dropout.template apply_dropout</*encode_dropout_in_sign_bit=*/true>(acc_s, ...);
```

When applying dropout to the softmax output $P$, instead of zeroing out elements, it **flips the sign bit to make them negative**. A single float simultaneously encodes:
- **Absolute value** = original $P_{ij}$
- **Sign** = whether it was dropped (negative = dropped)

#### 3. Using Sign Bit to Obtain $P \odot M$

```cpp
Tensor rP = Is_dropout
    ? FLASH_NAMESPACE::convert_type_relu<Element>(acc_s)   // negative → 0
    : FLASH_NAMESPACE::convert_type<Element>(acc_s);
```

`convert_type_relu` zeros out negative values. The result `rP` = $P \odot M$, written to shared memory `sP` for use in the $dV$ gemm.

#### 4. Computing $D'_i$ (Pre-compensated Scaling)

```cpp
dot_do_o<...>(tdOrdO, tdOrO, gdPsum, ..., params.p_dropout);
```

Stores $D'_i = (1-p) \cdot dO_i \cdot O_i$, rather than the true $D_i = dO_i \cdot O_i$.

**Reason**: The code uses a deferred scaling strategy where the epilogue multiplies the entire $dS$ by $\frac{1}{1-p}$. If $D_i$ were stored directly, it would be incorrectly divided by $(1-p)$ an extra time. Pre-multiplying by $(1-p)$ exactly cancels this extra scaling:

$$\frac{1}{1-p} \cdot P(d\tilde{P} - \underbrace{(1-p) D_i}_{D'}) = P\left(\frac{d\tilde{P}}{1-p} - D_i\right) \quad \checkmark$$

#### 5. `pointwise_mult`: Implicit Mask Handling for $dS$

```cpp
auto pointwise_mult = [](float p, float dp, float d) {
    return p * (!Is_dropout || p >= 0 ? dp - d : d);
};
```

- `p` = sign-encoded $P_{ij}$, `dp` = $d\tilde{P}_{ij}$ = $(dO \cdot V^T)_{ij}$, `d` = $D'_i$
- **Not dropped** (`p >= 0`): $dS' = P \cdot (d\tilde{P} - D')$
- **Dropped** (`p < 0`): $dS' = (-|P|) \cdot D'$ (the negative sign participates in the correct subtraction)

**No explicit mask operation** — the mask effect is entirely achieved through the sign-bit branch.

#### 6. Epilogue: Deferred $\frac{1}{1-p}$ Scaling

```cpp
// dV multiplied by 1/(1-p) separately
if (Is_dropout) { acc_dv(i) *= params.rp_dropout; }
// dK combines softmax_scale and 1/(1-p)
acc_dk(i) *= params.scale_softmax_rp_dropout;  // = scale / (1-p)
// dQ similarly
acc_dq(i) *= params.scale_softmax_rp_dropout;
```

All preceding computations exclude $\frac{1}{1-p}$, which is uniformly applied in the epilogue.

### Parameter Reference

| Parameter | Meaning |
|-----------|---------|
| `p_dropout` | Keep probability $1-p$ |
| `rp_dropout` | $\frac{1}{1-p}$ (reciprocal of keep prob) |
| `scale_softmax_rp_dropout` | $\frac{scale\_softmax}{1-p}$ |
| `p_dropout_in_uint8_t` | uint8-encoded dropout probability (for RNG comparison) |

### Design Philosophy Summary

| Technique | Purpose |
|-----------|---------|
| RNG state reconstruction | Avoids storing $O(n^2)$ mask tensor |
| Sign-bit encoding | A single float represents both the $P$ value and the mask, saving extra storage and operations |
| `convert_type_relu` | Obtains $P \odot M$ directly using the sign bit, zero overhead |
| $D'_i$ pre-multiplied by $(1-p)$ | Works with deferred scaling to prevent $D_i$ from being incorrectly scaled |
| Deferred scaling | Merges $\frac{1}{1-p}$ into a single multiplication in the epilogue, reducing intermediate computation |

---

### Intel XPU (SyclTLA) Code Implementation

The XPU backward implementation is mathematically equivalent to CUDA but uses an **immediate scaling** strategy (as opposed to CUDA's deferred scaling).

### Overall Flow

The XPU backward consists of 3 kernels:

1. **`mha_dot_do_o`** (`compute_o_dot_do`): Computes $D_i = \sum_j dO_{ij} \cdot O_{ij}$, also zeros out `dQaccum`
2. **`mha_backward_seq`** (`dq_dk_dv_1colblock`): Main loop, computes dS, dV, dK, dQ
3. **`mhd_convert_dq`** (`convert_dq`): Converts float32 `dQaccum` to bf16/fp16 and writes to `dQ`

### Key Differences from CUDA

#### 1. $D_i$ Without Pre-scaling

CUDA stores $D'_i = (1-p) \cdot dO_i \cdot O_i$ (pre-multiplied by dropout keep probability), while XPU directly stores $D_i = dO_i \cdot O_i$ without any preprocessing.

#### 2. `softmax_backward`: All Scaling Done Immediately

```cpp
auto pointwise_mult = [is_dropout, scale, rp_dropout](float p, float dp, float d) {
    return scale * p * (!is_dropout || p >= 0 ? dp * rp_dropout - d : d);
};
```

- `p` = sign-encoded $P_{ij}$, `dp` = $d\tilde{P}_{ij}$, `d` = $D_i$ (not pre-scaled)
- `scale` = softmax_scale = $\frac{1}{\sqrt{d}}$
- `rp_dropout` = $\frac{1}{1-p}$

**Not dropped** (`p >= 0`):

$$dS_{ij} = \text{scale} \cdot P_{ij} \cdot \left(\frac{d\tilde{P}_{ij}}{1-p} - D_i\right)$$

**Dropped** (`p < 0`):

$$dS_{ij} = \text{scale} \cdot (-|P_{ij}|) \cdot D_i = -\text{scale} \cdot |P_{ij}| \cdot D_i$$

Unlike CUDA, here dS already includes `scale` and `rp_dropout`, requiring no epilogue post-processing.

#### 3. $\tilde{P}$ Processing for dV

```cpp
// Apply relu + rescale on sign-encoded P, obtaining P_tilde in one step
void apply_dropout_on_signed_P(Tensor& P, const float& rp_dropout) {
    P(i) = P(i) >= 0 ? P(i) * rp_dropout : 0;  // = P * M / (1-p)
}
```

CUDA does this in two steps (`convert_type_relu` to get $P \odot M$, then epilogue multiplies by $\frac{1}{1-p}$), while XPU does it in one step.

#### 4. No Epilogue Scaling

CUDA uniformly multiplies scaling factors in the epilogue; XPU's dK/dQ/dV require no additional scalar multiplication before being written out.

### XPU Main Loop Pseudocode (`dq_dk_dv_1colblock`)

```
rdV = 0, rdK = 0                         // register accumulators

for m_block in 0..max_m_block:
    // 1. Reconstruct P
    rS = Q[m_block] * K^T                 // GEMM: S = Q K^T
    scores = exp2(rS * scale_log2 - LSE * log2e)  // P = softmax(S)

    // 2. Sign-bit encode dropout mask (same as CUDA)
    if is_dropout:
        dropout.apply_dropout<sign_bit=true>(rS)

    // 3. Compute d_tilde_P
    rdP = dO[m_block] * V^T               // GEMM: dP_tilde = dO V^T

    // 4. softmax_backward: immediate scaling (differs from CUDA)
    dS = scale * P_signed * (dP_tilde * rp_dropout - D_i)  // or dropped branch

    // 5. Process P → P_tilde (for dV)
    if is_dropout:
        rS = relu(rS) * rp_dropout        // apply_dropout_on_signed_P

    // 6. Write to global memory intermediate buffer
    store(rS → mP),  store(dS → mdP)

    // 7. GEMM to compute dV, dK, dQ
    rdV += P_tilde^T * dO[m_block]         // dV accumulation
    rdK += dS^T * Q[m_block]               // dK accumulation (dS already includes scale)
    dQaccum[m_block] += dS * K             // dQ atomic accumulation

store rdV → dV,  store rdK → dK           // write out after loop ends
```

### CUDA vs XPU Strategy Comparison

| Aspect | CUDA (Deferred Scaling) | XPU (Immediate Scaling) |
|--------|------------------------|------------------------|
| $D_i$ storage | $D'_i = (1-p) \cdot D_i$ (pre-scaled) | $D_i$ (raw value) |
| `softmax_backward` | Excludes `scale`, excludes `rp_dropout` | Includes `scale` and `rp_dropout` |
| dS output | Unscaled $dS'$ | Fully scaled final $dS$ |
| $P \odot M$ for dV | `convert_type_relu` → epilogue $\times \frac{1}{1-p}$ | `apply_dropout_on_signed_P` in one step |
| Epilogue dK/dQ | $\times \frac{\text{scale}}{1-p}$ | None |
| Epilogue dV | $\times \frac{1}{1-p}$ | None |
| Intermediate buffer | Shared memory (sP, sdS) | Global memory (pb_ptr) |

### Mathematical Equivalence Verification

Expanding the final $dK_{ij}$ for non-dropped elements:

**CUDA**:

$$dK = \frac{\text{scale}}{1-p} \cdot \underbrace{P \cdot (d\tilde{P} - (1-p) D_i)}_{dS'} \cdot Q = \text{scale} \cdot P \cdot \left(\frac{d\tilde{P}}{1-p} - D_i\right) \cdot Q$$

**XPU**:

$$dK = \underbrace{\text{scale} \cdot P \cdot \left(\frac{d\tilde{P}}{1-p} - D_i\right)}_{dS} \cdot Q \quad \checkmark$$

The dropped elements follow the same logic; both yield identical final results.

