### PR TITLE
Use c10d single collective backend names

### DIFF
--- a/src/xccl/ProcessGroupXCCL.cpp
+++ b/src/xccl/ProcessGroupXCCL.cpp
@@ -1685,7 +1685,7 @@ c10::intrusive_ptr<Work> ProcessGroupXCCL::allgather(
   }
 }
 
-c10::intrusive_ptr<Work> ProcessGroupXCCL::_allgather_base(
+c10::intrusive_ptr<Work> ProcessGroupXCCL::all_gather_single(
     at::Tensor& output_tensor,
     at::Tensor& input_tensor,
     const AllgatherOptions& opts) {
@@ -1736,7 +1736,7 @@ c10::intrusive_ptr<Work> ProcessGroupXCCL::_allgather_base(
       "xccl:_all_gather_base");
 }
 
-c10::intrusive_ptr<Work> ProcessGroupXCCL::allgather_into_tensor_coalesced(
+c10::intrusive_ptr<Work> ProcessGroupXCCL::all_gather_single_coalesced(
     std::vector<at::Tensor>& outputs,
     std::vector<at::Tensor>& inputs,
     const AllgatherOptions& opts) {
@@ -1867,7 +1867,7 @@ c10::intrusive_ptr<Work> ProcessGroupXCCL::reduce_scatter(
   }
 }
 
-c10::intrusive_ptr<Work> ProcessGroupXCCL::_reduce_scatter_base(
+c10::intrusive_ptr<Work> ProcessGroupXCCL::reduce_scatter_single(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     const ReduceScatterOptions& opts) {
@@ -1926,7 +1926,7 @@ c10::intrusive_ptr<Work> ProcessGroupXCCL::_reduce_scatter_base(
       "xccl:_reduce_scatter_base");
 }
 
-c10::intrusive_ptr<Work> ProcessGroupXCCL::reduce_scatter_tensor_coalesced(
+c10::intrusive_ptr<Work> ProcessGroupXCCL::reduce_scatter_single_coalesced(
     std::vector<at::Tensor>& outputs,
     std::vector<at::Tensor>& inputs,
     const ReduceScatterOptions& opts) {
@@ -2046,7 +2046,7 @@ c10::intrusive_ptr<Work> ProcessGroupXCCL::barrier(const BarrierOptions& opts) {
   return nullptr;
 }
 
-c10::intrusive_ptr<Work> ProcessGroupXCCL::alltoall_base(
+c10::intrusive_ptr<Work> ProcessGroupXCCL::all_to_all_single(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     std::vector<int64_t>& outputSplitSizes,

--- a/src/xccl/ProcessGroupXCCL.hpp
+++ b/src/xccl/ProcessGroupXCCL.hpp
@@ -406,12 +406,12 @@ class TORCH_API ProcessGroupXCCL : public Backend {
       std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
-  c10::intrusive_ptr<Work> _allgather_base(
+  c10::intrusive_ptr<Work> all_gather_single(
       at::Tensor& outputbuffer,
       at::Tensor& inputbuffer,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
-  c10::intrusive_ptr<Work> allgather_into_tensor_coalesced(
+  c10::intrusive_ptr<Work> all_gather_single_coalesced(
       std::vector<at::Tensor>& outputs,
       std::vector<at::Tensor>& inputs,
       const AllgatherOptions& opts = AllgatherOptions()) override;
@@ -421,12 +421,12 @@ class TORCH_API ProcessGroupXCCL : public Backend {
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  c10::intrusive_ptr<Work> _reduce_scatter_base(
+  c10::intrusive_ptr<Work> reduce_scatter_single(
       at::Tensor& outputTensor,
       at::Tensor& inputTensor,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  c10::intrusive_ptr<Work> reduce_scatter_tensor_coalesced(
+  c10::intrusive_ptr<Work> reduce_scatter_single_coalesced(
       std::vector<at::Tensor>& outputs,
       std::vector<at::Tensor>& inputs,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
@@ -434,7 +434,7 @@ class TORCH_API ProcessGroupXCCL : public Backend {
   c10::intrusive_ptr<Work> barrier(
       const BarrierOptions& opts = BarrierOptions()) override;
 
-  c10::intrusive_ptr<Work> alltoall_base(
+  c10::intrusive_ptr<Work> all_to_all_single(
       at::Tensor& outputTensor,
       at::Tensor& inputTensor,
       std::vector<int64_t>& outputSplitSizes,

--- a/src/xccl/Register.cpp
+++ b/src/xccl/Register.cpp
@@ -147,7 +147,7 @@ std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _allgather_base_XPU(
     int64_t timeout) {
   auto work =
       process_group->getBackend(c10::DeviceType::XPU)
-          ->_allgather_base(
+          ->all_gather_single(
               output_tensor,
               input_tensor,
               AllgatherOptions{std::chrono::milliseconds(timeout), asyncOp});
@@ -179,7 +179,7 @@ c10::intrusive_ptr<c10d::Work> allgather_into_tensor_coalesced_XPU(
   auto opts = AllgatherOptions{};
   opts.asyncOp = asyncOp;
   return process_group->getBackend(c10::DeviceType::XPU)
-      ->allgather_into_tensor_coalesced(output_vec, input_vec, opts);
+      ->all_gather_single_coalesced(output_vec, input_vec, opts);
 }
 
 std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> reduce_scatter_XPU(
@@ -211,7 +211,7 @@ std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _reduce_scatter_base_XPU(
     bool asyncOp,
     int64_t timeout) {
   auto work = process_group->getBackend(c10::DeviceType::XPU)
-                  ->_reduce_scatter_base(
+                  ->reduce_scatter_single(
                       output_tensor,
                       input_tensor,
                       ReduceScatterOptions{
@@ -231,7 +231,7 @@ c10::intrusive_ptr<c10d::Work> reduce_scatter_tensor_coalesced_XPU(
   auto output_vec = outputs.vec();
   auto input_vec = inputs.vec();
   return process_group->getBackend(c10::DeviceType::XPU)
-      ->reduce_scatter_tensor_coalesced(
+      ->reduce_scatter_single_coalesced(
           output_vec,
           input_vec,
           ReduceScatterOptions{
@@ -300,7 +300,7 @@ c10::intrusive_ptr<Work> alltoall_base_XPU(
     bool asyncOp,
     int64_t timeout) {
   return process_group->getBackend(c10::DeviceType::XPU)
-      ->alltoall_base(
+      ->all_to_all_single(
           output,
           input,
           output_split_sizes,


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/actions/runs/27445239982/job/81128773767?pr=187140

PyTorch added canonical c10d::Backend methods for single-tensor collectives and keeps the old names as deprecated forwarding aliases. torch-xpu-ops still called and overrode the old aliases in XCCL, which turns into -Werror=deprecated-declarations when PyTorch builds the bundled submodule. This migrates the XCCL registration call sites and ProcessGroupXCCL overrides to the new *_single names while leaving dispatcher op names and profiling strings unchanged for schema/log compatibility.

Test: none (build-only c10d C++ API migration; local XPU build unavailable because oneAPI compiler is not installed)