### PR TITLE
[agentic] Add nightly CI UT fix workflow

### DIFF
--- a/.github/skills/xpu-nightly-ci-fix/SKILL.md
+++ b/.github/skills/xpu-nightly-ci-fix/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: xpu-nightly-ci-fix
+description: Analyze CI nightly test failures and fix XPU test cases. Use when the user provides CI failure reports, nightly status emails, or lists of failing test cases. Covers triaging failures, reproducing locally, identifying root causes, and applying fixes.
+---
+> Please also read and refer to `CLAUDE.md` at the repository root for general behavioral guidelines before proceeding.
+
+# Nightly CI UT Fixing for XPU
+
+## When to Use
+
+- The user provides a CI nightly failure report (email content, test case list, or log snippets).
+- The goal is to analyze, triage, reproduce, and fix multiple failing XPU test cases in PyTorch, then output a summary report.
+
+## Step 1: Parse the failure report
+- Parse the Pytorch commit_id, report_date.
+- Extract the list of failing test cases (test file, class, method name)
+- Group failures by test file / module
+
+### Step 2: Reproduce locally
+- fetch latest pytorch origin main if commit_id is provided in previous step, checkout to it else use origin main.
+- Create a new branch for the fix, branch name: fix-<report_date>
+- build pytorch:
+  ```bash
+  source build_pytorch.env
+  python setup.py clean
+  pip install -e . -v --no-build-isolation
+  ```
+
+
+- Run each failing test on this machine:
+  ```bash
+  source build_pytorch.env && python <test_file> -k <test_name> 2>&1 | tail -80
+  ```
+- Confirm the failure reproduces.
+
+
+### Step 3: Analyze and categorize
+
+For each failure, determine the root cause category:
+- First, use git to check when the test case was added. If it was added recently, identify which commit or PR introduced it. If it's newly added, check the commit or PR for relevant changes, to see if xpu support is required. then go to fix step. otherwise proceed to categorize the failure.
+1. **XPU backend bug** — Fix in `torch/_inductor/` or `third_party/torch-xpu-ops/`
+2. **Tolerance too tight** — Increase atol/rtol to match CUDA tolerances
+3. **Skip decorator stale** — Remove `@skipIfXpu` or `@expectedFailure` if the test now passes
+4. **Community Upstream regression** — New upstream code broke XPU; needs XPU-specific workaround
+5. **Test infrastructure** — Environment, import, or setup issue
+
+### Step 4: Fix
+
+- For newly added test case: try to enable it for XPU, if not possible, leave it skipped with a proper reason.
+- For a regression test, first try to find the guilty commit by reviewing the recent commit history and identifying which change introduced the failure. Apply an XPU-specific fix if necessary.
+- If can not identify the guilty commit, start analysis, compare with cuda/rocm backend, and try to find the root cause.
+
+
+### Step 5: Verify
+
+- Run the fixed test and confirm it passes
+- Run the full test file to check for regressions
+- Linter check:
+```bash
+spin fixlint
+```
+- Analyze the output log and fix any linting issues.
+- Stage and commit changes. The commit message needs to include: title `[xpu][fix] <description>`, `## Motivation`, `## Solution`, `## Test plan`.
+
+### Step 6: Generate Summary Report
+
+For all the failing test cases provided in the initial CI report, write a structured summary to `summary_<date>.md`.
+
+Each entry in the summary should include:
+- Test case name / module
+- Root cause and category (from Step 3)
+- Resolution or fix applied (with commit reference if a change was made)
+- AR: Action required (e.g., submit PR, rebase, none)
+
+## Environment
+
+- Source `build_pytorch.env` before running any test
+- Build: `pip install -e . -v --no-build-isolation`
+- Scratch files go in `agent_space/` (git-ignored)
+
+## Best Practices
+
+- Always reproduce before fixing
+- **After fixing, run EVERY failing test case from the report individually to verify it passes.** Do not skip any case or assume that verifying one representative case is sufficient. Run all cases explicitly, batch by batch if needed, and confirm each one passes.
+- Match upstream CUDA tolerances when adjusting XPU tolerances
+- Remove unused imports when removing skip decorators
+- Keep commits focused: one fix per commit
+- **Never cherry-pick** upstream fixes into the fix branch. If a fix already landed on trunk after the CI commit, rebase the fix branch onto the latest trunk (`git rebase origin/main`) instead.
+- **Always rebuild after rebase or branch switch.** After `git rebase`, `git checkout`, or any operation that changes the commit base, you MUST rebuild (`source build_pytorch.env && pip install -e . -v --no-build-isolation`) before running any tests. Without rebuilding, the installed C++ extensions and generated code are stale and test results are **completely unreliable** — they may segfault, produce wrong pass/fail results, or mask real issues. Never trust test results from a stale build.
+- Editable installs resolve Python from source but C++ headers from the installed location (`torch/include/`). After editing a C++ header, **manually copy** it to the installed include path.
+- Delete the PCH cache (`/tmp/torchinductor_<user_name>/precompiled_headers/`) after modifying any header under `torch/csrc/inductor/cpp_wrapper/` — stale precompiled headers mask the fix.
+- For C++ compile errors in AOT Inductor generated code (`CppCompileError`), read the generated `.wrapper.cpp` error message carefully — the root cause is usually in the **codegen ordering** in `cpp_wrapper_cpu.py` (e.g. a function used before its definition is emitted). Check `write_wrapper_decl()` and `generate_input_output_runtime_checks()` ordering.
+
+
+## Requirements
+
+- PyTorch built from source with XPU support
+- `build_pytorch.env` file configured for the oneAPI environment

