### PR TITLE
[DO NOT MERGE] Align `test_register_autograd_defaults` test case with upstream.

### DIFF
--- a/test/xpu/test_custom_ops_xpu.py
+++ b/test/xpu/test_custom_ops_xpu.py
@@ -2851,7 +2851,7 @@ class TestCustomOpAPI(TestCase):
             def backward(ctx, grad):
                 nonlocal called
                 called = True
-                return grad * ctx.c
+                return grad * ctx.c, None
 
             def setup_context(ctx, inputs, keyword_only_inputs, output):
                 if len(inputs) != 2:


### PR DESCRIPTION
This PR aligns `test_register_autograd_defaults()` test case from  `test_custom_ops_xpu.py` test file to upstream.
The upstream commit that changed the file: [PYTORCH COMMIT](https://github.com/pytorch/pytorch/commit/211af9577bfc98328aae3d1bd00ad49bc1253075)

One consideration is that this test case is only CPU. It does not use XPU. We could also add it to skip list as it would be fixed when ported to upstream. We could also just remove the whole test case from local torch-xpu-ops copy and do not launch it at all. But for consistency, reports and tracking I decided to start with the approach to fix the test case instead of skipping it.