### PR TITLE
Remove the obsolete op dispatch _safe_softmax_xpu

### DIFF
--- a/src/ATen/native/xpu/SoftMax.cpp
+++ b/src/ATen/native/xpu/SoftMax.cpp
@@ -99,17 +99,6 @@ TORCH_IMPL_FUNC(log_softmax_xpu_out)
   xpu::_log_softmax_kernel(input, dim, half_to_float, output);
 }
 
-Tensor _safe_softmax_xpu(
-    const Tensor& self,
-    int64_t dim,
-    std::optional<ScalarType> dtype) {
-  // TODO: uncomment after XPU softmax support half_to_float=true
-  // if (self.scalar_type() == ScalarType::Half && dtype == ScalarType::Float)
-  //   return xpu::_safe_softmax_kernel(self, dim_, true);
-  Tensor converted = dtype.has_value() ? self.toType(dtype.value()) : self;
-  return xpu::_safe_softmax_kernel(converted, dim, false);
-}
-
 Tensor masked_softmax_xpu(
     const Tensor& input_,
     const Tensor& mask_,

--- a/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
+++ b/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
@@ -2275,29 +2275,6 @@ void _log_softmax_backward_kernel(
       grad.contiguous(), output.contiguous(), dim, half_to_float, grad_input);
 }
 
-Tensor _safe_softmax_kernel(
-    const Tensor& self,
-    int64_t dim,
-    const bool half_to_float) {
-  auto output_options =
-      self.options().memory_format(LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  if (half_to_float) {
-    output_options = output_options.dtype(ScalarType::Float);
-  }
-  Tensor output = at::empty_like(self, output_options);
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      ScalarType::Half,
-      ScalarType::BFloat16,
-      self.scalar_type(),
-      "_safe_softmax",
-      [&] {
-        host_softmax<false, true>(
-            self.contiguous(), dim, half_to_float, output);
-      });
-
-  return output;
-}
-
 Tensor masked_softmax_kernel(
     const Tensor& input_,
     const Tensor& mask_,

--- a/src/ATen/native/xpu/sycl/SoftMaxKernels.h
+++ b/src/ATen/native/xpu/sycl/SoftMaxKernels.h
@@ -42,9 +42,6 @@ TORCH_XPU_API void _log_softmax_backward_kernel(
     bool half_to_float,
     const Tensor& grad_input);
 
-TORCH_XPU_API Tensor
-_safe_softmax_kernel(const Tensor& self, int64_t dim, const bool half_to_float);
-
 TORCH_XPU_API Tensor masked_softmax_kernel(
     const Tensor& input_,
     const Tensor& mask_,


### PR DESCRIPTION
# Motivation
After https://github.com/pytorch/pytorch/pull/181233 and https://github.com/intel/torch-xpu-ops/pull/3970 landed, we could entirely obsolete op dispatch `_safe_softmax_xpu`. See https://github.com/pytorch/pytorch/blob/7d287fc446e5b99bca5d1d6de467ce5897a223fc/aten/src/ATen/native/native_functions.yaml#L15168-L15171, `_safe_softmax` doesn't need XPU dispatch now.
```yaml
- func: _safe_softmax(Tensor self, int dim, ScalarType? dtype=None) -> Tensor
  dispatch:
    CompositeExplicitAutograd: _safe_softmax
    NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA, NestedTensorXPU: _safe_softmax
```