### PR TITLE
Replace std::copysign with sycl::copysign for SYCL compatibility

### DIFF
--- a/src/ATen/native/xpu/sycl/CopysignKernel.cpp
+++ b/src/ATen/native/xpu/sycl/CopysignKernel.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <ATen/Dispatch.h>
+#include <ATen/OpMathType.h>
 #include <ATen/native/TensorIterator.h>
 
 #include <ATen/native/xpu/sycl/Loops.h>
@@ -20,7 +21,8 @@ namespace at::native::xpu {
 template <typename scalar_t>
 struct CopysignFunctor {
   scalar_t operator()(scalar_t a, scalar_t b) const {
-    return std::copysign(a, b);
+    using opmath_t = at::opmath_type<scalar_t>;
+    return sycl::copysign(static_cast<opmath_t>(a), static_cast<opmath_t>(b));
   }
 };
 

--- a/src/ATen/native/xpu/sycl/MathExtensions.h
+++ b/src/ATen/native/xpu/sycl/MathExtensions.h
@@ -101,7 +101,8 @@ static inline C10_HOST_DEVICE scalar_t calc_digamma(scalar_t in) {
   if (x == accscalar_t(0)) {
     // As per C++ standard for gamma related functions and SciPy,
     // If the argument is ±0, ±∞ is returned
-    return std::copysign(static_cast<scalar_t>(INFINITY), -x);
+    return static_cast<scalar_t>(
+        sycl::copysign(static_cast<accscalar_t>(INFINITY), -x));
   }
 
   bool x_is_integer = x == sycl::trunc(x);


### PR DESCRIPTION
This pull request updates the implementation of the copysign operation in the XPU SYCL backend to improve numerical consistency and compatibility. The main changes involve switching from the standard `std::copysign` to `sycl::copysign` and ensuring type safety by explicitly casting to appropriate types.

**Copysign operation improvements:**

* Updated the `CopysignFunctor` in `CopysignKernel.cpp` to use `sycl::copysign` with explicit casting to `opmath_type`, ensuring better type safety and compatibility with SYCL devices.
* Modified the digamma calculation in `MathExtensions.h` to use `sycl::copysign` for handling special cases, again with explicit type casting for correctness.

**Code maintenance:**

* Added an include for `ATen/OpMathType.h` in `CopysignKernel.cpp` to support the new type casting logic.…Extensions for SYCL compatibility