### PR TITLE
Use C++20 STL utils and enable C++20 for Windows SYCL device code

### DIFF
--- a/cmake/BuildFlags.cmake
+++ b/cmake/BuildFlags.cmake
@@ -101,14 +101,17 @@ macro(set_build_flags)
     # gcc -shared host.o kernel.o device-code.o -o libxxx.so
     set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -fno-sycl-unnamed-lambda)
     set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -sycl-std=2020)
-    set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -std=${CPP_STD})
     if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+      # icx runs in clang-cl mode on Windows and silently ignores GCC-style
+      # -std=; use the MSVC-style spelling so device code is really C++20.
+      set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -Qstd=${CPP_STD})
       set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} /fp:strict)
       set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} /Qfma)
       set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} /Qftz-)
       # Suppress warnings about dllexport.
       set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -Wno-ignored-attributes)
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -std=${CPP_STD})
       set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -Wno-absolute-value)
       set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -fno-fast-math)
       # -fma which we used before is an alias used for -ffp-contract=fast for compatibility reasons

--- a/cmake/BuildFlags.cmake
+++ b/cmake/BuildFlags.cmake
@@ -102,8 +102,8 @@ macro(set_build_flags)
     set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -fno-sycl-unnamed-lambda)
     set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -sycl-std=2020)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-      # icx runs in clang-cl mode on Windows and silently ignores GCC-style
-      # -std=; use the MSVC-style spelling so device code is really C++20.
+      # On Windows icx uses the clang-cl driver, which ignores -std= with
+      # only a warning; spell it as -Qstd= so device code is really C++20.
       set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -Qstd=${CPP_STD})
       set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} /fp:strict)
       set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} /Qfma)

--- a/src/ATen/native/transformers/SDPUtils.cpp
+++ b/src/ATen/native/transformers/SDPUtils.cpp
@@ -9,12 +9,11 @@
  */
 
 #include <ATen/native/transformers/sdp_utils_cpp.h>
-#include <c10/util/Array.h>
 #include <c10/util/Exception.h>
 
