### PR TITLE
Add parse-unitrace skill and profiling script

### DIFF
--- a/.claude/commands/validate-parse-unitrace.md
+++ b/.claude/commands/validate-parse-unitrace.md
@@ -1,0 +1,33 @@
+# Validate parse-unitrace Skill
+
+Validate the `parse-unitrace` skill by running its script against test fixtures
+with known expected outputs.
+
+## Instructions
+
+1. Load the `parse-unitrace` skill.
+2. Read `test/agentic/parse-unitrace/test_cases.md` for the full list of test cases.
+3. For each case:
+   - Run the script on the specified fixture file using the given options.
+   - Check each "Expected" criterion against the actual output.
+   - Record whether the criterion was met (CORRECT) or not (FAILED).
+4. Output a summary table showing:
+   - Case name
+   - Criterion
+   - Expected result (PASS)
+   - Actual result (CORRECT or FAILED)
+   - Notes (any discrepancy details)
+
+## Optional argument
+
+If a specific case number is provided as `$ARGUMENTS`, validate only that case
+instead of running all cases.
+
+## Goal
+
+This command validates that the parse-unitrace script correctly:
+- Filters out Level Zero runtime events (ze* prefix)
+- Aggregates GPU kernel durations by name
+- Handles SIMD suffix in kernel names
+- Ignores non-duration events (ph != "X")
+- Produces correct summary and timeline output

--- a/.claude/skills/action/parse-unitrace/SKILL.md
+++ b/.claude/skills/action/parse-unitrace/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: parse-unitrace
+description: >
+  Parse Intel unitrace chrome-kernel-logging JSON output into per-kernel GPU time
+  summaries. Use when analyzing XPU kernel performance without profiler overhead.
+---
+
+# Parse Unitrace
+
+Parse Intel unitrace `--chrome-kernel-logging` JSON output and produce per-kernel
+GPU time summary tables. Filters out Level Zero runtime events (`ze*`) to show only
+actual GPU compute kernels.
+
+## When to use
+
+- After collecting unitrace output on XPU (Intel GPU)
+- To get per-kernel GPU time without torch profiler overhead
+- To compare against profiler trace results for overhead estimation
+- As ground-truth kernel timing for roofline analysis
+
+## Why unitrace over torch profiler
+
+| | torch.profiler | unitrace |
+|--|----------------|----------|
+| Overhead | Adds ~5-15% inflation | Near-zero overhead |
+| Scope | CPU + GPU, full op tree | GPU kernels only |
+| Platform | XPU + CUDA | XPU only (Level Zero) |
+| Linkage | Has External id (op→kernel) | No op linkage (kernel-only) |
+
+Use unitrace when you need accurate absolute GPU kernel times on XPU.
+Use torch profiler when you need op-level attribution or CUDA support.
+
+## Quick start
+
+```bash
+python .claude/skills/action/parse-unitrace/scripts/parse_unitrace.py python.1234.json --top 20 --sort-by gpu_time
+```
+
+## Usage
+
+```bash
+python .claude/skills/action/parse-unitrace/scripts/parse_unitrace.py <unitrace_file> [options]
+
+Options:
+  --top N              Show top N kernels (default: 20)
+  --sort-by METRIC     Sort by: gpu_time, count (default: gpu_time)
+  --timeline           Print kernels in time order
+  --timeline-limit N   Max kernels to show in timeline (default: 50)
+```
+
+## How it works
+
+1. **Load JSON** — unitrace outputs Chrome trace format (`python.<pid>.json`)
+2. **Filter events** — Keep only `ph: "X"` (complete duration) events with `dur` field
+3. **Skip `ze*` events** — Level Zero runtime calls (e.g., `zeCommandListAppendLaunchKernel`)
+   are infrastructure, not user kernels
+4. **Aggregate** — Group by kernel name, sum durations, count invocations
+
+## Output format
+
+### Summary table
+
+```
+KERNEL NAME                                                            DUR(ms)    DUR%  COUNT
+----------------------------------------------------------------------------------------------------
+gen_conv_kernel_xpu<...>                                                 5.234   42.1%     12
+gemm_kernel<...>                                                         3.891   31.3%     24
+SoftMaxForwardKernel<...>                                                1.234    9.9%      6
+...
+----------------------------------------------------------------------------------------------------
+TOTAL                                                                   12.432    100%     78
+```
+
+### Timeline mode (`--timeline`)
+
+Kernels printed in execution order with timestamp, useful for identifying
+sequential dependencies and inter-kernel gaps.
+
+## Unitrace output format
+
+Unitrace with `--chrome-kernel-logging` produces a Chrome trace JSON:
+
+```json
+{
+  "traceEvents": [
+    {"ph": "X", "name": "zeCommandListAppendLaunchKernel", "ts": 100, "dur": 5, ...},
+    {"ph": "X", "name": "gen_conv_kernel_xpu<float>", "ts": 200, "dur": 1500, ...},
+    ...
+  ]
+}
+```
+
+- `ze*` prefixed events = Level Zero runtime (filtered out)
+- All other `ph: "X"` events = actual GPU compute kernels
+
+## Validation
+
+Compare against end-to-end measurement:
+
+```
+kernel_sum = sum(all kernel durations from unitrace)
+T2 = end-to-end wall clock time (from benchmark)
+
+kernel_sum should be close to T2.
+If kernel_sum << T2: significant host/launch overhead between kernels.
+```
+
+## Integration with other tools
+
+| Tool | Purpose |
+|------|---------|
+| `.claude/skills/action/parse-pytorch-trace/scripts/parse_trace.py` | Parse torch profiler trace (has op linkage, but with overhead) |
+| `.claude/skills/action/map-kernels-to-ops/scripts/map_kernels_to_ops.py` | Map unitrace kernels back to aten:: ops via trace.json External id + time-order matching |

