### PR TITLE
Set clang-format Standard to c++20

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -99,7 +99,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        c++17
+Standard:        c++20
 StatementMacros:
   - C10_DEFINE_bool
   - C10_DEFINE_int


### PR DESCRIPTION
The build is C++20 but .clang-format was still c++17, so clang-format mangled C++20 requires-clauses onto the declaration line. No-op for committed code.

