### PR TITLE
Align `test_unflatten_invalid_arg` test case from `test_nn_xpu.py` with upstream.

### DIFF
--- a/test/xpu/test_nn_xpu.py
+++ b/test/xpu/test_nn_xpu.py
@@ -9612,34 +9612,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""",
         ):
             nn.Unflatten(dim=1, unflattened_size=(2, 5, 5.0))
 
-        # Wrong type for unflattened_size (list of lists and list of tuples)
-        for us in ([["C", 2], ["W", 5], ["H", 5]], [("C", 2), ("W", 5), ("H", 5)]):
-            with self.assertRaisesRegex(
-                TypeError,
-                r"unflattened_size must be a tuple of tuples, but found type list",
-            ):
-                nn.Unflatten(dim="features", unflattened_size=us)
-
-        # Wrong type for unflattened_size (tuple of lists)
-
-        with self.assertRaisesRegex(
-            TypeError,
-            r"unflattened_size must be tuple of tuples, but found element of type list at pos 0",
-        ):
-            nn.Unflatten(
-                dim="features", unflattened_size=(["C", 2], ["W", 5], ["H", 5])
-            )
-
-        # Wrong type for unflattened_size (tuple of dicts)
-
-        with self.assertRaisesRegex(
-            TypeError,
-            r"unflattened_size must be tuple of tuples, but found element of type dict at pos 0",
-        ):
-            nn.Unflatten(
-                dim="features", unflattened_size=({"C": 2}, {"W": 5}, {"H": 5})
-            )
-
     def test_layer_norm_grads_with_create_graph_flag(self):
         atol = 1e-5
         rtol = 1e-3


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/4039

The upstream test case `test_unflatten_invalid_arg` was changed in the https://github.com/pytorch/pytorch/commit/00512145ec41f7421b339c5a6799707fbde4e94d
This PR simply aligns our torch-xpu-ops local copy with the upstream version.