### PR TITLE
Remove unused deprecated ProcessGroupXCCL constructor

### DIFF
--- a/src/xccl/ProcessGroupXCCL.hpp
+++ b/src/xccl/ProcessGroupXCCL.hpp
@@ -167,14 +167,6 @@ class TORCH_API ProcessGroupXCCL : public Backend {
       int size,
       c10::intrusive_ptr<Options> options = Options::create());
 
-  C10_DEPRECATED ProcessGroupXCCL(
-      const c10::intrusive_ptr<Store>& store,
-      int rank,
-      int size,
-      const std::string& groupName,
-      c10::intrusive_ptr<Options> options = Options::create())
-      : ProcessGroupXCCL(store, rank, size, std::move(options)) {}
-
   ~ProcessGroupXCCL() override;
 
   uint64_t getUid() const noexcept {


### PR DESCRIPTION
The `C10_DEPRECATED` `groupName` overload has no callers: nothing in this repo uses it, and upstream PyTorch's pybind registration (`torch/csrc/distributed/c10d/init.cpp`) constructs `ProcessGroupXCCL` only via the `(store, rank, size, options)` overload.

Test: none (header-only removal of an uncalled overload)

Authored with an AI assistant.