### PR TITLE
Fix Linux build by removing Intel GPU repo with expired SSL certificate

### DIFF
--- a/.github/workflows/_linux_build.yml
+++ b/.github/workflows/_linux_build.yml
@@ -59,6 +59,10 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     timeout-minutes: 300
     steps:
+      - name: Remove Intel GPU repo with expired SSL certificate
+        run: |
+          rm -f /etc/yum.repos.d/intel-gpu*.repo
+          dnf clean all || true
       - name: Install gh-cli
         run: |
           cat /etc/os-release


### PR DESCRIPTION
## Summary
- Fix Linux build failure caused by expired SSL certificate on `repositories.intel.com`
- Remove `intel-gpu*.repo` files from `/etc/yum.repos.d/` at the start of the build workflow to prevent `dnf` from trying to download metadata from the broken repo

## Root Cause
The `pytorch/manylinux2_28-builder:xpu-main` container image has pre-configured Intel GPU repo files. The SSL certificate on Intel's repository server has expired, causing `dnf` metadata refresh to fail with:
```
Errors during downloading metadata for repository 'intel-graphics-8.10-unified':
[SSL certificate problem: certificate has expired]
Error: Failed to download metadata for repo 'intel-graphics-8.10-unified'
```

## Fix
Add a step at the beginning of `_linux_build.yml` to remove the Intel GPU repo files before any `dnf` command runs. These repos are not needed for the build itself.