### PR TITLE
Replace std::trunc with sycl::trunc for compatibility

### DIFF
--- a/src/ATen/native/xpu/sycl/BinaryDivTruncKernel.cpp
+++ b/src/ATen/native/xpu/sycl/BinaryDivTruncKernel.cpp
@@ -26,7 +26,7 @@ struct DivTruncScalarFunctor {
   DivTruncScalarFunctor(accscalar_t inv_b) : inv_b_(inv_b) {}
 
   scalar_t operator()(scalar_t a) const {
-    return std::trunc(a * inv_b_);
+    return sycl::trunc(a * inv_b_);
   }
 
  private:
@@ -36,7 +36,9 @@ struct DivTruncScalarFunctor {
 template <typename scalar_t>
 struct DivTruncFunctor {
   scalar_t operator()(scalar_t a, scalar_t b) const {
-    return std::trunc(c10::xpu::compat::div(a, b));
+    using opmath_t = at::opmath_type<scalar_t>;
+    return sycl::trunc(static_cast<opmath_t>(
+        c10::xpu::compat::div(a, b)));
   }
 };
 

--- a/src/ATen/native/xpu/sycl/BinaryDivTruncKernel.cpp
+++ b/src/ATen/native/xpu/sycl/BinaryDivTruncKernel.cpp
@@ -37,8 +37,7 @@ template <typename scalar_t>
 struct DivTruncFunctor {
   scalar_t operator()(scalar_t a, scalar_t b) const {
     using opmath_t = at::opmath_type<scalar_t>;
-    return sycl::trunc(static_cast<opmath_t>(
-        c10::xpu::compat::div(a, b)));
+    return sycl::trunc(static_cast<opmath_t>(c10::xpu::compat::div(a, b)));
   }
 };
 

--- a/src/ATen/native/xpu/sycl/ForeachUnaryKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ForeachUnaryKernels.cpp
@@ -391,7 +391,7 @@ struct Round {
 template <typename T>
 struct Trunc {
   T operator()(T t) const {
-    return t - std::trunc(t);
+    return t - sycl::trunc(t);
   }
 };
 

--- a/src/ATen/native/xpu/sycl/MathExtensions.h
+++ b/src/ATen/native/xpu/sycl/MathExtensions.h
@@ -48,7 +48,7 @@ static inline C10_HOST_DEVICE scalar_t calc_digamma(scalar_t in) {
     return std::copysign(static_cast<scalar_t>(INFINITY), -x);
   }
 
-  bool x_is_integer = x == std::trunc(x);
+  bool x_is_integer = x == sycl::trunc(x);
   accscalar_t result = 0;
   if (x < accscalar_t(0)) {
     if (x_is_integer) {

--- a/src/ATen/native/xpu/sycl/UnaryFractionKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryFractionKernels.cpp
@@ -206,14 +206,14 @@ inline double trunc_wrapper(double a) {
 
 inline c10::complex<float> trunc_wrapper(c10::complex<float> a) {
   return c10::complex<float>(
-      std::truncf(static_cast<float>(a.real())),
-      std::truncf(static_cast<float>(a.imag())));
+      sycl::trunc(static_cast<float>(a.real())),
+      sycl::trunc(static_cast<float>(a.imag())));
 }
 
 inline c10::complex<double> trunc_wrapper(c10::complex<double> a) {
   return c10::complex<double>(
-      std::trunc(static_cast<double>(a.real())),
-      std::trunc(static_cast<double>(a.imag())));
+      sycl::trunc(static_cast<double>(a.real())),
+      sycl::trunc(static_cast<double>(a.imag())));
 }
 
 template <typename scalar_t>

--- a/src/ATen/native/xpu/sycl/UnaryFractionKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryFractionKernels.cpp
@@ -71,7 +71,8 @@ void reciprocal_kernel(TensorIteratorBase& iter) {
 template <typename scalar_t>
 struct FracFunctor {
   scalar_t operator()(scalar_t a) const {
-    return a - std::trunc(a);
+    using opmath_t = at::opmath_type<scalar_t>;
+    return a - sycl::trunc(static_cast<opmath_t>(a));
   }
 };
 
@@ -192,15 +193,15 @@ void floor_kernel(TensorIteratorBase& iter) {
       });
 }
 
-// We manually overload trunc because std::trunc does not work with std::complex
-// types and ROCm.
+// We manually overload trunc because sycl::trunc does not work with
+// std::complex types.
 template <typename scalar_t>
 inline scalar_t trunc_wrapper(scalar_t a) {
-  return static_cast<scalar_t>(std::truncf(static_cast<float>(a)));
+  return static_cast<scalar_t>(sycl::trunc(static_cast<float>(a)));
 }
 
 inline double trunc_wrapper(double a) {
-  return std::trunc(a);
+  return sycl::trunc(a);
 }
 
 inline c10::complex<float> trunc_wrapper(c10::complex<float> a) {

--- a/src/ATen/native/xpu/sycl/UnaryFractionKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryFractionKernels.cpp
@@ -204,16 +204,11 @@ inline double trunc_wrapper(double a) {
   return sycl::trunc(a);
 }
 
-inline c10::complex<float> trunc_wrapper(c10::complex<float> a) {
-  return c10::complex<float>(
-      sycl::trunc(static_cast<float>(a.real())),
-      sycl::trunc(static_cast<float>(a.imag())));
-}
-
-inline c10::complex<double> trunc_wrapper(c10::complex<double> a) {
-  return c10::complex<double>(
-      sycl::trunc(static_cast<double>(a.real())),
-      sycl::trunc(static_cast<double>(a.imag())));
+template <typename T>
+inline c10::complex<T> trunc_wrapper(c10::complex<T> a) {
+  return c10::complex<T>(
+      sycl::trunc(static_cast<T>(a.real())),
+      sycl::trunc(static_cast<T>(a.imag())));
 }
 
 template <typename scalar_t>


### PR DESCRIPTION
This pull request replaces all uses of `std::trunc` with `sycl::trunc` in the XPU SYCL backend to ensure compatibility with SYCL device code. Additionally, it updates comments to reflect this change and ensures proper type casting for mathematical operations.

**SYCL math function migration:**

* Replaced all instances of `std::trunc` with `sycl::trunc` in functors and kernels, including `DivTruncScalarFunctor`, `DivTruncFunctor`, `FracFunctor`, `trunc_wrapper`, and within the digamma calculation in `MathExtensions.h`, to ensure device compatibility.

**Type casting and numerical precision:**

* Updated functors to use `at::opmath_type` for type casting before applying `sycl::trunc`, improving numerical correctness and consistency.

**Code cleanup:**

* Unified the two explicit `trunc_wrapper` overloads for `c10::complex<float>` and `c10::complex<double>` into a single `template <typename T> c10::complex<T> trunc_wrapper(c10::complex<T> a)` template.

**ASM Difference**

* No significant difference between `sycl::trunc` and `std::trunc`