### PR TITLE
[test] Fix XPU von Mises sample test deterministic failure under fixed pytest seed

### DIFF
--- a/src/ATen/native/xpu/sycl/DistributionTemplates.h
+++ b/src/ATen/native/xpu/sycl/DistributionTemplates.h
@@ -45,10 +45,12 @@ inline std::tuple<uint64_t, uint32_t, uint32_t> calc_execution_policy(
   auto num_groups = (total_elements + group_size - 1) / group_size;
   auto hw_max_groups = syclMaxWorkItemsPerTile() / group_size;
   num_groups = num_groups > hw_max_groups ? hw_max_groups : num_groups;
-  // number of times random will be generated per thread, to offset philox
-  // counter in thc random state
+  // Increment must be at least the number of 32-bit values consumed per
+  // dist_func call. Our distribution functors consume one rand4-equivalent
+  // block per loop iteration for both float and double paths.
   uint64_t counter_offset =
-      ((total_elements - 1) / (group_size * num_groups * UNROLL) + 1) * UNROLL;
+      ((total_elements - 1) / (group_size * num_groups * UNROLL) + 1) *
+      rand4_engine_calls;
   return std::make_tuple(counter_offset, num_groups, group_size);
 }
 
@@ -133,7 +135,7 @@ void distribution_nullary_kernel(
     return;
   }
 
-  auto execution_policy = calc_execution_policy(numel);
+  auto execution_policy = calc_execution_policy<unroll_factor>(numel);
   auto counter_offset = std::get<0>(execution_policy);
   auto num_groups = std::get<1>(execution_policy);
   auto group_size = std::get<2>(execution_policy);


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/3977
Closes https://github.com/intel/torch-xpu-ops/issues/4004

## Root Cause

`calc_execution_policy` computed `counter_offset` using the `UNROLL` template
parameter as the stride multiplier:

```cpp
uint64_t counter_offset =
    ((total_elements - 1) / (group_size * num_groups * UNROLL) + 1) * UNROLL;
```

However, every call to `dist_func_` inside the kernel always advances the Philox counter by `rand4_engine_calls` (4) regardless of the unroll factor. When `unroll_factor != rand4_engine_calls`, the offset was wrong: kernel launches could receive overlapping or incorrectly spaced Philox sub-streams, producing statistically biased output at certain generator positions.

Additionally, `distribution_nullary_kernel` was calling `calc_execution_policy(numel)` (defaulting to `UNROLL=4`) rather than `calc_execution_policy<unroll_factor>(numel)`, so the number-of-groups calculation was decoupled from the actual kernel unroll factor.

## Fix

- Make `calc_execution_policy` a template function parameterized on `UNROLL` (defaulting to `rand4_engine_calls`).
- Replace `* UNROLL` with `* rand4_engine_calls` in the `counter_offset` formula so the stride always matches actual Philox consumption.
- Pass `unroll_factor` explicitly when calling `calc_execution_policy` from `distribution_nullary_kernel`.

## Validation

```bash
PYTORCH_TEST_WITH_SLOW=1 python -m pytest -xvs \
  third_party/torch-xpu-ops/test/xpu/test_distributions_xpu.py::TestDistributionsXPU::test_vonmises_sample_xpu
# 1 passed
```
