### PR TITLE
Guard empty tensors in BatchKernelConfig-based XPU ops

### DIFF
--- a/src/ATen/native/xpu/sycl/Indexing.cpp
+++ b/src/ATen/native/xpu/sycl/Indexing.cpp
@@ -569,6 +569,10 @@ static inline void index_copy_impl(
   if (sliceSize == 0) {
     return;
   }
+  // No indices: nothing to copy; dst already holds a copy of self.
+  if (indices.numel() == 0) {
+    return;
+  }
 
   TensorInfo<const int64_t, int64_t> indices_info =
       getTensorInfo<const int64_t, int64_t>(indices);

--- a/src/ATen/native/xpu/sycl/ScanUtils.h
+++ b/src/ATen/native/xpu/sycl/ScanUtils.h
@@ -1403,6 +1403,11 @@ void scan_with_indices(
   auto self = self_.contiguous();
   TORCH_INTERNAL_ASSERT(values.is_contiguous() && indices.is_contiguous());
 
+  // Empty input: values/indices are empty too, nothing to write.
+  if (self.numel() == 0) {
+    return;
+  }
+
   dimension = maybe_wrap_dim(dimension, self.dim());
   TORCH_CHECK(
       dimension >= 0 && dimension < self.dim(),

--- a/src/ATen/native/xpu/sycl/WeightNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/WeightNormKernels.cpp
@@ -19,6 +19,8 @@
 
 #include <ATen/native/xpu/sycl/WeightNormKernels.h>
 
+#include <limits>
+
 namespace at::native::xpu {
 
 template <typename T>
@@ -392,6 +394,12 @@ std::tuple<Tensor, Tensor> weight_norm_kernel(
   auto norms = at::empty(
       g.sizes(), g.options().dtype(scalar_acc_t), g.suggest_memory_format());
   auto w = at::empty(v.sizes(), v.options(), v.suggest_memory_format());
+
+  // Empty v: w is empty, norm of an empty vector is 0 (matches CPU/CUDA).
+  if (v.numel() == 0) {
+    norms.zero_();
+    return {w, norms};
+  }
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::Half,
@@ -890,6 +898,12 @@ std::tuple<Tensor, Tensor> weight_norm_backward_kernel(
     int64_t dim) {
   auto grad_v = at::empty_like(saved_v, c10::get_contiguous_memory_format());
   auto grad_g = at::empty_like(saved_g, c10::get_contiguous_memory_format());
+
+  // Empty saved_v: grad_v is empty, grad_g = 0/0 = NaN (matches CPU/CUDA).
+  if (saved_v.numel() == 0) {
+    grad_g.fill_(std::numeric_limits<double>::quiet_NaN());
+    return {grad_v, grad_g};
+  }
 
   at::ScalarType scalar_acc_t =
       (saved_g.scalar_type() == at::ScalarType::Half ||

--- a/test/regressions/test_index_and_index_put.py
+++ b/test/regressions/test_index_and_index_put.py
@@ -132,3 +132,51 @@ class TestTorchMethod(TestCase):
         y_xpu = x_xpu.index_add(0, idx_xpu, src_xpu)
 
         self.assertEqual(y_xpu.cpu(), y_cpu)
+
+    # Empty inputs below used to divide by zero in BatchKernelConfig (a zero
+    # range bound collapses a launch range to 0). Each checks XPU vs CPU.
+
+    def test_index_copy_empty(self):
+        # dst.size(dim)==0 with non-empty sliceSize and an empty index: nothing
+        # is copied, so the result equals dst.
+        dst = torch.randn(2, 0, 3)
+        index = torch.empty(0, dtype=torch.long)
+        source = torch.randn(2, 0, 3)
+        out_cpu = dst.index_copy(1, index, source)
+        out_xpu = dst.xpu().index_copy(1, index.xpu(), source.xpu())
+        self.assertEqual(out_xpu.cpu(), out_cpu)
+        self.assertEqual(out_xpu.cpu(), dst)
+
+    def test_weight_norm_empty(self):
+        # v empty along the reduced dim, kept dim non-empty: norm of an empty
+        # vector is 0 (forward); grad_g = 0/0 = NaN (backward).
+        def fwd(device):
+            v = torch.randn(4, 0, device=device)
+            g = torch.norm_except_dim(v, 2, 0)
+            return torch._weight_norm_interface(v, g, 0)
+
+        w_cpu, n_cpu = fwd("cpu")
+        w_xpu, n_xpu = fwd("xpu")
+        self.assertEqual(w_xpu.cpu(), w_cpu)
+        self.assertEqual(n_xpu.cpu(), n_cpu)
+        self.assertEqual(n_xpu.cpu(), torch.zeros_like(n_cpu))
+
+        def bwd(device):
+            v = torch.randn(4, 0, device=device, requires_grad=True)
+            g = torch.randn(4, 1, device=device, requires_grad=True)
+            torch._weight_norm(v, g, 0).sum().backward()
+            return v.grad, g.grad
+
+        gv_cpu, gg_cpu = bwd("cpu")
+        gv_xpu, gg_xpu = bwd("xpu")
+        self.assertEqual(gv_xpu.cpu(), gv_cpu)
+        self.assertEqual(gg_xpu.cpu(), gg_cpu)  # assertEqual treats NaN==NaN
+
+    def test_cummax_cummin_empty(self):
+        for op in (torch.cummax, torch.cummin):
+            for shape, dim in (((0,), 0), ((3, 0, 4), 2)):
+                x = torch.randn(shape)
+                v_cpu, i_cpu = op(x, dim)
+                v_xpu, i_xpu = op(x.xpu(), dim)
+                self.assertEqual(v_xpu.cpu(), v_cpu)
+                self.assertEqual(i_xpu.cpu(), i_cpu)


### PR DESCRIPTION
`BatchKernelConfig::build()` divides by zero when an empty input collapses a work-group/global range to 0. `weight_norm`, `index_copy` and `cummax`/`cummin` reached it without a `numel()==0` guard (unlike CPU/CUDA), so empty tensors crashed. Max-pool callers are unaffected (`Policy::pAdaptive` clamps the range to `>= 1`).

Each guard reproduces the CPU/CUDA reference:
- **weight_norm fwd** — zero-fill `norm` (norm of an empty vector is 0)
- **weight_norm bwd** — `grad_g = 0/0 = NaN` (matches CPU/CUDA rather than diverging to 0)
- **index_copy** — no-op (index empty; `out` already equals `self`)
- **cummax/cummin** — no-op (empty in, empty out)

Test: empty-tensor regression cases added to `test/regressions/test_index_and_index_put.py`

```
pytest test/regressions/test_index_and_index_put.py
```