### PR TITLE
[fix] Fix Windows build error

### DIFF
--- a/src/ATen/native/xpu/sycl/ResizeKernel.cpp
+++ b/src/ATen/native/xpu/sycl/ResizeKernel.cpp
@@ -74,7 +74,7 @@ TensorImpl* resize_impl_xpu_(
     IntArrayRef size,
     at::OptionalIntArrayRef stride,
     bool device_guard) {
-  if (self->sizes() == size && (!stride || self->strides() == stride)) {
+  if (self->sizes() == size && (!stride || self->strides() == *stride)) {
     return self;
   }
 


### PR DESCRIPTION
### Problem

Windows XPU build is broken due to pytorch/pytorch#185421, which modernized `OptionalArrayRef::operator==` from free function templates to hidden friends.

The following line in `ResizeKernel.cpp` no longer compiles on MSVC:

```cpp
if (self->sizes() == size && (!stride || self->strides() == stride)) {
```

`self->strides()` returns `IntArrayRef` and `stride` is `at::OptionalIntArrayRef`. With hidden friends, the compiler can only find `operator==` via ADL when `OptionalArrayRef` appears directly as an argument — MSVC strictly enforces this, causing the build failure.

Error:
```
ResizeKernel.cpp(77,60): error: invalid operands to binary expression
('IntArrayRef' (aka 'ArrayRef<long long>') and 'at::OptionalIntArrayRef'
(aka 'OptionalArrayRef<long long>'))
```

### Fix

Dereference `stride` to make both sides `IntArrayRef`:

```cpp
if (self->sizes() == size && (!stride || self->strides() == *stride)) {
```

This is safe because `||` short-circuit evaluation guarantees `stride` has a value before `*stride` is reached. This also aligns with how PyTorch upstream handles the same pattern in `aten/src/ATen/native/Resize.cpp:200`:

```cpp
(!stride || self->generic_strides<T>() == stride.value())
```

### Tracked in
pytorch/pytorch#185753
