### PR TITLE
Skip deprecated QuantizedXPU tests

### DIFF
--- a/test/xpu/quantization/core/test_quantized_tensor_xpu.py
+++ b/test/xpu/quantization/core/test_quantized_tensor_xpu.py
@@ -98,6 +98,7 @@ with XPUPatchForImport(False):
     def _test_dequantize_fp16_cuda(self):
         self._test_dequantize_fp16(torch.device("xpu"))
 
+
 TestQuantizedTensor.test_compare_per_channel_device_numerics = (
     _test_compare_per_channel_device_numerics
 )

--- a/test/xpu/quantization/core/test_quantized_tensor_xpu.py
+++ b/test/xpu/quantization/core/test_quantized_tensor_xpu.py
@@ -98,81 +98,6 @@ with XPUPatchForImport(False):
     def _test_dequantize_fp16_cuda(self):
         self._test_dequantize_fp16(torch.device("xpu"))
 
-    @unittest.skipIf(not TEST_CUDA, "No gpu is available.")
-    def _test_per_channel_qtensor_creation_cuda(self):
-        self._test_per_channel_qtensor_creation(torch.device("xpu"))
-
-    @unittest.skipIf(not TEST_CUDA, "No gpu is available.")
-    def _test_per_channel_to_device(self):
-        dtype_and_zero_types = [
-            (torch.quint8, torch.float),
-            (torch.qint8, torch.float),
-            #  (torch.qint32, torch.float) not supported for quantize_per_channel
-            (torch.quint8, torch.long),
-            (torch.qint8, torch.long),
-            (torch.qint32, torch.long),
-        ]
-        axis = 1
-        device = torch.device("xpu")
-        for dtype, zero_type in dtype_and_zero_types:
-            r = torch.rand(2, 2, dtype=torch.float) * 10
-            scales = torch.rand(2).abs()
-            zero_points = (torch.rand(2) * 10).round().to(zero_type)
-
-            dqr = torch.quantize_per_channel(r, scales, zero_points, axis, dtype)
-            dqr = dqr.to(device)
-            dqr_cuda = torch.quantize_per_channel(
-                r.to(device), scales.to(device), zero_points.to(device), axis, dtype
-            )
-            dqr_cuda = dqr_cuda.to("cpu")
-
-            self.assertEqual("xpu", dqr.device.type)
-            self.assertEqual("xpu", dqr.q_per_channel_scales().device.type)
-            self.assertEqual("xpu", dqr.q_per_channel_zero_points().device.type)
-
-            self.assertEqual("cpu", dqr_cuda.device.type)
-            self.assertEqual("cpu", dqr_cuda.q_per_channel_scales().device.type)
-            self.assertEqual("cpu", dqr_cuda.q_per_channel_zero_points().device.type)
-
-    @unittest.skipIf(not TEST_CUDA, "No gpu is available.")
-    def _test_per_tensor_to_device(self):
-        dtypes = [
-            torch.quint8,
-            torch.qint8,
-            torch.qint32,
-        ]
-        device = torch.device("xpu")
-        for dtype in dtypes:
-            r = torch.rand(2, 2, dtype=torch.float) * 10
-            scale = torch.rand(2).abs().max().item()
-            zero_point = (torch.rand(2) * 10).round().to(torch.long).max().item()
-
-            qr = torch.quantize_per_tensor(r, scale, zero_point, dtype)
-            qr = qr.to(device)
-            qr_cuda = torch.quantize_per_tensor(r.to(device), scale, zero_point, dtype)
-            qr_cuda = qr_cuda.to("cpu")
-            self.assertEqual("xpu", qr.device.type)
-            self.assertEqual("cpu", qr_cuda.device.type)
-
-    @unittest.skipIf(not TEST_CUDA, "No gpu is available.")
-    def _test_qtensor_cuda(self):
-        self._test_qtensor(torch.device("xpu"))
-        self._test_qtensor_dynamic(torch.device("xpu"))
-
-    @unittest.skipIf(not TEST_CUDA, "No gpu is available.")
-    def _test_qtensor_index_put_cuda(self):
-        self._test_qtensor_index_put("xpu")
-        self._test_qtensor_index_put_non_accumulate_deterministic("xpu")
-
-    @unittest.skipIf(not TEST_CUDA, "No gpu is available.")
-    def _test_qtensor_index_select_cuda(self):
-        self._test_qtensor_index_select("xpu")
-
-    @unittest.skipIf(not TEST_CUDA, "No gpu is available.")
-    def _test_qtensor_masked_fill_cuda(self):
-        self._test_qtensor_masked_fill("xpu")
-
-
 TestQuantizedTensor.test_compare_per_channel_device_numerics = (
     _test_compare_per_channel_device_numerics
 )
