### PR TITLE
Remove case from `test_unflatten`

### DIFF
--- a/test/xpu/test_torch_xpu.py
+++ b/test/xpu/test_torch_xpu.py
@@ -8151,12 +8151,6 @@ class TestTorch(TestCase):
         ):
             torch.tensor([1]).unflatten("A", (1, 1))
 
-        # test invalid args: tensor, str, namedshape
-        with self.assertRaisesRegex(
-            RuntimeError, r"Name 'A' not found in Tensor\[None\]."
-        ):
-            torch.ones(4).unflatten("A", (("A", 2), ("B", 2)))
-
         # test other invalid arguments
         with self.assertRaisesRegex(RuntimeError, r"sizes must be non-empty"):
             torch.tensor([1]).unflatten(0, [])


### PR DESCRIPTION
The support for named tensors was removed in PR [1]. However, the `test_unflatten` test still checked a case for named tensors. This commit removes this single case.

[1] https://github.com/pytorch/pytorch/pull/173895