### PR TITLE
Use C++20 std::bit_cast instead of union type punning

### DIFF
--- a/src/comm/Scalar.h
+++ b/src/comm/Scalar.h
@@ -12,24 +12,22 @@
 
 #include <sycl/sycl.hpp>
 
-#include <bit>
-
 static inline uint32_t __float_as_int(float val) {
-  return std::bit_cast<uint32_t>(val);
+  return sycl::bit_cast<uint32_t>(val);
 }
 
 static inline float __int_as_float(uint32_t val) {
-  return std::bit_cast<float>(val);
+  return sycl::bit_cast<float>(val);
 }
 
 static inline unsigned long long __double_as_long_long(double val) {
-  return std::bit_cast<unsigned long long>(val);
+  return sycl::bit_cast<unsigned long long>(val);
 }
 
 static inline double __long_long_as_double(unsigned long long val) {
-  return std::bit_cast<double>(val);
+  return sycl::bit_cast<double>(val);
 }
 
 static inline sycl::half __ushort_as_half(unsigned short int val) {
-  return std::bit_cast<sycl::half>(val);
+  return sycl::bit_cast<sycl::half>(val);
 }

--- a/src/comm/Scalar.h
+++ b/src/comm/Scalar.h
@@ -12,74 +12,24 @@
 
 #include <sycl/sycl.hpp>
 
-union u32_to_f32 {
-  uint32_t in;
-  float out;
-};
-
-union f32_to_u32 {
-  float in;
-  uint32_t out;
-};
-
-union double_to_ull {
-  double in;
-  unsigned long long out;
-};
-
-union ull_to_double {
-  unsigned long long in;
-  double out;
-};
-
-union ushort_to_half {
-  unsigned short int in;
-  sycl::half out;
-};
-
-union double_to_u32 {
-  double in;
-  struct {
-    uint32_t high, low;
-  };
-};
+#include <bit>
 
 static inline uint32_t __float_as_int(float val) {
-  f32_to_u32 cn;
-  cn.in = val;
-  return cn.out;
+  return std::bit_cast<uint32_t>(val);
 }
 
 static inline float __int_as_float(uint32_t val) {
-  u32_to_f32 cn;
-  cn.in = val;
-  return cn.out;
+  return std::bit_cast<float>(val);
 }
 
 static inline unsigned long long __double_as_long_long(double val) {
-  double_to_ull cn;
-  cn.in = val;
-  return cn.out;
+  return std::bit_cast<unsigned long long>(val);
 }
 
 static inline double __long_long_as_double(unsigned long long val) {
-  ull_to_double cn;
-  cn.in = val;
-  return cn.out;
-}
-
-static inline uint32_t __double_as_int(double val) {
-  double_to_u32 cn;
-  cn.in = val;
-  return cn.low;
-}
-
-static inline float __int_as_double(uint32_t val) {
-  return (double)val;
+  return std::bit_cast<double>(val);
 }
 
 static inline sycl::half __ushort_as_half(unsigned short int val) {
-  ushort_to_half cn;
-  cn.in = val;
-  return cn.out;
+  return std::bit_cast<sycl::half>(val);
 }


### PR DESCRIPTION
Rewrite the `__float_as_int` family in `comm/Scalar.h` with `std::bit_cast`; reading the inactive union member was UB. Also drop the unused `__double_as_int`/`__int_as_double` (the latter did a value conversion, not a bit cast) and the six now-unused union types. The helper names are kept since they mirror the CUDA intrinsics at the kernel call sites (Atomics.h, SortingCommon.h, SortingRadixSelect.h). `std::bit_cast` is constexpr and SYCL-device-safe.

Test: no behavior change; covered by existing atomics/sort UTs.