### PR TITLE
ci: enforce least-privilege token permissions across workflows

### DIFF
--- a/.claude/skills/pr-review/references/review-checklist.md
+++ b/.claude/skills/pr-review/references/review-checklist.md
@@ -188,7 +188,8 @@ When reviewing changes to workflows, build scripts, or CI configuration:
 - [ ] **Immutable artifact references** — Docker images use immutable tags; no overwriting of published artifacts
 - [ ] **No cache-dependent binaries in sensitive contexts** — sccache-backed builds are susceptible to cache corruption; these artifacts should not access sensitive info or be published for general use
 - [ ] **Workflow trigger scope** — `pull_request_target` workflows must not check out PR head code into a trusted context without proper isolation
-- [ ] **Token permissions minimized** — Workflow `permissions` block should request only what is needed (e.g., `contents: read` not `contents: write` unless required)
+- [ ] **Read-only top-level permissions** — Top-level `permissions` must be `read-all` or `contents: read`; all write permissions must be declared at the job level
+- [ ] **Job-level permissions scoped minimally** — Each job's `permissions` block requests only the specific write permissions that job actually needs
 - [ ] **Write permissions justified by GITHUB_TOKEN usage** — Every write permission declared must correspond to an actual API call using `GITHUB_TOKEN`; permissions needed only by PATs or other secrets should not be granted to the default token
 - [ ] **No arbitrary code execution from PR inputs** — PR title, body, branch name, and commit messages must not be interpolated into shell commands without sanitization
 - [ ] **Third-party action pinning** — Actions are pinned to a full commit SHA, not a mutable tag (e.g., `actions/checkout@<sha>` not `actions/checkout@v4`)

--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -17,8 +17,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 concurrency:
   group: auto-label-${{ github.event_name }}-${{ github.event.pull_request.number }}
@@ -30,6 +28,9 @@ jobs:
       ${{ github.repository_owner == 'intel'
       && !contains(github.event.pull_request.labels.*.name, 'disable_auto') }}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
     timeout-minutes: 5
     outputs:
       labels_changed: ${{ steps.apply-labels.outputs.labels_changed || 'false' }}

--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -260,6 +260,9 @@ jobs:
     needs: [auto-label]
     if: ${{ github.event_name == 'pull_request_target' && needs.auto-label.outputs.labels_changed == 'true' }}
     runs-on: ubuntu-24.04
+    # All API calls use MERGE_TOKEN PAT; no GITHUB_TOKEN write permissions needed.
+    permissions:
+      contents: read
     timeout-minutes: 5
     steps:
       - name: Cancel in-flight pull workflow and retrigger via draft toggle

--- a/.github/workflows/auto_merge_by_comment.yml
+++ b/.github/workflows/auto_merge_by_comment.yml
@@ -205,8 +205,8 @@ jobs:
             if (forceMerge) {
               const authorAssociation = context.payload.comment.author_association;
               if (!['OWNER', 'MEMBER'].includes(authorAssociation)) {
-                core.setOutput('result', 'denied');
-                core.setOutput('message', '⛔ Only maintainers (OWNER/MEMBER) can force merge. Please contact a maintainer.');
+                core.setOutput('merge_result', 'denied');
+                core.setOutput('merge_message', '⛔ Only maintainers (OWNER/MEMBER) can force merge. Please contact a maintainer.');
                 return;
               }
             }
@@ -218,19 +218,19 @@ jobs:
                 pull_number: prNumber,
                 merge_method: 'squash'
               });
-              core.setOutput('result', 'success');
-              core.setOutput('message', `✅ PR has been successfully merged by @${author}${forceMerge ? ' (force merge)' : ''}.`);
+              core.setOutput('merge_result', 'success');
+              core.setOutput('merge_message', `✅ PR has been successfully merged by @${author}${forceMerge ? ' (force merge)' : ''}.`);
             } catch (e) {
-              core.setOutput('result', 'failed');
-              core.setOutput('message', `❌ Failed to merge PR: ${e.message}`);
+              core.setOutput('merge_result', 'failed');
+              core.setOutput('merge_message', `❌ Failed to merge PR: ${e.message}`);
             }
 
       - name: Report Merge Result
-        if: always() && steps.merge.outputs.result
+        if: always() && steps.merge.outputs.merge_result
         uses: actions/github-script@v7
         env:
-          MERGE_RESULT: ${{ steps.merge.outputs.result }}
-          MERGE_MESSAGE: ${{ steps.merge.outputs.message }}
+          MERGE_RESULT: ${{ steps.merge.outputs.merge_result }}
+          MERGE_MESSAGE: ${{ steps.merge.outputs.merge_message }}
         with:
           script: |
             const prNumber = ${{ steps.prinfo.outputs.pr_number }};

--- a/.github/workflows/auto_merge_by_comment.yml
+++ b/.github/workflows/auto_merge_by_comment.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: read
-      issues: write
-      pull-requests: read
+      issues: write         # reactions + status comments via GITHUB_TOKEN
+      pull-requests: read   # pulls.get/listReviews; merge uses MERGE_TOKEN PAT
       statuses: read
     if: >-
       github.event.issue.pull_request

--- a/.github/workflows/auto_merge_by_comment.yml
+++ b/.github/workflows/auto_merge_by_comment.yml
@@ -5,14 +5,16 @@ on:
     types: [created]
 
 permissions:
-  checks: read
-  issues: write
-  pull-requests: write
-  statuses: read
+  contents: read
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      issues: write
+      pull-requests: read
+      statuses: read
     if: >-
       github.event.issue.pull_request
       && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)

--- a/.github/workflows/issue_operator.yml
+++ b/.github/workflows/issue_operator.yml
@@ -5,11 +5,13 @@ on:
     types: [opened, labeled]
 
 permissions:
-  issues: write
+  contents: read
 
 jobs:
   auto-milestone:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     # Only run when the 'skipped' label is present
     if: contains(github.event.issue.labels.*.name, 'skipped')
     steps:


### PR DESCRIPTION
## Summary

Move write permissions from top-level to job-level in three workflows to follow the <a href="https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions">OpenSSF Scorecard Token-Permissions</a> principle: top-level permissions should be read-only, write permissions scoped to individual jobs.

## Changes

### Workflow fixes

| Workflow | Issue | Fix |
|---|---|---|
| `auto_label.yml` | `pull-requests: write` + `issues: write` at top level | Move `pull-requests: write` to `auto-label` job; drop `issues: write` (unused by GITHUB_TOKEN); add explicit `contents: read` to `retrigger-pull` job with comment explaining it uses MERGE_TOKEN PAT |
| `auto_merge_by_comment.yml` | `pull-requests: write` + `issues: write` at top level | Move to job level with inline comments explaining each permission; downgrade `pull-requests` to `read` (merge uses MERGE_TOKEN PAT) |
| `issue_operator.yml` | `issues: write` at top level | Move to `auto-milestone` job level |

### Output rename in `auto_merge_by_comment.yml`

Rename merge step outputs from `result`/`message` to `merge_result`/`merge_message` to avoid potential collision with the `actions/github-script` built-in `result` output.

### PR review checklist update

Replace the single "Token permissions minimized" checklist item with two specific checks:
- **Read-only top-level permissions** -- top-level `permissions` must be `read-all` or `contents: read`
- **Job-level permissions scoped minimally** -- each job requests only the specific write permissions it needs