### PR TITLE
Fix warning for Indexing kernel

### DIFF
--- a/src/ATen/native/xpu/sycl/Indexing.cpp
+++ b/src/ATen/native/xpu/sycl/Indexing.cpp
@@ -981,8 +981,7 @@ template <
     bool IndexIsMajor,
     typename func_t>
 struct IndexFuncLargeIndexFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
-  SYCL_REQD_SUB_GROUP_SIZE(SIMD) void operator()(
-      sycl::nd_item<1> item) const {
+  SYCL_REQD_SUB_GROUP_SIZE(SIMD) void operator()(sycl::nd_item<1> item) const {
     auto local_range = item.get_local_range(0);
     T identity = (T)0;
 

--- a/src/ATen/native/xpu/sycl/Indexing.cpp
+++ b/src/ATen/native/xpu/sycl/Indexing.cpp
@@ -13,6 +13,8 @@
 DISABLE_RETURN_TYPE_WARNING_BEGIN
 // clang-format on
 
+#include <type_traits>
+
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/MemoryOverlap.h>
@@ -921,7 +923,12 @@ struct IndexFuncSmallIndexFunctor {
             IndexToOffset<const T, IndexType, SrcDim>::get(linearIndex, src_);
         srcOffset += srcIndex * src_.strides[srcAddDim_];
 
-        T val = src_.data[srcOffset] * alpha_;
+        T val;
+        if constexpr (std::is_same_v<T, bool>) {
+          val = src_.data[srcOffset] && alpha_;
+        } else {
+          val = src_.data[srcOffset] * alpha_;
+        }
         op_(dst_.data, dstOffset, dstNumel_, &val);
       }
     }
@@ -974,7 +981,7 @@ template <
     bool IndexIsMajor,
     typename func_t>
 struct IndexFuncLargeIndexFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
-  [[intel::reqd_sub_group_size(SIMD)]] void operator()(
+  SYCL_REQD_SUB_GROUP_SIZE(SIMD) void operator()(
       sycl::nd_item<1> item) const {
     auto local_range = item.get_local_range(0);
     T identity = (T)0;
@@ -1014,7 +1021,12 @@ struct IndexFuncLargeIndexFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
           IndexToOffset<const T, IndexType, SrcDim>::get(elementInSlice, src_);
       srcOffset += srcIndex * src_.strides[srcAddDim_];
 
-      T val = src_.data[srcOffset] * alpha_;
+      T val;
+      if constexpr (std::is_same_v<T, bool>) {
+        val = src_.data[srcOffset] && alpha_;
+      } else {
+        val = src_.data[srcOffset] * alpha_;
+      }
       const int smem_idx = dstOffset & (SMEM_SIZE - 1);
       IndexType current_offset = smem_offsets[smem_idx];
 


### PR DESCRIPTION
This PR is to fix `error: ‘*’ in boolean context, suggest ‘&&’ instead [-Werror=int-in-bool-context]`.

**Improvements to type handling:**

* Added `#include <type_traits>` to enable type trait checks for conditional logic based on data type.
* Updated both `IndexFuncSmallIndexFunctor` and `IndexFuncLargeIndexFunctor` to use `std::is_same_v<T, bool>`: now, if the data type is `bool`, the operation uses logical AND (`&&`) with `alpha_` instead of multiplication, ensuring correct behavior for boolean tensors.