### PR TITLE
Replace .github/copilot-instructions.md symlink with regular file

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1 +1,3 @@
-../CLAUDE.md
+# Copilot Instructions — torch-xpu-ops
+
+See `CLAUDE.md` at the repository root for all agent instructions, skills index, and repo conventions.


### PR DESCRIPTION
## Summary
- Replace the `.github/copilot-instructions.md` symlink (`-> ../CLAUDE.md`) with a regular file that points readers to `CLAUDE.md`
- Some tools don't follow symlinks correctly; a regular file avoids this issue