### PR TITLE
[xccl] Refine build symm logic

### DIFF
--- a/src/xccl/CMakeLists.txt
+++ b/src/xccl/CMakeLists.txt
@@ -13,17 +13,6 @@ file(GLOB xccl_cpp "*.cpp")
 list(REMOVE_ITEM xccl_cpp "${CMAKE_CURRENT_SOURCE_DIR}/NanCheck_XPU.cpp")
 list(REMOVE_ITEM xccl_cpp "${CMAKE_CURRENT_SOURCE_DIR}/Signal.cpp")
 
-# (__INTEL_LLVM_COMPILER >= 20260000). Skip compiling it on older compilers;
-# without this TU the XPU symmetric-memory allocator simply will not be
-# registered (header is still safe to include from other TUs since it does not
-# pull the experimental ipc_memory header).
-if(SYCL_COMPILER_VERSION VERSION_LESS 20260000)
-  message(STATUS
-    "XPU SymmetricMemory disabled: requires oneAPI >= 2026.0 "
-    "(SYCL_COMPILER_VERSION=${SYCL_COMPILER_VERSION})")
-  list(REMOVE_ITEM xccl_cpp "${CMAKE_CURRENT_SOURCE_DIR}/XPUSymmetricMemory.cpp")
-endif()
-
 list(APPEND ATen_XPU_XCCL_SRCS ${xccl_cpp})
 list(APPEND ATen_XPU_SYCL_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/NanCheck_XPU.cpp")
 list(APPEND ATen_XPU_SYCL_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/Signal.cpp")

--- a/src/xccl/XPUSymmetricMemory.cpp
+++ b/src/xccl/XPUSymmetricMemory.cpp
@@ -6,13 +6,15 @@
 
 // XPU symmetric memory is implemented on top of
 // <sycl/ext/oneapi/experimental/ipc_memory.hpp>, which is provided only by
-// Intel oneAPI DPC++/C++ Compiler >= 2026.0. We gate on the built-in
-// `__INTEL_LLVM_COMPILER` macro (icpx defines it automatically; this is the
-// same value `cmake/Modules/FindSYCLToolkit.cmake` extracts into the
-// `SYCL_COMPILER_VERSION` CMake variable, e.g. 20260000 for oneAPI 2026.0).
-// Using the compiler-builtin macro avoids having to propagate a CMake
-// `-D` definition into this TU.
-#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20260000
+// Intel oneAPI DPC++/C++ Compiler >= 2026.0. `SYCL_COMPILER_VERSION` is
+// already propagated as a `-D` definition by upstream PyTorch's
+// `cmake/public/xpu.cmake` (it appends
+// `-DSYCL_COMPILER_VERSION=${SYCL_COMPILER_VERSION}` to `XPU_HOST_CXX_FLAGS`,
+// which `cmake/Dependencies.cmake` then turns into a global
+// `add_definitions(...)`). The same macro is used elsewhere in PyTorch
+// (e.g. `c10/xpu/XPUFunctions.cpp`), so reusing it here keeps the gating
+// style consistent across the XPU stack.
+#if defined(SYCL_COMPILER_VERSION) && SYCL_COMPILER_VERSION >= 20260000
 #define XPU_SYMM_MEM_AVAILABLE 1
 #else
 #define XPU_SYMM_MEM_AVAILABLE 0
@@ -27,10 +29,6 @@
 #include <c10/core/DeviceGuard.h>
 #include <c10/util/error.h>
 #include <c10/xpu/XPUCachingAllocator.h>
-
-// Note: <sycl/ext/oneapi/experimental/ipc_memory.hpp> is included
-// transitively via <sycl/sycl.hpp> (pulled in by the ATen/c10 XPU headers
-// above) on oneAPI >= 2026.0, so no explicit include is needed here.
 
 #include <sys/prctl.h>
 #include <sys/socket.h>
@@ -509,9 +507,9 @@ namespace {
       "XPU SymmetricMemory requires Intel oneAPI DPC++/C++ Compiler 2026.0 "
       "or newer (which provides "
       "<sycl/ext/oneapi/experimental/ipc_memory.hpp>). Detected "
-      "__INTEL_LLVM_COMPILER="
-#ifdef __INTEL_LLVM_COMPILER
-      XPU_SYMM_MEM_STRINGIZE(__INTEL_LLVM_COMPILER)
+      "SYCL_COMPILER_VERSION="
+#ifdef SYCL_COMPILER_VERSION
+      XPU_SYMM_MEM_STRINGIZE(SYCL_COMPILER_VERSION)
 #else
       "<undefined>"
 #endif

--- a/src/xccl/XPUSymmetricMemory.cpp
+++ b/src/xccl/XPUSymmetricMemory.cpp
@@ -498,8 +498,6 @@ c10::intrusive_ptr<Block> XPUSymmetricMemoryAllocator::find_block(void* ptr) {
 // surfaces an actionable upgrade message instead of a silent failure or a
 // confusing missing-symbol error.
 namespace {
-#define XPU_SYMM_MEM_STRINGIZE_(x) #x
-#define XPU_SYMM_MEM_STRINGIZE(x) XPU_SYMM_MEM_STRINGIZE_(x)
 
 [[noreturn]] void throw_unsupported_compiler() {
   TORCH_CHECK(

--- a/src/xccl/XPUSymmetricMemory.cpp
+++ b/src/xccl/XPUSymmetricMemory.cpp
@@ -6,7 +6,12 @@
 
 // XPU symmetric memory is implemented on top of
 // <sycl/ext/oneapi/experimental/ipc_memory.hpp>, which is provided only by
-// Intel oneAPI DPC++/C++ Compiler >= 2026.0.
+// Intel oneAPI DPC++/C++ Compiler >= 2026.0. We gate on the built-in
+// `__INTEL_LLVM_COMPILER` macro (icpx defines it automatically; this is the
+// same value `cmake/Modules/FindSYCLToolkit.cmake` extracts into the
+// `SYCL_COMPILER_VERSION` CMake variable, e.g. 20260000 for oneAPI 2026.0).
+// Using the compiler-builtin macro avoids having to propagate a CMake
+// `-D` definition into this TU.
 #if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20260000
 #define XPU_SYMM_MEM_AVAILABLE 1
 #else
@@ -23,7 +28,9 @@
 #include <c10/util/error.h>
 #include <c10/xpu/XPUCachingAllocator.h>
 
-#include <sycl/ext/oneapi/experimental/ipc_memory.hpp>
+// Note: <sycl/ext/oneapi/experimental/ipc_memory.hpp> is included
+// transitively via <sycl/sycl.hpp> (pulled in by the ATen/c10 XPU headers
+// above) on oneAPI >= 2026.0, so no explicit include is needed here.
 
 #include <sys/prctl.h>
 #include <sys/socket.h>
@@ -500,14 +507,15 @@ namespace {
   TORCH_CHECK(
       false,
       "XPU SymmetricMemory requires Intel oneAPI DPC++/C++ Compiler 2026.0 "
-      "or newer (provides <sycl/ext/oneapi/experimental/ipc_memory.hpp>). "
-      "The current compiler is too old (__INTEL_LLVM_COMPILER="
+      "or newer (which provides "
+      "<sycl/ext/oneapi/experimental/ipc_memory.hpp>). Detected "
+      "__INTEL_LLVM_COMPILER="
 #ifdef __INTEL_LLVM_COMPILER
       XPU_SYMM_MEM_STRINGIZE(__INTEL_LLVM_COMPILER)
 #else
       "<undefined>"
 #endif
-          "). Please upgrade the compiler and rebuild PyTorch / torch-xpu-ops.");
+      ". Please rebuild PyTorch / torch-xpu-ops with oneAPI 2026.0 or newer.");
 }
 
 #undef XPU_SYMM_MEM_STRINGIZE

--- a/src/xccl/XPUSymmetricMemory.cpp
+++ b/src/xccl/XPUSymmetricMemory.cpp
@@ -508,11 +508,7 @@ namespace {
       "or newer (which provides "
       "<sycl/ext/oneapi/experimental/ipc_memory.hpp>). Detected "
       "SYCL_COMPILER_VERSION="
-#ifdef SYCL_COMPILER_VERSION
-      XPU_SYMM_MEM_STRINGIZE(SYCL_COMPILER_VERSION)
-#else
-      "<undefined>"
-#endif
+      C10_STRINGIZE(SYCL_COMPILER_VERSION)
       ". Please rebuild PyTorch / torch-xpu-ops with oneAPI 2026.0 or newer.");
 }
 

--- a/src/xccl/XPUSymmetricMemory.cpp
+++ b/src/xccl/XPUSymmetricMemory.cpp
@@ -38,7 +38,6 @@ namespace symmetric_memory {
 
 #if XPU_SYMM_MEM_AVAILABLE
 
-
 namespace {
 
 std::atomic<uint64_t> store_exchange_nonce{0};
@@ -508,7 +507,7 @@ namespace {
 #else
       "<undefined>"
 #endif
-      "). Please upgrade the compiler and rebuild PyTorch / torch-xpu-ops.");
+          "). Please upgrade the compiler and rebuild PyTorch / torch-xpu-ops.");
 }
 
 #undef XPU_SYMM_MEM_STRINGIZE

--- a/src/xccl/XPUSymmetricMemory.cpp
+++ b/src/xccl/XPUSymmetricMemory.cpp
@@ -1,13 +1,27 @@
-#include <xccl/ProcessGroupXCCL.hpp>
 #include <xccl/XPUSymmetricMemory.hpp>
 #include <xccl/XPUSymmetricMemoryUtils.hpp>
+
+#include <c10/util/Exception.h>
+#include <torch/csrc/distributed/c10d/GroupRegistry.hpp>
+
+// XPU symmetric memory is implemented on top of
+// <sycl/ext/oneapi/experimental/ipc_memory.hpp>, which is provided only by
+// Intel oneAPI DPC++/C++ Compiler >= 2026.0.
+#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20260000
+#define XPU_SYMM_MEM_AVAILABLE 1
+#else
+#define XPU_SYMM_MEM_AVAILABLE 0
+#endif
+
+#if XPU_SYMM_MEM_AVAILABLE
+
+#include <xccl/ProcessGroupXCCL.hpp>
 
 #include <ATen/ceil_div.h>
 #include <ATen/xpu/XPUContext.h>
 #include <c10/core/DeviceGuard.h>
 #include <c10/util/error.h>
 #include <c10/xpu/XPUCachingAllocator.h>
-#include <torch/csrc/distributed/c10d/GroupRegistry.hpp>
 
 #include <sycl/ext/oneapi/experimental/ipc_memory.hpp>
 
@@ -17,8 +31,13 @@
 #include <atomic>
 #include <mutex>
 
+#endif // XPU_SYMM_MEM_AVAILABLE
+
 namespace c10d {
 namespace symmetric_memory {
+
+#if XPU_SYMM_MEM_AVAILABLE
+
 
 namespace {
 
@@ -466,6 +485,75 @@ c10::intrusive_ptr<Block> XPUSymmetricMemoryAllocator::find_block(void* ptr) {
   }
   return it->second;
 }
+
+#else // !XPU_SYMM_MEM_AVAILABLE
+
+// Stub implementation for compilers that do not provide
+// <sycl/ext/oneapi/experimental/ipc_memory.hpp>. The allocator is still
+// registered (so the "XPU" backend remains discoverable) but invoking it
+// surfaces an actionable upgrade message instead of a silent failure or a
+// confusing missing-symbol error.
+namespace {
+#define XPU_SYMM_MEM_STRINGIZE_(x) #x
+#define XPU_SYMM_MEM_STRINGIZE(x) XPU_SYMM_MEM_STRINGIZE_(x)
+
+[[noreturn]] void throw_unsupported_compiler() {
+  TORCH_CHECK(
+      false,
+      "XPU SymmetricMemory requires Intel oneAPI DPC++/C++ Compiler 2026.0 "
+      "or newer (provides <sycl/ext/oneapi/experimental/ipc_memory.hpp>). "
+      "The current compiler is too old (__INTEL_LLVM_COMPILER="
+#ifdef __INTEL_LLVM_COMPILER
+      XPU_SYMM_MEM_STRINGIZE(__INTEL_LLVM_COMPILER)
+#else
+      "<undefined>"
+#endif
+      "). Please upgrade the compiler and rebuild PyTorch / torch-xpu-ops.");
+}
+
+#undef XPU_SYMM_MEM_STRINGIZE
+#undef XPU_SYMM_MEM_STRINGIZE_
+} // namespace
+
+void* XPUSymmetricMemoryAllocator::alloc(
+    size_t /*size*/,
+    int /*device_idx*/,
+    const std::optional<std::string>& /*group_name*/) {
+  throw_unsupported_compiler();
+}
+
+void XPUSymmetricMemoryAllocator::free(void* /*ptr*/) {
+  // No-op: alloc() always throws, so there is nothing to free.
+}
+
+size_t XPUSymmetricMemoryAllocator::get_alloc_size(void* /*ptr*/) {
+  throw_unsupported_compiler();
+}
+
+c10::intrusive_ptr<SymmetricMemory> XPUSymmetricMemoryAllocator::rendezvous(
+    void* /*ptr*/,
+    const std::optional<std::string>& /*group_name*/) {
+  throw_unsupported_compiler();
+}
+
+bool XPUSymmetricMemoryAllocator::has_multicast_support(int /*device_idx*/) {
+  return false;
+}
+
+c10::DeviceType XPUSymmetricMemoryAllocator::supported_device_type() {
+  return c10::DeviceType::XPU;
+}
+
+std::string XPUSymmetricMemoryAllocator::name() {
+  return "XPU";
+}
+
+c10::intrusive_ptr<Block> XPUSymmetricMemoryAllocator::find_block(
+    void* /*ptr*/) {
+  return nullptr;
+}
+
+#endif // XPU_SYMM_MEM_AVAILABLE
 
 struct RegisterXPUSymmetricMemoryAllocator {
   RegisterXPUSymmetricMemoryAllocator() {

--- a/src/xccl/XPUSymmetricMemory.cpp
+++ b/src/xccl/XPUSymmetricMemory.cpp
@@ -6,14 +6,7 @@
 
 // XPU symmetric memory is implemented on top of
 // <sycl/ext/oneapi/experimental/ipc_memory.hpp>, which is provided only by
-// Intel oneAPI DPC++/C++ Compiler >= 2026.0. `SYCL_COMPILER_VERSION` is
-// already propagated as a `-D` definition by upstream PyTorch's
-// `cmake/public/xpu.cmake` (it appends
-// `-DSYCL_COMPILER_VERSION=${SYCL_COMPILER_VERSION}` to `XPU_HOST_CXX_FLAGS`,
-// which `cmake/Dependencies.cmake` then turns into a global
-// `add_definitions(...)`). The same macro is used elsewhere in PyTorch
-// (e.g. `c10/xpu/XPUFunctions.cpp`), so reusing it here keeps the gating
-// style consistent across the XPU stack.
+// Intel oneAPI DPC++/C++ Compiler >= 2026.0.
 #if defined(SYCL_COMPILER_VERSION) && SYCL_COMPILER_VERSION >= 20260000
 #define XPU_SYMM_MEM_AVAILABLE 1
 #else
@@ -505,9 +498,8 @@ namespace {
       "XPU SymmetricMemory requires Intel oneAPI DPC++/C++ Compiler 2026.0 "
       "or newer (which provides "
       "<sycl/ext/oneapi/experimental/ipc_memory.hpp>). Detected "
-      "SYCL_COMPILER_VERSION="
-      C10_STRINGIZE(SYCL_COMPILER_VERSION)
-      ". Please rebuild PyTorch / torch-xpu-ops with oneAPI 2026.0 or newer.");
+      "SYCL_COMPILER_VERSION=" C10_STRINGIZE(
+          SYCL_COMPILER_VERSION) ". Please rebuild PyTorch / torch-xpu-ops with oneAPI 2026.0 or newer.");
 }
 
 #undef XPU_SYMM_MEM_STRINGIZE


### PR DESCRIPTION
From comments https://github.com/intel/torch-xpu-ops/pull/3914#issuecomment-4659530517, we add build time gate on cpp resource and always register symm; but for compiler lower than 2026.0, runtime raise upgrade error.