### PR TITLE
Update mha_fwd.h and mha_bwd.h headers

### DIFF
--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
@@ -21,7 +21,9 @@
 #pragma GCC diagnostic ignored "-Wchanges-meaning"
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #pragma GCC diagnostic ignored "-Wdangling-pointer"
+#if __GNUC__ >= 14
 #pragma GCC diagnostic ignored "-Wtemplate-id-cdtor"
+#endif
 #include <cute/tensor.hpp>
 #include <cute/util/compat.hpp>
 #include <cutlass/numeric_conversion.h>

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.h
@@ -19,7 +19,9 @@
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wchanges-meaning"
+#if __GNUC__ >= 14
 #pragma GCC diagnostic ignored "-Wtemplate-id-cdtor"
+#endif
 
 #include <cute/tensor.hpp>
 #include <cute/util/compat.hpp>


### PR DESCRIPTION

This pull request adds conditional suppression of the `-Wtemplate-id-cdtor` warning for GCC 14 and above in both the `mha_fwd.h` and `mha_bwd.h` headers. This ensures compatibility with newer GCC versions without affecting earlier versions.

Compiler warning handling:

* Added `#pragma GCC diagnostic ignored "-Wtemplate-id-cdtor"` within a `#if __GNUC__ >= 14` check in `mha_fwd.h` and `mha_bwd.h` to suppress warnings only for GCC 14 and newer. [[1]](diffhunk://#diff-8d5e37fd4410d6ed2d9f18416931bc01b6bce792fcce6cc8bcca0332fd065934R22-R24) [[2]](diffhunk://#diff-131f835912a1fd8d1fecbfab5a02a83bb484e97cad6439cce92393504e8e5995R24-R26)
