### PR TITLE
Add parse-pytorch-trace skill and profiling script

### DIFF
--- a/.claude/commands/validate-parse-pytorch-trace.md
+++ b/.claude/commands/validate-parse-pytorch-trace.md
@@ -1,0 +1,33 @@
+# Validate parse-pytorch-trace Skill
+
+Validate the `parse-pytorch-trace` skill by running its script against test fixtures
+with known expected outputs.
+
+## Instructions
+
+1. Load the `parse-pytorch-trace` skill.
+2. Read `test/agentic/parse-pytorch-trace/test_cases.md` for the full list of test cases.
+3. For each case:
+   - Run the script on the specified fixture file using the given options.
+   - Check each "Expected" criterion against the actual output.
+   - Record whether the criterion was met (CORRECT) or not (FAILED).
+4. Output a summary table showing:
+   - Case name
+   - Criterion
+   - Expected result (PASS)
+   - Actual result (CORRECT or FAILED)
+   - Notes (any discrepancy details)
+
+## Optional argument
+
+If a specific case number is provided as `$ARGUMENTS`, validate only that case
+instead of running all cases.
+
+## Goal
+
+This command validates that the parse-pytorch-trace script correctly:
+- Parses Chrome trace format JSON
+- Links device kernels to host ops via External id
+- Merges nested aten:: ops into top-level parents
+- Produces accurate per-op GPU time aggregation
+- Sorts and reports results correctly

--- a/.claude/skills/action/parse-pytorch-trace/SKILL.md
+++ b/.claude/skills/action/parse-pytorch-trace/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: parse-pytorch-trace
+description: >
+  Parse PyTorch profiler trace.json files into per-op GPU/CPU time summaries.
+  Use when analyzing profiler traces, identifying hot ops, or diagnosing
+  XPU/CUDA kernel performance from trace.json output.
+---
+
+# Parse PyTorch Trace
+
+Parse torch profiler `trace.json` and produce per-op summary tables showing GPU time,
+CPU time, kernel count, and kernel names for each top-level aten:: operator.
+
+## When to use
+
+- After collecting a profiler trace (`--profile_test` or `torch.profiler`)
+- To identify which aten:: ops consume the most GPU time
+- To get per-invocation detail for specific operators
+- As input for cross-platform performance comparison
+
+## Quick start
+
+```bash
+python .claude/skills/action/parse-pytorch-trace/scripts/parse_trace.py timeline/trace.json --top 30 --sort-by gpu_time
+```
+
+## Usage
+
+```bash
+python .claude/skills/action/parse-pytorch-trace/scripts/parse_trace.py <trace_file> [options]
+
+Options:
+  --top N              Show top N ops (default: 30)
+  --sort-by METRIC     Sort by: gpu_time, cpu_time, kernel_count (default: gpu_time)
+  --detail             Show per-invocation detail for top ops
+```
+
+## How it works
+
+1. **Load trace.json** — Standard Chrome trace format from `torch.profiler`
+2. **Extract events** — Separates `cpu_op` events (aten:: host ops) from `kernel`/`gpu_memcpy`
+   device events
+3. **Link via External id** — Maps device kernels back to their parent host ops using the
+   `External id` field in the trace
+4. **Merge nested ops** — Identifies top-level aten:: ops and merges nested child ops into
+   parents (avoids double-counting)
+5. **Aggregate** — Groups by op name, sums GPU/CPU time, counts calls and kernels
+
+## Output format
+
+### Summary table
+
+```
+==================================================================
+OP NAME                                       GPU(ms)    GPU%    CPU(ms)  Calls  Kernels  Kernel Names
+------------------------------------------------------------------
+aten::addmm                                    12.345   45.2%     0.891     24       24  gemm_kernel
+aten::convolution                               5.678   20.8%     1.234     12       12  gen_conv_kernel
+aten::_softmax                                  2.345    8.6%     0.456      6        6  SoftMaxForwardKernel
+...
+==================================================================
+TOTAL                                          27.321  100.0%     8.765
+```
+
+### Detail mode (`--detail`)
+
+Per-invocation breakdown showing GPU time, CPU time, kernel count, and input dimensions
+for each call of the top ops.
+
+## Understanding the trace
+
+### Event categories in trace.json
+
+| Category | Description |
+|----------|-------------|
+| `cpu_op` | PyTorch host-side aten:: ops |
+| `kernel` | Device compute kernels (SYCL/CUDA) |
+| `gpu_memcpy` | Memory transfers (H2D, D2H) |
+| `ac2g` | Async CPU-to-GPU flow events (linking host to device) |
+| `python_function` | Python call stack frames |
+| `xpu_runtime` / `xpu_driver` | Low-level XPU runtime calls (XPU only) |
+
+### Key relationships
+
+- Each host op (`cpu_op`) launches one or more device kernels
+- Host ops and device kernels are linked via `External id`
+- Nested aten:: ops (e.g., `aten::linear` containing `aten::addmm`) are merged into the
+  top-level parent to avoid double-counting GPU time
+
+## Validation
+
+After parsing, verify:
+
+```
+sum(all kernel GPU durations) ≈ T2_device (end-to-end device time)
+```
+
+- If kernel sum significantly exceeds end-to-end time, the profiler has overhead inflation —
+  treat per-op times with caution.
+- If kernel sum < end-to-end time, there is inter-kernel gap (host overhead between kernel launches).
+
+## Integration with other tools
+
+| Tool | Purpose |
+|------|---------|
+| `.claude/skills/action/map-kernels-to-ops/scripts/map_kernels_to_ops.py` | Maps unitrace kernel durations to aten:: ops (XPU, no profiler overhead) |

