### PR TITLE
ci: fix token usage in workflows and add Copilot API fallback for auto-label

### DIFF
--- a/.github/workflows/_linux_reproducer.yml
+++ b/.github/workflows/_linux_reproducer.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Comment on PR
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.MERGE_TOKEN }}
+          github-token: ${{ secrets.COPILOT_TOKEN }}
           script: |
             const fs = require('fs');
             const path = require('path');

--- a/.github/workflows/_linux_ut.yml
+++ b/.github/workflows/_linux_ut.yml
@@ -251,7 +251,7 @@ jobs:
               || github.event.pull_request.user.login == 'copilot[bot]') }}
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.MERGE_TOKEN }}
+          github-token: ${{ secrets.COPILOT_TOKEN }}
           script: |
             const fs = require('fs');
             const prNumber = context.issue.number;

--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -65,7 +65,7 @@ jobs:
           echo "Changed files:"
           echo "$FILES"
 
-      - name: Determine labels via GitHub Models
+      - name: Determine labels
         id: determine-labels
         env:
           GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
@@ -73,7 +73,7 @@ jobs:
         run: |
           SKILL_CONTENT=$(cat .claude/skills/auto-label/SKILL.md)
           FILES="$PR_FILES"
-          API_SUCCESS=false
+          LLM_SUCCESS=false
 
           # Build the prompt
           # NOTE: File list comes from PR contributors (including forks).
@@ -91,41 +91,62 @@ jobs:
 
           Respond with ONLY a comma-separated list of labels (e.g. 'disable_e2e,disable_distributed') or 'none' if no labels should be applied. No explanation."
 
-          # Call GitHub Models API
-          RESPONSE=$(gh api /models/chat/completions \
-            --method POST \
-            -f model="openai/gpt-4o-mini" \
-            -f "messages[][role]=user" \
-            -f "messages[][content]=${PROMPT}" \
-            --jq '.choices[0].message.content' 2>&1) && API_SUCCESS=true || {
-            echo "GitHub Models API failed, falling back to rule-based logic"
-          }
-
-          # Sanitize response - extract only valid label names (only labels used in pull.yml)
-          LABELS=""
-          if [ "$API_SUCCESS" = true ]; then
-            if [ "$RESPONSE" = "none" ] || echo "$RESPONSE" | grep -qiE '^\s*none\s*$'; then
-              # LLM explicitly said no labels needed — respect that, skip fallback
+          # Helper: parse LLM response into valid labels
+          parse_llm_response() {
+            local response="$1"
+            if [ "$response" = "none" ] || echo "$response" | grep -qiE '^\s*none\s*$'; then
               echo "LLM determined no labels needed (full CI)"
               echo "labels=" >> "$GITHUB_OUTPUT"
               echo "api_success=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            LABELS=$(echo "$RESPONSE" | tr -d ' \n' | grep -oE '(disable_all|disable_ut|disable_e2e|disable_distributed|disable_win|disable_build)(,(disable_all|disable_ut|disable_e2e|disable_distributed|disable_win|disable_build))*' || echo "")
-            if [ -n "$LABELS" ]; then
-              echo "LLM determined labels: $LABELS"
-              echo "labels=${LABELS}" >> "$GITHUB_OUTPUT"
+            local labels
+            labels=$(echo "$response" | tr -d ' \n' | grep -oE '(disable_all|disable_ut|disable_e2e|disable_distributed|disable_win|disable_build)(,(disable_all|disable_ut|disable_e2e|disable_distributed|disable_win|disable_build))*' || echo "")
+            if [ -n "$labels" ]; then
+              echo "LLM determined labels: $labels"
+              echo "labels=${labels}" >> "$GITHUB_OUTPUT"
               echo "api_success=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            # LLM returned something but no valid labels extracted — fall through to fallback
-            echo "LLM response could not be parsed: $RESPONSE"
+            echo "LLM response could not be parsed: $response"
+            return 1
+          }
+
+          # 1. Try Copilot API (uses GITHUB_TOKEN, no PAT needed)
+          echo "Trying Copilot API..."
+          RESPONSE=$(GH_TOKEN=${{ secrets.COPILOT_TOKEN }} gh api /copilot/chat/completions \
+            --method POST \
+            -f model="gpt-4o" \
+            -f "messages[][role]=user" \
+            -f "messages[][content]=${PROMPT}" \
+            --jq '.choices[0].message.content' 2>&1) && {
+            echo "Copilot API succeeded"
+            parse_llm_response "$RESPONSE" && LLM_SUCCESS=true
+          } || {
+            echo "Copilot API failed: $RESPONSE"
+          }
+
+          # 2. Try GitHub Models API (requires PAT)
+          if [ "$LLM_SUCCESS" = false ]; then
+            echo "Trying GitHub Models API..."
+            RESPONSE=$(gh api /models/chat/completions \
+              --method POST \
+              -f model="openai/gpt-4o-mini" \
+              -f "messages[][role]=user" \
+              -f "messages[][content]=${PROMPT}" \
+              --jq '.choices[0].message.content' 2>&1) && {
+              echo "GitHub Models API succeeded"
+              parse_llm_response "$RESPONSE" && LLM_SUCCESS=true
+            } || {
+              echo "GitHub Models API failed: $RESPONSE"
+            }
           fi
 
