### PR TITLE
Replace local min/max pool helpers with sycl::min/sycl::max

### DIFF
--- a/src/ATen/native/xpu/sycl/AveragePool2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/AveragePool2dKernels.cpp
@@ -27,14 +27,6 @@
 namespace at::native {
 namespace xpu {
 
-inline int min(int a, int b) {
-  return a <= b ? a : b;
-}
-
-inline int max(int a, int b) {
-  return a >= b ? a : b;
-}
-
 template <typename scalar_t, typename accscalar_t, typename index_t>
 struct AvgPool2dKernelFunctor {
   void operator()(sycl::nd_item<1> item) const {
@@ -46,13 +38,15 @@ struct AvgPool2dKernelFunctor {
 
       int hstart = ph * stride_h_ - pad_h_;
       int wstart = pw * stride_w_ - pad_w_;
-      int hend = min(hstart + kernel_h_, height_ + pad_h_);
-      int wend = min(wstart + kernel_w_, width_ + pad_w_);
+      int hend =
+          sycl::min(hstart + kernel_h_, static_cast<int>(height_ + pad_h_));
+      int wend =
+          sycl::min(wstart + kernel_w_, static_cast<int>(width_ + pad_w_));
       const int pool_size = (hend - hstart) * (wend - wstart);
-      hstart = max(hstart, 0);
-      wstart = max(wstart, 0);
-      hend = min(hend, height_);
-      wend = min(wend, width_);
+      hstart = sycl::max(hstart, 0);
+      wstart = sycl::max(wstart, 0);
+      hend = sycl::min(hend, static_cast<int>(height_));
+      wend = sycl::min(wend, static_cast<int>(width_));
 
       if (hstart >= hend || wstart >= wend) {
         top_data_[index] = scalar_t(0);
@@ -147,13 +141,15 @@ struct AvgPool2dChannelsLastKernelFunctor {
       const int n = index / channels_ / pooled_width_ / pooled_height_;
       int hstart = ph * stride_h_ - pad_h_;
       int wstart = pw * stride_w_ - pad_w_;
-      int hend = min(hstart + kernel_h_, height_ + pad_h_);
-      int wend = min(wstart + kernel_w_, width_ + pad_w_);
+      int hend =
+          sycl::min(hstart + kernel_h_, static_cast<int>(height_ + pad_h_));
+      int wend =
+          sycl::min(wstart + kernel_w_, static_cast<int>(width_ + pad_w_));
       const int pool_size = (hend - hstart) * (wend - wstart);
-      hstart = max(hstart, 0);
-      wstart = max(wstart, 0);
-      hend = min(hend, height_);
-      wend = min(wend, width_);
+      hstart = sycl::max(hstart, 0);
+      wstart = sycl::max(wstart, 0);
+      hend = sycl::min(hend, static_cast<int>(height_));
+      wend = sycl::min(wend, static_cast<int>(width_));
 
       if (hstart >= hend || wstart >= wend) {
         top_data_[index] = scalar_t(0);
@@ -342,9 +338,9 @@ struct AvgPool2dChannelsLastBackwardKernelFunctor {
       const int h = (index / channels_ / width_) % height_ + pad_h_;
       const int n = index / channels_ / width_ / height_;
       const int phstart = (h < kernel_h_) ? 0 : (h - kernel_h_) / stride_h_ + 1;
-      const int phend = min(h / stride_h_ + 1, pooled_height_);
+      const int phend = sycl::min(h / stride_h_ + 1, pooled_height_);
       const int pwstart = (w < kernel_w_) ? 0 : (w - kernel_w_) / stride_w_ + 1;
-      const int pwend = min(w / stride_w_ + 1, pooled_width_);
+      const int pwend = sycl::min(w / stride_w_ + 1, pooled_width_);
       accscalar_t gradient = accscalar_t(0);
       const scalar_t* const top_slice =
           top_data_ + n * channels_ * pooled_height_ * pooled_width_ + c;
@@ -353,13 +349,15 @@ struct AvgPool2dChannelsLastBackwardKernelFunctor {
           // figure out the pooling size
           int hstart = ph * stride_h_ - pad_h_;
           int wstart = pw * stride_w_ - pad_w_;
-          int hend = min(hstart + kernel_h_, height_ + pad_h_);
-          int wend = min(wstart + kernel_w_, width_ + pad_w_);
+          int hend =
+              sycl::min(hstart + kernel_h_, static_cast<int>(height_ + pad_h_));
+          int wend =
+              sycl::min(wstart + kernel_w_, static_cast<int>(width_ + pad_w_));
           int pool_size = (hend - hstart) * (wend - wstart);
-          hstart = max(hstart, 0);
-          wstart = max(wstart, 0);
-          hend = min(hend, height_);
-          wend = min(wend, width_);
+          hstart = sycl::max(hstart, 0);
+          wstart = sycl::max(wstart, 0);
+          hend = sycl::min(hend, static_cast<int>(height_));
+          wend = sycl::min(wend, static_cast<int>(width_));
           if (hstart >= hend || wstart >= wend) {
             continue;
           }
@@ -447,9 +445,9 @@ struct AvgPool2dBackwarKernelFunctor {
       const int c = (index / width_ / height_) % channels_;
       const int n = index / width_ / height_ / channels_;
       const int phstart = (h < kernel_h_) ? 0 : (h - kernel_h_) / stride_h_ + 1;
-      const int phend = min(h / stride_h_ + 1, pooled_height_);
+      const int phend = sycl::min(h / stride_h_ + 1, pooled_height_);
       const int pwstart = (w < kernel_w_) ? 0 : (w - kernel_w_) / stride_w_ + 1;
-      const int pwend = min(w / stride_w_ + 1, pooled_width_);
+      const int pwend = sycl::min(w / stride_w_ + 1, pooled_width_);
       accscalar_t gradient = accscalar_t(0);
       const scalar_t* const top_data_slice =
           top_data_ + (n * channels_ + c) * pooled_height_ * pooled_width_;
@@ -458,13 +456,15 @@ struct AvgPool2dBackwarKernelFunctor {
           // figure out the pooling size
           int hstart = ph * stride_h_ - pad_h_;
           int wstart = pw * stride_w_ - pad_w_;
-          int hend = min(hstart + kernel_h_, height_ + pad_h_);
-          int wend = min(wstart + kernel_w_, width_ + pad_w_);
+          int hend =
+              sycl::min(hstart + kernel_h_, static_cast<int>(height_ + pad_h_));
+          int wend =
+              sycl::min(wstart + kernel_w_, static_cast<int>(width_ + pad_w_));
           int pool_size = (hend - hstart) * (wend - wstart);
-          hstart = max(hstart, 0);
-          wstart = max(wstart, 0);
-          hend = min(hend, height_);
-          wend = min(wend, width_);
+          hstart = sycl::max(hstart, 0);
+          wstart = sycl::max(wstart, 0);
+          hend = sycl::min(hend, static_cast<int>(height_));
+          wend = sycl::min(wend, static_cast<int>(width_));
           if (hstart >= hend || wstart >= wend) {
             continue;
           }

--- a/src/ATen/native/xpu/sycl/AveragePool3dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/AveragePool3dKernels.cpp
@@ -30,14 +30,6 @@ DISABLE_RETURN_TYPE_WARNING_BEGIN
 
 namespace at::native::xpu {
 
-inline int min(int a, int b) {
-  return a <= b ? a : b;
-}
-
-inline int max(int a, int b) {
-  return a >= b ? a : b;
-}
-
 template <typename scalar_t, typename accscalar_t, typename index_t>
 struct AvgPool3dKernelFunctor {
   void operator()(sycl::nd_item<3> item) const {
@@ -52,17 +44,20 @@ struct AvgPool3dKernelFunctor {
       index_t tstart = oFrame * dT_ - padT_;
       index_t hstart = oRow * dH_ - padH_;
       index_t wstart = oCol * dW_ - padW_;
-      index_t tend = min(tstart + kT_, input_.size(1) + padT_);
-      index_t hend = min(hstart + kH_, input_.size(2) + padH_);
-      index_t wend = min(wstart + kW_, input_.size(3) + padW_);
+      index_t tend =
+          sycl::min(tstart + kT_, static_cast<index_t>(input_.size(1) + padT_));
+      index_t hend =
+          sycl::min(hstart + kH_, static_cast<index_t>(input_.size(2) + padH_));
+      index_t wend =
+          sycl::min(wstart + kW_, static_cast<index_t>(input_.size(3) + padW_));
       index_t pool_size = (tend - tstart) * (hend - hstart) * (wend - wstart);
 
-      tstart = max(tstart, 0);
-      hstart = max(hstart, 0);
-      wstart = max(wstart, 0);
-      tend = min(tend, input_.size(1));
-      hend = min(hend, input_.size(2));
-      wend = min(wend, input_.size(3));
+      tstart = sycl::max(tstart, index_t(0));
+      hstart = sycl::max(hstart, index_t(0));
+      wstart = sycl::max(wstart, index_t(0));
+      tend = sycl::min(tend, static_cast<index_t>(input_.size(1)));
+      hend = sycl::min(hend, static_cast<index_t>(input_.size(2)));
+      wend = sycl::min(wend, static_cast<index_t>(input_.size(3)));
 
       if (tstart >= tend || hstart >= hend || wstart >= wend) {
         out_data[slice][oFrame][oRow][oCol] = static_cast<scalar_t>(0.0);
@@ -321,19 +316,21 @@ struct AvgPool3dBackwardStride1KernelFunctor {
     auto grad_input_data = grad_input_;
     if (iRow < grad_input_.size(2) && iCol < grad_input_.size(3)) {
       accscalar_t sum = 0.0;
-      const scalar_t* gOut = &grad_output_[slice][max(0, iFrame - kT_ + 1)][max(
-          0, iRow - kH_ + 1)][max(0, iCol - kW_ + 1)];
+      const scalar_t* gOut =
+          &grad_output_[slice][sycl::max(index_t(0), iFrame - kT_ + 1)]
+                       [sycl::max(index_t(0), iRow - kH_ + 1)]
+                       [sycl::max(index_t(0), iCol - kW_ + 1)];
       index_t frameOffset = 0;
-      for (index_t oFrame = max(0, iFrame - kT_ + 1);
-           oFrame < min(iFrame + 1, grad_output_.size(1));
+      for (index_t oFrame = sycl::max(index_t(0), iFrame - kT_ + 1); oFrame <
+           sycl::min(iFrame + 1, static_cast<index_t>(grad_output_.size(1)));
            ++oFrame) {
         index_t rowOffset = frameOffset;
-        for (index_t oRow = max(0, iRow - kH_ + 1);
-             oRow < min(iRow + 1, grad_output_.size(2));
+        for (index_t oRow = sycl::max(index_t(0), iRow - kH_ + 1); oRow <
+             sycl::min(iRow + 1, static_cast<index_t>(grad_output_.size(2)));
              ++oRow) {
           index_t colOffset = rowOffset;
-          for (index_t oCol = max(0, iCol - kW_ + 1);
-               oCol < min(iCol + 1, grad_output_.size(3));
+          for (index_t oCol = sycl::max(index_t(0), iCol - kW_ + 1); oCol <
+               sycl::min(iCol + 1, static_cast<index_t>(grad_output_.size(3)));
                ++oCol) {
             sum += gOut[colOffset];
             ++colOffset;
@@ -422,16 +419,19 @@ struct AvgPool3dBackwardAtomicKernelFunctor {
       index_t tstart = oFrame * dT_ - padT_;
       index_t hstart = oRow * dH_ - padH_;
       index_t wstart = oCol * dW_ - padW_;
-      index_t tend = min(tstart + kT_, grad_input_.size(1) + padT_);
-      index_t hend = min(hstart + kH_, grad_input_.size(2) + padH_);
-      index_t wend = min(wstart + kW_, grad_input_.size(3) + padW_);
+      index_t tend = sycl::min(
+          tstart + kT_, static_cast<index_t>(grad_input_.size(1) + padT_));
+      index_t hend = sycl::min(
+          hstart + kH_, static_cast<index_t>(grad_input_.size(2) + padH_));
+      index_t wend = sycl::min(
+          wstart + kW_, static_cast<index_t>(grad_input_.size(3) + padW_));
       index_t pool_size = (tend - tstart) * (hend - hstart) * (wend - wstart);
-      tstart = max(tstart, 0);
-      hstart = max(hstart, 0);
-      wstart = max(wstart, 0);
-      tend = min(tend, grad_input_.size(1));
-      hend = min(hend, grad_input_.size(2));
-      wend = min(wend, grad_input_.size(3));
+      tstart = sycl::max(tstart, index_t(0));
+      hstart = sycl::max(hstart, index_t(0));
+      wstart = sycl::max(wstart, index_t(0));
+      tend = sycl::min(tend, static_cast<index_t>(grad_input_.size(1)));
+      hend = sycl::min(hend, static_cast<index_t>(grad_input_.size(2)));
+      wend = sycl::min(wend, static_cast<index_t>(grad_input_.size(3)));
 
       accscalar_t divide_factor;
       if (divisor_override_) {
@@ -581,16 +581,19 @@ struct AvgPool3dBackwardKernelFunctor {
       index_t tstart = oFrame * dT_ - padT_;
       index_t hstart = oRow * dH_ - padH_;
       index_t wstart = oCol * dW_ - padW_;
-      index_t tend = min(tstart + kT_, grad_input_.size(1) + padT_);
-      index_t hend = min(hstart + kH_, grad_input_.size(2) + padH_);
-      index_t wend = min(wstart + kW_, grad_input_.size(3) + padW_);
+      index_t tend = sycl::min(
+          tstart + kT_, static_cast<index_t>(grad_input_.size(1) + padT_));
+      index_t hend = sycl::min(
+          hstart + kH_, static_cast<index_t>(grad_input_.size(2) + padH_));
+      index_t wend = sycl::min(
+          wstart + kW_, static_cast<index_t>(grad_input_.size(3) + padW_));
       index_t pool_size = (tend - tstart) * (hend - hstart) * (wend - wstart);
-      tstart = max(tstart, 0);
-      hstart = max(hstart, 0);
-      wstart = max(wstart, 0);
-      tend = min(tend, grad_input_.size(1));
-      hend = min(hend, grad_input_.size(2));
-      wend = min(wend, grad_input_.size(3));
+      tstart = sycl::max(tstart, index_t(0));
+      hstart = sycl::max(hstart, index_t(0));
+      wstart = sycl::max(wstart, index_t(0));
+      tend = sycl::min(tend, static_cast<index_t>(grad_input_.size(1)));
+      hend = sycl::min(hend, static_cast<index_t>(grad_input_.size(2)));
+      wend = sycl::min(wend, static_cast<index_t>(grad_input_.size(3)));
 
       accscalar_t divide_factor;
       if (divisor_override_) {

--- a/src/ATen/native/xpu/sycl/ReplicationPaddingKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ReplicationPaddingKernels.cpp
@@ -26,23 +26,17 @@ DISABLE_RETURN_TYPE_WARNING_BEGIN
 
 namespace at::native::xpu {
 
-inline int imin(int a, int b) {
-  return a > b ? b : a;
-}
-inline int imax(int a, int b) {
-  return a > b ? a : b;
-}
-
 template <typename input_scalar_t, typename output_scalar_t, typename F>
 struct ParallelReplicationPad1dKernelFunctor {
   void operator()(sycl::nd_item<3> item) const {
     auto output_id = item.get_global_id(2);
     if (output_id < output_plane_size_) {
       int64_t output_x = output_id % output_.size(2);
-      int64_t i_start_x = imax(0, -pad_left_);
-      int64_t o_start_x = imax(0, pad_left_);
+      int64_t i_start_x = sycl::max(int64_t(0), -pad_left_);
+      int64_t o_start_x = sycl::max(int64_t(0), pad_left_);
       int64_t input_x =
-          imin(imax(pad_left_, output_x), input_.size(2) + pad_left_ - 1) -
+          sycl::min(
+              sycl::max(pad_left_, output_x), input_.size(2) + pad_left_ - 1) -
           o_start_x + i_start_x;
 
       f_(input_,
@@ -162,17 +156,19 @@ struct ParallelReplicationPad2dKernelFunctor {
       const int output_x = output_id / output_.size(3); // height
       const int output_y = output_id % output_.size(3); // width
 
-      const int iStartX = imax(0, -padT_);
-      const int iStartY = imax(0, -padL_);
-      const int oStartX = imax(0, padT_);
-      const int oStartY = imax(0, padL_);
+      const int iStartX = sycl::max(0, static_cast<int>(-padT_));
+      const int iStartY = sycl::max(0, static_cast<int>(-padL_));
+      const int oStartX = sycl::max(0, static_cast<int>(padT_));
+      const int oStartY = sycl::max(0, static_cast<int>(padL_));
 
-      const int input_x =
-          imin(imax(padT_, output_x), input_.size(2) + padT_ - 1) - oStartX +
-          iStartX;
-      const int input_y =
-          imin(imax(padL_, output_y), input_.size(3) + padL_ - 1) - oStartY +
-          iStartY;
+      const int input_x = sycl::min(
+                              sycl::max(static_cast<int>(padT_), output_x),
+                              static_cast<int>(input_.size(2) + padT_ - 1)) -
+          oStartX + iStartX;
+      const int input_y = sycl::min(
+                              sycl::max(static_cast<int>(padL_), output_y),
+                              static_cast<int>(input_.size(3) + padL_ - 1)) -
+          oStartY + iStartY;
 
       f_(input_, output_, batch, plane, input_x, input_y, output_x, output_y);
     }
@@ -281,21 +277,24 @@ struct ParallelReplicationPad3dKernelFunctor {
       int64_t output_y = (output_id / output_.size(4)) % output_.size(3);
       int64_t output_z = output_id / (output_.size(3) * output_.size(4));
 
-      int64_t i_start_x = imax(0, -pad_left_);
-      int64_t i_start_y = imax(0, -pad_top_);
-      int64_t i_start_z = imax(0, -pad_front_);
-      int64_t o_start_x = imax(0, pad_left_);
-      int64_t o_start_y = imax(0, pad_top_);
-      int64_t o_start_z = imax(0, pad_front_);
+      int64_t i_start_x = sycl::max(int64_t(0), -pad_left_);
+      int64_t i_start_y = sycl::max(int64_t(0), -pad_top_);
+      int64_t i_start_z = sycl::max(int64_t(0), -pad_front_);
+      int64_t o_start_x = sycl::max(int64_t(0), pad_left_);
+      int64_t o_start_y = sycl::max(int64_t(0), pad_top_);
+      int64_t o_start_z = sycl::max(int64_t(0), pad_front_);
 
       int64_t input_x =
-          imin(imax(pad_left_, output_x), input_.size(4) + pad_left_ - 1) -
+          sycl::min(
+              sycl::max(pad_left_, output_x), input_.size(4) + pad_left_ - 1) -
           o_start_x + i_start_x;
       int64_t input_y =
-          imin(imax(pad_top_, output_y), input_.size(3) + pad_top_ - 1) -
+          sycl::min(
+              sycl::max(pad_top_, output_y), input_.size(3) + pad_top_ - 1) -
           o_start_y + i_start_y;
-      int64_t input_z =
-          imin(imax(pad_front_, output_z), input_.size(2) + pad_front_ - 1) -
+      int64_t input_z = sycl::min(
+                            sycl::max(pad_front_, output_z),
+                            input_.size(2) + pad_front_ - 1) -
           o_start_z + i_start_z;
 
       f_(input_,


### PR DESCRIPTION
AveragePool2dKernels, AveragePool3dKernels, and ReplicationPaddingKernels each defined file-local `int` `min`/`max` (`imin`/`imax`) helpers. Replace them with `sycl::min`/`sycl::max`, the SYCL device convention, matching the cleanup direction of recent commits that removed local arithmetic-helper clones (#3943, #3944).

`sycl::min`/`sycl::max` don't coerce arguments, so operands are explicitly cast to a common type — the destination variable's type (`int` / `index_t` / `int64_t`). This matches the old `int` helpers' results for all real inputs.



Authored with an AI assistant.
