### PR TITLE
[Build] Skip build warning in SYCLTLA for gcc15

### DIFF
--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
@@ -21,6 +21,7 @@
 #pragma GCC diagnostic ignored "-Wchanges-meaning"
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #pragma GCC diagnostic ignored "-Wdangling-pointer"
+#pragma GCC diagnostic ignored "-Wtemplate-id-cdtor"
 #include <cute/tensor.hpp>
 #include <cute/util/compat.hpp>
 #include <cutlass/numeric_conversion.h>

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.h
@@ -19,6 +19,7 @@
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wchanges-meaning"
+#pragma GCC diagnostic ignored "-Wtemplate-id-cdtor"
 
 #include <cute/tensor.hpp>
 #include <cute/util/compat.hpp>


### PR DESCRIPTION
Gcc-15 will throw warning
```
error: template-id not allowed for constructor in c++20
[-Werror=template-id-cdtor]
```
in cutlass source code. Here we skip the warning.