### PR TITLE
Remove unconditional CUDNN_ATTENTION append for XPU vmap SDPA tests

### DIFF
--- a/test/xpu/functorch/test_vmap_xpu.py
+++ b/test/xpu/functorch/test_vmap_xpu.py
@@ -105,10 +105,6 @@ def get_platform_specific_sdpa():
 
 PLATFORM_SPECIFIC_SDPA = get_platform_specific_sdpa()
 
-# For XPU, add CUDNN_ATTENTION even though it's not supported - tests will fail with known issue
-if TEST_XPU and SDPBackend.CUDNN_ATTENTION not in PLATFORM_SPECIFIC_SDPA:
-    PLATFORM_SPECIFIC_SDPA.append(SDPBackend.CUDNN_ATTENTION)
-
 FALLBACK_REGEX = "There is a performance drop"
 
 


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/3545

XPU has no cuDNN attention backend. The unconditional append of SDPBackend.CUDNN_ATTENTION to PLATFORM_SPECIFIC_SDPA at module level caused four _backend3_* test parametrizations to be generated that always fail with "No viable backend for scaled_dot_product_attention was found."

Remove the XPU-specific append so PLATFORM_SPECIFIC_SDPA matches the upstream logic: CUDNN_ATTENTION is only included when PLATFORM_SUPPORTS_CUDNN_ATTENTION is true (which it never is on XPU). This eliminates the backend3 parametrization entirely, matching CPU/ROCm behavior on hardware without cuDNN.

Test:
```
  cd third_party/torch-xpu-ops/test/xpu/functorch
  PYTHONPATH=$(git -C ../../../.. rev-parse --show-toplevel)/test/functorch:$PYTHONPATH \
    python -m pytest -sxv test_vmap_xpu.py \
    -k 'test_randomness_backend3 or test_sdpa_backend3'
   # Result: 0 collected (parametrization no longer generated)
```