### PR TITLE
Add skill to avoid using shift_group_left for reduction

### DIFF
--- a/.claude/commands/validate-pr-review-test.md
+++ b/.claude/commands/validate-pr-review-test.md
@@ -1,0 +1,25 @@
+# Review Test Cases
+
+Review the files under `test/agentic/pr-review` to validate the pr-review skill.
+
+## Instructions
+
+1. Load the `pr-review` skill.
+2. For each file in `test/agentic/pr-review/`, perform a review as if the file were part of a PR submission.
+3. For each test case in the file:
+   - Identify whether it is marked as "Expected: FLAG" (bad) or "Expected: PASS" (good).
+   - Apply the pr-review skill's detection rules (e.g., subgroup reduction anti-pattern).
+   - Report whether the skill would correctly flag or pass each case.
+4. Output a summary table showing:
+   - Case name
+   - Expected result (FLAG or PASS)
+   - Actual result from review (FLAGGED or PASSED)
+   - Verdict (CORRECT or MISSED or FALSE POSITIVE)
+
+## Optional argument
+
+If a specific file path is provided as `$ARGUMENTS`, review only that file instead of scanning the full `test/agentic/pr-review` directory.
+
+## Goal
+
+This command validates that the pr-review skill correctly identifies all anti-patterns (true positives) and does not flag correct code (no false positives).

--- a/.claude/commands/validate-pr-review.md
+++ b/.claude/commands/validate-pr-review.md
@@ -1,4 +1,4 @@
-# Review Test Cases
+# Review SKILL Test Cases
 
 Review the files under `test/agentic/pr-review` to validate the pr-review skill.
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -309,24 +309,26 @@ int xecore_count = zeDeviceGetSubsliceCount(device);  // legacy API name
 
 ## Subgroup Reduction Anti-Pattern
 
-**Principle: Never use `sycl::shift_group_left` in a loop to perform subgroup reductions (sum, min, max, mean). Always use `sycl::reduce_over_group` instead.**
+**Principle: Never use `sycl::shift_group_left` combined with a reduction operation to perform subgroup reductions. Always use `sycl::reduce_over_group` instead.**
 
 This is a **🔴 Must Fix** category.
 
+### Detection Criterion
+
+Flag any code where `sycl::shift_group_left` is combined with a reduction combiner (any binary operation that accumulates values: add, min, max, mean, product, bitwise-or/and, etc.). The true signal is the **shift + combine** combination, not the loop itself — the loop may be at a different call site or abstracted behind a helper.
+
 ### The Problem
 
-The following pattern manually implements subgroup reduction using shift operations:
+`sycl::shift_group_left` produces excessive integer ALU instructions for index manipulation, which stalls the ALU-INT pipeline and degrades performance. The SYCL runtime's built-in `reduce_over_group` can use hardware-optimized reduction paths.
 
 ```cpp
 // 🔴 Bad — shift_group_left generates massive int-related instructions,
 // causing ALU-INT pipe stall
 for (int offset = 1; offset < sg_size; offset <<= 1) {
   arg_t other = sycl::shift_group_left(sg, value[i], offset);
-  value[i] = combine(value[i], other);  // combine = add/min/max
+  value[i] = combine(value[i], other);  // combine = any reduction op
 }
 ```
-
-`sycl::shift_group_left` produces excessive integer ALU instructions for index manipulation, which stalls the ALU-INT pipeline and degrades performance. The SYCL runtime's built-in `reduce_over_group` can use hardware-optimized reduction paths.
 
 ### The Fix
 
@@ -341,14 +343,21 @@ value[i] = sycl::reduce_over_group(sg, value[i], sycl::maximum<arg_t>()); // for
 
 ### Variants to Flag
 