--- a/.claude/skills/action/parse-unitrace/scripts/parse_unitrace.py
+++ b/.claude/skills/action/parse-unitrace/scripts/parse_unitrace.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""
+parse_unitrace.py
+
+Parse unitrace chrome-kernel-logging JSON output and print per-kernel summary.
+Filters out Level Zero runtime events (ze*) to show only GPU compute kernels.
+
+Usage:
+    python tools/profiling/parse_unitrace.py python.1234.json --top 20 --sort-by gpu_time
+    python tools/profiling/parse_unitrace.py python.1234.json --timeline
+"""
+
+import json
+import argparse
+from collections import defaultdict
+
+
+def parse_unitrace(path):
+    """Parse unitrace JSON and return GPU kernel events (excluding ze* runtime events).
+
+    Returns list of dicts: name, dur_us, ts_us
+    """
+    with open(path) as f:
+        data = json.load(f)
+
+    events = [
+        e
+        for e in data["traceEvents"]
+        if isinstance(e, dict) and e.get("ph") == "X" and "dur" in e
+    ]
+
+    # Split into GPU kernels vs runtime events
+    gpu_kernels = []
+    for e in events:
+        name = e.get("name", "")
+        if name.startswith("ze"):
+            continue  # Skip Level Zero runtime calls
+        gpu_kernels.append(
+            {
+                "name": name,
+                "dur_us": e["dur"],
+                "ts_us": e["ts"],
+            }
+        )
+
+    gpu_kernels.sort(key=lambda e: e["ts_us"])
+    return gpu_kernels
+
+
+def aggregate_kernels(kernels):
+    """Aggregate by kernel name."""
+    agg = defaultdict(lambda: {"dur": 0, "count": 0})
+    for k in kernels:
+        agg[k["name"]]["dur"] += k["dur_us"]
+        agg[k["name"]]["count"] += 1
+    return agg
+
+
+def print_summary(agg, total_gpu_us, sort_by="gpu_time", top_n=20):
+    """Print aggregate summary table."""
+    if sort_by == "gpu_time":
+        items = sorted(agg.items(), key=lambda x: x[1]["dur"], reverse=True)
+    elif sort_by == "count":
+        items = sorted(agg.items(), key=lambda x: x[1]["count"], reverse=True)
+    else:
+        items = sorted(agg.items(), key=lambda x: x[1]["dur"], reverse=True)
+
+    print()
+    print("%-70s %10s %7s %6s" % ("KERNEL NAME", "DUR(ms)", "DUR%", "COUNT"))
+    print("-" * 100)
+    for name, v in items[:top_n]:
+        pct = v["dur"] / total_gpu_us * 100 if total_gpu_us > 0 else 0
+        short = name[:67] + "..." if len(name) > 70 else name
+        print(
+            "%-70s %10.3f %6.1f%% %6d" % (short, v["dur"] / 1000, pct, v["count"])
+        )
+    print("-" * 100)
+    total_count = sum(v["count"] for v in agg.values())
+    print("%-70s %10.3f %7s %6d" % ("TOTAL", total_gpu_us / 1000, "100%", total_count))
+
+
+def print_timeline(kernels, limit=50):
+    """Print kernels in time order."""
+    print()
+    print("%-6s %-70s %10s %15s" % ("#", "KERNEL NAME", "DUR(us)", "TS(us)"))
+    print("-" * 110)
+    for i, k in enumerate(kernels[:limit]):
+        short = k["name"][:67] + "..." if len(k["name"]) > 70 else k["name"]
+        print(
+            "%-6d %-70s %10.1f %15.1f" % (i + 1, short, k["dur_us"], k["ts_us"])
+        )
+    if len(kernels) > limit:
+        print("... (%d more)" % (len(kernels) - limit))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Parse unitrace chrome-kernel-logging JSON"
+    )
+    parser.add_argument(
+        "unitrace_file", help="Path to unitrace JSON (python.<pid>.json)"
+    )
+    parser.add_argument(
+        "--top", type=int, default=20, help="Show top N kernels (default: 20)"
+    )
+    parser.add_argument(
+        "--sort-by",
+        choices=["gpu_time", "count"],
+        default="gpu_time",
+        help="Sort metric (default: gpu_time)",
+    )
+    parser.add_argument(
+        "--timeline", action="store_true", help="Print kernels in time order"
+    )
+    parser.add_argument(
+        "--timeline-limit",
+        type=int,
+        default=50,
+        help="Max kernels to show in timeline (default: 50)",
+    )
+    args = parser.parse_args()
+
+    print("Loading unitrace from %s..." % args.unitrace_file)
+    kernels = parse_unitrace(args.unitrace_file)
+
+    total_gpu_us = sum(k["dur_us"] for k in kernels)
+    if len(kernels) > 0:
+        span = (
+            kernels[-1]["ts_us"] + kernels[-1]["dur_us"] - kernels[0]["ts_us"]
+        ) / 1000
+    else:
+        span = 0
+
+    print("GPU kernels: %d" % len(kernels))
+    print("GPU kernel sum: %.3f ms" % (total_gpu_us / 1000))
+    print("Time span (first to last): %.3f ms" % span)
+
+    agg = aggregate_kernels(kernels)
+    print_summary(agg, total_gpu_us, sort_by=args.sort_by, top_n=args.top)
+
+    if args.timeline:
+        print_timeline(kernels, limit=args.timeline_limit)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/agentic/parse-unitrace/fixtures/basic_unitrace.json
+++ b/test/agentic/parse-unitrace/fixtures/basic_unitrace.json
@@ -1,0 +1,14 @@
+{
+  "traceEvents": [
+    {"ph": "X", "name": "zeCommandListAppendLaunchKernel", "ts": 100, "dur": 5, "pid": 1, "tid": 1},
+    {"ph": "X", "name": "zeCommandListAppendMemoryCopy", "ts": 110, "dur": 3, "pid": 1, "tid": 1},
+    {"ph": "X", "name": "gemm_kernel<float>", "ts": 200, "dur": 5000, "pid": 1, "tid": 2},
+    {"ph": "X", "name": "zeCommandListAppendLaunchKernel", "ts": 5300, "dur": 4, "pid": 1, "tid": 1},
+    {"ph": "X", "name": "SoftMaxForwardKernel<float>", "ts": 5400, "dur": 2000, "pid": 1, "tid": 2},
+    {"ph": "X", "name": "zeCommandListAppendLaunchKernel", "ts": 7500, "dur": 4, "pid": 1, "tid": 1},
+    {"ph": "X", "name": "gemm_kernel<float>", "ts": 7600, "dur": 4000, "pid": 1, "tid": 2},
+    {"ph": "X", "name": "zeCommandListAppendLaunchKernel", "ts": 11700, "dur": 4, "pid": 1, "tid": 1},
+    {"ph": "X", "name": "mul_kernel<float>", "ts": 11800, "dur": 800, "pid": 1, "tid": 2},
+    {"ph": "X", "name": "zeFenceHostSynchronize", "ts": 12700, "dur": 2, "pid": 1, "tid": 1}
+  ]
+}

--- a/test/agentic/parse-unitrace/fixtures/unitrace_with_simd_suffix.json
+++ b/test/agentic/parse-unitrace/fixtures/unitrace_with_simd_suffix.json
@@ -1,0 +1,10 @@
+{
+  "traceEvents": [
+    {"ph": "X", "name": "gemm_kernel<float>[SIMD32 {64; 1; 1} {16; 16; 1}]", "ts": 200, "dur": 5000, "pid": 1, "tid": 2},
+    {"ph": "X", "name": "gemm_kernel<float>[SIMD32 {64; 1; 1} {16; 16; 1}]", "ts": 5300, "dur": 4500, "pid": 1, "tid": 2},
+    {"ph": "X", "name": "SoftMaxForwardKernel<float>[SIMD16 {128; 1; 1} {32; 1; 1}]", "ts": 9900, "dur": 2000, "pid": 1, "tid": 2},
+    {"ph": "X", "name": "mul_kernel<float>[SIMD32 {32; 1; 1} {16; 1; 1}]", "ts": 12000, "dur": 800, "pid": 1, "tid": 2},
+    {"ph": "M", "name": "process_name", "pid": 1, "args": {"name": "GPU"}},
+    {"ph": "i", "name": "marker", "ts": 0, "pid": 1, "tid": 1, "s": "g"}
+  ]
+}

--- a/test/agentic/parse-unitrace/test_cases.md
+++ b/test/agentic/parse-unitrace/test_cases.md
@@ -1,0 +1,36 @@
+# Test Cases for parse-unitrace
+
+## Case 1: Basic unitrace with ze* runtime filtering
+Input: `test/agentic/parse-unitrace/fixtures/basic_unitrace.json`
+Task: Parse the unitrace with `--top 10 --sort-by gpu_time`
+
+### Expected results
+- Expected: PASS - Script exits with code 0
+- Expected: PASS - All ze* events are excluded (zeCommandListAppendLaunchKernel, zeCommandListAppendMemoryCopy, zeFenceHostSynchronize)
+- Expected: PASS - gemm_kernel<float> is the top kernel by GPU time (total 9000 us from 2 invocations)
+- Expected: PASS - SoftMaxForwardKernel<float> has GPU time of 2000 us with count 1
+- Expected: PASS - mul_kernel<float> has GPU time of 800 us with count 1
+- Expected: PASS - Total GPU time is 11800 us
+- Expected: PASS - gemm_kernel<float> shows count of 2
+
+## Case 2: Unitrace with SIMD suffix in kernel names
+Input: `test/agentic/parse-unitrace/fixtures/unitrace_with_simd_suffix.json`
+Task: Parse the unitrace with `--top 10 --sort-by gpu_time`
+
+### Expected results
+- Expected: PASS - Script exits with code 0
+- Expected: PASS - Kernels with [SIMDxx {...} {...}] suffix are treated as valid GPU kernels (not filtered)
+- Expected: PASS - gemm_kernel<float>[SIMD32 ...] entries are aggregated together (total 9500 us, count 2)
+- Expected: PASS - Non-duration events (ph: "M", ph: "i") are ignored
+- Expected: PASS - Total GPU time is 12300 us
+- Expected: PASS - 3 unique kernel names reported
+
+## Case 3: Timeline mode
+Input: `test/agentic/parse-unitrace/fixtures/basic_unitrace.json`
+Task: Parse the unitrace with `--timeline`
+
+### Expected results
+- Expected: PASS - Script exits with code 0
+- Expected: PASS - Kernels appear in chronological order (gemm first, then SoftMax, then gemm, then mul)
+- Expected: PASS - Timestamps are shown for each kernel entry
+- Expected: PASS - ze* events do not appear in timeline output


### PR DESCRIPTION
## Summary

- Add a Claude skill (`parse-unitrace`) for parsing Intel unitrace chrome-kernel-logging JSON into per-kernel GPU time summaries
- Add `tools/profiling/parse_unitrace.py` — filters Level Zero runtime events, aggregates kernel durations, supports summary and timeline views

## Motivation

Unitrace provides near-zero-overhead GPU kernel timing on XPU (Intel GPU), complementing the torch profiler trace which has op-level attribution but adds overhead. This tool helps analyze raw kernel performance without profiler inflation.

## Usage

```bash
python tools/profiling/parse_unitrace.py python.1234.json --top 20 --sort-by gpu_time
python tools/profiling/parse_unitrace.py python.1234.json --timeline
```

## Files

| File | Purpose |
|------|---------|
| `.claude/skills/parse-unitrace/SKILL.md` | Skill definition for AI agents |
| `tools/profiling/parse_unitrace.py` | Unitrace parsing script (no external dependencies) |