### PR TITLE
Fix IndexFuncLargeIndexFunctor: Replace deprecated sub-group size

### DIFF
--- a/src/ATen/native/xpu/sycl/Indexing.cpp
+++ b/src/ATen/native/xpu/sycl/Indexing.cpp
@@ -974,7 +974,7 @@ template <
     bool IndexIsMajor,
     typename func_t>
 struct IndexFuncLargeIndexFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
-  [[intel::reqd_sub_group_size(SIMD)]] void operator()(
+  SYCL_REQD_SUB_GROUP_SIZE(SIMD) void operator()(
       sycl::nd_item<1> item) const {
     auto local_range = item.get_local_range(0);
     T identity = (T)0;

--- a/src/ATen/native/xpu/sycl/Indexing.cpp
+++ b/src/ATen/native/xpu/sycl/Indexing.cpp
@@ -974,8 +974,7 @@ template <
     bool IndexIsMajor,
     typename func_t>
 struct IndexFuncLargeIndexFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
-  SYCL_REQD_SUB_GROUP_SIZE(SIMD) void operator()(
-      sycl::nd_item<1> item) const {
+  SYCL_REQD_SUB_GROUP_SIZE(SIMD) void operator()(sycl::nd_item<1> item) const {
     auto local_range = item.get_local_range(0);
     T identity = (T)0;
 


### PR DESCRIPTION
This issue was resolved by the changes introduced in PR #2834.

The pull request updates the `IndexFuncLargeIndexFunctor` implementation in `src/ATen/native/xpu/sycl/Indexing.cpp` by replacing the Intel-specific sub-group size attribute with the standard SYCL macro. This change improves code portability, maintainability, and compiler compatibility.

**Changes:**

* Replaced the Intel-specific attribute `[[intel::reqd_sub_group_size(SIMD)]]` with the portable `SYCL_REQD_SUB_GROUP_SIZE(SIMD)` macro in the `operator()` method of `IndexFuncLargeIndexFunctor`.
* Standardized the mechanism used to specify the required sub-group size across SYCL implementations.

