### PR TITLE
Sync FakeTensor assertRaisesRegex messages with upstream

### DIFF
--- a/test/xpu/test_fake_tensor_xpu.py
+++ b/test/xpu/test_fake_tensor_xpu.py
@@ -33,6 +33,7 @@ from torch._subclasses.fake_tensor import (
     extract_tensor_metadata,
     FakeTensor,
     FakeTensorConverter,
+    FakeTensorDeviceMismatchError,
     FakeTensorMode,
     MetadataMismatchError,
     unset_fake_temporarily,
@@ -245,7 +246,8 @@ class FakeTensorTest(TestCase):
         fake_y = mode.from_tensor(y)
 
         with self.assertRaisesRegex(
-            RuntimeError, "Expected all tensors to be on the same device"
+            FakeTensorDeviceMismatchError,
+            "Expected all tensors to be on the same device"
         ) as exc:
             torch.nextafter(fake_x, fake_y)
 
@@ -278,7 +280,8 @@ class FakeTensorTest(TestCase):
             y = torch.randn(10, device=device_type)
 
             with self.assertRaisesRegex(
-                RuntimeError, "Expected all tensors to be on the same device"
+                FakeTensorDeviceMismatchError,
+                "Expected all tensors to be on the same device"
             ) as exc:
                 x + y
 
@@ -2676,7 +2679,8 @@ class FakeTensorPreferDeviceType(TestCase):
 
             # Without the config, this should raise a device mismatch error
             with self.assertRaisesRegex(
-                RuntimeError, "Expected all tensors to be on the same device"
+                RuntimeError,
+                "Expected all tensors to be on the same device"
             ):
                 mixed_device_op(cuda_tensor, None)
 
@@ -2714,7 +2718,8 @@ class FakeTensorPreferDeviceType(TestCase):
 
             # After exiting the config context, should raise error again
             with self.assertRaisesRegex(
-                RuntimeError, "Expected all tensors to be on the same device"
+                RuntimeError,
+                "Expected all tensors to be on the same device"
             ):
                 mixed_device_op(cuda_tensor, None)
 

--- a/test/xpu/test_fake_tensor_xpu.py
+++ b/test/xpu/test_fake_tensor_xpu.py
@@ -245,7 +245,7 @@ class FakeTensorTest(TestCase):
         fake_y = mode.from_tensor(y)
 
         with self.assertRaisesRegex(
-            RuntimeError, "Unhandled FakeTensor Device Propagation for.*"
+            RuntimeError, "Expected all tensors to be on the same device"
         ) as exc:
             torch.nextafter(fake_x, fake_y)
 
@@ -278,7 +278,7 @@ class FakeTensorTest(TestCase):
             y = torch.randn(10, device=device_type)
 
             with self.assertRaisesRegex(
-                RuntimeError, "Unhandled FakeTensor Device Propagation for.*"
+                RuntimeError, "Expected all tensors to be on the same device"
             ) as exc:
                 x + y
 
@@ -2676,7 +2676,7 @@ class FakeTensorPreferDeviceType(TestCase):
 
             # Without the config, this should raise a device mismatch error
             with self.assertRaisesRegex(
-                RuntimeError, "Unhandled FakeTensor Device Propagation"
+                RuntimeError, "Expected all tensors to be on the same device"
             ):
                 mixed_device_op(cuda_tensor, None)
 
@@ -2714,7 +2714,7 @@ class FakeTensorPreferDeviceType(TestCase):
 
             # After exiting the config context, should raise error again
             with self.assertRaisesRegex(
-                RuntimeError, "Unhandled FakeTensor Device Propagation"
+                RuntimeError, "Expected all tensors to be on the same device"
             ):
                 mixed_device_op(cuda_tensor, None)
 

--- a/test/xpu/test_fake_tensor_xpu.py
+++ b/test/xpu/test_fake_tensor_xpu.py
@@ -247,7 +247,7 @@ class FakeTensorTest(TestCase):
 
         with self.assertRaisesRegex(
             FakeTensorDeviceMismatchError,
-            "Expected all tensors to be on the same device"
+            "Expected all tensors to be on the same device",
         ) as exc:
             torch.nextafter(fake_x, fake_y)
 
@@ -281,7 +281,7 @@ class FakeTensorTest(TestCase):
 
             with self.assertRaisesRegex(
                 FakeTensorDeviceMismatchError,
-                "Expected all tensors to be on the same device"
+                "Expected all tensors to be on the same device",
             ) as exc:
                 x + y
 
@@ -2679,8 +2679,7 @@ class FakeTensorPreferDeviceType(TestCase):
 
             # Without the config, this should raise a device mismatch error
             with self.assertRaisesRegex(
-                RuntimeError,
-                "Expected all tensors to be on the same device"
+                RuntimeError, "Expected all tensors to be on the same device"
             ):
                 mixed_device_op(cuda_tensor, None)
 
@@ -2718,8 +2717,7 @@ class FakeTensorPreferDeviceType(TestCase):
 
             # After exiting the config context, should raise error again
             with self.assertRaisesRegex(
-                RuntimeError,
-                "Expected all tensors to be on the same device"
+                RuntimeError, "Expected all tensors to be on the same device"
             ):
                 mixed_device_op(cuda_tensor, None)
 


### PR DESCRIPTION
This patch fixes #3847 by updating stale FakeTensor assertRaisesRegex expectations in XPU tests to match the current upstream device-mismatch error message: `Expected all tensors to be on the same device` (introduced in https://github.com/pytorch/pytorch/commit/feeaefc86dfd44d6fe2883bf74e6bf8352eb71c7)