--- a/.claude/skills/action/parse-pytorch-trace/scripts/parse_trace.py
+++ b/.claude/skills/action/parse-pytorch-trace/scripts/parse_trace.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+parse_trace.py
+
+Parse torch profiler trace.json and print per-op summary table.
+Shows GPU time, CPU time, kernel count, and kernel names for each aten:: op.
+
+Usage:
+    python tools/profiling/parse_trace.py timeline/trace.json --top 30 --sort-by gpu_time
+    python tools/profiling/parse_trace.py timeline/trace.json --detail
+"""
+
+import json
+import argparse
+from collections import defaultdict
+
+
+def parse_trace(path):
+    """Parse trace.json and return per-op events with GPU/CPU times and kernel info.
+
+    Returns list of dicts: name, cpu_dur_us, gpu_dur_us, ext_id, input_dims, kernel_names
+    """
+    with open(path) as f:
+        data = json.load(f)
+    events = data["traceEvents"]
+
+    cpu_ops = []
+    device_events = []
+
+    for e in events:
+        if not isinstance(e, dict) or e.get("ph") != "X":
+            continue
+        cat = e.get("cat", "")
+        if cat == "cpu_op":
+            cpu_ops.append(e)
+        elif cat in ("kernel", "gpu_memcpy"):
+            device_events.append(e)
+
+    # Build external id -> (total device time, kernel names)
+    ext_map = defaultdict(lambda: {"dur": 0, "kernels": []})
+    for d in device_events:
+        ext_id = d.get("args", {}).get("External id")
+        if ext_id is not None:
+            ext_map[ext_id]["dur"] += d.get("dur", 0)
+            ext_map[ext_id]["kernels"].append(d.get("name", ""))
+
+    cpu_ops.sort(key=lambda e: e["ts"])
+
+    # Filter to aten:: ops, identify top-level ops (not nested inside another aten:: op)
+    aten_ops = []
+    for op in cpu_ops:
+        name = op.get("name", "")
+        if not name.startswith("aten::"):
+            continue
+        ts = op.get("ts", 0)
+        dur = op.get("dur", 0)
+        ext_id = op.get("args", {}).get("External id")
+        dev = (
+            ext_map.get(ext_id, {"dur": 0, "kernels": []})
+            if ext_id
+            else {"dur": 0, "kernels": []}
+        )
+        input_dims = op.get("args", {}).get("Input Dims", "")
+        concrete_inputs = op.get("args", {}).get("Concrete Inputs", [])
+        aten_ops.append(
+            {
+                "name": name,
+                "ts": ts,
+                "end": ts + dur,
+                "cpu_dur_us": dur,
+                "gpu_dur_us": dev["dur"],
+                "ext_id": ext_id,
+                "input_dims": str(input_dims),
+                "concrete_inputs": concrete_inputs,
+                "kernel_names": dev["kernels"],
+            }
+        )
+
+    # Merge nested ops into parent (top-level) ops
+    result = []
+    parent_stack = []  # (end_ts, result_index)
+
+    for op in aten_ops:
+        while parent_stack and parent_stack[-1][0] <= op["ts"]:
+            parent_stack.pop()
+
+        if parent_stack:
+            # Nested — merge into parent
+            parent_idx = parent_stack[-1][1]
+            result[parent_idx]["gpu_dur_us"] += op["gpu_dur_us"]
+            result[parent_idx]["kernel_names"].extend(op["kernel_names"])
+            parent_stack.append((op["end"], parent_idx))
+        else:
+            # Top-level op
+            idx = len(result)
+            result.append(
+                {
+                    "name": op["name"],
+                    "cpu_dur_us": op["cpu_dur_us"],
+                    "gpu_dur_us": op["gpu_dur_us"],
+                    "ext_id": op["ext_id"],
+                    "input_dims": op["input_dims"],
+                    "concrete_inputs": op["concrete_inputs"],
+                    "kernel_names": list(op["kernel_names"]),
+                }
+            )
+            parent_stack.append((op["end"], idx))
+
+    return result
+
+
+def aggregate_ops(ops):
+    """Aggregate per-invocation ops into per-op-name summary."""
+    agg = defaultdict(
+        lambda: {
+            "gpu_us": 0,
+            "cpu_us": 0,
+            "count": 0,
+            "kernel_count": 0,
+            "kernel_names": set(),
+        }
+    )
+    for op in ops:
+        name = op["name"]
+        agg[name]["gpu_us"] += op["gpu_dur_us"]
+        agg[name]["cpu_us"] += op["cpu_dur_us"]
+        agg[name]["count"] += 1
+        agg[name]["kernel_count"] += len(op["kernel_names"])
+        agg[name]["kernel_names"].update(op["kernel_names"])
+    return agg
+
+
+def print_summary(agg, sort_by="gpu_time", top_n=30):
+    """Print aggregate summary table."""
+    if sort_by == "gpu_time":
+        items = sorted(agg.items(), key=lambda x: x[1]["gpu_us"], reverse=True)
+    elif sort_by == "cpu_time":
+        items = sorted(agg.items(), key=lambda x: x[1]["cpu_us"], reverse=True)
+    elif sort_by == "kernel_count":
+        items = sorted(agg.items(), key=lambda x: x[1]["kernel_count"], reverse=True)
+    else:
+        items = sorted(agg.items(), key=lambda x: x[1]["gpu_us"], reverse=True)
+
+    total_gpu = sum(v["gpu_us"] for v in agg.values())
+    total_cpu = sum(v["cpu_us"] for v in agg.values())
+
+    print(f"\n{'='*130}")
+    print(
+        f"{'OP NAME':<45} {'GPU(ms)':>10} {'GPU%':>7} {'CPU(ms)':>10}"
+        f" {'Calls':>6} {'Kernels':>8}  {'Kernel Names'}"
+    )
+    print(f"{'-'*130}")
+
+    for name, v in items[:top_n]:
+        gpu_pct = v["gpu_us"] / total_gpu * 100 if total_gpu > 0 else 0
+        kernel_str = ", ".join(sorted(v["kernel_names"]))
+        if len(kernel_str) > 50:
+            kernel_str = kernel_str[:47] + "..."
+        print(
+            f"{name:<45} {v['gpu_us']/1000:>10.3f} {gpu_pct:>6.1f}%"
+            f" {v['cpu_us']/1000:>10.3f} {v['count']:>6} {v['kernel_count']:>8}"
+            f"  {kernel_str}"
+        )
+
+    print(f"{'='*130}")
+    print(
+        f"{'TOTAL':<45} {total_gpu/1000:>10.3f} {'100.0%':>7} {total_cpu/1000:>10.3f}"
+    )
+    print()
+
+
+def print_detail(ops, top_names, max_invocations=10):
+    """Print per-invocation detail for top ops."""
+    for name in top_names:
+        invocations = [op for op in ops if op["name"] == name]
+        print(f"\n--- {name} ({len(invocations)} invocations) ---")
+        print(f"  {'#':>4} {'GPU(ms)':>10} {'CPU(ms)':>10} {'Kernels':>8}  {'Input Dims'}")
+        for i, op in enumerate(invocations[:max_invocations]):
+            print(
+                f"  {i+1:>4} {op['gpu_dur_us']/1000:>10.3f}"
+                f" {op['cpu_dur_us']/1000:>10.3f} {len(op['kernel_names']):>8}"
+                f"  {op['input_dims']}"
+            )
+        if len(invocations) > max_invocations:
+            print(f"  ... ({len(invocations) - max_invocations} more)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Parse torch profiler trace.json")
+    parser.add_argument("trace_file", help="Path to trace.json")
+    parser.add_argument(
+        "--top", type=int, default=30, help="Show top N ops (default: 30)"
+    )
+    parser.add_argument(
+        "--sort-by",
+        choices=["gpu_time", "cpu_time", "kernel_count"],
+        default="gpu_time",
+        help="Sort metric (default: gpu_time)",
+    )
+    parser.add_argument(
+        "--detail",
+        action="store_true",
+        help="Show per-invocation detail for top ops",
+    )
+    args = parser.parse_args()
+
+    print(f"Loading trace from {args.trace_file}...")
+    ops = parse_trace(args.trace_file)
+    print(f"Found {len(ops)} top-level aten:: ops")
+
+    total_gpu = sum(op["gpu_dur_us"] for op in ops) / 1000
+    print(f"Total GPU time (sum of kernels): {total_gpu:.3f} ms")
+
+    agg = aggregate_ops(ops)
+    print_summary(agg, sort_by=args.sort_by, top_n=args.top)
+
+    if args.detail:
+        # Get top N op names by GPU time
+        sorted_names = sorted(agg.keys(), key=lambda n: agg[n]["gpu_us"], reverse=True)
+        print_detail(ops, sorted_names[: args.top])
+
+
+if __name__ == "__main__":
+    main()

--- a/test/agentic/parse-pytorch-trace/fixtures/basic_trace.json
+++ b/test/agentic/parse-pytorch-trace/fixtures/basic_trace.json
@@ -1,0 +1,12 @@
+{
+  "traceEvents": [
+    {"ph": "X", "cat": "cpu_op", "name": "aten::addmm", "ts": 1000, "dur": 500, "args": {"External id": 1, "Input Dims": "[[64, 768], [768, 3072]]"}},
+    {"ph": "X", "cat": "cpu_op", "name": "aten::_softmax", "ts": 2000, "dur": 300, "args": {"External id": 2, "Input Dims": "[[64, 12, 128, 128]]"}},
+    {"ph": "X", "cat": "cpu_op", "name": "aten::addmm", "ts": 3000, "dur": 450, "args": {"External id": 3, "Input Dims": "[[64, 768], [768, 768]]"}},
+    {"ph": "X", "cat": "cpu_op", "name": "aten::mul", "ts": 4000, "dur": 100, "args": {"External id": 4, "Input Dims": "[[64, 768]]"}},
+    {"ph": "X", "cat": "kernel", "name": "gemm_kernel", "ts": 1100, "dur": 5000, "args": {"External id": 1}},
+    {"ph": "X", "cat": "kernel", "name": "SoftMaxForwardKernel", "ts": 6200, "dur": 2000, "args": {"External id": 2}},
+    {"ph": "X", "cat": "kernel", "name": "gemm_kernel", "ts": 8300, "dur": 4000, "args": {"External id": 3}},
+    {"ph": "X", "cat": "kernel", "name": "mul_kernel", "ts": 12400, "dur": 800, "args": {"External id": 4}}
+  ]
+}

--- a/test/agentic/parse-pytorch-trace/fixtures/nested_ops_trace.json
+++ b/test/agentic/parse-pytorch-trace/fixtures/nested_ops_trace.json
@@ -1,0 +1,13 @@
+{
+  "traceEvents": [
+    {"ph": "X", "cat": "cpu_op", "name": "aten::linear", "ts": 1000, "dur": 800, "args": {"External id": 10, "Input Dims": "[[64, 768], [3072, 768]]"}},
+    {"ph": "X", "cat": "cpu_op", "name": "aten::addmm", "ts": 1050, "dur": 700, "args": {"External id": 11, "Input Dims": "[[64, 768], [768, 3072]]"}},
+    {"ph": "X", "cat": "cpu_op", "name": "aten::gelu", "ts": 2000, "dur": 200, "args": {"External id": 12, "Input Dims": "[[64, 3072]]"}},
+    {"ph": "X", "cat": "cpu_op", "name": "aten::linear", "ts": 3000, "dur": 600, "args": {"External id": 13, "Input Dims": "[[64, 3072], [768, 3072]]"}},
+    {"ph": "X", "cat": "cpu_op", "name": "aten::addmm", "ts": 3050, "dur": 550, "args": {"External id": 14, "Input Dims": "[[64, 3072], [3072, 768]]"}},
+    {"ph": "X", "cat": "kernel", "name": "gemm_kernel", "ts": 1200, "dur": 6000, "args": {"External id": 11}},
+    {"ph": "X", "cat": "kernel", "name": "GeluKernelVec", "ts": 7300, "dur": 1500, "args": {"External id": 12}},
+    {"ph": "X", "cat": "kernel", "name": "gemm_kernel", "ts": 8900, "dur": 4500, "args": {"External id": 14}},
+    {"ph": "X", "cat": "gpu_memcpy", "name": "Memcpy DtoH", "ts": 13500, "dur": 200, "args": {"External id": 15}}
+  ]
+}

--- a/test/agentic/parse-pytorch-trace/test_cases.md
+++ b/test/agentic/parse-pytorch-trace/test_cases.md
@@ -1,0 +1,25 @@
+# Test Cases for parse-pytorch-trace
+
+## Case 1: Basic trace with distinct ops
+Input: `test/agentic/parse-pytorch-trace/fixtures/basic_trace.json`
+Task: Parse the trace with `--top 10 --sort-by gpu_time`
+
+### Expected results
+- Expected: PASS - Script exits with code 0
+- Expected: PASS - aten::addmm is the top op by GPU time (total 9000 us from two kernels)
+- Expected: PASS - aten::_softmax has GPU time of 2000 us
+- Expected: PASS - aten::mul has GPU time of 800 us
+- Expected: PASS - aten::addmm shows 2 kernel invocations
+- Expected: PASS - Total GPU time across all ops is 11800 us
+
+## Case 2: Nested ops (aten::linear containing aten::addmm)
+Input: `test/agentic/parse-pytorch-trace/fixtures/nested_ops_trace.json`
+Task: Parse the trace with `--top 10 --sort-by gpu_time`
+
+### Expected results
+- Expected: PASS - Script exits with code 0
+- Expected: PASS - aten::linear appears as a top-level op (merges child aten::addmm)
+- Expected: PASS - aten::addmm is NOT listed separately (merged into parent aten::linear)
+- Expected: PASS - aten::linear total GPU time includes the gemm_kernel durations (10500 us)
+- Expected: PASS - aten::gelu has GPU time of 1500 us
+- Expected: PASS - Total reported GPU time is 12000 us (only attributed kernels)


### PR DESCRIPTION
## Summary

- Add a Claude skill (`parse-pytorch-trace`) for parsing PyTorch profiler trace.json files into per-op GPU/CPU time summaries
- Add `tools/profiling/parse_trace.py` — a standalone script that extracts top-level aten:: ops, links device kernels via External id, and produces summary tables

## Motivation

This is the first in a series of profiling analysis tools being contributed from the Auto Projection performance analysis framework. The tool helps identify hot ops from profiler traces on both XPU and CUDA platforms.

## Usage

```bash
python tools/profiling/parse_trace.py timeline/trace.json --top 30 --sort-by gpu_time
python tools/profiling/parse_trace.py timeline/trace.json --detail
```

## Files

| File | Purpose |
|------|---------|
| `.claude/skills/parse-pytorch-trace/SKILL.md` | Skill definition for AI agents |
| `tools/profiling/parse_trace.py` | Trace parsing script (no external dependencies) |