### PR TITLE
Use at::ceil_div instead of local div_up/divup/ceil_div clones

### DIFF
--- a/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
@@ -10,6 +10,7 @@
 
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
+#include <ATen/ceil_div.h>
 #include <ATen/core/TensorAccessor.h>
 #include <ATen/native/CanUse32BitIndexMath.h>
 #include <ATen/native/ReduceOps.h>
@@ -367,10 +368,6 @@ scalar_t plane_reduce(
   return shared[0];
 }
 
-inline int div_up(int a, int b) {
-  return (a + b - 1) / b;
-}
-
 constexpr int ELEMENTS_PER_ITER =
     4; // enables concurrency within each thread to hide latency
 constexpr int ELEMENTS_PER_WORK_ITEM = 4;
@@ -383,14 +380,15 @@ std::tuple<sycl::range<2>, sycl::range<2>> get_adaptive_launch_config(
     const int loops_per_item = 1) {
   int group_x = std::min(last_pow2(stride), 32);
   int group_y = std::min(
-      last_pow2(div_up(reduction, loops_per_item)), max_wg_size / group_x);
+      last_pow2(at::ceil_div(reduction, loops_per_item)),
+      max_wg_size / group_x);
   if (group_x * group_y != max_wg_size) {
     group_x = std::min(last_pow2(stride), max_wg_size / group_y);
   }
 
-  int nwg_x = div_up(stride, group_x);
+  int nwg_x = at::ceil_div(stride, group_x);
   int nwg_y = std::min(
-      div_up(reduction, group_y * loops_per_item),
+      at::ceil_div(reduction, group_y * loops_per_item),
       int(syclMaxWorkItemsPerTile()) / (nwg_x * group_x) / (group_y));
   nwg_y = std::max(nwg_y, 1);
 

--- a/src/ATen/native/xpu/sycl/TensorModeKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorModeKernel.cpp
@@ -14,6 +14,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
+#include <ATen/ceil_div.h>
 #include <ATen/native/CanUse32BitIndexMath.h>
 #include <ATen/native/ReduceOpsUtils.h>
 #include <ATen/native/Resize.h>
@@ -32,11 +33,6 @@ using namespace at::xpu::detail;
 
 constexpr int64_t MAX_GROUP_SIZE = 256;
 constexpr int64_t MAX_GRID_SIZE = 65535LL;
