### PR TITLE
ci: add workflow to validate build with dpclang

### DIFF
--- a/.github/actions/linux-uttest/action.yml
+++ b/.github/actions/linux-uttest/action.yml
@@ -5,10 +5,6 @@ inputs:
   ut_name:
     required: true
     description: Which ut to launch
-  env_file:
-    required: false
-    default: ""
-    description: Environment file to source
 
 runs:
   using: composite

--- a/.github/actions/linux-uttest/action.yml
+++ b/.github/actions/linux-uttest/action.yml
@@ -5,6 +5,10 @@ inputs:
   ut_name:
     required: true
     description: Which ut to launch
+  env_file:
+    required: false
+    default: ""
+    description: Environment file to source
 
 runs:
   using: composite

--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -13,6 +13,7 @@ PYTORCH_REPO=${PYTORCH_REPO:-"https://github.com/pytorch/pytorch.git"}
 PYTORCH_COMMIT=${PYTORCH_COMMIT:-"main"}
 TORCH_XPU_OPS_REPO=${TORCH_XPU_OPS_REPO:-"https://github.com/intel/torch-xpu-ops.git"}
 TORCH_XPU_OPS_COMMIT=${TORCH_XPU_OPS_COMMIT:-"main"}
+USE_DPCLANG=${USE_DPCLANG:-"no"}
 for var; do
     eval "export $(echo ${var@Q} |sed "s/^'-*//g;s/=/='/")"
 done
@@ -71,7 +72,7 @@ fi
 python -m pip install -r requirements.txt
 python -m pip install mkl-static==2026.0.0 mkl-include==2026.0.0
 export USE_STATIC_MKL=1
-if [ "${XPU_ONEAPI_PATH}" == "" ];then
+if [ "${XPU_ONEAPI_PATH}" == "" ] && [ "${USE_DPCLANG}" == "no" ]; then
     export PYTORCH_EXTRA_INSTALL_REQUIREMENTS=" \
         intel-cmplr-lib-rt==2026.0.0 | \
         intel-cmplr-lib-ur==2026.0.0 | \
@@ -95,6 +96,12 @@ if [ "${XPU_ONEAPI_PATH}" == "" ];then
         umf==1.1.0 | \
         intel-pti==0.17.0
     "
+fi
+
+if [ "${USE_DPCLANG}" == "yes" ]; then
+    export XPU_SYCL_COMPILER=dpclang
+    export USE_KINETO=0
+    export USE_ONEMKL_XPU=0
 fi
 
 # Build

--- a/.github/workflows/_linux_build.yml
+++ b/.github/workflows/_linux_build.yml
@@ -95,6 +95,34 @@ jobs:
           path: |
             known_issue_static.log
             issues_snapshot.log
