### PR TITLE
ci: remove unnecessary actions:write permission from auto_label workflow

### DIFF
--- a/.claude/skills/pr-review/references/review-checklist.md
+++ b/.claude/skills/pr-review/references/review-checklist.md
@@ -122,6 +122,7 @@ When reviewing changes to workflows, build scripts, or CI configuration:
 - [ ] **No cache-dependent binaries in sensitive contexts** — sccache-backed builds are susceptible to cache corruption; these artifacts should not access sensitive info or be published for general use
 - [ ] **Workflow trigger scope** — `pull_request_target` workflows must not check out PR head code into a trusted context without proper isolation
 - [ ] **Token permissions minimized** — Workflow `permissions` block should request only what is needed (e.g., `contents: read` not `contents: write` unless required)
+- [ ] **Write permissions justified by GITHUB_TOKEN usage** — Every write permission declared must correspond to an actual API call using `GITHUB_TOKEN`; permissions needed only by PATs or other secrets should not be granted to the default token
 - [ ] **No arbitrary code execution from PR inputs** — PR title, body, branch name, and commit messages must not be interpolated into shell commands without sanitization
 - [ ] **Third-party action pinning** — Actions are pinned to a full commit SHA, not a mutable tag (e.g., `actions/checkout@<sha>` not `actions/checkout@v4`)
 - [ ] **CI logic changes clearly explain impact** — Changes to workflow triggers, conditions, or job structure must document what validation coverage is gained or lost

--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -19,7 +19,6 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
-  actions: write
 
 concurrency:
   group: auto-label-${{ github.event_name }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- Remove `actions: write` permission from `auto_label.yml` GITHUB_TOKEN since the workflow cancellation step uses `MERGE_TOKEN` (PAT), not GITHUB_TOKEN
- Follows principle of least privilege for workflow token permissions
- Addresses OpenSSF Scorecard warning about excessive token permissions

## Details

The `auto_label.yml` workflow declared `actions: write` at the top level, but the only step that interacts with the Actions API (cancelling workflow runs at line 272-278) uses `secrets.MERGE_TOKEN` (a PAT), not `GITHUB_TOKEN`. Therefore `actions: write` on the default token is unnecessary and should be removed.