### PR TITLE
Remove suppression of -Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,6 @@ cmake_minimum_required(VERSION 3.27 FATAL_ERROR)
 
 # Avoid SYCL compiler error
 if(NOT WIN32)
-  string(APPEND CMAKE_CXX_FLAGS " -Wno-error")
   if("$ENV{IS_XPU_CI}" STREQUAL "1")
     string(APPEND CMAKE_CXX_FLAGS " -Werror=unused-variable")
   endif()


### PR DESCRIPTION
This PR fixes an issue where the -Werror flag could be unintentionally suppressed when building with WERROR=1.
For example, a simplified `CMAKE_HOST_FLAGS` might look like:`-Werror;-Wno-error;-Werror`
After applying `REMOVE_DUPLICATES` in [run_sycl.cmake](https://github.com/intel/torch-xpu-ops/blob/24fa8b1ea6025b2f268790e09eda5b79b85119aa/cmake/Modules/FindSYCL/run_sycl.cmake#L73), the flags become:`-Werror;-Wno-error`
As a result, the final `-Werror` is supressed.