-All of these are the same anti-pattern regardless of loop direction:
+All of these are the same anti-pattern:
 
 ```cpp
-// 🔴 Bad — ascending offset
+// 🔴 Bad — inline loop (any direction)
 for (int offset = 1; offset < sg_size; offset <<= 1) { ... shift_group_left ... }
-
-// 🔴 Bad — descending offset
 for (int offset = (sg_size >> 1); offset > 0; offset >>= 1) { ... shift_group_left ... }
+
+// 🔴 Bad — shift+combine split into a functor (loop lives elsewhere)
+struct ShiftAndCombine {
+  arg_t operator()(sycl::sub_group sg, arg_t value, int offset) const {
+    arg_t other = sycl::shift_group_left(sg, value, offset);
+    return combine_(value, other);
+  }
+  BinaryOp combine_;
+};
 
 // 🔴 Bad — with vectorized inner loop
 for (int offset = 1; offset < sg_size; offset <<= 1) {
@@ -362,8 +371,9 @@ for (int offset = 1; offset < sg_size; offset <<= 1) {
 ### Where to Check
 
 - `src/ATen/native/xpu/sycl/` — All SYCL kernel files
-- Any file using `sycl::shift_group_left` in combination with arithmetic/comparison operators
+- Any file using `sycl::shift_group_left` in combination with a reduction combiner
 - Reduction kernels, softmax, norm, and scan operations are common locations
+- Functors or lambdas whose body contains shift+combine — trace callers for the loop
 
 ## Files to Reference
 

--- a/.claude/skills/pr-review/references/review-checklist.md
+++ b/.claude/skills/pr-review/references/review-checklist.md
@@ -130,7 +130,7 @@ Also flag during review:
 - [ ] Claimed optimizations come with benchmark evidence or at least a concrete design rationale
 - [ ] **No unnecessary allocations** — Tensors are not repeatedly created in hot loops
 - [ ] **Appropriate in-place operations** — Use in-place ops where possible in performance-critical paths
-- [ ] **No manual subgroup reduction via shift_group_left** — Loops using `sycl::shift_group_left` + combine (add/min/max) for subgroup reduction must use `sycl::reduce_over_group` instead; the shift pattern generates excessive integer ALU instructions causing pipeline stalls
+- [ ] **No shift_group_left + reduction combiner** — Any `sycl::shift_group_left` combined with a reduction op (add, min, max, mean, product, etc.) must use `sycl::reduce_over_group` instead; the shift pattern generates excessive integer ALU instructions causing pipeline stalls. The loop may be at a different call site or inside a functor — trace callers if needed
 
 ## Dispatch, Fallback, And Generated Wiring
 

--- a/test/agentic/pr-review/subgroup_reduction_antipattern_cases.cpp
+++ b/test/agentic/pr-review/subgroup_reduction_antipattern_cases.cpp
@@ -1,0 +1,252 @@
+// Verification cases for subgroup reduction anti-pattern rule.
+// All "BAD" cases should be flagged by the reviewer.
+// All "GOOD" cases should pass without complaint.
+
+#include <sycl/sycl.hpp>
+
+using arg_t = float;
+
+// ============================================================
+// CASE 1: Direct inline loop — ascending offset (classic)
+// Expected: FLAG
+// ============================================================
+void bad_case_1_inline_ascending(sycl::sub_group sg, arg_t* value, int sg_size) {
+  for (int offset = 1; offset < sg_size; offset <<= 1) {
+    arg_t other = sycl::shift_group_left(sg, value[0], offset);
+    value[0] = value[0] + other;
+  }
+}
+
+// ============================================================
+// CASE 2: Direct inline loop — descending offset
+// Expected: FLAG
+// ============================================================
+void bad_case_2_inline_descending(sycl::sub_group sg, arg_t* value, int sg_size) {
+  for (int offset = (sg_size >> 1); offset > 0; offset >>= 1) {
+    arg_t other = sycl::shift_group_left(sg, value[0], offset);
+    value[0] = value[0] + other;
+  }
+}
+
+// ============================================================
+// CASE 3: Vectorized inner loop
+// Expected: FLAG
+// ============================================================
+void bad_case_3_vectorized(sycl::sub_group sg, arg_t* value, int sg_size, int vec_sz) {
+  for (int offset = 1; offset < sg_size; offset <<= 1) {
+    for (int i = 0; i < vec_sz; ++i) {
+      arg_t other = sycl::shift_group_left(sg, value[i], offset);
+      value[i] = value[i] + other;
+    }
+  }
+}
+
+// ============================================================
+// CASE 4: Using min as the combiner
+// Expected: FLAG
+// ============================================================
+void bad_case_4_min(sycl::sub_group sg, arg_t* value, int sg_size) {
+  for (int offset = 1; offset < sg_size; offset <<= 1) {
+    arg_t other = sycl::shift_group_left(sg, value[0], offset);
+    value[0] = (value[0] < other) ? value[0] : other;
+  }
+}
+
+// ============================================================
+// CASE 5: Using max as the combiner
+// Expected: FLAG
+// ============================================================
+void bad_case_5_max(sycl::sub_group sg, arg_t* value, int sg_size) {
+  for (int offset = 1; offset < sg_size; offset <<= 1) {
+    arg_t other = sycl::shift_group_left(sg, value[0], offset);
+    value[0] = (value[0] > other) ? value[0] : other;
+  }
+}
+
+// ============================================================
+// CASE 6: Mean reduction (sum then divide)
+// Expected: FLAG
+// ============================================================
+void bad_case_6_mean(sycl::sub_group sg, arg_t* value, int sg_size) {
+  for (int offset = 1; offset < sg_size; offset <<= 1) {
+    arg_t other = sycl::shift_group_left(sg, value[0], offset);
+    value[0] = value[0] + other;
+  }
+  value[0] = value[0] / static_cast<arg_t>(sg_size);
+}
+
+// ============================================================
+// CASE 7: Product reduction
+// Expected: FLAG
+// ============================================================
+void bad_case_7_product(sycl::sub_group sg, arg_t* value, int sg_size) {
+  for (int offset = 1; offset < sg_size; offset <<= 1) {
+    arg_t other = sycl::shift_group_left(sg, value[0], offset);
+    value[0] = value[0] * other;
+  }
+}
+
+// ============================================================
+// CASE 8: Bitwise-OR reduction (integer case)
+// Expected: FLAG
+// ============================================================
+void bad_case_8_bitwise_or(sycl::sub_group sg, int* value, int sg_size) {
+  for (int offset = 1; offset < sg_size; offset <<= 1) {
+    int other = sycl::shift_group_left(sg, value[0], offset);
+    value[0] = value[0] | other;
+  }
+}
+
+// ============================================================
+// CASE 9: Functor with shift+combine, loop at call site
+// Expected: FLAG (both the functor definition and the call site)
+// ============================================================
+template <typename BinaryOp>
+struct ShiftAndCombineFunctor {
+  arg_t operator()(sycl::sub_group sg, arg_t val, int offset) const {
+    arg_t other = sycl::shift_group_left(sg, val, offset);
+    return op_(val, other);
+  }
+  BinaryOp op_;
+};
+
+struct AddOp {
+  arg_t operator()(arg_t a, arg_t b) const { return a + b; }
+};
+
+void bad_case_9_functor_caller(sycl::sub_group sg, arg_t* value, int sg_size) {
+  ShiftAndCombineFunctor<AddOp> func{AddOp{}};
+  for (int offset = 1; offset < sg_size; offset <<= 1) {
+    value[0] = func(sg, value[0], offset);
+  }
+}
+
+// ============================================================
+// CASE 10: Lambda with shift+combine, loop at call site
+// Expected: FLAG
+// ============================================================
+void bad_case_10_lambda_caller(sycl::sub_group sg, arg_t* value, int sg_size) {
+  auto shift_and_add = [](sycl::sub_group sg, arg_t val, int offset) {
+    arg_t other = sycl::shift_group_left(sg, val, offset);
+    return val + other;
+  };
+  for (int offset = 1; offset < sg_size; offset <<= 1) {
+    value[0] = shift_and_add(sg, value[0], offset);
+  }
+}
+
+// ============================================================
+// CASE 11: Template function wrapping the shift+combine
+// Expected: FLAG
+// ============================================================
+template <typename T, typename BinaryOp>
+T shift_and_reduce_step(sycl::sub_group sg, T val, int offset, BinaryOp op) {
+  T other = sycl::shift_group_left(sg, val, offset);
+  return op(val, other);
+}
+
+void bad_case_11_template_helper(sycl::sub_group sg, arg_t* value, int sg_size) {
+  for (int offset = 1; offset < sg_size; offset <<= 1) {
+    value[0] = shift_and_reduce_step(sg, value[0], offset, AddOp{});
+  }
+}
+
+// ============================================================
+// CASE 12: Combine via std::plus (recognizable reduction op)
+// Expected: FLAG
+// ============================================================
+void bad_case_12_std_plus(sycl::sub_group sg, arg_t* value, int sg_size) {
+  std::plus<arg_t> combine;
+  for (int offset = 1; offset < sg_size; offset <<= 1) {
+    arg_t other = sycl::shift_group_left(sg, value[0], offset);
+    value[0] = combine(value[0], other);
+  }
+}
+
+// ============================================================
+// CASE 13: While-loop instead of for-loop
+// Expected: FLAG
+// ============================================================
+void bad_case_13_while_loop(sycl::sub_group sg, arg_t* value, int sg_size) {
+  int offset = 1;
+  while (offset < sg_size) {
+    arg_t other = sycl::shift_group_left(sg, value[0], offset);
+    value[0] = value[0] + other;
+    offset <<= 1;
+  }
+}
+
+// ============================================================
+// CASE 14: Unrolled shifts (no explicit loop, but same pattern)
+// Expected: FLAG
+// ============================================================
+void bad_case_14_unrolled(sycl::sub_group sg, arg_t* value) {
+  arg_t tmp;
+  tmp = sycl::shift_group_left(sg, value[0], 1);
+  value[0] += tmp;
+  tmp = sycl::shift_group_left(sg, value[0], 2);
+  value[0] += tmp;
+  tmp = sycl::shift_group_left(sg, value[0], 4);
+  value[0] += tmp;
+  tmp = sycl::shift_group_left(sg, value[0], 8);
+  value[0] += tmp;
+  tmp = sycl::shift_group_left(sg, value[0], 16);
+  value[0] += tmp;
+}
+
+// ============================================================
+// GOOD CASE 1: reduce_over_group for sum
+// Expected: PASS
+// ============================================================
+void good_case_1_reduce_sum(sycl::sub_group sg, arg_t* value) {
+  value[0] = sycl::reduce_over_group(sg, value[0], sycl::plus<arg_t>());
+}
+
+// ============================================================
+// GOOD CASE 2: reduce_over_group for min
+// Expected: PASS
+// ============================================================
+void good_case_2_reduce_min(sycl::sub_group sg, arg_t* value) {
+  value[0] = sycl::reduce_over_group(sg, value[0], sycl::minimum<arg_t>());
+}
+
+// ============================================================
+// GOOD CASE 3: reduce_over_group for max
+// Expected: PASS
+// ============================================================
+void good_case_3_reduce_max(sycl::sub_group sg, arg_t* value) {
+  value[0] = sycl::reduce_over_group(sg, value[0], sycl::maximum<arg_t>());
+}
+
+// ============================================================
+// GOOD CASE 4: Single shift_group_left for neighbor access (not a reduction)
+// Expected: PASS
+// ============================================================
+void good_case_4_neighbor_access(sycl::sub_group sg, arg_t* value) {
+  arg_t neighbor = sycl::shift_group_left(sg, value[0], 1);
+  value[0] = value[0] - neighbor;  // difference with neighbor, not a reduction
+}
+
+// ============================================================
+// GOOD CASE 5: shift_group_left for exclusive scan (not a reduction)
+// Expected: PASS
+// ============================================================
+void good_case_5_scan(sycl::sub_group sg, arg_t* value, int sg_size) {
+  // Inclusive prefix sum using shift — this is a SCAN, not a reduction.
+  // Each work-item retains a distinct partial result.
+  for (int offset = 1; offset < sg_size; offset <<= 1) {
+    arg_t other = sycl::shift_group_left(sg, value[0], offset);
+    if (sg.get_local_linear_id() >= (unsigned)offset) {
+      value[0] = value[0] + other;
+    }
+  }
+}
+
+// ============================================================
+// GOOD CASE 6: shift_group_left used for data shuffle (no combine)
+// Expected: PASS
+// ============================================================
+void good_case_6_shuffle_only(sycl::sub_group sg, arg_t* value) {
+  // Just moving data around, no reduction
+  value[0] = sycl::shift_group_left(sg, value[0], 4);
+}


### PR DESCRIPTION
Refine the pr-review skill to address Liangang's comments and add more test cases to validate the newly added changes for `reduce over subgroup`