-namespace sdp {
+#include <array>
 
-using c10::array_of;
+namespace sdp {
 
 bool check_all_tensors_on_device(sdp_params const& params, bool debug) {
   // Check that all tensors are on the GPU device
@@ -46,11 +45,11 @@ inline bool check_head_dim(sdp_params const& params, bool debug) {
 bool can_use_mem_efficient_attention(sdp::sdp_params params, bool debug) {
   //  Define gate functions that determine if a flash kernel can be ran
   constexpr auto general_constraints =
-      array_of<bool (*)(sdp_params const&, bool)>(
-          sdp::check_runtime_disabled_mem_efficient,
-          check_all_tensors_on_device,
-          sdp::check_tensor_shapes,
-          check_head_dim);
+      std::to_array<bool (*)(sdp_params const&, bool)>(
+          {sdp::check_runtime_disabled_mem_efficient,
+           check_all_tensors_on_device,
+           sdp::check_tensor_shapes,
+           check_head_dim});
   for (auto& constraint : general_constraints) {
     if (!constraint(params, debug)) {
       return false;
@@ -59,10 +58,10 @@ bool can_use_mem_efficient_attention(sdp::sdp_params params, bool debug) {
 
   if (has_for_nested_inputs(params)) {
     constexpr auto nested_constraints =
-        array_of<bool (*)(sdp_params const&, bool)>(
-            sdp::check_requires_grad_and_nested,
-            sdp::check_batch_size_nested,
-            sdp::check_for_seq_len_0_nested_tensor);
+        std::to_array<bool (*)(sdp_params const&, bool)>(
+            {sdp::check_requires_grad_and_nested,
+             sdp::check_batch_size_nested,
+             sdp::check_for_seq_len_0_nested_tensor});
     for (auto& constraint : nested_constraints) {
       if (!constraint(params, debug)) {
         return false;
@@ -72,12 +71,12 @@ bool can_use_mem_efficient_attention(sdp::sdp_params params, bool debug) {
 
   if (has_only_dense_inputs(params)) {
     constexpr auto dense_constraints =
-        array_of<bool (*)(sdp_params const&, bool)>(
-            sdp::check_nonzero_sequence_lengths_dense,
-            sdp::check_last_dim_stride_equals_1_dense<
-                false /*ignore_singleton_dim=*/>,
-            sdp::check_batch_size_and_num_heads_dense<
-                false /*supports_grouped_query_attention=*/>);
+        std::to_array<bool (*)(sdp_params const&, bool)>(
+            {sdp::check_nonzero_sequence_lengths_dense,
+             sdp::check_last_dim_stride_equals_1_dense<
+                 false /*ignore_singleton_dim=*/>,
+             sdp::check_batch_size_and_num_heads_dense<
+                 false /*supports_grouped_query_attention=*/>});
     for (auto& constraint : dense_constraints) {
       if (!constraint(params, debug)) {
         return false;

--- a/src/ATen/native/xpu/sycl/LogAddExpKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LogAddExpKernels.cpp
@@ -15,10 +15,10 @@
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/xpu/sycl/Loops.h>
-#include <c10/util/MathConstants.h>
 #include <c10/util/complex.h>
 #include <cmath>
 #include <limits>
+#include <numbers>
 
 #include <ATen/native/xpu/sycl/LogAddExpKernels.h>
 
@@ -151,7 +151,8 @@ template <typename scalar_t>
 struct LogAddExp2Functor {
   scalar_t operator()(scalar_t a_, scalar_t b_) const {
     using opmath_t = at::opmath_type<scalar_t>;
-    const auto inv_log_2 = static_cast<opmath_t>(1.0 / c10::ln_2<double>);
+    const auto inv_log_2 =
+        static_cast<opmath_t>(1.0 / std::numbers::ln2_v<double>);
     const auto a = static_cast<opmath_t>(a_);
     const auto b = static_cast<opmath_t>(b_);
     if (sycl::isinf(a) && a == b) {

--- a/src/ATen/native/xpu/sycl/MathExtensions.h
+++ b/src/ATen/native/xpu/sycl/MathExtensions.h
@@ -18,10 +18,10 @@
 #include <c10/macros/Macros.h>
 #include <c10/util/BFloat16.h>
 #include <c10/util/Half.h>
-#include <c10/util/MathConstants.h>
 #include <sycl/sycl.hpp>
 
 #include <limits>
+#include <numbers>
 #include <type_traits>
 
 namespace at::native::xpu {
@@ -62,9 +62,11 @@ inline std::enable_if_t<std::is_floating_point_v<T>, T> calc_erfinv(T y) {
   }
   /* Two steps of Newton-Raphson correction */
   x = x -
-      (sycl::erf(x) - y) / ((T(2) * c10::frac_1_sqrt_pi<T>)*sycl::exp(-x * x));
+      (sycl::erf(x) - y) /
+          ((T(2) * std::numbers::inv_sqrtpi_v<T>)*sycl::exp(-x * x));
   x = x -
-      (sycl::erf(x) - y) / ((T(2) * c10::frac_1_sqrt_pi<T>)*sycl::exp(-x * x));
+      (sycl::erf(x) - y) /
+          ((T(2) * std::numbers::inv_sqrtpi_v<T>)*sycl::exp(-x * x));
   return x;
 }
 

--- a/src/ATen/native/xpu/sycl/Reduce.h
+++ b/src/ATen/native/xpu/sycl/Reduce.h
@@ -202,7 +202,18 @@ inline int last_pow2(int n) {
 }
 
 static void reduce_fraction(size_t& numerator, size_t& denominator) {
+#ifdef _MSC_VER
+  // MSVC's std::gcd does runtime ISA dispatch through a global variable and
+  // CPU builtins, which cannot be used in device code; use Euclid's algorithm.
+  size_t gcd = denominator;
+  size_t b = numerator;
+  while (b != 0) {
+    gcd %= b;
+    std::swap(gcd, b);
+  }
+#else
   auto gcd = std::gcd(numerator, denominator);
+#endif
   numerator /= gcd;
   denominator /= gcd;
 }


### PR DESCRIPTION
Replace c10 utility usages with their C++20 standard-library equivalents:

- `c10::array_of` -> `std::to_array` in SDPUtils.cpp
- `c10::ln_2<T>` -> `std::numbers::ln2_v<T>` in LogAddExpKernels.cpp
- `c10::frac_1_sqrt_pi<T>` -> `std::numbers::inv_sqrtpi_v<T>` in MathExtensions.h

The math constant replacements are bit-for-bit identical for both `float` and `double`: c10 and `std::numbers` represent the same mathematical constants and round to the same IEEE-754 value. `calc_erfinv<T>` is only instantiated with `float`/`double` (the `BFloat16`/`Half` overloads cast to `float`), so `std::numbers` (floating-point only) covers all cases.

Also fixes C++20 support for Windows SYCL device compilation, which `std::numbers` (here and in upstream `c10/util/MathConstants.h` after pytorch/pytorch#186877) depends on:

- icx in clang-cl mode ignores the GCC-style `-std=c++20`, so Windows device code silently compiled as C++17. Pass `-Qstd=c++20` instead.
- Real C++20 exposed that MSVC's `std::gcd` dispatches on a runtime ISA global and x86 builtins, which SYCL kernels cannot use. `reduce_fraction` now uses Euclid's algorithm on MSVC (matching CUDA's `Reduce.cuh`).

Test: windows-build CI; constants verified bit-identical.