### PR TITLE
ci: use MERGE_TOKEN for all write operations in auto merge workflow

### DIFF
--- a/.github/workflows/auto_merge_by_comment.yml
+++ b/.github/workflows/auto_merge_by_comment.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: read
-      issues: write         # reactions + status comments via GITHUB_TOKEN
-      pull-requests: read   # pulls.get/listReviews; merge uses MERGE_TOKEN PAT
+      issues: read
+      pull-requests: read
       statuses: read
     if: >-
       github.event.issue.pull_request
@@ -23,6 +23,7 @@ jobs:
       - name: Acknowledge Command
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
           script: |
             await github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,
@@ -50,6 +51,7 @@ jobs:
         uses: actions/github-script@v7
         id: reviews
         with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
           script: |
             const prNumber = ${{ steps.prinfo.outputs.pr_number }};
 
@@ -90,6 +92,7 @@ jobs:
         uses: actions/github-script@v7
         id: status
         with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
           script: |
             const prNumber = ${{ steps.prinfo.outputs.pr_number }};
             const sha = '${{ steps.prinfo.outputs.head_sha }}';
@@ -158,6 +161,7 @@ jobs:
         uses: actions/github-script@v7
         id: conflict
         with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
           script: |
             const prNumber = ${{ steps.prinfo.outputs.pr_number }};
             const mergeable = '${{ steps.prinfo.outputs.mergeable }}';
@@ -232,6 +236,7 @@ jobs:
           MERGE_RESULT: ${{ steps.merge.outputs.merge_result }}
           MERGE_MESSAGE: ${{ steps.merge.outputs.merge_message }}
         with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
           script: |
             const prNumber = ${{ steps.prinfo.outputs.pr_number }};
             const result = process.env.MERGE_RESULT;


### PR DESCRIPTION
## Summary

Follow-up to #4031. The org restricts GITHUB_TOKEN from **all** write operations, not just reactions. Every step that calls `issues.createComment` also fails with `403: Resource not accessible by integration`.

## Root Cause

Same org-level restriction as #4031, but affecting comment posting (not just reactions). The "Check Reviews" step failed when trying to post a "not enough approvals" comment ([log](https://github.com/intel/torch-xpu-ops/actions/runs/27671120314/job/81835475454#step:4:45)).

## Fix

- Use `secrets.MERGE_TOKEN` for all steps that perform write operations (reactions + comments)
- Downgrade GITHUB_TOKEN permissions to read-only since it is no longer used for writes

## Test Plan

Trigger `/merge` on a PR and verify all steps (reaction, review check comments, CI status comments, merge result comments) succeed.