-
-template <typename integer>
-inline integer ceil_div(integer n, integer m) {
-  return (n + m - 1) / m;
-}
 
 // Returns 2^(ceil(lg(n)) from Stanford bit twiddling hacks
 inline uint64_t next_highest_power_of_2(uint64_t n) {
@@ -64,11 +60,11 @@ std::tuple<int64_t, int64_t, int64_t> get_workgroup_number_from_tiles(
   int64_t gridZ = 1;
 
   if (gridTiles > MAX_GRID_SIZE) {
-    gridTiles = ceil_div(gridTiles, MAX_GRID_SIZE);
+    gridTiles = at::ceil_div(gridTiles, MAX_GRID_SIZE);
     gridY = gridTiles > MAX_GRID_SIZE ? MAX_GRID_SIZE : gridTiles;
 
     if (gridTiles > MAX_GRID_SIZE) {
-      gridTiles = ceil_div(gridTiles, MAX_GRID_SIZE);
+      gridTiles = at::ceil_div(gridTiles, MAX_GRID_SIZE);
       gridZ = gridTiles > MAX_GRID_SIZE ? MAX_GRID_SIZE : gridTiles;
     }
   }

--- a/src/ATen/native/xpu/sycl/TensorShapeKernels.cpp
+++ b/src/ATen/native/xpu/sycl/TensorShapeKernels.cpp
@@ -10,6 +10,7 @@
 
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/Dispatch.h>
+#include <ATen/ceil_div.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/TensorShape.h>
@@ -32,10 +33,6 @@ namespace at::native::xpu {
 static constexpr int64_t GROUP_SIZE = 128;
 static constexpr int64_t BYTES_PER_THREAD = 16;
 static constexpr int64_t BYTES_PER_GROUP = BYTES_PER_THREAD * GROUP_SIZE;
-
-inline int64_t div_up(int64_t a, int64_t b) {
-  return (a + b - 1) / b;
-}
 
 template <typename T>
 inline void stream_load128(uint4& val, const T* addr) {
@@ -91,7 +88,7 @@ static inline void get_aligned_region(
     int64_t& align_off,
     int64_t& aligned_size) {
   const int64_t ptr_val = reinterpret_cast<uintptr_t>(ptr);
-  align_off = div_up(ptr_val, alignment) * alignment - ptr_val;
+  align_off = at::ceil_div(ptr_val, alignment) * alignment - ptr_val;
   aligned_size = (chunk_size - align_off) / alignment * alignment;
 }
 
@@ -311,7 +308,8 @@ static inline std::pair<int64_t, int64_t> get_pad_size(
     trailing_numel =
         c10::multiply_integers(sizes.slice(dim + 1, sizes.size() - dim - 1));
   }
-  int64_t pad_size_along_dim = div_up(sizes[dim], num_chunks) * num_chunks;
+  int64_t pad_size_along_dim =
+      at::ceil_div(sizes[dim], num_chunks) * num_chunks;
   return std::make_pair(pad_size_along_dim, trailing_numel);
 }
 
@@ -569,7 +567,8 @@ get_chunk_cat_metadata(
     pad_tensor_chunk_sizes.push_back(pad_tensor_chunk_size);
     chunk_size += pad_tensor_chunk_size;
     // Number of groups required to process this tensor chunk.
-    const int64_t num_groups = div_up(pad_tensor_chunk_size, BYTES_PER_GROUP);
+    const int64_t num_groups =
+        at::ceil_div(pad_tensor_chunk_size, BYTES_PER_GROUP);
     num_groups_per_tensor_chunk.push_back(num_groups);
 
     start_group_idx_per_tensor_chunk.push_back(
@@ -676,7 +675,7 @@ void split_with_sizes_copy_out_xpu_contiguous_no_cast(
   // splits, assuming each thread only processes BYTES_PER_THREAD bytes.
   int64_t num_groups = 0;
   for (const auto& split_chunk_size : split_chunk_sizes) {
-    num_groups += div_up(split_chunk_size, GROUP_SIZE * BYTES_PER_THREAD);
+    num_groups += at::ceil_div(split_chunk_size, GROUP_SIZE * BYTES_PER_THREAD);
   }
 
   int64_t tile_size = syclMaxWorkItemsPerTile();
@@ -685,10 +684,10 @@ void split_with_sizes_copy_out_xpu_contiguous_no_cast(
   // Make each thread process BYTES_PER_THREAD * iter_factor bytes to regulate
   // group size. Spread iter_factor evenly between chunks_per_group and
   // iters_per_chunk.
-  int64_t iter_factor = div_up(num_groups * num_chunks, max_groups);
+  int64_t iter_factor = at::ceil_div(num_groups * num_chunks, max_groups);
   int64_t chunks_per_group = std::ceil(std::sqrt(iter_factor));
   chunks_per_group = std::min(chunks_per_group, num_chunks);
-  const int64_t iters_per_chunk = div_up(iter_factor, chunks_per_group);
+  const int64_t iters_per_chunk = at::ceil_div(iter_factor, chunks_per_group);
 
   // Launch a logically jagged grid of shape
   // (chunk_size*, num_splits, num_chunks / chunks_per_group)
@@ -699,7 +698,7 @@ void split_with_sizes_copy_out_xpu_contiguous_no_cast(
   std::vector<int64_t> groups_cumsums{0};
   group_idx_to_split_idx.reserve(num_groups);
   for (size_t split_idx = 0; split_idx < split_sizes.size(); ++split_idx) {
-    const auto groups = div_up(
+    const auto groups = at::ceil_div(
         split_chunk_sizes[split_idx],
         GROUP_SIZE * BYTES_PER_THREAD * iters_per_chunk);
     group_idx_to_split_idx.insert(

--- a/src/ATen/native/xpu/sycl/WelfordNorm.h
+++ b/src/ATen/native/xpu/sycl/WelfordNorm.h
@@ -10,17 +10,13 @@
 
 #pragma once
 
+#include <ATen/ceil_div.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/xpu/sycl/MemoryAccess.h>
 #include <comm/SYCLContext.h>
 #include <comm/XPUMathCompat.h>
 
 namespace at::native::xpu {
-
-template <typename T>
-inline T divup(T a, T b) {
-  return (a + b - 1) / b;
-}
 
 std::tuple<int, int, int, int> get_adaptive_config(
     const int reduction,
@@ -31,15 +27,16 @@ std::tuple<int, int, int, int> get_adaptive_config(
   loops_per_item /= vec_size;
   int group_size_x = std::min(last_pow2(n_channels / vec_size), 32);
   int group_size_y = std::min(
-      last_pow2(divup(reduction, loops_per_item)), max_wg_size / group_size_x);
+      last_pow2(at::ceil_div(reduction, loops_per_item)),
+      max_wg_size / group_size_x);
   if (group_size_x * group_size_y != max_wg_size) {
     group_size_x =
         std::min(last_pow2(n_channels / vec_size), max_wg_size / group_size_y);
   }
 
-  int nwg_x = divup(n_channels, group_size_x * vec_size);
+  int nwg_x = at::ceil_div(n_channels, group_size_x * vec_size);
   int nwg_y = std::min(
-      divup(reduction, group_size_y * loops_per_item),
+      at::ceil_div(reduction, group_size_y * loops_per_item),
       int(syclMaxWorkItemsPerTile()) / (nwg_x * group_size_x) / (group_size_y));
   nwg_y = std::max(nwg_y, 1);
 


### PR DESCRIPTION
Follow-up to #3943: replace four more local spellings of ceiling division (`ceil_div` in TensorModeKernel, `div_up` in TensorShapeKernels and BatchNormKernels, `divup` in WelfordNorm.h) with `at::ceil_div`. All call sites pass matching integral types, so results are bit-identical.

`Reduce.h` keeps its `div_up`: it mirrors CUDA's `Reduce.cuh`, which has the same local helper, and its call sites rely on implicit `int`->`int64_t` promotion that the deducing template would reject.

Test: no behavior change; covered by existing mode/cat/batch_norm UTs.