### PR TITLE
Fix HardtanhBackwardFunctor: use opmath_t instead of scalar_t for min_val/max_val

### DIFF
--- a/src/ATen/native/xpu/sycl/ActivationHardtanhKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ActivationHardtanhKernels.cpp
@@ -25,19 +25,20 @@ namespace xpu {
 
 template <typename scalar_t>
 struct HardtanhBackwardFunctor {
+  using opmath_t = at::opmath_type<scalar_t>;
+
   scalar_t operator()(scalar_t a, scalar_t b) const {
-    using opmath_t = at::opmath_type<scalar_t>;
     opmath_t aop = static_cast<opmath_t>(a);
     opmath_t bop = static_cast<opmath_t>(b);
     return (bop <= min_val_) || (bop >= max_val_) ? opmath_t(0) : aop;
   }
 
-  HardtanhBackwardFunctor(scalar_t min_val, scalar_t max_val)
+  HardtanhBackwardFunctor(opmath_t min_val, opmath_t max_val)
       : min_val_(min_val), max_val_(max_val) {}
 
  private:
-  scalar_t min_val_;
-  scalar_t max_val_;
+  opmath_t min_val_;
+  opmath_t max_val_;
 };
 
 void hardtanh_backward_kernel(


### PR DESCRIPTION
## Summary

Fix `HardtanhBackwardFunctor` to store `min_val_`/`max_val_` as `opmath_t` (float) instead of `scalar_t` (bf16), matching the CUDA reference implementation.

## Root Cause

The XPU `HardtanhBackwardFunctor` stores boundary values as `scalar_t`. When the caller computes `min.to<opmath_t>()` (float 0.7) and passes it to the constructor, the value is truncated back to bf16 → 0.69921875. This causes the eager kernel to use wrong bounds, while the inductor-decompiled path correctly compares in fp32 → gradient mismatch.

CUDA reference uses lambda capture of `opmath_t` directly (no struct truncation):
```cpp
auto min_val = min.to<opmath_t>();  // stays float
gpu_kernel(iter, [min_val, max_val] GPU_LAMBDA(...) { ... bop <= min_val ... });
```

## Fix

Change `HardtanhBackwardFunctor` member types from `scalar_t` → `opmath_t`:
- Move `using opmath_t = at::opmath_type<scalar_t>;` to struct scope
- Constructor params: `scalar_t` → `opmath_t`
- Members: `scalar_t min_val_, max_val_` → `opmath_t min_val_, max_val_`

**1 file changed, 5 insertions, 4 deletions.**

## Related Issues

- Fixes pytorch/pytorch#186313 (`test_hardtanh_backward_low_precision_boundary_xpu`)
- Fixes pytorch/pytorch#186312 (`test_hardtanh_backward_low_precision_boundary_dynamic_shapes_xpu`) — auto-resolved via CommonTemplate inheritance

## Dependencies

No pytorch-side PR needed — upstream main already has the test without `@expectedFailureXPU`. Once this merges and `xpu.txt` pin is updated, both tests pass.

---

**Rebased onto main** (`77cbdc3d`) — 2025-06-05. Single clean commit with only the kernel fix.