--- a/.github/skills/xpu-nightly-ci-fix/SKILL.md
+++ b/.github/skills/xpu-nightly-ci-fix/SKILL.md
@@ -46,7 +46,7 @@ For each failure, determine the root cause category:
 
 ### Step 4: Fix
 
-- For newly added test case: try to enable it for XPU, if not possible, leave it skipped with a proper reason.
+- For newly added test case: try to enable it for XPU. If it cannot be enabled directly, leave it skipped with a proper reason, add a TODO with issue ID, and file a tracking issue in `intel/torch-xpu-ops` for engineering follow-up.
 - For a regression test, first try to find the guilty commit by reviewing the recent commit history and identifying which change introduced the failure. Apply an XPU-specific fix if necessary.
 - If can not identify the guilty commit, start analysis, compare with cuda/rocm backend, and try to find the root cause.
 

--- a/tools/agentic_xpu/nightly_ci_fix/README.md
+++ b/tools/agentic_xpu/nightly_ci_fix/README.md
@@ -45,8 +45,9 @@ Create `build_pytorch.env` at the repo root (or set `BUILD_ENV` env var):
 
 ```bash
 export TORCH_XPU_ARCH_LIST=pvc
-ONEAPI_VARS=/opt/intel/oneapi/2026.0/oneapi-vars.sh
-ONEAPI_PTI=/opt/intel/oneapi/pti/latest/env/vars.sh
+ONEAPI_ROOT=${ONEAPI_ROOT:-/opt/intel/oneapi}
+ONEAPI_VARS=${ONEAPI_VARS:-${ONEAPI_ROOT}/setvars.sh}
+ONEAPI_PTI=${ONEAPI_PTI:-${ONEAPI_ROOT}/pti/latest/env/vars.sh}
 
 export USE_XPU=1
 export USE_CUDA=0

--- a/tools/agentic_xpu/nightly_ci_fix/README.md
+++ b/tools/agentic_xpu/nightly_ci_fix/README.md
@@ -66,9 +66,21 @@ source "${ONEAPI_PTI}"
 
 ## Workflow (from SKILL.md)
 
-1. **Parse** — Extract commit ID and failing test cases from the report
-2. **Reproduce** — Build PyTorch, run each failing test on XPU
-3. **Analyze** — Categorize root cause (XPU bug, tolerance, stale skip, upstream regression, infra)
-4. **Fix** — Apply appropriate fix per category
-5. **Verify** — Confirm fix passes, run full test file, lint
-6. **Report** — Write structured summary with root cause / fix / AR per test
+```
+report.md (CI failure report)
+      │
+      ▼
+run_fix.sh (pipeline entry point)
+      │
+      ├─► OpenCode + SKILL.md (6-step workflow)
+      │       │
+      │       ├─ Step 1: Parse failure report
+      │       ├─ Step 2: Reproduce locally
+      │       ├─ Step 3: Analyze & categorize root cause
+      │       ├─ Step 4: Fix
+      │       ├─ Step 5: Verify fix + lint
+      │       └─ Step 6: Generate summary report
+      │
+      ▼
+summary_<date>.md (structured fix report)
+```

--- a/tools/agentic_xpu/nightly_ci_fix/README.md
+++ b/tools/agentic_xpu/nightly_ci_fix/README.md
@@ -1,0 +1,74 @@
+<!-- Copyright 2024-2026 Intel Corporation -->
+<!-- Co-authored with GitHub Copilot -->
+<!-- Licensed under the Apache License, Version 2.0 -->
+
+# XPU Nightly CI UT Fix
+
+Agent-assisted workflow for analyzing and fixing nightly CI test failures on XPU.
+
+## Directory Layout
+
+```
+tools/agentic_xpu/nightly_ci_fix/
+├── README.md              # This file
+└── run_fix.sh             # Pipeline entry point (invokes OpenCode)
+
+.github/skills/xpu-nightly-ci-fix/
+├── SKILL.md               # Full workflow definition (6 steps)
+└── PRINCIPLES.md          # LLM behavioral guidelines
+```
+
+## Prerequisites
+
+- [OpenCode](https://github.com/opencode-ai/opencode) installed and connected to an LLM
+- Local PyTorch source with XPU support buildable
+- `build_pytorch.env` with oneAPI paths configured (see below)
+
+## Quick Start
+
+```bash
+# 1. Prepare CI failure report
+cat > /tmp/report.md << 'EOF'
+Commit: abc1234
+Failures:
+- test/test_torch.py::TestTorchDeviceTypeXPU::test_foo
+- test/test_ops.py::TestCommonXPU::test_bar
+EOF
+
+# 2. Run the fix pipeline
+bash tools/agentic_xpu/nightly_ci_fix/run_fix.sh /tmp/report.md 0603
+```
+
+## build_pytorch.env
+
+Create `build_pytorch.env` at the repo root (or set `BUILD_ENV` env var):
+
+```bash
+export TORCH_XPU_ARCH_LIST=pvc
+ONEAPI_VARS=/opt/intel/oneapi/2026.0/oneapi-vars.sh
+ONEAPI_PTI=/opt/intel/oneapi/pti/latest/env/vars.sh
+
+export USE_XPU=1
+export USE_CUDA=0
+
+source "${ONEAPI_VARS}" --force
+source "${ONEAPI_PTI}"
+```
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OPENCODE_BIN` | Path to `opencode` binary | `opencode` in `$PATH` |
+| `PYTORCH_DIR` | Path to local PyTorch source | `~/pytorch` |
+| `BUILD_ENV` | Path to `build_pytorch.env` | `<repo_root>/build_pytorch.env` |
+| `ENV_FILE` | Path to tokens.env | `<repo_root>/tokens.env` |
+
+## Workflow (from SKILL.md)
+
+1. **Parse** — Extract commit ID and failing test cases from the report
+2. **Reproduce** — Build PyTorch, run each failing test on XPU
+3. **Analyze** — Categorize root cause (XPU bug, tolerance, stale skip, upstream regression, infra)
+4. **Fix** — Apply appropriate fix per category
+5. **Verify** — Confirm fix passes, run full test file, lint
+6. **Report** — Write structured summary with root cause / fix / AR per test

