### PR TITLE
Remove -Werror flag from SYCL host flags to avoid warnings as errors

### DIFF
--- a/cmake/BuildFlags.cmake
+++ b/cmake/BuildFlags.cmake
@@ -54,7 +54,6 @@ macro(set_build_flags)
       list(APPEND SYCL_HOST_FLAGS -std=${CPP_STD})
       list(APPEND SYCL_HOST_FLAGS -Wunused-variable)
       list(APPEND SYCL_HOST_FLAGS -Wno-interference-size)
-      list(APPEND SYCL_HOST_FLAGS -Werror) # treat warnings as errors
       # Some versions of DPC++ compiler pass paths to SYCL headers as user include paths (`-I`) rather
       # than system paths (`-isystem`). This makes host compiler to report warnings encountered in the
       # SYCL headers, such as deprecated warnings, even if warned API is not actually used in the program.


### PR DESCRIPTION
This pull request makes a small adjustment to the build configuration by removing the `-Werror` flag from the SYCL host build flags. This change prevents compiler warnings from being treated as errors during the build process, which can improve build flexibility and reduce unnecessary build failures.

* Removed the `-Werror` flag from the `SYCL_HOST_FLAGS` in the `set_build_flags` macro in `cmake/BuildFlags.cmake`, so warnings will no longer cause build errors.