### PR TITLE
Enable torch_xpu and inductor test suites in CI

### DIFF
--- a/.github/actions/linux-uttest/action.yml
+++ b/.github/actions/linux-uttest/action.yml
@@ -81,18 +81,35 @@ runs:
         echo -e "Reproduce Command: pytest -sv failed_case" | tee -a ${{ github.workspace }}/ut_log/reproduce_skipped_ut.log
     - name: torch_xpu
       shell: timeout 72000 bash -xe {0}
-      if: ${{ inputs.ut_name == 'torch_xpu' }}
+      if: ${{ inputs.ut_name == 'torch_xpu' || inputs.ut_name == 'basic' }}
       run: |
         export PYTORCH_TEST_WITH_SLOW=1
         export PYTORCH_TESTING_DEVICE_ONLY_FOR="xpu"
         mkdir -p ut_log/torch_xpu
         cd pytorch
+        # Test pyzes related cases in test_xpu.py
+        pip install pyzes
         test_cmd="python test/run_test.py --include "
-        for test in $(ls test/inductor | grep test); do test_cmd="${test_cmd} inductor/$test"; done
         for test in $(ls test/xpu | grep test); do test_cmd="${test_cmd} xpu/$test"; done
-        if [ -f "test/test_xpu.py" ]; then test_cmd="${test_cmd} test_xpu.py"; fi
+        if [ -f "test/test_xpu.py" ]; then test_cmd="${test_cmd} test_xpu"; fi
         eval $test_cmd 2> ${{ github.workspace }}/ut_log/torch_xpu/torch_xpu_test_error.log | \
           tee ${{ github.workspace }}/ut_log/torch_xpu/torch_xpu_test.log
+        # Collect JUnit XML reports
+        find test/test-reports -type f -name "*.xml" -exec cp {} ${{ github.workspace }}/ut_log/ \; 2>/dev/null || true
+    - name: inductor
+      shell: timeout 72000 bash -xe {0}
+      if: ${{ inputs.ut_name == 'inductor' }}
+      run: |
+        export PYTORCH_TEST_WITH_SLOW=1
+        export PYTORCH_TESTING_DEVICE_ONLY_FOR="xpu"
+        mkdir -p ut_log/inductor
+        cd pytorch
+        test_cmd="python test/run_test.py --include "
+        for test in $(ls test/inductor | grep test); do test_cmd="${test_cmd} inductor/$test"; done
+        eval $test_cmd 2> ${{ github.workspace }}/ut_log/inductor/inductor_test_error.log | \
+          tee ${{ github.workspace }}/ut_log/inductor/inductor_test.log
+        # Collect JUnit XML reports
+        find test/test-reports -type f -name "*.xml" -exec cp {} ${{ github.workspace }}/ut_log/ \; 2>/dev/null || true
     - name: xpu_profiling
       shell: timeout 3600 bash -xe {0}
       if: ${{ inputs.ut_name == 'xpu_profiling' }}

--- a/.github/scripts/check-ut.py
+++ b/.github/scripts/check-ut.py
@@ -260,6 +260,10 @@ def determine_category(ut):
         return 'test_xpu'
     elif 'op_ut' in ut:
         return 'op_ut'
+    elif 'inductor' in ut:
+        return 'inductor'
+    elif 'torch_xpu' in ut:
+        return 'torch_xpu'
     else:
         return 'unknown'
 

--- a/.github/scripts/ut_result_check.sh
+++ b/.github/scripts/ut_result_check.sh
@@ -2,7 +2,7 @@
 # Test Suite Runner for Intel Torch-XPU-Ops
 # Usage: TEST_PLATFORM=linux ./script.sh <test_suite>
 
-# Available suites: op_regression, op_extended, op_ut, test_xpu, xpu_distributed, skipped_ut
+# Available suites: op_regression, op_extended, op_ut, test_xpu, torch_xpu, inductor, xpu_distributed, skipped_ut
 readonly ut_suite="${1:-op_regression}"  # Default to op_regression if no suite specified
 readonly inputs_pytorch="${2:-nightly_wheel}"
 readonly REPO="intel/torch-xpu-ops"
@@ -35,6 +35,8 @@ declare -A EXPECTED_CASES=(
     ["op_regression_dev1"]=1
     ["op_ut"]="${OP_UT_EXPECTED[$TEST_PLATFORM]}"
     ["test_xpu"]=69
+    ["torch_xpu"]=""
+    ["inductor"]=""
 )
 
 # Tests that are known to randomly pass and should be ignored when detecting new passes
@@ -376,7 +378,7 @@ mark_passed_issue() {
 
 # Main dispatcher - route to appropriate test runner based on suite type
 case "$ut_suite" in
-    op_regression|op_regression_dev1|op_extended|op_ut|test_xpu)
+    op_regression|op_regression_dev1|op_extended|op_ut|test_xpu|torch_xpu|inductor)
         run_main_tests "$ut_suite"
         ;;
     xpu_distributed)
@@ -391,6 +393,6 @@ case "$ut_suite" in
     *)
         echo "❌ Unknown test suite: ${ut_suite}" >&2
         printf "💡 Available: op_regression, op_regression_dev1, op_extended, " >&2
-        printf "op_ut, test_xpu, xpu_distributed, skipped_ut, xpu_profiling\n" >&2
+        printf "op_ut, test_xpu, torch_xpu, inductor, xpu_distributed, skipped_ut, xpu_profiling\n" >&2
         ;;
 esac

--- a/.github/workflows/_linux_ut.yml
+++ b/.github/workflows/_linux_ut.yml
@@ -191,7 +191,7 @@ jobs:
           bash ${{ github.workspace }}/.github/scripts/fetch_issues.sh static >> Known_issue.log.tmp
           bash ${{ github.workspace }}/.github/scripts/fetch_issues.sh open >> issues.log
           if [ "${{ inputs.ut }}" == "basic" ];then
-            ut_list="op_regression op_extended op_regression_dev1"
+            ut_list="op_regression op_extended op_regression_dev1 torch_xpu"
           else
             ut_list="${{ inputs.ut }}"
           fi
@@ -214,7 +214,7 @@ jobs:
           latest_dir=$(find . -type d -name "Inductor-XPU-UT-Data-${{ github.event.pull_request.number || github.sha }}-${{ inputs.ut }}-*" |sort -V |tail -n 1)
           ut_dir="${latest_dir}/${{ inputs.ut }}"
           if [ "${{ inputs.ut }}" == "basic" ]; then
-            ut_list="op_regression op_extended op_regression_dev1"
+            ut_list="op_regression op_extended op_regression_dev1 torch_xpu"
           else
             ut_list="${{ inputs.ut }}"
           fi


### PR DESCRIPTION
## Summary

- Add `torch_xpu` (test/xpu/* + test_xpu.py) to the basic CI suite with full log processing and failure capture
- Add `inductor` (test/inductor/*) as a standalone test suite (not in basic scope) with its own log/failure pipeline
- Integrate both suites into `ut_result_check.sh`, `check-ut.py`, and the workflow failure collection steps
- Collect JUnit XML reports from `run_test.py` for structured failure analysis