--- a/tools/agentic_xpu/nightly_ci_fix/README.md
+++ b/tools/agentic_xpu/nightly_ci_fix/README.md
@@ -13,7 +13,7 @@ tools/agentic_xpu/nightly_ci_fix/
 ├── README.md              # This file
 └── run_fix.sh             # Pipeline entry point (invokes OpenCode)
 
-.github/skills/xpu-nightly-ci-fix/
+.claude/skills/xpu-nightly-ci-fix/
 ├── SKILL.md               # Full workflow definition (6 steps)
 └── PRINCIPLES.md          # LLM behavioral guidelines
 ```

--- a/tools/agentic_xpu/nightly_ci_fix/run_fix.sh
+++ b/tools/agentic_xpu/nightly_ci_fix/run_fix.sh
@@ -73,7 +73,7 @@ OUTPUT_FILE="$OUTPUT_DIR/summary_${DATE_ARG}.md"
 mkdir -p "$OUTPUT_DIR"
 
 # --- Sync skill into workspace ---
-SKILL_SRC="$REPO_ROOT/.github/skills/xpu-nightly-ci-fix"
+SKILL_SRC="$REPO_ROOT/.claude/skills/xpu-nightly-ci-fix"
 SKILL_DST="$WORKSPACE/.opencode/skills/xpu-nightly-ci-fix"
 mkdir -p "$SKILL_DST"
 cp "$SKILL_SRC/SKILL.md" "$SKILL_DST/SKILL.md"

--- a/tools/agentic_xpu/nightly_ci_fix/run_fix.sh
+++ b/tools/agentic_xpu/nightly_ci_fix/run_fix.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Copyright 2024-2026 Intel Corporation
+# Co-authored with GitHub Copilot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+set -euo pipefail
+
+# Nightly CI UT fix pipeline for XPU.
+#
+# Usage:
+#   bash run_fix.sh <report_file> [DATE]
+#
+# Arguments:
+#   report_file   Path to the nightly CI failure report (plain text or markdown).
+#                 Defaults to agent_inputs/nightly_CI_ut_fix/report_<DATE>.md if not given.
+#   DATE          Date string used for output naming, e.g. 0521 or 2026-05-21.
+#                 Defaults to today (MMDD format).
+#
+# Outputs:
+#   agent_outputs/nightly_CI_ut_fix/summary_<DATE>.md
+#
+# Env vars (optional overrides):
+#   OPENCODE_BIN   path to opencode binary (default: opencode in PATH)
+#   WORKSPACE      repo working directory (default: git root of this repo)
+#   ENV_FILE       path to .env (default: tools/agentic_xpu/.env)
+#   BUILD_ENV      path to build_pytorch.env (default: <repo_root>/build_pytorch.env)
+#   PYTORCH_DIR    path to local pytorch source (default: ~/pytorch)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
+# --- Parse args ---
+REPORT_FILE="${1:-}"
+DATE_ARG="${2:-$(date '+%m%d')}"
+
+# --- Resolve paths ---
+OPENCODE_BIN="${OPENCODE_BIN:-$(command -v opencode 2>/dev/null || echo "")}"
+[[ -n "$OPENCODE_BIN" ]] || { echo "ERROR: opencode not found. Set OPENCODE_BIN or add to PATH." >&2; exit 1; }
+
+WORKSPACE="${WORKSPACE:-$REPO_ROOT}"
+
+# Load shared env (tokens, build config, PYTORCH_DIR, etc.)
+ENV_FILE="${ENV_FILE:-$REPO_ROOT/tools/agentic_xpu/.env}"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  set +a
+fi
+
+BUILD_ENV="${BUILD_ENV:-$REPO_ROOT/build_pytorch.env}"
+PYTORCH_DIR="${PYTORCH_DIR:-$HOME/pytorch}"
+
+# Default report path
+if [[ -z "$REPORT_FILE" ]]; then
+  REPORT_FILE="$REPO_ROOT/agent_inputs/nightly_CI_ut_fix/report_${DATE_ARG}.md"
+fi
+
+[[ -f "$REPORT_FILE" ]] || {
+  echo "ERROR: report file not found: $REPORT_FILE" >&2
+  echo "Usage: bash run_fix.sh <report_file> [DATE]" >&2
+  exit 1
+}
+
+# --- Output path ---
+OUTPUT_DIR="$REPO_ROOT/agent_outputs/nightly_CI_ut_fix"
+OUTPUT_FILE="$OUTPUT_DIR/summary_${DATE_ARG}.md"
+mkdir -p "$OUTPUT_DIR"
+
+# --- Sync skill into workspace ---
+SKILL_SRC="$REPO_ROOT/.github/skills/xpu-nightly-ci-fix"
+SKILL_DST="$WORKSPACE/.opencode/skills/xpu-nightly-ci-fix"
+mkdir -p "$SKILL_DST"
+cp "$SKILL_SRC/SKILL.md" "$SKILL_DST/SKILL.md"
+
+# --- Run log ---
+LOG_FILE="$OUTPUT_DIR/run_${DATE_ARG}.log"
+
+echo "=== XPU Nightly CI UT Fix: $DATE_ARG  ($(date -Iseconds)) ==="
+echo "  Report:   $REPORT_FILE"
+echo "  Output:   $OUTPUT_FILE"
+echo "  Log:      $LOG_FILE"
+echo "  PyTorch:  $PYTORCH_DIR"
+
+REPORT_CONTENT="$(cat "$REPORT_FILE")"
+
+PROMPT="Use the xpu-nightly-ci-fix skill.
+
+CI failure report for $DATE_ARG:
+
+$REPORT_CONTENT
+
+Work in pytorch source directory: $PYTORCH_DIR
+Build env: $BUILD_ENV
+
+Run all steps (Step 1–6) from the skill.
+
+At the end (Step 6), write the summary report to:
+  $OUTPUT_FILE
+
+Use the exact format from the skill: Report Info section, one entry per failing test with
+root cause / fix / AR, a Summary Table, and a Verification section."
+
+"$OPENCODE_BIN" run \
+  --dir "$PYTORCH_DIR" \
+  --dangerously-skip-permissions \
+  --title "nightly-ci-fix-$DATE_ARG" \
+  "$PROMPT" \
+  2>&1 | tee "$LOG_FILE"
+
+rc=${PIPESTATUS[0]}
+echo "=== Finished: $(date -Iseconds) (exit $rc) ==="
+
+if [[ -f "$OUTPUT_FILE" ]]; then
+  echo "Summary written: $OUTPUT_FILE"
+else
+  echo "WARNING: summary file not produced at $OUTPUT_FILE" >&2
+  rc=1
+fi
+
+exit "$rc"


### PR DESCRIPTION
## What

Agent-assisted workflow for analyzing and fixing nightly CI test failures on XPU.
Given a CI failure report (email, test case list, or log snippets), the agent
triages, reproduces, categorizes root causes, applies fixes, and generates a
structured summary report.

## Workflow

```
report.md (CI failure report)
      │
      ▼
