### PR TITLE
Use at::ceil_div instead of local CeilDiv helpers

### DIFF
--- a/src/ATen/native/xpu/sycl/EmbeddingBackwardKernel.h
+++ b/src/ATen/native/xpu/sycl/EmbeddingBackwardKernel.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <ATen/AccumulateType.h>
+#include <ATen/ceil_div.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/xpu/sycl/pstl/PSTLFunctions.h>
 #include <comm/SYCLContext.h>
@@ -19,11 +20,6 @@ namespace at::native::xpu {
 
 using namespace at::xpu;
 constexpr int64_t NROWS_PER_THREAD = 64;
-
-template <typename T, typename V>
-inline auto CeilDiv(T a, V b) {
-  return (a + b - 1) / b;
-}
 
 template <typename index_t>
 struct KrnPartialsPerSegmentKernelFunctor {
@@ -37,7 +33,7 @@ struct KrnPartialsPerSegmentKernelFunctor {
           ? static_cast<index_t>(numel_)
           : offsets_ptr[id + 1];
       const index_t size = idx_end - idx_start;
-      ret_ptr[id] = CeilDiv(size, static_cast<index_t>(NROWS_PER_THREAD));
+      ret_ptr[id] = at::ceil_div(size, static_cast<index_t>(NROWS_PER_THREAD));
     }
   }
   KrnPartialsPerSegmentKernelFunctor(
@@ -263,7 +259,7 @@ void compute_grad_weight_bags(
 
   int64_t max_sub_group_size = syclMaxSubGroupSize();
   int64_t stride_warped =
-      CeilDiv(stride, max_sub_group_size) * max_sub_group_size;
+      at::ceil_div(stride, max_sub_group_size) * max_sub_group_size;
 
   auto kfn = ComputeGradWeightBagsKernelFunctor<scalar_t, index_t>(
       numel,
@@ -285,7 +281,7 @@ void compute_grad_weight_bags(
 
   int64_t work_group_size = syclMaxWorkGroupSize(kfn);
   int64_t group_size = std::min(stride_warped, work_group_size);
-  auto num_groups = CeilDiv(num_of_segments * stride_warped, group_size);
+  auto num_groups = at::ceil_div(num_of_segments * stride_warped, group_size);
   auto total_items = num_groups * group_size;
   auto global_range = sycl::range<1>((size_t)total_items);
   auto local_range = sycl::range<1>((size_t)group_size);
@@ -383,7 +379,7 @@ void compute_grad_weight(
 
   int64_t max_sub_group_size = syclMaxSubGroupSize();
   int64_t stride_warped =
-      CeilDiv(stride, max_sub_group_size) * max_sub_group_size;
+      at::ceil_div(stride, max_sub_group_size) * max_sub_group_size;
 
   auto kfn = ComputeGradWeightKernelFunctor<scalar_t, index_t>(
       numel,
@@ -399,7 +395,7 @@ void compute_grad_weight(
 
   int64_t work_group_size = syclMaxWorkGroupSize(kfn);
   int64_t group_size = std::min(stride_warped, work_group_size);
-  auto num_groups = CeilDiv(num_of_segments * stride_warped, group_size);
+  auto num_groups = at::ceil_div(num_of_segments * stride_warped, group_size);
   auto total_items = num_groups * group_size;
   auto global_range = sycl::range<1>((size_t)total_items);
   auto local_range = sycl::range<1>((size_t)group_size);
@@ -511,11 +507,12 @@ void sum_and_scatter(
       segment_sizes_offsets_data);
 
   int64_t work_group_size = syclMaxWorkGroupSize(kfn);
-  int64_t stride_warped = CeilDiv(stride, work_group_size) * work_group_size;
+  int64_t stride_warped =
+      at::ceil_div(stride, work_group_size) * work_group_size;
   kfn.set_stride_warped(stride_warped);
 
   int64_t group_size = std::min(stride_warped, work_group_size);
-  auto num_groups = CeilDiv(num_of_segments * stride_warped, group_size);
+  auto num_groups = at::ceil_div(num_of_segments * stride_warped, group_size);
   auto total_items = num_groups * group_size;
   auto global_range = sycl::range<1>((size_t)total_items);
   auto local_range = sycl::range<1>((size_t)group_size);

--- a/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
+++ b/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
@@ -15,6 +15,7 @@ DISABLE_RETURN_TYPE_WARNING_BEGIN
 
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
+#include <ATen/ceil_div.h>
 #include <comm/xpu_aten.h>
 
 #include <ATen/native/xpu/sycl/Atomics.h>
@@ -672,7 +673,7 @@ void EmbeddingBag_accGradParametersKernel_max(
     scalar_t* gradWeight,
     int64_t stride,
     int64_t numBags) {
-  auto chunksPerBag = CeilDiv(stride, (int64_t)64);
+  auto chunksPerBag = at::ceil_div(stride, (int64_t)64);
   auto numChunks = numBags * chunksPerBag;
   auto kernel_range = 1024 * 64;
 

--- a/src/ATen/native/xpu/sycl/ScanUtils.h
+++ b/src/ATen/native/xpu/sycl/ScanUtils.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <ATen/ceil_div.h>
 #include <ATen/native/Math.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/xpu/sycl/BatchKernel.h>
@@ -20,10 +21,6 @@
 namespace at::native::xpu {
 using namespace at::xpu::detail;
 using namespace at::xpu;
-template <typename T>
-inline T CeilDiv(T a, T b) {
-  return (a + b - 1) / b;
-}
 
 typedef enum {
   EXCLUSIVE_TYPE = 0,
@@ -357,7 +354,7 @@ class LoopScanConfig {
     ;
     const size_t max_work_group_num = target_global_size / wg_size;
     const size_t wg_number =
-        std::min(max_work_group_num, CeilDiv(batch_, wg_range_y_));
+        std::min(max_work_group_num, at::ceil_div(batch_, wg_range_y_));
     glb_range_x_ = wg_range_x_;
     glb_range_y_ = wg_range_y_ * wg_number;
 

--- a/src/ATen/native/xpu/sycl/TensorFactoriesKernels.cpp
+++ b/src/ATen/native/xpu/sycl/TensorFactoriesKernels.cpp
@@ -8,6 +8,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <ATen/ceil_div.h>
 #include <ATen/native/TensorFactories.h>
 #include <ATen/native/xpu/sycl/ScanUtils.h>
 #include <ATen/native/xpu/sycl/TensorFactoriesKernels.h>
@@ -139,7 +140,7 @@ void triu_indices_kernel_template(
   using Kernel = TriuIndicesKernelFunctor<scalar_t>;
   int64_t group_size = syclMaxWorkGroupSize<Kernel>();
   auto totalElements = triu_size;
-  auto num_groups = CeilDiv(totalElements, group_size);
+  auto num_groups = at::ceil_div(totalElements, group_size);
   auto total_items = num_groups * group_size;
 
   auto data = tensor;
@@ -217,7 +218,7 @@ void tril_indices_kernel_template(
   using Kernel = TrilIndicesKernelFunctor<scalar_t>;
   int64_t group_size = syclMaxWorkGroupSize<Kernel>();
   auto totalElements = tril_size;
-  auto num_groups = CeilDiv(totalElements, group_size);
+  auto num_groups = at::ceil_div(totalElements, group_size);
   auto total_items = num_groups * group_size;
 
   auto data = tensor;


### PR DESCRIPTION
Delete the duplicate `CeilDiv` templates in `ScanUtils.h` and `EmbeddingBackwardKernel.h` and call `at::ceil_div` (`ATen/ceil_div.h`), already used in 10+ files in this repo. Same formula, bit-identical results; all call sites pass matching integral types, and the upstream template is stricter (mixed types fail to compile instead of silently promoting).

Test: no behavior change; covered by existing scan/embedding/triu-tril UTs.