### PR TITLE
Fix minor CMake issues

### DIFF
--- a/cmake/Modules/FindONEMKL.cmake
+++ b/cmake/Modules/FindONEMKL.cmake
@@ -74,6 +74,10 @@ foreach(LIB_NAME IN LISTS MKL_LIB_NAMES)
     NAMES ${LIB_NAME}
     HINTS ${ONEMKL_LIB_DIR}
     NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH)
+  if(NOT ${LIB_NAME}_library)
+    message(WARNING "${LIB_NAME} not found in ${ONEMKL_LIB_DIR}!!")
+    return()
+  endif()
   list(APPEND ONEMKL_LIBRARIES ${${LIB_NAME}_library})
 endforeach()
 

--- a/cmake/Modules/FindSYCL.cmake
+++ b/cmake/Modules/FindSYCL.cmake
@@ -379,7 +379,6 @@ macro(SYCL_LINK_DEVICE_OBJECTS output_file sycl_target)
     set(important_host_flags)
     _sycl_get_important_host_flags(important_host_flags "${SYCL_HOST_FLAGS}")
     set(SYCL_device_link_flags
-        ${link_type_flag}
         ${important_host_flags}
         ${SYCL_DEVICE_LINK_FLAGS})
 

--- a/cmake/Modules/FindSYCL/run_sycl.cmake
+++ b/cmake/Modules/FindSYCL/run_sycl.cmake
@@ -39,7 +39,7 @@ set(SYCL_compile_flags @SYCL_COMPILE_FLAGS@) # list
 set(SYCL_include_dirs [==[@SYCL_include_dirs@]==]) # list
 set(SYCL_compile_definitions [==[@SYCL_compile_definitions@]==]) # list
 
-list(REMOVE_DUPLICATES SYCL_INCLUDE_DIRS)
+list(REMOVE_DUPLICATES SYCL_include_dirs)
 
 set(SYCL_host_compiler_flags "-fsycl-host-compiler-options=")
 set(SYCL_include_args)

--- a/cmake/ONEMKL.cmake
+++ b/cmake/ONEMKL.cmake
@@ -20,12 +20,15 @@ endif()
 
 find_package(ONEMKL)
 if(NOT ONEMKL_FOUND)
-  message(FATAL_ERROR "Can NOT find ONEMKL cmake helpers module!")
+  message(FATAL_ERROR "oneMKL not found or installation is incomplete; see warnings above for details.")
 endif()
 
 set(TORCH_XPU_OPS_ONEMKL_INCLUDE_DIR ${ONEMKL_INCLUDE_DIR})
 
 set(TORCH_XPU_OPS_ONEMKL_LIBRARIES ${ONEMKL_LIBRARIES})
 
-list(PREPEND TORCH_XPU_OPS_ONEMKL_LIBRARIES "-Wl,--start-group")
-list(APPEND TORCH_XPU_OPS_ONEMKL_LIBRARIES "-Wl,--end-group")
+# --start-group/--end-group are GNU ld options; MSVC link does not know them.
+if(NOT WIN32)
+  list(PREPEND TORCH_XPU_OPS_ONEMKL_LIBRARIES "-Wl,--start-group")
+  list(APPEND TORCH_XPU_OPS_ONEMKL_LIBRARIES "-Wl,--end-group")
+endif()

--- a/src/BuildOnLinux.cmake
+++ b/src/BuildOnLinux.cmake
@@ -34,7 +34,7 @@ endmacro()
 if(BUILD_SEPARATE_OPS)
   setup_common_libraries()
   foreach(sycl_src ${ATen_XPU_SYCL_SRCS})
-    get_filename_component(name ${sycl_src} NAME_WLE REALPATH)
+    get_filename_component(name ${sycl_src} NAME_WLE)
     set(sycl_lib torch-xpu-ops-sycl-${name})
     sycl_add_library(
       ${sycl_lib}

--- a/src/BuildOnWindows.cmake
+++ b/src/BuildOnWindows.cmake
@@ -26,7 +26,7 @@ endmacro()
 if(BUILD_SEPARATE_OPS)
   setup_common_libraries()
   foreach(sycl_src ${ATen_XPU_SYCL_SRCS})
-    get_filename_component(name ${sycl_src} NAME_WLE REALPATH)
+    get_filename_component(name ${sycl_src} NAME_WLE)
     set(sycl_lib torch-xpu-ops-sycl-${name})
     sycl_add_library(
       ${sycl_lib}

--- a/test/sycl/CMakeLists.txt
+++ b/test/sycl/CMakeLists.txt
@@ -14,7 +14,7 @@ set(TEST_SYCL_CXX_SRCS ${TEST_SYCL_ROOT}/main.cpp)
 sycl_add_executable(
   test_sycl_build_standalone
   SYCL_SOURCES ${TEST_SYCL_SYCL_SRCS}
-  CXX_SOURCES ${TEST_SYCL_CXX_SRCS} ${TEST_SYCL_CXX_SRCS})
+  CXX_SOURCES ${TEST_SYCL_CXX_SRCS})
 
 if(INSTALL_TEST)
   install(TARGETS test_sycl_build_standalone DESTINATION bin)


### PR DESCRIPTION
Cleanups from a CMake audit: the include-dir dedup in run_sycl.cmake referenced a misspelled variable and never ran; GNU ld's --start-group/--end-group were passed to MSVC link on Windows (ignored with warnings); FindONEMKL accepted *-NOTFOUND libraries and still reported success, deferring a partial oneMKL install to an obscure link error instead of failing at configure time. Also removes an undefined variable reference, a stray get_filename_component() argument, and a duplicated source listing, none of which affect the build output.

Authored with Claude Code.
