### PR TITLE
[1/N] Replace shift_group_left with reduce_over_group in Reduce Sum

### DIFF
--- a/src/ATen/native/xpu/sycl/Reduce.h
+++ b/src/ATen/native/xpu/sycl/Reduce.h
@@ -39,7 +39,49 @@ using at::detail::Array;
 
 namespace detail {
 
-template <class arg_t, class item_t, class CombineFunc, int out_vec_sz = 1>
+template <class T, class = void>
+struct get_native_sycl_op {
+  using type = void;
+};
+template <class T>
+struct get_native_sycl_op<T, std::void_t<typename T::native_sycl_op>> {
+  using type = typename T::native_sycl_op;
+};
+template <class T>
+using native_sycl_op_t = typename get_native_sycl_op<T>::type;
+
+template <class arg_t, class CombineFunc, class NativeOp, int out_vec_sz>
+void tree_reduce(
+    sycl::sub_group sg,
+    at::detail::Array<arg_t, out_vec_sz>& value,
+    CombineFunc combine) {
+  constexpr bool is_fast_path_supported =
+      std::is_same_v<NativeOp, sycl::plus<arg_t>> &&
+      std::is_arithmetic_v<arg_t> && !std::is_same_v<arg_t, bool>;
+
+  if constexpr (is_fast_path_supported) {
+#pragma unroll(out_vec_sz)
+    for (int i = 0; i < out_vec_sz; ++i) {
+      value[i] = sycl::reduce_over_group(sg, value[i], NativeOp{});
+    }
+  } else {
+    int sg_size = sg.get_local_range()[0];
+    for (int offset = 1; offset < sg_size; offset <<= 1) {
+#pragma unroll(out_vec_sz)
+      for (int i = 0; i < out_vec_sz; ++i) {
+        arg_t other = sycl::shift_group_left(sg, value[i], offset);
+        value[i] = combine(value[i], other);
+      }
+    }
+  }
+}
+
+template <
+    class arg_t,
+    class item_t,
+    class CombineFunc,
+    class NativeOp = void,
+    int out_vec_sz = 1>
 inline at::detail::Array<arg_t, out_vec_sz> group_reduce(
     item_t item,
     int wg_size,
@@ -60,13 +102,8 @@ inline at::detail::Array<arg_t, out_vec_sz> group_reduce(
   SYCL_KERNEL_ASSERT(
       wg_size % sg_size == 0 && "unsupported workgroup size for group reduce");
 
-  for (int offset = 1; offset < sg_size; offset <<= 1) {
-#pragma unroll(out_vec_sz)
-    for (int i = 0; i < out_vec_sz; ++i) {
-      arg_t other = sycl::shift_group_left(sg, value[i], offset);
-      value[i] = combine(value[i], other);
-    }
-  }
+  // tree reduce in subgroup
+  tree_reduce<arg_t, CombineFunc, NativeOp, out_vec_sz>(sg, value, combine);
 
   if (sg_lid == 0) {
     shared_[sg_gid] = value;
@@ -448,6 +485,8 @@ template <typename out_scalar_t, typename func_t>
 struct func_wrapper_t {
   using arg_t = typename binary_function_traits<func_t>::arg1_t;
   using scalar_t = typename binary_function_traits<func_t>::arg2_t;
+  // Propagate native_sycl_op from func_t
+  using native_sycl_op = native_sycl_op_t<func_t>;
 
   func_t combine;
   static inline out_scalar_t project(arg_t arg) {
@@ -573,11 +612,14 @@ struct ReduceOp {
       return ops.combine(value, other);
     };
 
+    using native_op_t = native_sycl_op_t<ops_t>;
+
     if (config.should_group_x_reduce() && config.should_group_y_reduce()) {
       value = group_reduce<
           arg_t,
           decltype(pos),
           decltype(combine),
+          native_op_t,
           output_vec_size>(
           pos, config.num_items, shared, value, combine, ident);
     } else {

--- a/src/ATen/native/xpu/sycl/Reduce.h
+++ b/src/ATen/native/xpu/sycl/Reduce.h
@@ -103,7 +103,8 @@ inline at::detail::Array<arg_t, out_vec_sz> group_reduce(
       wg_size % sg_size == 0 && "unsupported workgroup size for group reduce");
 
   // tree reduce in subgroup
-  subgroup_tree_reduce<arg_t, CombineFunc, NativeOp, out_vec_sz>(sg, value, combine);
+  subgroup_tree_reduce<arg_t, CombineFunc, NativeOp, out_vec_sz>(
+      sg, value, combine);
 
   if (sg_lid == 0) {
     shared_[sg_gid] = value;

--- a/src/ATen/native/xpu/sycl/Reduce.h
+++ b/src/ATen/native/xpu/sycl/Reduce.h
@@ -51,7 +51,7 @@ template <class T>
 using native_sycl_op_t = typename get_native_sycl_op<T>::type;
 
 template <class arg_t, class CombineFunc, class NativeOp, int out_vec_sz>
-void tree_reduce(
+void subgroup_tree_reduce(
     sycl::sub_group sg,
     at::detail::Array<arg_t, out_vec_sz>& value,
     CombineFunc combine) {
@@ -103,7 +103,7 @@ inline at::detail::Array<arg_t, out_vec_sz> group_reduce(
       wg_size % sg_size == 0 && "unsupported workgroup size for group reduce");
 
   // tree reduce in subgroup
-  tree_reduce<arg_t, CombineFunc, NativeOp, out_vec_sz>(sg, value, combine);
+  subgroup_tree_reduce<arg_t, CombineFunc, NativeOp, out_vec_sz>(sg, value, combine);
 
   if (sg_lid == 0) {
     shared_[sg_gid] = value;

--- a/src/ATen/native/xpu/sycl/ReduceSumProdKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ReduceSumProdKernels.cpp
@@ -55,7 +55,7 @@ template <typename acc_t>
 struct SumFunctor {
   using native_sycl_op = sycl::plus<acc_t>;
   inline acc_t operator()(acc_t a, acc_t b) const {
-    return a + b;
+    return native_sycl_op{}(a, b);
   }
 };
 

--- a/src/ATen/native/xpu/sycl/ReduceSumProdKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ReduceSumProdKernels.cpp
@@ -53,6 +53,7 @@ static void reduce_dispatch(TensorIterator& iter, GeneralDispatcher op) {
 
 template <typename acc_t>
 struct SumFunctor {
+  using native_sycl_op = sycl::plus<acc_t>;
   inline acc_t operator()(acc_t a, acc_t b) const {
     return a + b;
   }


### PR DESCRIPTION
This PR refactors and optimizes the reduction logic in the SYCL backend, focusing on improved support for native SYCL operations and more efficient subgroup reductions. The changes introduce a mechanism to propagate and utilize native SYCL reduction operators where possible, and restructure the reduction code to allow for better compile-time dispatch and unrolling.

Key changes:

**Native SYCL operator support:**
* Added a `get_native_sycl_op` type trait and `native_sycl_op_t` alias to extract a `native_sycl_op` type from functors if available, enabling the use of native SYCL reduction operations in generic code.
* Updated `SumFunctor` in `ReduceSumProdKernels.cpp` to define and use `native_sycl_op`, allowing `SumFunctor` to leverage `sycl::plus` for reductions.

**Subgroup reduction optimization:**
* Introduced the `subgroup_tree_reduce` function, which performs a tree-based reduction within a SYCL subgroup, using a fast path for supported native operations and a generic path otherwise. This enables efficient reductions with compile-time unrolling based on subgroup size.
* Refactored `group_reduce` to dispatch to `subgroup_tree_reduce` with the exact subgroup size at runtime, allowing for optimal unrolling and performance.

**Propagation of native operators:**
* Modified `func_wrapper_t` and `ReduceOp` to propagate and utilize the `native_sycl_op` type from the provided functor, ensuring that native SYCL operations are used when available throughout the reduction pipeline.

Speedup on B60:

| Shape (batch=1024, dim) | FP32 | FP16 | BF16 |
|----------------------|------------|------------|-------------|
| (1024, 16384)          | 1.05x        | 1.38x        | 1.34x         |
