### PR TITLE
Replace std::pow with sycl::pow for SYCL compatibility

### DIFF
--- a/src/ATen/native/xpu/sycl/DistanceKernels.cpp
+++ b/src/ATen/native/xpu/sycl/DistanceKernels.cpp
@@ -89,8 +89,7 @@ struct DistsLtTwo {
                   static_cast<opmath_t>(p - 1)) *
               grad /
               sycl::pow(
-                  static_cast<opmath_t>(dist),
-                  static_cast<opmath_t>(p - 1)));
+                  static_cast<opmath_t>(dist), static_cast<opmath_t>(p - 1)));
   }
 };
 
@@ -120,8 +119,8 @@ template <typename scalar_t>
 struct DistsP {
   static void inc(scalar_t& agg, const scalar_t diff, const scalar_t p) {
     using opmath_t = at::opmath_type<scalar_t>;
-    agg += static_cast<scalar_t>(sycl::pow(
-        static_cast<opmath_t>(diff), static_cast<opmath_t>(p)));
+    agg += static_cast<scalar_t>(
+        sycl::pow(static_cast<opmath_t>(diff), static_cast<opmath_t>(p)));
   }
   static scalar_t finish(const scalar_t agg, const scalar_t p) {
     using opmath_t = at::opmath_type<scalar_t>;
@@ -147,8 +146,7 @@ struct DistsP {
                   static_cast<opmath_t>(p - 2)) *
               grad /
               sycl::pow(
-                  static_cast<opmath_t>(dist),
-                  static_cast<opmath_t>(p - 1)));
+                  static_cast<opmath_t>(dist), static_cast<opmath_t>(p - 1)));
   }
 };
 

--- a/src/ATen/native/xpu/sycl/DistanceKernels.cpp
+++ b/src/ATen/native/xpu/sycl/DistanceKernels.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <ATen/AccumulateType.h>
+#include <ATen/OpMathType.h>
 #include <ATen/native/xpu/sycl/BatchKernel.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/sum.h>
@@ -78,11 +79,18 @@ struct DistsLtTwo {
       const scalar_t grad,
       const scalar_t dist,
       const scalar_t p) {
+    using opmath_t = at::opmath_type<scalar_t>;
     return (dist == 0.0f || (diff == 0.0f && p < 1.f))
         ? static_cast<scalar_t>(0)
         : static_cast<scalar_t>(
-              Dists<scalar_t>::sign(diff) * std::pow(std::abs(diff), p - 1) *
-              grad / std::pow(dist, p - 1));
+              Dists<scalar_t>::sign(diff) *
+              sycl::pow(
+                  static_cast<opmath_t>(std::abs(diff)),
+                  static_cast<opmath_t>(p - 1)) *
+              grad /
+              sycl::pow(
+                  static_cast<opmath_t>(dist),
+                  static_cast<opmath_t>(p - 1)));
   }
 };
 
@@ -111,11 +119,14 @@ struct DistsTwo {
 template <typename scalar_t>
 struct DistsP {
   static void inc(scalar_t& agg, const scalar_t diff, const scalar_t p) {
-    agg += static_cast<scalar_t>(std::pow(static_cast<scalar_t>(diff), p));
+    using opmath_t = at::opmath_type<scalar_t>;
+    agg += static_cast<scalar_t>(sycl::pow(
+        static_cast<opmath_t>(diff), static_cast<opmath_t>(p)));
   }
   static scalar_t finish(const scalar_t agg, const scalar_t p) {
+    using opmath_t = at::opmath_type<scalar_t>;
     return static_cast<scalar_t>(
-        std::pow(static_cast<scalar_t>(agg), 1.0f / p));
+        sycl::pow(static_cast<opmath_t>(agg), static_cast<opmath_t>(1.0f / p)));
   }
   static void agg(scalar_t& update, const scalar_t other) {
     update += other;
@@ -126,10 +137,18 @@ struct DistsP {
       const scalar_t grad,
       const scalar_t dist,
       const scalar_t p) {
-    return dist == 0.0f ? static_cast<scalar_t>(0)
-                        : static_cast<scalar_t>(
-                              diff * std::pow(std::abs(diff), p - 2) * grad /
-                              std::pow(dist, p - 1));
+    using opmath_t = at::opmath_type<scalar_t>;
+    return dist == 0.0f
+        ? static_cast<scalar_t>(0)
+        : static_cast<scalar_t>(
+              diff *
+              sycl::pow(
+                  static_cast<opmath_t>(std::abs(diff)),
+                  static_cast<opmath_t>(p - 2)) *
+              grad /
+              sycl::pow(
+                  static_cast<opmath_t>(dist),
+                  static_cast<opmath_t>(p - 1)));
   }
 };
 

--- a/src/ATen/native/xpu/sycl/Embedding.cpp
+++ b/src/ATen/native/xpu/sycl/Embedding.cpp
@@ -115,7 +115,7 @@ struct RenormKernelFunctor {
       } else if (norm_type_ == 2) {
         v += x * x;
       } else {
-        v += std::pow(x, norm_type_);
+        v += sycl::pow(x, norm_type_);
       }
     }
 
