### PR TITLE
Use C++20 bit_ceil/bit_floor instead of hand-rolled power-of-2 helpers

### DIFF
--- a/src/ATen/native/xpu/sycl/BatchKernel.h
+++ b/src/ATen/native/xpu/sycl/BatchKernel.h
@@ -9,10 +9,9 @@
  */
 
 #pragma once
-#include <c10/util/llvmMathExtras.h>
-
 #include <comm/SYCLContext.h>
 #include <algorithm>
+#include <bit>
 
 namespace at::native::xpu {
 
@@ -229,18 +228,16 @@ class BatchKernelConfig {
     // 1. assign proper x/y to accommodate workload exactly.
     // 2. prefer enough x (at least limit_x) to access memory coalecsingly.
     // Spare y for x if workload is not large along y.
-    wg_range_y_ = std::min<size_t>(
-        wg_range_y_, c10::llvm::PowerOf2Ceil((uint64_t)range_bound_y));
+    wg_range_y_ =
+        std::min<size_t>(wg_range_y_, std::bit_ceil((uint64_t)range_bound_y));
     // Subscribe appropriate x at least limit_x.
     wg_range_x_ = std::max<size_t>(
         std::min<size_t>(
-            wg_size / wg_range_y_,
-            c10::llvm::PowerOf2Ceil((uint64_t)range_bound_x)),
+            wg_size / wg_range_y_, std::bit_ceil((uint64_t)range_bound_x)),
         limit_x);
     // Retieve y if necessary, if x is not large.
     wg_range_y_ = std::min<size_t>(
-        wg_size / wg_range_x_,
-        c10::llvm::PowerOf2Ceil((uint64_t)range_bound_y));
+        wg_size / wg_range_x_, std::bit_ceil((uint64_t)range_bound_y));
 
     if ((uint8_t)policy_ & (uint8_t)Policy::pAdaptive) {
       size_t target_glb_range = syclMaxWorkItemsPerTile() /

--- a/src/ATen/native/xpu/sycl/SortingKernels.h
+++ b/src/ATen/native/xpu/sycl/SortingKernels.h
@@ -18,6 +18,8 @@
 #include <comm/SYCLContext.h>
 #include <cstdint>
 
+#include <bit>
+
 namespace at {
 namespace native {
 namespace xpu {
@@ -676,17 +678,6 @@ void sort_pairs(
       keys_in, keys_out, values_in, values_out, 1, num_elements, descending);
 }
 
-inline uint64_t radix_select_last_power2(uint64_t n) {
-  n--;
-  n |= n >> 1;
-  n |= n >> 2;
-  n |= n >> 4;
-  n |= n >> 8;
-  n |= n >> 16;
-  n++;
-  return n;
-}
-
 template <
     typename key_t,
     typename value_t,
@@ -719,7 +710,7 @@ void segmented_group_select_pairs_(
   }
   constexpr int max_group_size = 1024; // simd32-specific
   if (num_elements <= max_group_size * 4) {
-    switch (radix_select_last_power2(num_elements)) {
+    switch (std::bit_ceil(static_cast<uint64_t>(num_elements))) {
       case 4096:
         RUN_RADIX_SELECT(4096); // gsz 1024
         break;

--- a/src/ATen/native/xpu/sycl/TensorModeKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorModeKernel.cpp
@@ -27,27 +27,14 @@
 #include <comm/SYCLHelpers.h>
 #include <comm/TensorInfo.h>
 
+#include <bit>
+
 namespace at::native::xpu {
 
 using namespace at::xpu::detail;
 
 constexpr int64_t MAX_GROUP_SIZE = 256;
 constexpr int64_t MAX_GRID_SIZE = 65535LL;
-
-// Returns 2^(ceil(lg(n)) from Stanford bit twiddling hacks
-inline uint64_t next_highest_power_of_2(uint64_t n) {
-  n--;
-  n |= n >> 1;
-  n |= n >> 2;
-  n |= n >> 4;
-  n |= n >> 8;
-  n |= n >> 16;
-#ifndef _MSC_VER
-  n |= n >> 32;
-#endif
-  n++;
-  return n;
-}
 
 std::tuple<int64_t, int64_t, int64_t> get_workgroup_number_from_tiles(
     int64_t gridTiles) {
@@ -523,7 +510,7 @@ void fused_mode(
 
   // The groupsize is two elements per thread, rounded up to the nearest power
   // of 2
-  auto ceilPowerOf2 = next_highest_power_of_2(slice_size);
+  auto ceilPowerOf2 = std::bit_ceil(static_cast<uint64_t>(slice_size));
 
   // Tradeoff between compilation time and the number of specializations.
   // Ideally we would have one handle_fused_mode for each power of 2

--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
@@ -21,8 +21,9 @@
 #include <ATen/native/xpu/sycl/TensorTopKSbtopkKernel.h>
 #include <ATen/native/xpu/sycl/TensorTopKSbtopkKernelImpl.h>
 #include <ATen/native/xpu/sycl/TensorTopKSingleWgKernel.h>
-#include <c10/util/llvmMathExtras.h>
 #include <comm/DeviceProperties.h>
+
+#include <bit>
 
 namespace at::native::xpu {
 
@@ -46,7 +47,7 @@ static bool subgroup_topk_try_launch(
   }
 
   int K_sel = std::min<int>(
-      static_cast<int>(c10::llvm::PowerOf2Ceil(static_cast<uint64_t>(k))), 8);
+      static_cast<int>(std::bit_ceil(static_cast<uint64_t>(k))), 8);
 
   switch (K_sel) {
     case 1:

--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernelImpl.h
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernelImpl.h
@@ -23,7 +23,6 @@
 #include <ATen/ceil_div.h>
 #include <ATen/native/xpu/sycl/MemoryAccessUtils.h>
 #include <ATen/native/xpu/sycl/TensorTopKSbtopkKernel.h>
-#include <c10/util/llvmMathExtras.h>
 #include <comm/DeviceProperties.h>
 #include <comm/SYCLHelpers.h>
 #include <sycl/ext/intel/experimental/grf_size_properties.hpp>

--- a/src/ATen/native/xpu/sycl/TensorTopKSingleWgKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorTopKSingleWgKernel.cpp
@@ -36,10 +36,11 @@
 #include <ATen/native/xpu/sycl/MemoryAccessUtils.h>
 #include <ATen/native/xpu/sycl/SortingRadixSelect.h>
 #include <ATen/native/xpu/sycl/TensorTopKSingleWgKernel.h>
-#include <c10/util/llvmMathExtras.h>
 #include <comm/SYCLHelpers.h>
 #include <sycl/ext/intel/experimental/grf_size_properties.hpp>
 #include <sycl/ext/oneapi/sub_group_mask.hpp>
+
+#include <bit>
 
 namespace at::native::xpu {
 
@@ -614,11 +615,10 @@ static void single_wg_launch_kernel(
   // With ept=32 and 1024 threads, each iteration covers 32K elements,
   // keeping the number of gatherTopK iterations small (~4 for dim=131072).
   int64_t ratio = sliceSize / SBTOPK_BLOCK;
-  int ept = ratio >= 1 ? std::min(
-                             32,
-                             static_cast<int>(c10::llvm::PowerOf2Floor(
-                                 static_cast<uint64_t>(ratio))))
-                       : 1;
+  int ept = ratio >= 1
+      ? std::min(
+            32, static_cast<int>(std::bit_floor(static_cast<uint64_t>(ratio))))
+      : 1;
 
   // Determine VEC_SIZE: largest power-of-2 dividing sliceSize,
   // capped by type max AND by EPT (vec <= ept required).


### PR DESCRIPTION
Replace `c10::llvm::PowerOf2Ceil`/`PowerOf2Floor` (BatchKernel.h, top-k kernels) and the local bit-twiddling helpers `next_highest_power_of_2` (TensorModeKernel) and `radix_select_last_power2` (SortingKernels, whose body is actually a bit_ceil despite the name) with `std::bit_ceil`/`std::bit_floor`.

Behavior is identical on all reachable inputs: for n >= 1 the helpers and `std::bit_ceil` agree bit-for-bit, and at n=0 both switch call sites land in the same `default`/assert branch. `std::bit_ceil` additionally fixes the MSVC path in TensorModeKernel that skipped the `n >> 32` smear. The `lastPow2`/`last_pow2` helpers are deliberately kept: they return `max(1, bit_floor(n))`, a different contract that guards work-group sizes against 0.

Test: no behavior change; covered by existing top-k/mode/sort UTs.