### PR TITLE
Align test `TestInvokeSubgraphCompile::test_stack_trace` with upsteam.

### DIFF
--- a/test/xpu/higher_order_ops/test_invoke_subgraph_xpu.py
+++ b/test/xpu/higher_order_ops/test_invoke_subgraph_xpu.py
@@ -14,6 +14,7 @@
 # flake8: noqa
 
 import contextlib
+import re
 import sys
 import unittest
 import unittest.mock as mock
@@ -252,7 +253,9 @@ class TestInvokeSubgraphCompile(TestCase):
         for node in invoke_subgraph_nodes:
             stack_trace = node.meta["stack_trace"]
             if not TEST_WITH_CROSSREF:
-                self.assertTrue(stack_trace.endswith("return mod(x, y) + mod(x, y)\n"))
+                # Strip caret lines (e.g. "  ~~~^^^^") that 3.13+ appends
+                clean = re.sub(r"\n[ ~^]*[~^][ ~^]*(?=\n|\Z)", "", stack_trace)
+                self.assertTrue(clean.endswith("return mod(x, y) + mod(x, y)\n"))
 
     def test_gen_schema(self):
         class Mod(torch.nn.Module):


### PR DESCRIPTION
The local copy of the `TestInvokeSubgraphCompile::test_stack_trace` test case diverged from the upstream, thus causing test case to fail in some configurations.

This PR aligns the local version with upstream 1 to 1 without any additional modifications.

The upstream test case was changed in [THIS COMMIT](https://github.com/pytorch/pytorch/commit/7542fdc966ebd82583132bab2e9353e38072a921)