### PR TITLE
Fix GitHub Models API endpoint URL in auto-label workflow

### DIFF
--- a/.claude/skills/auto-label/SKILL.md
+++ b/.claude/skills/auto-label/SKILL.md
@@ -49,6 +49,7 @@ Rules are evaluated top-to-bottom; use the FIRST matching rule set.
 - If modifying `_linux_e2e.yml` or e2e-related actions/scripts → keep linux-e2e running: `disable_ut,disable_distributed,disable_win`
 - If modifying `_windows_*.yml` → keep windows jobs running, add `windows_ci`: `disable_ut,disable_e2e,disable_distributed`
 - If modifying `pull.yml` only (trigger/condition/concurrency changes) → `disable_all`
+- If modifying only non-functional workflows (`auto_label.yml`, `auto_merge_by_comment.yml`, `issue_operator.yml`) → `disable_all`
 - If modifying MULTIPLE workflow areas or unclear scope → run full CI: `none`
 
 **Additional:** If no `src/`, `cmake/`, `CMakeLists.txt` files changed, add `disable_build`.

--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -69,6 +69,7 @@ jobs:
         id: determine-labels
         env:
           GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
+          MODELS_TOKEN: ${{ secrets.MODELS_TOKEN }}
           PR_FILES: ${{ steps.changed-files.outputs.files }}
         run: |
           SKILL_CONTENT=$(cat .claude/skills/auto-label/SKILL.md)
@@ -112,37 +113,22 @@ jobs:
             return 1
           }
 
-          # 1. Try Copilot API (uses GITHUB_TOKEN, no PAT needed)
-          echo "Trying Copilot API..."
-          RESPONSE=$(GH_TOKEN=${{ secrets.COPILOT_TOKEN }} gh api /copilot/chat/completions \
-            --method POST \
-            -f model="gpt-4o" \
-            -f "messages[][role]=user" \
-            -f "messages[][content]=${PROMPT}" \
-            --jq '.choices[0].message.content' 2>&1) && {
-            echo "Copilot API succeeded"
+          # Try GitHub Models API (requires PAT with models scope)
+          echo "Trying GitHub Models API..."
+          RESPONSE=$(curl -sf --max-time 30 \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $MODELS_TOKEN" \
+            -d "$(jq -nc --arg model "openai/gpt-4o-mini" --arg content "$PROMPT" \
+              '{model: $model, messages: [{role: "user", content: $content}]}')" \
+            "https://models.github.ai/inference/chat/completions" | \
+            jq -r '.choices[0].message.content' 2>/dev/null) && {
+            echo "GitHub Models API succeeded"
             parse_llm_response "$RESPONSE" && LLM_SUCCESS=true
           } || {
-            echo "Copilot API failed: $RESPONSE"
+            echo "GitHub Models API failed: $RESPONSE"
           }
 
-          # 2. Try GitHub Models API (requires PAT)
-          if [ "$LLM_SUCCESS" = false ]; then
-            echo "Trying GitHub Models API..."
-            RESPONSE=$(gh api /models/chat/completions \
-              --method POST \
-              -f model="openai/gpt-4o-mini" \
-              -f "messages[][role]=user" \
-              -f "messages[][content]=${PROMPT}" \
-              --jq '.choices[0].message.content' 2>&1) && {
-              echo "GitHub Models API succeeded"
-              parse_llm_response "$RESPONSE" && LLM_SUCCESS=true
-            } || {
-              echo "GitHub Models API failed: $RESPONSE"
-            }
-          fi
-
-          # 3. Fallback: rule-based deterministic logic
+          # Fallback: rule-based deterministic logic
           if [ "$LLM_SUCCESS" = false ]; then
             echo "Using fallback rule-based logic..."
 
@@ -172,6 +158,7 @@ jobs:
                   test/xpu/skip_list_common.py|test/xpu/expect/*|test/xpu/test_decomp_xpu.py|test/xpu/extended/skip_list_*.py) ;;
                   *) ONLY_SKIP_EXPECT=false ;;
                 esac ;;
+              .github/workflows/auto_label.yml|.github/workflows/auto_merge_by_comment.yml|.github/workflows/issue_operator.yml) HAS_GITHUB_META=true ;;
               .github/workflows/*) HAS_WORKFLOW=true ;;
               .github/actions/*|.github/scripts/*) HAS_CI_SCRIPTS=true ;;
               .github/*) HAS_GITHUB_META=true ;;


### PR DESCRIPTION
## Summary
- Fixes #4080 GitHub Models API endpoint: use `https://models.github.ai/inference/chat/completions` via `curl` (the old `gh api /models/chat/completions` hit a non-existent `api.github.com` route)
- Remove Copilot API path (endpoint does not exist)
- Add `MODELS_TOKEN` repo secret for authentication
- Classify non-functional workflows (`auto_label.yml`, `auto_merge_by_comment.yml`, `issue_operator.yml`) as metadata so they get `disable_all`

## Changes

| File | Change |
|------|--------|
| `.github/workflows/auto_label.yml` | Replace `gh api` + Copilot fallback with single `curl` call to `models.github.ai`; classify non-functional workflows as metadata in rule-based fallback |
| `.claude/skills/auto-label/SKILL.md` | Add rule: non-functional workflow changes → `disable_all` |

## Root Cause
1. `gh api /models/chat/completions` → `api.github.com/models/chat/completions` (404, endpoint does not exist)
2. `gh api /copilot/chat/completions` → same issue (404)
3. `gh api --hostname models.github.ai` → adds `/api/v3/` prefix (designed for GHES only)

The correct endpoint is `https://models.github.ai/inference/chat/completions`, accessible only via direct HTTP calls.

## Test
Verified on PR re-run:
```
Trying GitHub Models API...
GitHub Models API succeeded
LLM determined labels: disable_all
```