### PR TITLE
ci: fix reaction permission in auto merge workflow

### DIFF
--- a/.github/workflows/auto_merge_by_comment.yml
+++ b/.github/workflows/auto_merge_by_comment.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: read
-      issues: write         # reactions + status comments via GITHUB_TOKEN
+      issues: write         # status comments via GITHUB_TOKEN
       pull-requests: read   # pulls.get/listReviews; merge uses MERGE_TOKEN PAT
       statuses: read
     if: >-
@@ -23,6 +23,7 @@ jobs:
       - name: Acknowledge Command
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
           script: |
             await github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary

Fixes the auto merge workflow failing at the very first step due to a reaction permission error.

## Root Cause

The Acknowledge step creates a thumbs-up reaction on the `/merge` comment via `reactions.createForIssueComment`. This fails with `403: Resource not accessible by integration` (<a href="https://github.com/intel/torch-xpu-ops/actions/runs/27605775454/job/81617302689#step:2:18">log</a>).

The workflow declares `issues: write` and the API response header confirms `issues=write` is the accepted permission, yet the call is denied. This is an org-level restriction on the GITHUB_TOKEN that prevents reaction creation.

## Fix

Use `secrets.MERGE_TOKEN` (the same PAT already used by the Merge step) for the Acknowledge step's reaction API call. This token has sufficient permissions to create reactions, making the acknowledgment succeed without relying on org-level GITHUB_TOKEN permissions.

## Test Plan

Trigger `/merge` on a PR and verify the workflow proceeds past the Acknowledge step with the reaction successfully created.