### PR TITLE
Enhance auto-label: rename skill, support forks, add test/agentic

### DIFF
--- a/.claude/skills/auto-label/SKILL.md
+++ b/.claude/skills/auto-label/SKILL.md
@@ -65,7 +65,11 @@ Rules are evaluated top-to-bottom; use the FIRST matching rule set.
 
 **Condition:** Changed files include `test/xpu/xpu_test_utils.py` or `test/xpu/run_test_with_skip.py` (test infrastructure used by all test suites).
 
-**Labels:** `none` (run full CI — these files affect all tests).
+**Labels:** `disable_e2e`, `disable_distributed`
+
+**Rationale:** Test infrastructure affects all UT suites across platforms, so UT must run and `disable_win` must NOT be added. E2E and distributed use separate infrastructure.
+
+**Additional:** Always add `disable_build` (test-only changes don't need source build).
 
 ### Rule 5: Test-only changes
 

--- a/.claude/skills/auto-label/SKILL.md
+++ b/.claude/skills/auto-label/SKILL.md
@@ -30,38 +30,46 @@ Note: Only labels consumed by `pull.yml` are in scope. Other labels (`disable_ac
 Evaluate the file paths changed in the PR and apply labels using the following logic.
 Rules are evaluated top-to-bottom; use the FIRST matching rule set.
 
-### Rule 1: Pure CI infrastructure (no functional logic change)
+### Rule 1: Pure CI metadata (no functional logic change)
 
-**Condition:** ALL changed files match `.github/workflows/`, `.github/scripts/`, `.github/ISSUE_TEMPLATE/`, `.github/copilot-instructions.md`, `.claude/skills/`, `test/agentic/`, or other `.github/`/`.claude/` non-workflow metadata files AND the workflow changes do NOT alter job execution logic (only change triggers, permissions, concurrency, comments, labels conditions, yaml formatting).
+**Condition:** ALL changed files match `.github/ISSUE_TEMPLATE/`, `.github/copilot-instructions.md`, `.claude/`, `test/agentic/`, or other non-functional metadata files. No `.github/workflows/`, `.github/actions/`, or `.github/scripts/` changes.
 
 **Labels:** `disable_all`
 
-**Examples:** Fixing lint workflow permissions, updating issue templates, adding skills docs.
+**Examples:** Updating issue templates, adding skills docs, agentic test fixtures.
 
-### Rule 2: CI workflow with execution logic changes
+### Rule 2: CI workflow / action / script changes
 
-**Condition:** Changed files include `.github/workflows/` AND the changes alter actual job steps, scripts, environment, or build/test commands.
+**Condition:** Changed files include `.github/workflows/`, `.github/actions/`, or `.github/scripts/`.
 
-**Labels:** Disable all jobs EXCEPT the ones whose workflows are being modified. The modified workflow's jobs must run to validate the change.
+**Labels:** Determined by WHICH workflows/actions/scripts are modified:
 
-- If modifying `_linux_build.yml` → keep linux-build running
-- If modifying `_linux_ut.yml` → keep linux-ut running
-- If modifying `_linux_e2e.yml` → keep linux-e2e running
-- If modifying `_windows_*.yml` → keep windows jobs running, add `windows_ci` to force trigger
+- If modifying `_linux_build.yml` or build-related actions/scripts → keep linux-build running, disable others: `disable_ut,disable_e2e,disable_distributed,disable_win`
+- If modifying `_linux_ut.yml` or UT-related actions/scripts → keep linux-ut running: `disable_e2e,disable_distributed,disable_win`
+- If modifying `_linux_e2e.yml` or e2e-related actions/scripts → keep linux-e2e running: `disable_ut,disable_distributed,disable_win`
+- If modifying `_windows_*.yml` → keep windows jobs running, add `windows_ci`: `disable_ut,disable_e2e,disable_distributed`
+- If modifying `pull.yml` only (trigger/condition/concurrency changes) → `disable_all`
+- If modifying MULTIPLE workflow areas or unclear scope → run full CI: `none`
 
 **Additional:** If no `src/`, `cmake/`, `CMakeLists.txt` files changed, add `disable_build`.
 
 ### Rule 3: Only skip/expect list changes
 
-**Condition:** ALL changed files are `test/xpu/skip_list_common.py`, `test/xpu/expect/`, or `test/xpu/test_decomp_xpu.py` (pure skip list / expect file updates with no test logic change).
+**Condition:** ALL changed files are `test/xpu/skip_list_common.py`, `test/xpu/expect/`, `test/xpu/extended/skip_list_*.py`, or `test/xpu/test_decomp_xpu.py` (pure skip list / expect file updates with no test logic change).
 
 **Labels:** `disable_all`
 
 **Rationale:** Skip list changes don't need functional validation beyond lint.
 
-### Rule 4: Test-only changes
+### Rule 4: Test infrastructure changes
 
-**Condition:** ALL changed files are under `test/` (excluding pure skip/expect files handled by Rule 3).
+**Condition:** Changed files include `test/xpu/xpu_test_utils.py` or `test/xpu/run_test_with_skip.py` (test infrastructure used by all test suites).
+
+**Labels:** `none` (run full CI — these files affect all tests).
+
+### Rule 5: Test-only changes
+
+**Condition:** ALL changed files are under `test/` (excluding files handled by Rules 3-4).
 
 **Labels (base):** `disable_e2e`, `disable_distributed`
 
@@ -71,9 +79,9 @@ Rules are evaluated top-to-bottom; use the FIRST matching rule set.
 
 **Additional:** Always add `disable_build` (test-only changes don't need source build).
 
-### Rule 5: Kernel/operator source changes (src/)
+### Rule 6: Kernel/operator source changes (src/)
 
-**Condition:** Changed files include `src/ATen/` or `src/xccl/`.
+**Condition:** Changed files include `src/ATen/` or `src/xccl/` (but NOT `src/*.cmake`, `src/CMakeLists.txt`, or `src/Build*.cmake` — those are build system files, see Rule 7).
 
 **Labels:** Depends on which subdirectory:
 
@@ -87,15 +95,15 @@ Rules are evaluated top-to-bottom; use the FIRST matching rule set.
 
 **Note:** Do NOT add `disable_build` — source changes require compilation.
 
-### Rule 6: Build system changes
+### Rule 7: Build system changes
 
-**Condition:** Changed files include `cmake/`, `CMakeLists.txt`, `src/**/*.cmake`, or `tools/`.
+**Condition:** Changed files include `cmake/`, `CMakeLists.txt`, `src/**/*.cmake`, `src/Build*.cmake`, or `tools/`.
 
 **Labels:** None (or minimal). Build system changes need full CI validation.
 
 **If ONLY build system files changed** (no test, no kernel): `disable_e2e`, `disable_distributed`
 
-### Rule 7: yaml/ definition changes
+### Rule 8: yaml/ definition changes
 
 **Condition:** Changed files include `yaml/` (operator definitions).
 
@@ -103,7 +111,7 @@ Rules are evaluated top-to-bottom; use the FIRST matching rule set.
 
 Apply: `none` (run full CI by default).
 
-### Rule 8: Mixed changes (fallback)
+### Rule 9: Mixed changes (fallback)
 
 **Condition:** None of the above rules fully apply (mixed src + test + CI, etc.).
 

--- a/.claude/skills/auto-label/SKILL.md
+++ b/.claude/skills/auto-label/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: xpu-pr-auto-labeling
+name: auto-label
 description: >
   Rules for automatically determining which disable_* labels to apply to a PR
   based on the file paths changed. Used by the auto-label workflow.
@@ -32,7 +32,7 @@ Rules are evaluated top-to-bottom; use the FIRST matching rule set.
 
 ### Rule 1: Pure CI infrastructure (no functional logic change)
 
-**Condition:** ALL changed files match `.github/workflows/`, `.github/scripts/`, `.github/ISSUE_TEMPLATE/`, `.github/copilot-instructions.md`, `.claude/skills/`, or other `.github/` non-workflow metadata files AND the workflow changes do NOT alter job execution logic (only change triggers, permissions, concurrency, comments, labels conditions, yaml formatting).
+**Condition:** ALL changed files match `.github/workflows/`, `.github/scripts/`, `.github/ISSUE_TEMPLATE/`, `.github/copilot-instructions.md`, `.claude/skills/`, `test/agentic/`, or other `.github/`/`.claude/` non-workflow metadata files AND the workflow changes do NOT alter job execution logic (only change triggers, permissions, concurrency, comments, labels conditions, yaml formatting).
 
 **Labels:** `disable_all`
 

--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -144,7 +144,7 @@ jobs:
               src/*|CMakeLists.txt) HAS_SRC=true ;;
               cmake/*|tools/*) HAS_CMAKE=true ;;
               test/agentic/*) HAS_GITHUB_META=true ;;
-              test/xpu/xpu_test_utils.py|test/xpu/run_test_with_skip.py) HAS_TEST_INFRA=true ;;
+              test/xpu/xpu_test_utils.py|test/xpu/run_test_with_skip.py) HAS_TEST=true; HAS_TEST_INFRA=true; ONLY_SKIP_EXPECT=false ;;
               test/xpu/test_ops*.py|test/xpu/core/*|test/xpu/test_nn*.py) HAS_TEST=true; ONLY_SKIP_EXPECT=false; HAS_WIN_TEST=true ;;
               test/*) HAS_TEST=true
                 case "$file" in
@@ -159,10 +159,7 @@ jobs:
             esac
           done <<< "$FILES"
 
-          if [ "$HAS_TEST_INFRA" = true ]; then
-            # Test infrastructure (xpu_test_utils.py etc.) affects all tests — full CI
-            LABELS=""
-          elif [ "$HAS_SRC" = false ] && [ "$HAS_CMAKE" = false ] && [ "$HAS_TEST" = false ] && [ "$HAS_YAML" = false ] && [ "$HAS_TEST_INFRA" = false ]; then
+          if [ "$HAS_SRC" = false ] && [ "$HAS_CMAKE" = false ] && [ "$HAS_TEST" = false ] && [ "$HAS_YAML" = false ]; then
             if [ "$HAS_WORKFLOW" = true ] || [ "$HAS_CI_SCRIPTS" = true ]; then
               # CI workflow/action/script changes — can't determine scope from paths alone, run full CI
               LABELS=""
@@ -176,7 +173,7 @@ jobs:
               LABELS="disable_all"
             else
               LABELS="disable_e2e,disable_distributed,disable_build"
-              if [ "$HAS_WIN_TEST" = false ]; then
+              if [ "$HAS_WIN_TEST" = false ] && [ "$HAS_TEST_INFRA" = false ]; then
                 LABELS="${LABELS},disable_win"
               fi
             fi

--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -13,7 +13,7 @@ on:
       - release/*
     paths:
       - '.github/workflows/auto_label.yml'
-      - '.claude/skills/xpu-pr-auto-labeling/**'
+      - '.claude/skills/auto-label/**'
 
 permissions:
   contents: read
@@ -28,7 +28,6 @@ jobs:
   auto-label:
     if: >-
       ${{ github.repository_owner == 'intel'
-      && github.event.pull_request.head.repo.full_name == github.repository
       && !contains(github.event.pull_request.labels.*.name, 'disable_auto') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -49,7 +48,7 @@ jobs:
       - name: Checkout repo (for skill file)
         uses: actions/checkout@v4
         with:
-          sparse-checkout: .claude/skills/xpu-pr-auto-labeling
+          sparse-checkout: .claude/skills/auto-label
           sparse-checkout-cone-mode: false
 
       - name: Get changed files
@@ -71,12 +70,12 @@ jobs:
           GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
           PR_FILES: ${{ steps.changed-files.outputs.files }}
         run: |
-          SKILL_CONTENT=$(cat .claude/skills/xpu-pr-auto-labeling/SKILL.md)
+          SKILL_CONTENT=$(cat .claude/skills/auto-label/SKILL.md)
           FILES="$PR_FILES"
           API_SUCCESS=false
 
           # Build the prompt
-          # NOTE: File list comes from PR contributors (internal PRs only per job-level if).
+          # NOTE: File list comes from PR contributors (including forks).
           # The file list is treated as untrusted data by the model prompt framing.
           PROMPT="You are a CI label bot. Based on the labeling rules below, determine which disable_* labels should be applied to this PR.
 
@@ -141,6 +140,7 @@ jobs:
               src/xccl/*) HAS_SRC=true; HAS_XCCL=true ;;
               src/*|CMakeLists.txt) HAS_SRC=true ;;
               cmake/*|tools/*) HAS_CMAKE=true ;;
+              test/agentic/*) HAS_GITHUB_META=true ;;
               test/xpu/test_ops*.py|test/xpu/core/*|test/xpu/test_nn*.py) HAS_TEST=true; ONLY_SKIP_EXPECT=false; HAS_WIN_TEST=true ;;
               test/*) HAS_TEST=true
                 case "$file" in

--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -128,7 +128,9 @@ jobs:
           HAS_XCCL=false
           HAS_CMAKE=false
           HAS_TEST=false
+          HAS_TEST_INFRA=false
           HAS_WORKFLOW=false
+          HAS_CI_SCRIPTS=false
           HAS_GITHUB_META=false
           HAS_YAML=false
           ONLY_SKIP_EXPECT=true
@@ -138,28 +140,37 @@ jobs:
             [ -z "$file" ] && continue
             case "$file" in
               src/xccl/*) HAS_SRC=true; HAS_XCCL=true ;;
+              src/*.cmake|src/CMakeLists.txt|src/Build*.cmake) HAS_CMAKE=true ;;
               src/*|CMakeLists.txt) HAS_SRC=true ;;
               cmake/*|tools/*) HAS_CMAKE=true ;;
               test/agentic/*) HAS_GITHUB_META=true ;;
+              test/xpu/xpu_test_utils.py|test/xpu/run_test_with_skip.py) HAS_TEST_INFRA=true ;;
               test/xpu/test_ops*.py|test/xpu/core/*|test/xpu/test_nn*.py) HAS_TEST=true; ONLY_SKIP_EXPECT=false; HAS_WIN_TEST=true ;;
               test/*) HAS_TEST=true
                 case "$file" in
-                  test/xpu/skip_list_common.py|test/xpu/expect/*|test/xpu/test_decomp_xpu.py) ;;
+                  test/xpu/skip_list_common.py|test/xpu/expect/*|test/xpu/test_decomp_xpu.py|test/xpu/extended/skip_list_*.py) ;;
                   *) ONLY_SKIP_EXPECT=false ;;
                 esac ;;
               .github/workflows/*) HAS_WORKFLOW=true ;;
+              .github/actions/*|.github/scripts/*) HAS_CI_SCRIPTS=true ;;
               .github/*) HAS_GITHUB_META=true ;;
               .claude/*) HAS_GITHUB_META=true ;;
               yaml/*) HAS_YAML=true ;;
             esac
           done <<< "$FILES"
 
-          if [ "$HAS_SRC" = false ] && [ "$HAS_CMAKE" = false ] && [ "$HAS_TEST" = false ] && [ "$HAS_YAML" = false ]; then
-            # Only .github/ files changed
-            if [ "$HAS_WORKFLOW" = true ] || [ "$HAS_GITHUB_META" = true ]; then
+          if [ "$HAS_TEST_INFRA" = true ]; then
+            # Test infrastructure (xpu_test_utils.py etc.) affects all tests — full CI
+            LABELS=""
+          elif [ "$HAS_SRC" = false ] && [ "$HAS_CMAKE" = false ] && [ "$HAS_TEST" = false ] && [ "$HAS_YAML" = false ] && [ "$HAS_TEST_INFRA" = false ]; then
+            if [ "$HAS_WORKFLOW" = true ] || [ "$HAS_CI_SCRIPTS" = true ]; then
+              # CI workflow/action/script changes — can't determine scope from paths alone, run full CI
+              LABELS=""
+            elif [ "$HAS_GITHUB_META" = true ]; then
+              # Pure metadata (.claude/, .github/ templates, test/agentic/)
               LABELS="disable_all"
             fi
-          elif [ "$HAS_SRC" = false ] && [ "$HAS_CMAKE" = false ] && [ "$HAS_WORKFLOW" = false ] && [ "$HAS_YAML" = false ] && [ "$HAS_TEST" = true ]; then
+          elif [ "$HAS_SRC" = false ] && [ "$HAS_CMAKE" = false ] && [ "$HAS_WORKFLOW" = false ] && [ "$HAS_CI_SCRIPTS" = false ] && [ "$HAS_YAML" = false ] && [ "$HAS_TEST" = true ]; then
             # Test-only changes
             if [ "$ONLY_SKIP_EXPECT" = true ]; then
               LABELS="disable_all"
@@ -169,7 +180,7 @@ jobs:
                 LABELS="${LABELS},disable_win"
               fi
             fi
-          elif [ "$HAS_SRC" = true ] && [ "$HAS_CMAKE" = false ] && [ "$HAS_WORKFLOW" = false ] && [ "$HAS_YAML" = false ]; then
+          elif [ "$HAS_SRC" = true ] && [ "$HAS_CMAKE" = false ] && [ "$HAS_WORKFLOW" = false ] && [ "$HAS_CI_SCRIPTS" = false ] && [ "$HAS_YAML" = false ]; then
             # Source changes (possibly with tests)
             if [ "$HAS_XCCL" = true ]; then
               # xccl is distributed backend — must run distributed tests, Linux-only
@@ -178,10 +189,10 @@ jobs:
               LABELS="disable_e2e,disable_distributed"
             fi
           elif [ "$HAS_CMAKE" = true ] && [ "$HAS_SRC" = false ] && [ "$HAS_TEST" = false ] && [ "$HAS_YAML" = false ]; then
-            # Build system only
+            # Build system only (including src/*.cmake)
             LABELS="disable_e2e,disable_distributed"
           fi
-          # yaml/ changes or mixed → no labels (full CI)
+          # yaml/ changes, CI script changes, or mixed → no labels (full CI)
 
           echo "labels=${LABELS}" >> "$GITHUB_OUTPUT"
           echo "api_success=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -141,8 +141,8 @@ jobs:
             case "$file" in
               src/xccl/*) HAS_SRC=true; HAS_XCCL=true ;;
               src/*.cmake|src/CMakeLists.txt|src/Build*.cmake) HAS_CMAKE=true ;;
-              src/*|CMakeLists.txt) HAS_SRC=true ;;
-              cmake/*|tools/*) HAS_CMAKE=true ;;
+              src/*) HAS_SRC=true ;;
+              CMakeLists.txt|cmake/*|tools/*) HAS_CMAKE=true ;;
               test/agentic/*) HAS_GITHUB_META=true ;;
               test/xpu/xpu_test_utils.py|test/xpu/run_test_with_skip.py) HAS_TEST=true; HAS_TEST_INFRA=true; ONLY_SKIP_EXPECT=false ;;
               test/xpu/test_ops*.py|test/xpu/core/*|test/xpu/test_nn*.py) HAS_TEST=true; ONLY_SKIP_EXPECT=false; HAS_WIN_TEST=true ;;


### PR DESCRIPTION
## Summary

- Rename skill from `xpu-pr-auto-labeling` to `auto-label`
- Support fork repo PRs (remove same-repo restriction)
- Add `test/agentic/` to `disable_all` paths

## Changes

### Skill rename
`.claude/skills/xpu-pr-auto-labeling/` -> `.claude/skills/auto-label/`

All workflow references updated accordingly.

### Fork PR support
Removed `github.event.pull_request.head.repo.full_name == github.repository` from job condition. This is safe because the workflow:
- Checks out only the **base branch** skill file (not PR code)
- Reads file **names** via `gh pr diff --name-only` (API call, no code execution)
- File list is framed as untrusted data in the LLM prompt

### test/agentic path
`test/agentic/*` is matched before the general `test/*` pattern in the fallback case statement, so agentic skill test files are treated as metadata (-> `disable_all`) rather than functional tests.