### PR TITLE
Fix test_nan_assert in test_c10d_xccl suite

### DIFF
--- a/test/xpu/distributed/test_c10d_xccl.py
+++ b/test/xpu/distributed/test_c10d_xccl.py
@@ -336,6 +336,7 @@ class ProcessGroupXCCLTest(MultiProcessTestCase):
         self.assertEqual(pg_2.group_desc, "undefined")
 
     @requires_xccl()
+    @skip_if_lt_x_gpu(2)
     @parametrize(
         "type",
         [


### PR DESCRIPTION
Fix test_nan_assert in test_c10d_xccl suite by adding skip if GPUs device count is lower than expected