run_fix.sh (pipeline entry point)
      │
      ├─► OpenCode + SKILL.md (6-step workflow)
      │       │
      │       ├─ Step 1: Parse failure report
      │       ├─ Step 2: Reproduce locally
      │       ├─ Step 3: Analyze & categorize root cause
      │       ├─ Step 4: Fix
      │       ├─ Step 5: Verify fix + lint
      │       └─ Step 6: Generate summary report
      │
      ▼
summary_<date>.md (structured fix report)
```

## File structure

```
.github/skills/xpu-nightly-ci-fix/
└── SKILL.md                        ← agent skill (6-step workflow definition)

tools/agentic_xpu/
├── .env.example                    ← shared env config (tokens, paths)
└── nightly_ci_fix/
    ├── README.md                   ← usage docs
    └── run_fix.sh                  ← pipeline entry point (invokes OpenCode)
```

## Quick start

```bash
cd tools/agentic_xpu
cp .env.example .env && chmod 600 .env
# Edit .env — set GITHUB_TOKEN

cd nightly_ci_fix
bash run_fix.sh /path/to/report.md 0603
```

## Root cause categories

1. **XPU backend bug** — Fix in `torch/_inductor/` or `third_party/torch-xpu-ops/`
2. **Tolerance too tight** — Increase atol/rtol to match CUDA tolerances
3. **Skip decorator stale** — Remove `@skipIfXpu` / `@expectedFailure` if test now passes
4. **Upstream regression** — New upstream code broke XPU; needs XPU-specific workaround
5. **Test infrastructure** — Environment, import, or setup issue

Co-authored with GitHub Copilot.
