### PR TITLE
partially enable test_fused_attention_vs_math_ref_grads

### DIFF
--- a/test/xpu/test_transformers_xpu.py
+++ b/test/xpu/test_transformers_xpu.py
@@ -5468,7 +5468,6 @@ class TestSDPACudaOnly(NNTestCase):
             fudge_factors=fudge_factors,
         )
 
-    @skipIfXpu(msg="torch-xpu-ops: #3140")
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION,
         "Does not support SDPA or pre-SM80 hardware",
@@ -5479,7 +5478,7 @@ class TestSDPACudaOnly(NNTestCase):
     @parametrize("seq_len_k", [4, 127, 579, 2048])
     @parametrize("head_dim", [8, 203, 256])
     @parametrize("is_causal", [True, False])
-    @parametrize("dropout_p", [0.0, 0.22, 0.48])
+    @parametrize("dropout_p", [0.0] if TEST_XPU else [0.0, 0.22])  # torch-xpu-ops: #3140 is WIP
     @parametrize("dtype", [torch.float16, torch.bfloat16])
     @parametrize("scale", [None, "l1"])
     @parametrize("enable_gqa", [True, False])


### PR DESCRIPTION
#3142 is fixed for dropout 0, still disable dropout 0.22 because of #3140