-          # Fallback: rule-based deterministic logic
-          echo "Using fallback rule-based logic..."
+          # 3. Fallback: rule-based deterministic logic
+          if [ "$LLM_SUCCESS" = false ]; then
+            echo "Using fallback rule-based logic..."
 
-          HAS_SRC=false
+            HAS_SRC=false
           HAS_XCCL=false
           HAS_CMAKE=false
           HAS_TEST=false
@@ -195,6 +216,7 @@ jobs:
           echo "labels=${LABELS}" >> "$GITHUB_OUTPUT"
           echo "api_success=false" >> "$GITHUB_OUTPUT"
           echo "Determined labels: ${LABELS:-none}"
+          fi
 
       - name: Apply labels
         if: >-

--- a/.github/workflows/auto_merge_by_comment.yml
+++ b/.github/workflows/auto_merge_by_comment.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: read
-      issues: write         # status comments via GITHUB_TOKEN
-      pull-requests: read   # pulls.get/listReviews; merge uses MERGE_TOKEN PAT
+      issues: read
+      pull-requests: read
       statuses: read
     if: >-
       github.event.issue.pull_request
@@ -51,6 +51,7 @@ jobs:
         uses: actions/github-script@v7
         id: reviews
         with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
           script: |
             const prNumber = ${{ steps.prinfo.outputs.pr_number }};
 
@@ -91,6 +92,7 @@ jobs:
         uses: actions/github-script@v7
         id: status
         with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
           script: |
             const prNumber = ${{ steps.prinfo.outputs.pr_number }};
             const sha = '${{ steps.prinfo.outputs.head_sha }}';
@@ -159,6 +161,7 @@ jobs:
         uses: actions/github-script@v7
         id: conflict
         with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
           script: |
             const prNumber = ${{ steps.prinfo.outputs.pr_number }};
             const mergeable = '${{ steps.prinfo.outputs.mergeable }}';
@@ -233,6 +236,7 @@ jobs:
           MERGE_RESULT: ${{ steps.merge.outputs.merge_result }}
           MERGE_MESSAGE: ${{ steps.merge.outputs.merge_message }}
         with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
           script: |
             const prNumber = ${{ steps.prinfo.outputs.pr_number }};
             const result = process.env.MERGE_RESULT;

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -64,7 +64,7 @@ jobs:
           && (contains(github.event.pull_request.labels.*.name, 'ai_generated')
               || github.event.pull_request.user.login == 'copilot[bot]') }}
         env:
-          GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
+          GH_TOKEN: ${{ secrets.COPILOT_TOKEN }}
         run: |
           FAILED_STEPS=""
           if [ "${{ steps.lint-python.outcome }}" = "failure" ]; then
@@ -108,7 +108,7 @@ jobs:
         if: ${{ contains(github.event.pull_request.labels.*.name, 'ai_generated') && github.event.pull_request.head.repo.full_name == github.repository }}
         id: reproducer-check
         env:
-          GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
+          GH_TOKEN: ${{ secrets.COPILOT_TOKEN }}
         run: |
           cd ./torch-xpu-ops
           FAIL_MSG=""


### PR DESCRIPTION
## Summary

Three changes to token usage and LLM provider strategy in workflows:

1. **Auto merge workflow**: Use `MERGE_TOKEN` for all write operations (comments, reactions). Follow-up to #4031 — the org restricts GITHUB_TOKEN from all writes, not just reactions (<a href="https://github.com/intel/torch-xpu-ops/actions/runs/27671120314/job/81835475454#step:4:45">failure log</a>).

2. **Copilot-related steps**: Switch from `MERGE_TOKEN` to `COPILOT_TOKEN` in steps that only run for `ai_generated` or `copilot[bot]` PRs. Better scopes token usage — `MERGE_TOKEN` for merge operations, `COPILOT_TOKEN` for copilot feedback comments.

3. **Auto-label workflow**: Add Copilot API (`/copilot/chat/completions`) as the primary LLM provider using `COPILOT_TOKEN`, with GitHub Models API as fallback. Refactors LLM response parsing into a reusable helper function.

## Files Changed

| File | Change |
|------|--------|
| `auto_merge_by_comment.yml` | Add `github-token: MERGE_TOKEN` to all write steps; downgrade GITHUB_TOKEN to read-only |
| `pull.yml` | `MERGE_TOKEN` → `COPILOT_TOKEN` for lint comment + reproducer check steps |
| `_linux_reproducer.yml` | `MERGE_TOKEN` → `COPILOT_TOKEN` for PR comment step |
| `_linux_ut.yml` | `MERGE_TOKEN` → `COPILOT_TOKEN` for new-failures comment step |
| `auto_label.yml` | Add Copilot API as primary LLM with GitHub Models fallback; refactor response parsing into helper function |

Supersedes #4033.

## Test Plan

- Trigger `/merge` on a PR to verify auto merge reactions/comments work
- Verify copilot-related comment steps still work on `ai_generated` PRs
- Verify auto-label workflow tries Copilot API first, falls back to GitHub Models, then rule-based logic