@@ -183,21 +108,10 @@ TestQuantizedTensor.test_cuda_quantization_does_not_pin_memory = (
     _test_cuda_quantization_does_not_pin_memory
 )
 TestQuantizedTensor.test_dequantize_fp16_cuda = _test_dequantize_fp16_cuda
-TestQuantizedTensor.test_per_channel_qtensor_creation_cuda = (
-    _test_per_channel_qtensor_creation_cuda
-)
-TestQuantizedTensor.test_per_channel_to_device = _test_per_channel_to_device
-TestQuantizedTensor.test_per_tensor_to_device = _test_per_tensor_to_device
-TestQuantizedTensor.test_qtensor_cuda = _test_qtensor_cuda
-TestQuantizedTensor.test_qtensor_index_put_cuda = _test_qtensor_index_put_cuda
-TestQuantizedTensor.test_qtensor_index_select_cuda = _test_qtensor_index_select_cuda
-TestQuantizedTensor.test_qtensor_masked_fill_cuda = _test_qtensor_masked_fill_cuda
-
 
 instantiate_device_type_tests(
     TestQuantizedTensor, globals(), only_for="xpu", allow_xpu=True
 )
-
 
 if __name__ == "__main__":
     TestCase._default_dtype_check_enabled = True

--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -37,7 +37,16 @@ skip_dict = {
         "test_qgelu_xpu",
         "test_qrelu_xpu",
     ),
-    "quantization/core/test_quantized_tensor_xpu.py": None,
+    "quantization/core/test_quantized_tensor_xpu.py": (
+        # QuantizedXPU is deprecated https://github.com/pytorch/pytorch/pull/173923
+        "test_qtensor_cuda_xpu",
+        "test_qtensor_masked_fill_cuda_xpu",
+        "test_qtensor_index_put_cuda_xpu",
+        "test_qtensor_index_select_cuda_xpu",
+        "test_per_channel_qtensor_creation_cuda_xpu",
+        "test_per_channel_to_device_xpu",
+        "test_per_tensor_to_device_xpu",
+    ),
     "quantization/core/test_workflow_module_xpu.py": None,
     "quantization/core/test_workflow_ops_xpu.py": (
         # AssertionError:
@@ -223,7 +232,11 @@ skip_dict = {
     ),
     "test_type_promotion_xpu.py": None,
     "test_unary_ufuncs_xpu.py": None,
-    "test_view_ops_xpu.py": None,
+    "test_view_ops_xpu.py": (
+        # QuantizedXPU is deprecated https://github.com/pytorch/pytorch/pull/173923
+        "test_ravel_xpu",
+        "test_flatten_xpu",
+    ),
     "test_schema_check.py": None,
     "test_nestedtensor_xpu.py": None,
     "functorch/test_eager_transforms_xpu.py": None,


### PR DESCRIPTION
Add tests using deprecated `QuantizedXPU` to the skip list as it is deprecated in upstream and not registered.

Reference: 
https://github.com/intel/torch-xpu-ops/issues/2358 -> https://github.com/intel/torch-xpu-ops/pull/3424

Fixes: https://github.com/intel/torch-xpu-ops/issues/3763