### PR TITLE
Fix compile-backward nextafter OpInfo failures via parity xfail

### DIFF
--- a/test/xpu/test_nestedtensor_xpu.py
+++ b/test/xpu/test_nestedtensor_xpu.py
@@ -8688,6 +8688,11 @@ BACKWARD_SKIPS_AND_XFAILS = [
         ),
         name="unimplemented_masked_fill",
     ),
+    XFailRule(
+        sample_match_fn=lambda device, sample: "(T, NT)" in sample.name,
+        op_match_fn=lambda device, op: op.full_name == "nextafter",
+        name="nextafter_backward_not_implemented",
+    ),
 ]
 
 COMPILE_FORWARD_SKIPS_AND_XFAILS = [


### PR DESCRIPTION
This patch fixes #3795 by restoring missing XPU parity handling for nextafter backward in nestedtensor OpInfo compile-backward coverage. Prior this change `test_compile_backward_nextafter_xpu_float32` had reproducible subfailures with BackendCompilerFailed for (T, NT) broadcasting samples. The patch is following https://github.com/pytorch/pytorch/commit/fc5e84b652f4edc6ba1353814c274752c724f3f1 fix.
