### PR TITLE
Fix adaptive_max_pool2d 3D forward dropping non-contiguous output

### DIFF
--- a/src/ATen/native/xpu/sycl/AdaptiveMaxPooling2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/AdaptiveMaxPooling2dKernels.cpp
@@ -236,13 +236,13 @@ void adaptive_max_pool2d_kernel(
               istrideH,
               istrideW);
         });
+  }
 
-    if (!output.is_contiguous()) {
-      output.copy_(output_c);
-    }
-    if (!indices.is_contiguous()) {
-      indices.copy_(indices_c);
-    }
+  if (!output.is_contiguous()) {
+    output.copy_(output_c);
+  }
+  if (!indices.is_contiguous()) {
+    indices.copy_(indices_c);
   }
 }
 


### PR DESCRIPTION
`adaptive_max_pool2d_kernel` stages results into contiguous temporaries (`output_c`/`indices_c`) when the `output`/`indices` tensors are non-contiguous, but the copy-back ran **only in the 4D branch**. A 3D input with non-contiguous `output`/`indices` wrote into the discarded temporary and the caller's tensors kept their uninitialized `at::empty` contents (garbage).

Hoist the copy-back out of the `if/else` so it runs for both 3D and 4D, matching what the backward path already does.