@@ -126,7 +126,7 @@ struct RenormKernelFunctor {
             smem_.template get_multi_ptr<sycl::access::decorated::no>().get()));
 
     if (tid == 0) {
-      smem_[0] = std::pow(v, static_cast<accscalar_t>(1.0 / norm_type_));
+      smem_[0] = sycl::pow(v, static_cast<accscalar_t>(1.0 / norm_type_));
     }
     sycl::group_barrier(item.get_group());
 

--- a/src/ATen/native/xpu/sycl/FusedAdamUtils.h
+++ b/src/ATen/native/xpu/sycl/FusedAdamUtils.h
@@ -136,8 +136,10 @@ struct FusedAdamMathFunctor {
         [&]() -> std::pair<double, double> {
       auto* step_count = reinterpret_cast<const float*>(
           tlAddress[tensor_loc].state_steps_addresses);
-      const auto bias_correction1 = 1 - std::pow(beta1, *step_count);
-      const auto bias_correction2 = 1 - std::pow(beta2, *step_count);
+      const auto bias_correction1 =
+          1 - sycl::pow(beta1, static_cast<double>(*step_count));
+      const auto bias_correction2 =
+          1 - sycl::pow(beta2, static_cast<double>(*step_count));
       const auto bias_correction2_sqrt = std::sqrt(bias_correction2);
       return {bias_correction1, bias_correction2_sqrt};
     }();

--- a/src/ATen/native/xpu/sycl/MathExtensions.h
+++ b/src/ATen/native/xpu/sycl/MathExtensions.h
@@ -185,7 +185,7 @@ scalar_t ratevl(
   }
   if (absx > 1) {
     i = N - M;
-    return std::pow(x, static_cast<accscalar_t>(i)) * num_ans / denom_ans;
+    return sycl::pow(x, static_cast<accscalar_t>(i)) * num_ans / denom_ans;
   } else {
     return num_ans / denom_ans;
   }
@@ -268,7 +268,7 @@ static scalar_t _igam_helper_fac(scalar_t a, scalar_t x) {
   res = std::sqrt(fac / EXP1) / lanczos_sum_expg_scaled(a);
 
   if ((a < 200) && (x < 200)) {
-    res *= sycl::exp(a - x) * std::pow(x / fac, a);
+    res *= sycl::exp(a - x) * sycl::pow(x / fac, a);
   } else {
     num = x - a - lanczos_g + 0.5;
     numfac = num / fac;

--- a/src/ATen/native/xpu/sycl/Pow.h
+++ b/src/ATen/native/xpu/sycl/Pow.h
@@ -64,7 +64,8 @@ pow_(Base_type base, Exp_type exp) {
 template <typename Base_type, typename Exp_type>
 static inline Base_type pow_(Base_type base, Exp_type exp) {
   using opmath_t = at::opmath_type<Base_type>;
-  if constexpr (std::is_integral<Exp_type>::value) {
+  if constexpr (
+      std::is_integral<Exp_type>::value && sizeof(Exp_type) <= sizeof(int)) {
     return sycl::pown(static_cast<opmath_t>(base), static_cast<int>(exp));
   } else {
     return sycl::pow(static_cast<opmath_t>(base), static_cast<opmath_t>(exp));

--- a/src/ATen/native/xpu/sycl/Pow.h
+++ b/src/ATen/native/xpu/sycl/Pow.h
@@ -63,6 +63,10 @@ pow_(Base_type base, Exp_type exp) {
 #else
 template <typename Base_type, typename Exp_type>
 static inline Base_type pow_(Base_type base, Exp_type exp) {
+  // Both base and exp have the same scalar type in all current call paths
+  // They are promoted to opmath_t before entering at::native::xpu::pow_.
+  // Therefore a single opmath_t derived from Base_type.
+  // is sufficient for both operands.
   using opmath_t = at::opmath_type<Base_type>;
   if constexpr (
       std::is_integral<Exp_type>::value && sizeof(Exp_type) <= sizeof(int)) {

--- a/src/ATen/native/xpu/sycl/Pow.h
+++ b/src/ATen/native/xpu/sycl/Pow.h
@@ -9,8 +9,10 @@
  */
 
 #pragma once
+#include <ATen/OpMathType.h>
 #include <ATen/native/Pow.h>
 #include <c10/core/Scalar.h>
+#include <sycl/sycl.hpp>
 
 namespace at::native::xpu {
 
@@ -27,12 +29,12 @@ namespace {
 // pow for at::Half
 static inline at::Half pow_(at::Half base, at::Half exp) {
   return static_cast<at::Half>(
-      std::pow(static_cast<float>(base), static_cast<float>(exp)));
+      sycl::pow(static_cast<float>(base), static_cast<float>(exp)));
 }
 // pow for at::BFloat16
 static inline at::BFloat16 pow_(at::BFloat16 base, at::BFloat16 exp) {
   return static_cast<at::BFloat16>(
-      std::pow(static_cast<float>(base), static_cast<float>(exp)));
+      sycl::pow(static_cast<float>(base), static_cast<float>(exp)));
 }
 // pow (floating, floating/int)
 template <typename Base_type, typename Exp_type>
@@ -42,7 +44,11 @@ static inline typename std::enable_if<
          std::is_same<Exp_type, int>::value),
     Base_type>::type
 pow_(Base_type base, Exp_type exp) {
-  return std::pow(base, exp);
+  if constexpr (std::is_same_v<Exp_type, int>) {
+    return sycl::pown(base, exp);
+  } else {
+    return sycl::pow(base, exp);
+  }
 }
 // pow (Otherwise)
 template <typename Base_type, typename Exp_type>
@@ -52,12 +58,17 @@ static inline typename std::enable_if<
     Base_type>::type
 pow_(Base_type base, Exp_type exp) {
   return static_cast<Base_type>(
-      std::pow(static_cast<double>(base), static_cast<double>(exp)));
+      sycl::pow(static_cast<double>(base), static_cast<double>(exp)));
 }
 #else
 template <typename Base_type, typename Exp_type>
 static inline Base_type pow_(Base_type base, Exp_type exp) {
-  return std::pow(base, exp);
+  using opmath_t = at::opmath_type<Base_type>;
+  if constexpr (std::is_integral<Exp_type>::value) {
+    return sycl::pown(static_cast<opmath_t>(base), static_cast<int>(exp));
+  } else {
+    return sycl::pow(static_cast<opmath_t>(base), static_cast<opmath_t>(exp));
+  }
 }
 #endif
 

--- a/src/ATen/native/xpu/sycl/PowKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PowKernels.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <ATen/Dispatch.h>
+#include <ATen/OpMathType.h>
 #include <ATen/native/Pow.h>
 #include <ATen/native/TensorIterator.h>
 
@@ -17,6 +18,8 @@
 #include <ATen/native/xpu/sycl/UnaryKernels.h>
 
 #include <ATen/native/xpu/sycl/PowKernels.h>
+
+#include <sycl/sycl.hpp>
 
 namespace at {
 namespace native {
@@ -30,7 +33,8 @@ namespace impl {
 
 template <typename Base_type, typename Exp_type>
 static inline Base_type pow_(Base_type base, Exp_type exp) {
-  return std::pow(base, exp);
+  using opmath_t = at::opmath_type<Base_type>;
+  return sycl::pow(static_cast<opmath_t>(base), static_cast<opmath_t>(exp));
 }
 
 template <typename T>

--- a/src/ATen/native/xpu/sycl/PowKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PowKernels.cpp
@@ -33,6 +33,10 @@ namespace impl {
 
 template <typename Base_type, typename Exp_type>
 static inline Base_type pow_(Base_type base, Exp_type exp) {
+  // Both base and exp have the same scalar type in all current call paths
+  // They are promoted to opmath_t before entering impl::pow_.
+  // Therefore a single opmath_t derived from Base_type.
+  // is sufficient for both operands.
   using opmath_t = at::opmath_type<Base_type>;
   return sycl::pow(static_cast<opmath_t>(base), static_cast<opmath_t>(exp));
 }

--- a/src/ATen/native/xpu/sycl/RangeFactoriesKernel.cpp
+++ b/src/ATen/native/xpu/sycl/RangeFactoriesKernel.cpp
@@ -10,6 +10,7 @@
 
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
+#include <ATen/OpMathType.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/detail/FunctionTraits.h>
 #include <comm/SYCLContext.h>
@@ -241,11 +242,22 @@ Tensor& linspace_kernel(
 template <typename scalar_t, typename step_type>
 struct LogspaceFunctor {
   scalar_t operator()(int64_t ind) const {
-    if (ind < halfway_) {
-      return std::pow(scalar_base_, scalar_start_ + step_ * ind);
+    if constexpr (c10::is_complex<step_type>::value) {
+      if (ind < halfway_) {
+        return std::pow(scalar_base_, scalar_start_ + step_ * ind);
+      }
+      return std::pow(scalar_base_, scalar_end_ - step_ * (steps_ - ind - 1));
+    } else {
+      using opmath_t = at::opmath_type<step_type>;
+      if (ind < halfway_) {
+        return static_cast<scalar_t>(sycl::pow(
+            static_cast<opmath_t>(scalar_base_),
+            static_cast<opmath_t>(scalar_start_ + step_ * ind)));
+      }
+      return static_cast<scalar_t>(sycl::pow(
+          static_cast<opmath_t>(scalar_base_),
+          static_cast<opmath_t>(scalar_end_ - step_ * (steps_ - ind - 1))));
     }
-
-    return std::pow(scalar_base_, scalar_end_ - step_ * (steps_ - ind - 1));
   }
   LogspaceFunctor(
       scalar_t scalar_start,

--- a/src/ATen/native/xpu/sycl/SharedReduceOps.h
+++ b/src/ATen/native/xpu/sycl/SharedReduceOps.h
@@ -19,6 +19,7 @@
 #include <ATen/native/cpu/zmath.h>
 #include <c10/macros/Macros.h>
 #include <comm/XPUPair.h>
+#include <sycl/sycl.hpp>
 #include <cmath>
 #include <complex>
 #include <type_traits>
@@ -27,7 +28,7 @@
 #define MIN(X, Y) min_impl(X, Y)
 
 #define device_sqrt std::sqrt
-#define compat_pow std::pow
+#define compat_pow sycl::pow
 
 namespace at {
 namespace native {


### PR DESCRIPTION
This pull request refactors several math kernel implementations to consistently use SYCL's `sycl::pow` and `sycl::pown` functions instead of the standard library's `std::pow` for elementwise power operations on the XPU backend. This change improves compatibility and performance for SYCL devices, and ensures correct type promotion using `at::opmath_type`. The update is applied across distance, embedding, Adam optimizer, math extensions, and power-related kernels and utilities.

**SYCL math function adoption:**

* Replaced all uses of `std::pow` with `sycl::pow` (and `sycl::pown` for integer exponents) in distance kernels, embedding kernels, Adam optimizer math, math extensions, and power-related utilities and kernels, including macros and functors. 

**Type promotion and header improvements:**

* Introduced use of `at::opmath_type` to ensure correct type promotion for mathematical operations, and included the necessary header in affected files. 

**Device macro updates:**

* Updated the `compat_pow` macro in `SharedReduceOps.h` to use `sycl::pow` instead of `std::pow`.

** ASM Difference:**
* No Significant Difference between std::pow and sycl::pow.

These changes collectively improve device compatibility, numerical consistency, and code maintainability for power operations on the XPU backend.