### PR TITLE
Update `test_binary_ufuncs_xpu.py` test class

### DIFF
--- a/test/xpu/test_binary_ufuncs_xpu.py
+++ b/test/xpu/test_binary_ufuncs_xpu.py
@@ -21,10 +21,10 @@ except Exception as e:
     from .xpu_test_utils import XPUPatchForImport
 
 with XPUPatchForImport(False):
-    from test_binary_ufuncs import TestBinaryUfuncs
+    from test_binary_ufuncs import TestBinaryUfuncsDevice
 
 instantiate_device_type_tests(
-    TestBinaryUfuncs, globals(), only_for="xpu", allow_xpu=True
+    TestBinaryUfuncsDevice, globals(), only_for="xpu", allow_xpu=True
 )
 
 


### PR DESCRIPTION
In PR [1], the upstream file `test_binary_ufuncs.py` was refactored and the `TestBinaryUfuncs` class was renamed to `TestBinaryUfuncsDevice`. The previous name is still used for CPU only tests, but it is directly wrapped in `instantiate_parametrized_tests`, so when imported on XPU side, it was already overwritten to `None`. This commit updates the imported class name on XPU side.

[1] https://github.com/pytorch/pytorch/pull/185699