### PR TITLE
Fix GCC 13 build failure in sycltla flash attention headers.

### DIFF
--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
@@ -16,6 +16,7 @@
 #pragma clang diagnostic ignored "-Wunused-local-typedefs"
 #pragma clang diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wchanges-meaning"

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_fwd.h
@@ -16,6 +16,7 @@
 #pragma clang diagnostic ignored "-Wunused-local-typedefs"
 #pragma clang diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wchanges-meaning"


### PR DESCRIPTION
This PR fixes the build error when building with GCC 13.

Add `#pragma GCC diagnostic ignored "-Wpragmas"` before the existing GCC diagnostic suppression
blocks in `mha_bwd.h` and `mha_fwd.h`. This silences the `-Wpragmas` warning that GCC 13 emits
when it encounters the unrecognized `-Wtemplate-id-cdtor` flag (introduced in GCC 14), preventing
`-Werror=pragmas` from turning it into a hard error.

The problematic `-Wtemplate-id-cdtor` was introduced in [THIS RECENT COMMIT](https://github.com/intel/torch-xpu-ops/commit/0b3806ed41694c14d7f30851167204bdee41ccab)

The fix has no effect on GCC 14+ (which recognizes the flag natively) or on clang/icpx builds
(which use the `#pragma clang diagnostic` path and already suppress unknown warning options).