### PR TITLE
Skip prepacked linear UTs due to XNNPACK disablement

### DIFF
--- a/test/xpu/export/test_converter_xpu.py
+++ b/test/xpu/export/test_converter_xpu.py
@@ -28,6 +28,12 @@ from torch.testing._internal.torchbind_impls import (
     init_torchbind_implementations,
 )
 
+# prepacked linear requires XNNPACK support.
+requires_prepacked_linear = unittest.skipIf(
+    not hasattr(torch.ops.prepacked, "linear_clamp_prepack"),
+    "requires XNNPACK (prepacked linear ops)",
+)
+
 
 class TestConverter(TestCase):
     def setUp(self):
@@ -1463,6 +1469,7 @@ class TestConverter(TestCase):
     # and
     # torch.ops.prepacked.linear_clamp_run
     @xfailIfS390X
+    @requires_prepacked_linear
     def test_ts2ep_convert_quantized_model_with_opcontext(self):
         class M(torch.nn.Module):
             def __init__(self, linear_op):
@@ -1486,6 +1493,7 @@ class TestConverter(TestCase):
     # and
     # torch.ops.prepacked.linear_clamp_run
     @xfailIfS390X
+    @requires_prepacked_linear
     def test_ts2ep_convert_quantized_model_with_opcontext_and_constant(self):
         class M(torch.nn.Module):
             def __init__(self, linear_op):


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/3889

PyTorch upstream disabled XNNPACK in CMake, as it's being phased out. Tests are failing on lack of `linear_clamp_prepack` so they need to be decorated to run only if XNNPACK is available