### PR TITLE
Fix build break from upstream named tensor removal

### DIFF
--- a/src/ATen/native/xpu/sycl/Indexing.cpp
+++ b/src/ATen/native/xpu/sycl/Indexing.cpp
@@ -2198,7 +2198,7 @@ Tensor& index_select_kernel(
   at::assert_no_overlap(out, self);
   at::assert_no_overlap(out, index);
 
-  dim = at::maybe_wrap_dim(dim, self);
+  dim = at::maybe_wrap_dim(dim, self.dim());
   TORCH_CHECK(
       self.dim() <= XPU_MAX_TENSORINFO_DIMS,
       "Tensor too large or too many (> ",


### PR DESCRIPTION
Fix compilation error caused by pytorch/pytorch#173895 (Remove named tensor), which removed `ATen/NamedTensorUtils.h` and `ATen/TensorNames.h`. These headers transitively included `ATen/WrapDimUtils.h`, which provided a `maybe_wrap_dim(int64_t, TensorList)` overload that `const Tensor&` could implicitly convert to.

Without that transitive include, the call `at::maybe_wrap_dim(dim, self)` no longer compiles as only the base overloads in `c10/core/WrapDimMinimal.h` (accepting int64_t or c10::SymInt) are visible.

Fix by calling `self.dim()` explicitly instead of relying on the implicit `Tensor` to `TensorList` conversion, which is more readable and robust against future header changes.