+      - name: Download dpclang
+        if: ${{ inputs.category == 'dpclang' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: dpclang
+      - name: Setup dpclang
+        if: ${{ inputs.category == 'dpclang' }}
+        run: |
+          rm -rf install-dpclang && mkdir install-dpclang
+          tar xzvf install-dpclang.tgz -C install-dpclang
+          echo "CMAKE_PREFIX_PATH=$(pwd)/install-dpclang" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=$(pwd)/install-dpclang/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$(pwd)/install-dpclang/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "PATH=$(pwd)/install-dpclang/bin:$PATH" >> $GITHUB_ENV
+          echo "USE_DPCLANG=yes" >> $GITHUB_ENV
+      - name: Setup dpclang
+        if: ${{ inputs.category == 'dpclang' }}
+        run: |
+          dnf install -y tree libzstd-devel
+          tree install-dpclang
+          echo "aaa"
+          find install-dpclang -name clang
+          ls -al install-dpclang/bin/
+          which clang
+          which dpclang
+          which pkg-config
+          pkg-config --cflags sycl-dpcpp-7
+          #false
       - name: Build Pytorch
         run: |
           export USE_XCCL=1
@@ -119,7 +147,9 @@ jobs:
           fi
           # gcc 13
           source /opt/rh/gcc-toolset-13/enable
-          source ${{ github.workspace }}/torch-xpu-ops/.github/scripts/env.sh
+          if [ "${{inputs.category}}" != "dpclang" ]; then
+            source ${{ github.workspace }}/torch-xpu-ops/.github/scripts/env.sh
+          fi
           export ONEDNN_COMMIT='${{ inputs.onednn }}'
           ${{ github.workspace }}/torch-xpu-ops/.github/scripts/build.sh \
             --WORKSPACE="${{ github.workspace }}" \

--- a/.github/workflows/_linux_build.yml
+++ b/.github/workflows/_linux_build.yml
@@ -110,19 +110,6 @@ jobs:
           echo "LD_LIBRARY_PATH=$(pwd)/install-dpclang/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
           echo "PATH=$(pwd)/install-dpclang/bin:$PATH" >> $GITHUB_ENV
           echo "USE_DPCLANG=yes" >> $GITHUB_ENV
-      - name: Setup dpclang
-        if: ${{ inputs.category == 'dpclang' }}
-        run: |
-          dnf install -y tree libzstd-devel
-          tree install-dpclang
-          echo "aaa"
-          find install-dpclang -name clang
-          ls -al install-dpclang/bin/
-          which clang
-          which dpclang
-          which pkg-config
-          pkg-config --cflags sycl-dpcpp-7
-          #false
       - name: Build Pytorch
         run: |
           export USE_XCCL=1

--- a/.github/workflows/_linux_ut.yml
+++ b/.github/workflows/_linux_ut.yml
@@ -115,20 +115,6 @@ jobs:
     steps:
       - name: Checkout torch-xpu-ops
         uses: actions/checkout@v4
-      - name: Download dpclang
-        if: ${{ inputs.category == 'dpclang' }}
-        uses: actions/download-artifact@v8
-        with:
-          name: dpclang
-      - name: Setup dpclang
-        if: ${{ inputs.category == 'dpclang' }}
-        run: |
-          rm -rf install-dpclang && mkdir install-dpclang
-          tar xzvf install-dpclang.tgz -C install-dpclang
-          echo "CMAKE_PREFIX_PATH=$(pwd)/install-dpclang" >> $GITHUB_ENV
-          echo "PKG_CONFIG_PATH=$(pwd)/install-dpclang/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=$(pwd)/install-dpclang/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-          echo "PATH=$(pwd)/install-dpclang/bin:$PATH" >> $GITHUB_ENV
       - name: Prepare test env
         uses: ./.github/actions/linux-testenv
         with:

--- a/.github/workflows/_linux_ut.yml
+++ b/.github/workflows/_linux_ut.yml
@@ -61,6 +61,20 @@ jobs:
     steps:
       - name: Checkout torch-xpu-ops
         uses: actions/checkout@v4
+      - name: Download dpclang
+        if: ${{ inputs.category == 'dpclang' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: dpclang
+      - name: Setup dpclang
+        if: ${{ inputs.category == 'dpclang' }}
+        run: |
+          rm -rf install-dpclang && mkdir install-dpclang
+          tar xzvf install-dpclang.tgz -C install-dpclang
+          echo "CMAKE_PREFIX_PATH=$(pwd)/install-dpclang" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=$(pwd)/install-dpclang/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$(pwd)/install-dpclang/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "PATH=$(pwd)/install-dpclang/bin:$PATH" >> $GITHUB_ENV
       - name: Prepare test env
         uses: ./.github/actions/linux-testenv
         with:
@@ -101,6 +115,20 @@ jobs:
     steps:
       - name: Checkout torch-xpu-ops
         uses: actions/checkout@v4
+      - name: Download dpclang
+        if: ${{ inputs.category == 'dpclang' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: dpclang
+      - name: Setup dpclang
+        if: ${{ inputs.category == 'dpclang' }}
+        run: |
+          rm -rf install-dpclang && mkdir install-dpclang
+          tar xzvf install-dpclang.tgz -C install-dpclang
+          echo "CMAKE_PREFIX_PATH=$(pwd)/install-dpclang" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=$(pwd)/install-dpclang/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$(pwd)/install-dpclang/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "PATH=$(pwd)/install-dpclang/bin:$PATH" >> $GITHUB_ENV
       - name: Prepare test env
         uses: ./.github/actions/linux-testenv
         with:

--- a/.github/workflows/pull_dpclang.yml
+++ b/.github/workflows/pull_dpclang.yml
@@ -31,8 +31,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: intel/llvm
-          # WA for https://github.com/intel/llvm/issues/22308
-          ref: 8c9609e0723795c0c82b7d2d097eed406e71156b # sycl-rel-7_0
+          # TODO: change to versioned release tag when available
+          ref: eb36014ea34e57e534af8febd14f58dfb181f96e  # branch: sycl-rel-7_0
           path: intel-llvm
       - name: Install prerequisites
         run: |
@@ -111,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ut_name: [basic]  #[op_ut, basic]
+        ut_name: [basic, op_ut]
     uses: ./.github/workflows/_linux_ut.yml
     with:
       category: dpclang

--- a/.github/workflows/pull_dpclang.yml
+++ b/.github/workflows/pull_dpclang.yml
@@ -100,3 +100,22 @@ jobs:
       category: dpclang
       runner: build
       pytorch: ${{ contains(github.event.pull_request.labels.*.name, 'disable_build') && 'nightly_wheel' || github.base_ref }}
+
+  linux-ut:
+    needs: build-wheels
+    secrets: inherit
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        ut_name: [basic]  #[op_ut, basic]
+    uses: ./.github/workflows/_linux_ut.yml
+    with:
+      category: dpclang
+      runner: pvc
+      pytorch: ${{ contains(github.event.pull_request.labels.*.name, 'disable_build') && 'nightly_wheel' || github.base_ref }}
+      torch_xpu_ops: ${{ contains(github.event.pull_request.labels.*.name, 'disable_build') && 'pinned' || 'main' }}
+      ut: ${{ matrix.ut_name }}

--- a/.github/workflows/pull_dpclang.yml
+++ b/.github/workflows/pull_dpclang.yml
@@ -1,0 +1,102 @@
+name: pull dpclang
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release/*
+    paths:
+      - .github/workflows/pull_dpclang.yml
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-prereq:
+    if: ${{ github.repository_owner == 'intel' }}
+    runs-on: build
+    container:
+      image: 'pytorch/manylinux2_28-builder:xpu-main'
+      volumes:
+        - ${{ github.workspace }}:${{ github.workspace }}
+      env:
+        PATH: /tmp/xpu-tool/myvenv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        AGENT_TOOLSDIRECTORY: /tmp/xpu-tool
+        PIP_CACHE_DIR: /tmp/xpu-tool/.pipcache
+    steps:
+      - name: Checkout intel-llvm
+        uses: actions/checkout@v6
+        with:
+          repository: intel/llvm
+          # WA for https://github.com/intel/llvm/issues/22308
+          ref: 8c9609e0723795c0c82b7d2d097eed406e71156b # sycl-rel-7_0
+          path: intel-llvm
+      - name: Install prerequisites
+        run: |
+          rm -rf /tmp/xpu-tool/myvenv
+          /opt/python/cp314-cp314/bin/python3 -m venv /tmp/xpu-tool/myvenv
+          pip install cmake ninja
+          dnf install -y libtool libzstd-devel
+      - name: Build intel-llvm
+        run: |
+          source /opt/rh/gcc-toolset-13/enable
+          # WA for https://github.com/intel/llvm/pull/22294
+          sed -i 's/\${zstd_STATIC_LIBRARY}/zstd::libzstd_shared/' sycl/source/CMakeLists.txt
+          cmake -B build -S llvm -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=$(pwd)/install \
+            -DBUILD_SHARED_LIBS=ON \
+            -DLLVM_BUILD_TOOLS=ON \
+            -DLLVM_ENABLE_ASSERTIONS=ON \
+            -DLLVM_ENABLE_DOXYGEN=OFF \
+            -DLLVM_ENABLE_LLD=OFF \
+            -DLLVM_ENABLE_PROJECTS='clang;sycl;llvm-spirv;opencl;xpti;xptifw;compiler-rt;libdevice;sycl-jit' \
+            -DLLVM_ENABLE_RTTI=ON \
+            -DLLVM_ENABLE_SPHINX=OFF \
+            -DLLVM_ENABLE_ZSTD=ON \
+            -DLLVM_EXTERNAL_PROJECTS='sycl;llvm-spirv;opencl;xpti;xptifw;compiler-rt;libdevice;sycl-jit' \
+            -DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=OFF \
+            -DLLVM_TARGETS_TO_BUILD='host;SPIRV' \
+            -DSYCL_ENABLE_EXTENSION_JIT=ON \
+            -DSYCL_ENABLE_MAJOR_RELEASE_PREVIEW_LIB=OFF \
+            -DSYCL_ENABLE_WERROR=OFF \
+            -DSYCL_ENABLE_XPTI_TRACING=ON \
+            -DLLVM_EXTERNAL_LIBDEVICE_SOURCE_DIR=$(pwd)/libdevice \
+            -DLLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR=$(pwd)/llvm-spirv \
+            -DLLVM_EXTERNAL_SYCL_JIT_SOURCE_DIR=$(pwd)/sycl-jit \
+            -DLLVM_EXTERNAL_SYCL_SOURCE_DIR=$(pwd)/sycl \
+            -DLLVM_EXTERNAL_XPTI_SOURCE_DIR=$(pwd)/xpti \
+            -DLLVM_EXTERNAL_XPTIFW_SOURCE_DIR=$(pwd)/xptifw \
+            -DSYCL_INCLUDE_TESTS=OFF \
+            -DXPTI_ENABLE_WERROR=OFF
+          cmake --build build
+          cmake --install build
+        working-directory: ./intel-llvm
+      - name:
+        run: |
+          # WA for https://github.cim/intel/llvm/issues/21511
+          ln -s clang dpclang
+          ln -s clang++ dpclang++
+        working-directory: ./intel-llvm/install/bin
+      - name: Compress output
+        run: |
+          # Compressing manually to preserve access permissions for executables
+          tar czvf install-dpclang.tgz -C intel-llvm/install .
+      - name: Upload dpclang
+        uses: actions/upload-artifact@v7
+        with:
+          name: dpclang
+          path: install-dpclang.tgz
+
+  build-wheels:
+    needs: build-prereq
+    if: ${{ github.repository_owner == 'intel' }}
+    secrets: inherit
+    uses: ./.github/workflows/_linux_build.yml
+    with:
+      category: dpclang
+      runner: build
+      pytorch: ${{ contains(github.event.pull_request.labels.*.name, 'disable_build') && 'nightly_wheel' || github.base_ref }}

--- a/.github/workflows/pull_dpclang.yml
+++ b/.github/workflows/pull_dpclang.yml
@@ -1,3 +1,6 @@
+# This workflow intends to verify pytorch built against full open source
+# stack (oneAPI not used).
+
 name: pull dpclang
 
 on:
@@ -7,6 +10,11 @@ on:
       - release/*
     paths:
       - .github/workflows/pull_dpclang.yml
+      - ./.github/workflows/_linux_build.yml
+      - ./.github/workflows/_linux_ut.yml
+  schedule:
+    # 9:00 AM UTC every Sunday
+    - cron: '0 9 * * 0'
 
 permissions: read-all
 
@@ -99,7 +107,7 @@ jobs:
     with:
       category: dpclang
       runner: build
-      pytorch: ${{ contains(github.event.pull_request.labels.*.name, 'disable_build') && 'nightly_wheel' || github.base_ref }}
+      pytorch: ${{ github.base_ref }}
 
   linux-ut:
     needs: build-wheels
@@ -116,6 +124,6 @@ jobs:
     with:
       category: dpclang
       runner: pvc
-      pytorch: ${{ contains(github.event.pull_request.labels.*.name, 'disable_build') && 'nightly_wheel' || github.base_ref }}
-      torch_xpu_ops: ${{ contains(github.event.pull_request.labels.*.name, 'disable_build') && 'pinned' || 'main' }}
+      pytorch: ${{ github.base_ref }}
+      torch_xpu_ops: ${{ 'main' }}
       ut: ${{ matrix.ut_name }}


### PR DESCRIPTION
Current limitations for the pytorch build with dpclang:
1. Triton can not find dpclang and dpclang sycl (dynamo and inductor cases fail)
2. oneCCL not available: https://github.com/uxlfoundation/oneCCL/issues/191
3. PTI not available: https://github.com/intel/pti-gpu/issues/111
4. MKL not enabled (as it's closed source library)