### PR TITLE
Add native_group_norm to noncontiguous UT skiplist

### DIFF
--- a/test/xpu/functorch/test_ops_xpu.py
+++ b/test/xpu/functorch/test_ops_xpu.py
@@ -430,6 +430,7 @@ aliasing_ops_list_return = {
 skip_noncontig = {
     "_batch_norm_with_update",
     "as_strided_copy",
+    "native_group_norm",
 }
 
 bool_unsupported_ordered_ops = {


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/3845

Aligns `test_ops_xpu.py` with upstream `test_ops.py`. Test is expected to fail, but it should be xfailed explicitly via `skip_noncontig` variable.