### PR TITLE
Replace std::nearbyint with sycl::rint for SYCL compatibility

### DIFF
--- a/src/ATen/native/quantized/sycl/AffineQuantizerKernels.cpp
+++ b/src/ATen/native/quantized/sycl/AffineQuantizerKernels.cpp
@@ -49,7 +49,7 @@ struct QuantizerTensorPerChannelAffineFunctor {
       double scale,
       int64_t zero_point) const {
     int64_t qvalue =
-        static_cast<int64_t>(std::nearbyint(raw_val / scale) + zero_point);
+        static_cast<int64_t>(sycl::rint(raw_val / scale) + zero_point);
     qvalue = std::max<int64_t>(qvalue, qmin_);
     qvalue = std::min<int64_t>(qvalue, qmax_);
     quantized_val.val_ = qvalue;
@@ -238,7 +238,7 @@ template <typename scalar_t>
 struct QuantizerTensorPerTensorAffineFunctor {
   scalar_t operator()(float raw_val, scalar_t quantized_val) const {
     int64_t qvalue =
-        static_cast<int64_t>(std::nearbyint(raw_val / scale_) + zero_point_);
+        static_cast<int64_t>(sycl::rint(raw_val / scale_) + zero_point_);
     qvalue = std::max<int64_t>(qvalue, qmin_);
     qvalue = std::min<int64_t>(qvalue, qmax_);
     quantized_val.val_ = qvalue;

--- a/src/ATen/native/quantized/sycl/FakeQuantizeCoreKernels.cpp
+++ b/src/ATen/native/quantized/sycl/FakeQuantizeCoreKernels.cpp
@@ -20,8 +20,8 @@ namespace at::native::xpu {
 template <typename scalar_t>
 struct FakeQuantizeTensorCachemaskKernelFunctor {
   std::tuple<scalar_t, bool> operator()(scalar_t input_val) const {
-    const auto qval = static_cast<int64_t>(
-        std::nearbyint(input_val * inv_scale_) + zero_point_);
+    const auto qval =
+        static_cast<int64_t>(sycl::rint(input_val * inv_scale_) + zero_point_);
     return {// fake_quantized value
             (fminf(quant_max_, fmaxf(quant_min_, qval)) - zero_point_) * scale_,
             // mask for grad
@@ -91,8 +91,8 @@ struct FakeQuantizeTensorCachemaskTensorQparamsFunctor {
       return {input_val, 1};
     }
     float inv_scale = 1.0f / (*scale_ptr_);
-    const auto qval = static_cast<int64_t>(
-        std::nearbyint(input_val * inv_scale) + (*zp_ptr_));
+    const auto qval =
+        static_cast<int64_t>(sycl::rint(input_val * inv_scale) + (*zp_ptr_));
     return {// fake_quantized value
             (std::min(quant_max_, std::max(quant_min_, qval)) - (*zp_ptr_)) *
                 (*scale_ptr_),
@@ -163,7 +163,7 @@ struct FakeQuantizeGradLearnableTensorFunctor {
   std::tuple<float, float, float> operator()(float XInput, float dYInput)
       const {
     float dXOutput, dZeroPointOutput, dScaleOutput;
-    int64_t xq = std::nearbyint(XInput * inv_scale_) + zero_point_;
+    int64_t xq = sycl::rint(XInput * inv_scale_) + zero_point_;
     dXOutput = dYInput * (xq >= quant_min_ && xq <= quant_max_);
     float xfq = static_cast<float>(
         (std::max(std::min(xq, quant_max_), quant_min_) - zero_point_) *
@@ -285,8 +285,7 @@ struct FakeQuantPerChannelCachemaskHelperCFunctor {
       const int64_t zero_point) const {
     const float inv_scale = 1.0f / scale;
     const auto qval =
-        static_cast<int64_t>(std::nearbyint(input_val * inv_scale)) +
-        zero_point;
+        static_cast<int64_t>(sycl::rint(input_val * inv_scale)) + zero_point;
     return ((quant_min_ <= qval) && (qval <= quant_max_));
   }
   FakeQuantPerChannelCachemaskHelperCFunctor(
@@ -307,8 +306,7 @@ struct FakeQuantPerChannelCachemaskHelperDFunctor {
       const int64_t zero_point) const {
     const float inv_scale = 1.0f / scale;
     const auto qval =
-        static_cast<int64_t>(std::nearbyint(input_val * inv_scale)) +
-        zero_point;
+        static_cast<int64_t>(sycl::rint(input_val * inv_scale)) + zero_point;
     const auto bounded_qval = std::min(quant_max_, std::max(quant_min_, qval));
     return (bounded_qval - zero_point) * scale;
   }
@@ -393,7 +391,7 @@ struct FakeQuantizeGradLearnableChannelFunctor {
     float dscale_small = quant_min_ - zero_point_input;
     float dscale_big = quant_max_ - zero_point_input;
     // Calculate gradients for X.
-    int64_t xqi = std::nearbyint(x_input * inv_scale) +
+    int64_t xqi = sycl::rint(x_input * inv_scale) +
         static_cast<int64_t>(zero_point_input);
     dx_output = dy_input * (xqi >= quant_min_ && xqi <= quant_max_);
     // Calculate gradients for scale and zero point.

--- a/src/ATen/native/quantized/sycl/FusedObsFakeQuantKernels.cpp
+++ b/src/ATen/native/quantized/sycl/FusedObsFakeQuantKernels.cpp
@@ -215,7 +215,7 @@ void ChooseQuantizationParamsKernelImpl(
     } else if (initial_zero_point > qmax) {
       nudged_zero_point = qmax;
     } else {
-      nudged_zero_point = std::nearbyint(initial_zero_point);
+      nudged_zero_point = sycl::rint(initial_zero_point);
     }
     zero_point[i] = nudged_zero_point;
   }

--- a/src/ATen/native/xpu/sycl/ForeachUnaryKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ForeachUnaryKernels.cpp
@@ -384,7 +384,7 @@ struct Sigmoid {
 template <typename T>
 struct Round {
   T operator()(T t) const {
-    return std::nearbyint(t);
+    return sycl::rint(static_cast<at::opmath_type<T>>(t));
   }
 };
 

--- a/src/ATen/native/xpu/sycl/GridSampler.cpp
+++ b/src/ATen/native/xpu/sycl/GridSampler.cpp
@@ -93,8 +93,8 @@ struct GridSampler2dKernelFunctor {
         *out_ptr_NCHW = out_acc;
       }
     } else if (interpolation_mode_ == GridSamplerInterpolation::Nearest) {
-      index_t ix_nearest = static_cast<index_t>(std::nearbyint(ix));
-      index_t iy_nearest = static_cast<index_t>(std::nearbyint(iy));
+      index_t ix_nearest = static_cast<index_t>(sycl::rint(ix));
+      index_t iy_nearest = static_cast<index_t>(sycl::rint(iy));
 
       // assign nearest neighor pixel value to output pixel
       auto inp_ptr_NC = input_.data + n * inp_sN_;
@@ -494,8 +494,10 @@ struct GridSampler2dBackwardKernelFunctor {
       gGrid_ptr_NHW[1] = giy_mult * giy;
     } else if (interpolation_mode_ == GridSamplerInterpolation::Nearest) {
       if (input_requires_grad_) {
-        index_t ix_nearest = static_cast<index_t>(std::nearbyint(ix));
-        index_t iy_nearest = static_cast<index_t>(std::nearbyint(iy));
+        index_t ix_nearest = static_cast<index_t>(
+            sycl::rint(static_cast<at::opmath_type<scalar_t>>(ix)));
+        index_t iy_nearest = static_cast<index_t>(
+            sycl::rint(static_cast<at::opmath_type<scalar_t>>(iy)));
 
         // assign nearest neighor pixel value to output pixel
         const scalar_t* gOut_ptr_NCHW =
@@ -989,9 +991,9 @@ struct GridSampler3dKernelFunctor {
         *out_ptr_NCDHW = out_acc;
       }
     } else if (interpolation_mode_ == GridSamplerInterpolation::Nearest) {
-      index_t ix_nearest = static_cast<index_t>(std::nearbyint(ix));
-      index_t iy_nearest = static_cast<index_t>(std::nearbyint(iy));
-      index_t iz_nearest = static_cast<index_t>(std::nearbyint(iz));
+      index_t ix_nearest = static_cast<index_t>(sycl::rint(ix));
+      index_t iy_nearest = static_cast<index_t>(sycl::rint(iy));
+      index_t iz_nearest = static_cast<index_t>(sycl::rint(iz));
 
       // assign nearest neighor pixel value to output_ pixel
       auto inp_ptr_NC = input_.data + n * inp_sN_;

--- a/src/ATen/native/xpu/sycl/UnaryFractionKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryFractionKernels.cpp
@@ -107,24 +107,24 @@ void ceil_kernel(TensorIteratorBase& iter) {
 
 template <typename scalar_t>
 inline scalar_t nearbyint_wrapper(scalar_t a) {
-  return static_cast<scalar_t>(std::nearbyintf(static_cast<float>(a)));
+  return static_cast<scalar_t>(sycl::rint(static_cast<float>(a)));
 }
 
 inline double nearbyint_wrapper(double a) {
-  return std::nearbyint(a);
+  return sycl::rint(a);
 }
 
 #pragma push
 inline c10::complex<float> nearbyint_wrapper(c10::complex<float> a) {
   return c10::complex<float>(
-      std::nearbyintf(static_cast<float>(a.real())),
-      std::nearbyintf(static_cast<float>(a.imag())));
+      sycl::rint(static_cast<float>(a.real())),
+      sycl::rint(static_cast<float>(a.imag())));
 }
 
 inline c10::complex<double> nearbyint_wrapper(c10::complex<double> a) {
   return c10::complex<double>(
-      std::nearbyint(static_cast<double>(a.real())),
-      std::nearbyint(static_cast<double>(a.imag())));
+      sycl::rint(static_cast<double>(a.real())),
+      sycl::rint(static_cast<double>(a.imag())));
 }
 #pragma pop
 
@@ -139,8 +139,12 @@ template <typename scalar_t>
 struct RoundDecimalsFunctor {
   scalar_t operator()(scalar_t a) const {
     return neg_flag_
-        ? std::nearbyint(a / ten_pow_decimals_) * ten_pow_decimals_
-        : std::nearbyint(a * ten_pow_decimals_) / ten_pow_decimals_;
+        ? sycl::rint(
+              static_cast<at::opmath_type<scalar_t>>(a / ten_pow_decimals_)) *
+            ten_pow_decimals_
+        : sycl::rint(
+              static_cast<at::opmath_type<scalar_t>>(a * ten_pow_decimals_)) /
+            ten_pow_decimals_;
   }
   RoundDecimalsFunctor(scalar_t ten_pow_decimals, bool neg_flag)
       : ten_pow_decimals_(ten_pow_decimals), neg_flag_(neg_flag) {}


### PR DESCRIPTION
This pull request updates several SYCL-based kernel implementations to replace usage of the standard C++ `std::nearbyint` and related functions with the SYCL-specific `sycl::rint` function. This change ensures proper rounding behavior and compatibility within the SYCL environment, which is important for cross-platform and device-agnostic code execution. The updates are made across quantization, fake quantization, grid sampling, and unary math kernel files.

The most important changes are:

**Quantization and Fake Quantization Kernels:**
* Replaced all instances of `std::nearbyint` with `sycl::rint` in quantization, per-channel, and fake quantization functors to ensure device-compatible rounding in `AffineQuantizerKernels.cpp` and `FakeQuantizeCoreKernels.cpp`. 
**Grid Sampler Kernels:**
* Updated grid sampler 2D/3D forward and backward functors to use `sycl::rint` for nearest neighbor index calculation, ensuring consistent rounding across devices in `GridSampler.cpp`. 

**Unary Math and Fraction Kernels:**
* Replaced `std::nearbyint` and related calls with `sycl::rint` in rounding, nearbyint wrappers, and decimal rounding functors to maintain device compatibility in `UnaryFractionKernels.cpp` and `ForeachUnaryKernels.cpp`. 

**Fused Observer/Fake Quantization Kernels:**
* Changed rounding of zero points in quantization parameter selection to use `sycl::rint` in `FusedObsFakeQuantKernels.cpp`.

These changes collectively improve the portability and correctness of rounding operations in SYCL-based kernels.