### PR TITLE
[DO NOT MERGE] Add XPUPatchForImportMinimal context manager

### DIFF
--- a/test/xpu/export/test_export_training_ir_to_run_decomp_xpu.py
+++ b/test/xpu/export/test_export_training_ir_to_run_decomp_xpu.py
@@ -19,9 +19,9 @@ torch_xpu_ops_path = Path(__file__).resolve().parents[1]
 if str(torch_xpu_ops_path) not in sys.path:
     sys.path.insert(0, str(torch_xpu_ops_path))
 
-from xpu_test_utils import XPUPatchForImport
+from xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(patch_test_case=False) as patcher:
+with XPUPatchForImportMinimal(patch_test_case=False) as patcher:
     __pytorch_test_dir = Path(patcher.test_package[0]).resolve()
     if str(__pytorch_test_dir) not in sys.path:
         sys.path.insert(0, str(__pytorch_test_dir))
@@ -226,7 +226,7 @@ def make_dynamic_cls(cls, strict):
     return test_class
 
 
-with XPUPatchForImport(patch_test_case=False):
+with XPUPatchForImportMinimal(patch_test_case=False):
     tests = [
         test_export.TestDynamismExpression,
         test_export.TestExport,

--- a/test/xpu/extended/test_ops_xpu.py
+++ b/test/xpu/extended/test_ops_xpu.py
@@ -38,17 +38,17 @@ try:
         _ops_without_cuda_support,
         _xpu_computation_op_list,
         get_wrapped_fn,
-        XPUPatchForImport,
+        XPUPatchForImportMinimal,
     )
 except Exception as e:
     from ..xpu_test_utils import (
         _ops_without_cuda_support,
         _xpu_computation_op_list,
         get_wrapped_fn,
-        XPUPatchForImport,
+        XPUPatchForImportMinimal,
     )
 
-with XPUPatchForImport():
+with XPUPatchForImportMinimal(False):
     from test_ops import (
         TestCommon as TestCommonBase,
         TestCompositeCompliance as TestCompositeComplianceBase,

--- a/test/xpu/extended/test_tensor_creation_ops_xpu.py
+++ b/test/xpu/extended/test_tensor_creation_ops_xpu.py
@@ -15,11 +15,11 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import NoTest, run_tests, TEST_XPU, TestCase
 
 try:
-    from xpu_test_utils import copy_tests, XPUPatchForImport
+    from xpu_test_utils import copy_tests, XPUPatchForImportMinimal
 except Exception as e:
-    from ..xpu_test_utils import copy_tests, XPUPatchForImport
+    from ..xpu_test_utils import copy_tests, XPUPatchForImportMinimal
 
-with XPUPatchForImport():
+with XPUPatchForImportMinimal(False):
     from test_tensor_creation_ops import TestTensorCreation as TestTensorCreationBase
 
 if not TEST_XPU:

--- a/test/xpu/nn/test_convolution_xpu.py
+++ b/test/xpu/nn/test_convolution_xpu.py
@@ -72,11 +72,11 @@ def onlyNativeDeviceTypes(fn):
 
 
 try:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from ..xpu_test_utils import XPUPatchForImport
+    from ..xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_convolution import TestConvolutionNN, TestConvolutionNNDeviceType
 
     @dtypes(torch.float, torch.double, torch.half)

--- a/test/xpu/nn/test_embedding_xpu.py
+++ b/test/xpu/nn/test_embedding_xpu.py
@@ -12,11 +12,11 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from ..xpu_test_utils import XPUPatchForImport
+    from ..xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_embedding import TestEmbeddingNNDeviceType
 
 

--- a/test/xpu/nn/test_init_xpu.py
+++ b/test/xpu/nn/test_init_xpu.py
@@ -11,11 +11,11 @@
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from ..xpu_test_utils import XPUPatchForImport
+    from ..xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_init import TestNNInit  # noqa: F401
 
 

--- a/test/xpu/nn/test_lazy_modules_xpu.py
+++ b/test/xpu/nn/test_lazy_modules_xpu.py
@@ -12,11 +12,11 @@ from torch.nn.parameter import UninitializedParameter
 from torch.testing._internal.common_utils import run_tests, suppress_warnings
 
 try:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from ..xpu_test_utils import XPUPatchForImport
+    from ..xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_lazy_modules import LazyModule, TestLazyModules
 
 

--- a/test/xpu/nn/test_load_state_dict_xpu.py
+++ b/test/xpu/nn/test_load_state_dict_xpu.py
@@ -15,11 +15,11 @@ from torch.testing._internal.common_utils import (
 )
 
 try:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from ..xpu_test_utils import XPUPatchForImport
+    from ..xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_load_state_dict import TestLoadStateDict, TestLoadStateDictSwap
 
 

--- a/test/xpu/nn/test_module_hooks_xpu.py
+++ b/test/xpu/nn/test_module_hooks_xpu.py
@@ -15,11 +15,11 @@ from torch.testing._internal.common_utils import (
 )
 
 try:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from ..xpu_test_utils import XPUPatchForImport
+    from ..xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_module_hooks import TestModuleHooks
 
 instantiate_parametrized_tests(TestModuleHooks)

--- a/test/xpu/nn/test_multihead_attention_xpu.py
+++ b/test/xpu/nn/test_multihead_attention_xpu.py
@@ -15,11 +15,11 @@ from torch.testing._internal.common_utils import (
 )
 
 try:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from ..xpu_test_utils import XPUPatchForImport
+    from ..xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     import unittest
     import unittest.mock as mock
     from typing import Optional

--- a/test/xpu/nn/test_packed_sequence_xpu.py
+++ b/test/xpu/nn/test_packed_sequence_xpu.py
@@ -15,11 +15,11 @@
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from ..xpu_test_utils import XPUPatchForImport
+    from ..xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     import torch
     import torch.nn.utils.rnn as rnn_utils
     from test_packed_sequence import PackedSequenceTest

--- a/test/xpu/nn/test_parametrization_xpu.py
+++ b/test/xpu/nn/test_parametrization_xpu.py
@@ -15,11 +15,11 @@ from torch.testing._internal.common_utils import (
 )
 
 try:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from ..xpu_test_utils import XPUPatchForImport
+    from ..xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_parametrization import TestNNParametrization, TestNNParametrizationDevice
 
 

--- a/test/xpu/nn/test_pooling_xpu.py
+++ b/test/xpu/nn/test_pooling_xpu.py
@@ -33,11 +33,11 @@ from torch.testing._internal.common_utils import (
 )
 
 try:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from ..xpu_test_utils import XPUPatchForImport
+    from ..xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_pooling import TestAvgPool, TestPoolingNN, TestPoolingNNDeviceType
 
 

--- a/test/xpu/nn/test_pruning_xpu.py
+++ b/test/xpu/nn/test_pruning_xpu.py
@@ -14,11 +14,11 @@ from torch.testing._internal.common_utils import (
 )
 
 try:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from ..xpu_test_utils import XPUPatchForImport
+    from ..xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_pruning import TestPruningNN
 
 

--- a/test/xpu/quantization/core/test_quantized_op_xpu.py
+++ b/test/xpu/quantization/core/test_quantized_op_xpu.py
@@ -15,16 +15,16 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
     import os
     import sys
 
     script_path = os.path.split(__file__)[0]
     sys.path.insert(0, os.path.realpath(os.path.join(script_path, "../..")))
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_quantized_op import TestQuantizedOps
 
 

--- a/test/xpu/quantization/core/test_quantized_tensor_xpu.py
+++ b/test/xpu/quantization/core/test_quantized_tensor_xpu.py
@@ -20,16 +20,16 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
     import os
     import sys
 
     script_path = os.path.split(__file__)[0]
     sys.path.insert(0, os.path.realpath(os.path.join(script_path, "../..")))
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_quantized_tensor import TestQuantizedTensor
     from torch.testing._internal.common_cuda import TEST_CUDA
 

--- a/test/xpu/quantization/core/test_workflow_module_xpu.py
+++ b/test/xpu/quantization/core/test_workflow_module_xpu.py
@@ -15,16 +15,16 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
     import os
     import sys
 
     script_path = os.path.split(__file__)[0]
     sys.path.insert(0, os.path.realpath(os.path.join(script_path, "../..")))
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_workflow_module import (
         TestDistributed,
         TestFakeQuantize,

--- a/test/xpu/quantization/core/test_workflow_ops_xpu.py
+++ b/test/xpu/quantization/core/test_workflow_ops_xpu.py
@@ -21,16 +21,16 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
     import os
     import sys
 
     script_path = os.path.split(__file__)[0]
     sys.path.insert(0, os.path.realpath(os.path.join(script_path, "../..")))
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_workflow_ops import (
         NP_RANDOM_SEED,
         TestFakeQuantizeOps,

--- a/test/xpu/test_autograd_fallback_xpu.py
+++ b/test/xpu/test_autograd_fallback_xpu.py
@@ -14,11 +14,11 @@ from torch.testing._internal.common_utils import (
 )
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_autograd_fallback import TestAutogradFallback
 
 

--- a/test/xpu/test_autograd_xpu.py
+++ b/test/xpu/test_autograd_xpu.py
@@ -576,13 +576,13 @@ def _test_consumer_to_single_producer_case_3_correctness(
 
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
 torch.utils.checkpoint.DefaultDeviceType.set_device_type("xpu")
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from autograd.test_complex import TestAutogradComplex  # noqa: F401
     from autograd.test_functional import (  # noqa: F401
         base_and_logging_tensor,

--- a/test/xpu/test_basic_torch_np_xpu.py
+++ b/test/xpu/test_basic_torch_np_xpu.py
@@ -22,19 +22,19 @@ from torch._numpy.testing import assert_allclose
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
 # torch_np test lives under pytorch/test/torch_np, which is not in the default
-# XPUPatchForImport search path. Add it here so the hook-override import works.
+# XPUPatchForImportMinimal search path. Add it here so the hook-override import works.
 _TORCH_NP_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "../../../../test/torch_np")
 )
 if _TORCH_NP_DIR not in sys.path:
     sys.path.insert(0, _TORCH_NP_DIR)
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_basic import TestMisc
 
 

--- a/test/xpu/test_binary_ufuncs_xpu.py
+++ b/test/xpu/test_binary_ufuncs_xpu.py
@@ -22,11 +22,11 @@ from torch.testing._internal.common_dtype import integral_types
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_binary_ufuncs import TestBinaryUfuncsDevice
 
 

--- a/test/xpu/test_complex_xpu.py
+++ b/test/xpu/test_complex_xpu.py
@@ -12,11 +12,11 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_complex import TestComplexTensor
 
 instantiate_device_type_tests(

--- a/test/xpu/test_content_store_xpu.py
+++ b/test/xpu/test_content_store_xpu.py
@@ -12,11 +12,11 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_content_store import TestContentStore
 
 

--- a/test/xpu/test_dataloader_xpu.py
+++ b/test/xpu/test_dataloader_xpu.py
@@ -23,9 +23,9 @@ from torch.utils.data import DataLoader, Dataset, IterDataPipe
 from torch.utils.data.datapipes.iter import IterableWrapper
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
 
 class CountingDataset(Dataset):
@@ -46,7 +46,7 @@ test_package = (
 )
 
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
 
     def _set_allocator_settings(device=None):
         pass

--- a/test/xpu/test_distributions_xpu.py
+++ b/test/xpu/test_distributions_xpu.py
@@ -17,10 +17,10 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
-with XPUPatchForImport(False):
+    from .xpu_test_utils import XPUPatchForImportMinimal
+with XPUPatchForImportMinimal(False):
     from test_distributions import (
         _get_examples,
         pairwise,

--- a/test/xpu/test_dynamic_shapes_xpu.py
+++ b/test/xpu/test_dynamic_shapes_xpu.py
@@ -14,11 +14,11 @@ from torch.testing._internal.common_utils import (
 )
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_dynamic_shapes import TestSymNumberMagicMethods
 
 instantiate_parametrized_tests(TestSymNumberMagicMethods)

--- a/test/xpu/test_foreach_xpu.py
+++ b/test/xpu/test_foreach_xpu.py
@@ -25,9 +25,9 @@ from torch.testing._internal.common_methods_invocations import (
 from torch.testing._internal.common_utils import parametrize, run_tests, serialTest
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
 
 def get_device_capability(device=None):
@@ -36,7 +36,7 @@ def get_device_capability(device=None):
 
 torch.cuda.get_device_capability = get_device_capability
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_foreach import TestForeach
 
 

--- a/test/xpu/test_fx_xpu.py
+++ b/test/xpu/test_fx_xpu.py
@@ -21,11 +21,11 @@ from torch.profiler import profile, ProfilerActivity
 from torch.testing._internal.common_utils import IS_WINDOWS, run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-# test/fx is not in the XPUPatchForImport default search path; add it so
+# test/fx is not in the XPUPatchForImportMinimal default search path; add it so
 # the TestCommonPass import works.
 _FX_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "../../../../test/fx")
@@ -33,7 +33,7 @@ _FX_DIR = os.path.abspath(
 if _FX_DIR not in sys.path:
     sys.path.insert(0, _FX_DIR)
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     import test_common_passes
     from test_fx import _enrich_profiler_traces, TestFX
 

--- a/test/xpu/test_indexing_xpu.py
+++ b/test/xpu/test_indexing_xpu.py
@@ -21,11 +21,11 @@ from torch.testing._internal.common_dtype import all_types_complex_float8_and
 from torch.testing._internal.common_utils import DeterministicGuard, run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     import torch
     from test_indexing import NumpyTests, TestIndexing
 

--- a/test/xpu/test_linalg_xpu.py
+++ b/test/xpu/test_linalg_xpu.py
@@ -46,9 +46,9 @@ from torch.testing._internal.common_utils import (
 )
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
 
 def _group_quantize_tensor_impl(w, n_bit=4, q_group_size=16):
@@ -594,7 +594,7 @@ def matrix_rank_out_errors_and_warnings(self, device, dtype):
             self.assertTrue("Aten Op fallback from XPU to CPU" in str(w[1].message))
 
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_linalg import TestLinalg
 
 

--- a/test/xpu/test_masked_xpu.py
+++ b/test/xpu/test_masked_xpu.py
@@ -12,11 +12,11 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_masked import TestMasked
 
 instantiate_device_type_tests(TestMasked, globals(), only_for="xpu", allow_xpu=True)

--- a/test/xpu/test_maskedtensor_xpu.py
+++ b/test/xpu/test_maskedtensor_xpu.py
@@ -15,11 +15,11 @@ from torch.testing._internal.common_utils import (
 )
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_maskedtensor import (
         TestBasics,
         TestBinary,

--- a/test/xpu/test_modules_xpu.py
+++ b/test/xpu/test_modules_xpu.py
@@ -181,11 +181,11 @@ def _test_multiple_device_transfer(self, device, dtype, module_info, training):
 
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_modules import TestModule
 
     TestModule._test_gradients_helper = _gradients_helper

--- a/test/xpu/test_multiprocessing_xpu.py
+++ b/test/xpu/test_multiprocessing_xpu.py
@@ -21,11 +21,11 @@ import torch.multiprocessing as mp
 from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase
 
 try:
-    from xpu_test_utils import ensure_pytorch_test_path, XPUPatchForImport
+    from xpu_test_utils import ensure_pytorch_test_path, XPUPatchForImportMinimal
 except Exception:
-    from .xpu_test_utils import ensure_pytorch_test_path, XPUPatchForImport
+    from .xpu_test_utils import ensure_pytorch_test_path, XPUPatchForImportMinimal
 
-with XPUPatchForImport(False) as patcher:
+with XPUPatchForImportMinimal(False) as patcher:
     from test_multiprocessing import TestMultiprocessing
 
 

--- a/test/xpu/test_native_functions_xpu.py
+++ b/test/xpu/test_native_functions_xpu.py
@@ -11,11 +11,11 @@
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_native_functions import TestNativeFunctions  # noqa: F401
 
 if __name__ == "__main__":

--- a/test/xpu/test_native_mha_xpu.py
+++ b/test/xpu/test_native_mha_xpu.py
@@ -12,11 +12,11 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_native_mha import TestMHADeviceType
 
 instantiate_device_type_tests(

--- a/test/xpu/test_numba_integration_xpu.py
+++ b/test/xpu/test_numba_integration_xpu.py
@@ -18,9 +18,9 @@ import torch
 from torch.testing._internal.common_utils import run_tests, TEST_NUMPY
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
 # numba.cuda may fail to import due to numpy ABI. Detect at module scope.
 try:
@@ -30,7 +30,7 @@ try:
 except Exception:
     TEST_NUMBA_XPU = False
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_numba_integration import TestNumbaIntegration
 
 

--- a/test/xpu/test_numpy_interop_xpu.py
+++ b/test/xpu/test_numpy_interop_xpu.py
@@ -12,11 +12,11 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_numpy_interop import TestNumPyInterop
 
 

--- a/test/xpu/test_ops_fwd_gradients_xpu.py
+++ b/test/xpu/test_ops_fwd_gradients_xpu.py
@@ -12,11 +12,11 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_ops_fwd_gradients import TestFwdGradients
 TestFwdGradients._default_dtype_check_enabled = True
 instantiate_device_type_tests(

--- a/test/xpu/test_ops_gradients_xpu.py
+++ b/test/xpu/test_ops_gradients_xpu.py
@@ -12,11 +12,11 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_ops_gradients import TestBwdGradients
 
 instantiate_device_type_tests(

--- a/test/xpu/test_ops_xpu.py
+++ b/test/xpu/test_ops_xpu.py
@@ -13,10 +13,10 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
-with XPUPatchForImport(False):
+    from .xpu_test_utils import XPUPatchForImportMinimal
+with XPUPatchForImportMinimal(False):
     from test_ops import (
         fake_autocast_device_skips,
         TestCommon,

--- a/test/xpu/test_optim_xpu.py
+++ b/test/xpu/test_optim_xpu.py
@@ -13,10 +13,10 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
-with XPUPatchForImport(False):
+    from .xpu_test_utils import XPUPatchForImportMinimal
+with XPUPatchForImportMinimal(False):
     from test_optim import TestOptimRenewed
 
 from copy import deepcopy

--- a/test/xpu/test_out_dtype_op_xpu.py
+++ b/test/xpu/test_out_dtype_op_xpu.py
@@ -15,11 +15,11 @@ from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_out_dtype_op import TestOutDtypeOp
 
 

--- a/test/xpu/test_prims_xpu.py
+++ b/test/xpu/test_prims_xpu.py
@@ -12,11 +12,11 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_prims import TestDecomp, TestPrims, TestRefs
 
 

--- a/test/xpu/test_proxy_tensor_xpu.py
+++ b/test/xpu/test_proxy_tensor_xpu.py
@@ -14,11 +14,11 @@ from torch.fx.passes.runtime_assert import insert_deferred_runtime_asserts
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_proxy_tensor import (
         TestGenericProxyTensorFake,
         TestGenericProxyTensorReal,

--- a/test/xpu/test_python_dispatch_xpu.py
+++ b/test/xpu/test_python_dispatch_xpu.py
@@ -12,11 +12,11 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_python_dispatch import TestWrapperSubclassAliasing
 
 

--- a/test/xpu/test_reductions_xpu.py
+++ b/test/xpu/test_reductions_xpu.py
@@ -12,11 +12,11 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_reductions import TestReductions
 
 

--- a/test/xpu/test_scaled_matmul_cuda_xpu.py
+++ b/test/xpu/test_scaled_matmul_cuda_xpu.py
@@ -14,11 +14,11 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import parametrize, run_tests, skipIfXpu
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_scaled_matmul_cuda import (
         e4m3_type,
         e5m2_type,

--- a/test/xpu/test_scatter_gather_ops_xpu.py
+++ b/test/xpu/test_scatter_gather_ops_xpu.py
@@ -12,11 +12,11 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_scatter_gather_ops import TestScatterGather
 
 

--- a/test/xpu/test_segment_reductions_xpu.py
+++ b/test/xpu/test_segment_reductions_xpu.py
@@ -13,10 +13,10 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
-with XPUPatchForImport(False):
+    from .xpu_test_utils import XPUPatchForImportMinimal
+with XPUPatchForImportMinimal(False):
     from test_segment_reductions import TestSegmentReductions
 
 instantiate_device_type_tests(

--- a/test/xpu/test_serialization_xpu.py
+++ b/test/xpu/test_serialization_xpu.py
@@ -24,11 +24,11 @@ from torch.testing._internal.common_utils import (
 )
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_serialization import (
         TestBothSerialization,
         TestSerialization,
@@ -38,7 +38,7 @@ with XPUPatchForImport(False):
 
 
 # Override TestCase-level (non-device) tests that hardcode cuda; mirror upstream
-# bodies on the xpu device. Required because XPUPatchForImport leaves @unittest.skipIf(
+# bodies on the xpu device. Required because XPUPatchForImportMinimal leaves @unittest.skipIf(
 # not torch.cuda.is_available()) intact, which auto-skips on XPU machines.
 def _xpu_test_serialization_mmap_loading_with_map_location(self):
     class DummyModel(torch.nn.Module):

--- a/test/xpu/test_shape_ops_xpu.py
+++ b/test/xpu/test_shape_ops_xpu.py
@@ -12,11 +12,11 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_shape_ops import TestShapeOps
 
 instantiate_device_type_tests(TestShapeOps, globals(), only_for="xpu", allow_xpu=True)

--- a/test/xpu/test_sort_and_select_xpu.py
+++ b/test/xpu/test_sort_and_select_xpu.py
@@ -22,11 +22,11 @@ from torch.testing._internal.common_dtype import all_types_and, floating_types_a
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_sort_and_select import TestSortAndSelect
 
     @dtypes(*all_types_and(torch.half, torch.bfloat16, torch.bool))

--- a/test/xpu/test_spectral_ops_xpu.py
+++ b/test/xpu/test_spectral_ops_xpu.py
@@ -27,11 +27,11 @@ from torch.testing._internal.common_methods_invocations import (
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from ..xpu_test_utils import XPUPatchForImport
+    from ..xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_spectral_ops import TestFFT
 
 has_scipy_fft = False

--- a/test/xpu/test_type_promotion_xpu.py
+++ b/test/xpu/test_type_promotion_xpu.py
@@ -15,11 +15,11 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     import itertools
     import operator
 

--- a/test/xpu/test_view_ops_xpu.py
+++ b/test/xpu/test_view_ops_xpu.py
@@ -12,11 +12,11 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUPatchForImport
+    from xpu_test_utils import XPUPatchForImportMinimal
 except Exception as e:
-    from .xpu_test_utils import XPUPatchForImport
+    from .xpu_test_utils import XPUPatchForImportMinimal
 
-with XPUPatchForImport(False):
+with XPUPatchForImportMinimal(False):
     from test_view_ops import TestOldViewOps, TestViewOps
 
     def is_view_of(self, base, other):

--- a/test/xpu/xpu_test_utils.py
+++ b/test/xpu/xpu_test_utils.py
@@ -983,6 +983,59 @@ def get_dtypesIf_mock(src_device_type: str):
     return dtypesIfXPUMock
 
 
+class XPUPatchForImportMinimal:
+    """Minimal context manager for importing upstream test modules on XPU.
+
+    Only performs the essential import mechanics:
+    - Extends sys.path so upstream test modules can be imported
+    - Suppresses instantiate_device_type_tests during import
+    - Suppresses instantiate_parametrized_tests during import
+    - Optionally replaces TestCase with NoTest to hide upstream classes from pytest
+
+    Does NOT apply any decorator remapping, op_db manipulation, or global state
+    faking. Test files using this are expected to work with upstream decorators
+    as-is, relying on upstream's native XPU support.
+    """
+
+    def __init__(self, patch_test_case=True) -> None:
+        test_dir = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "../../../../test"
+        )
+        self.test_package = (
+            test_dir,
+            os.path.join(test_dir, "nn"),
+            os.path.join(test_dir, "distributions"),
+            os.path.join(test_dir, "quantization/core"),
+        )
+        self.patch_test_case = patch_test_case
+        self.original_path = sys.path.copy()
+        self.test_case_cls = common_utils.TestCase
+        self.instantiate_device_type_tests_fn = (
+            common_device_type.instantiate_device_type_tests
+        )
+        self.instantiate_parametrized_tests_fn = (
+            common_utils.instantiate_parametrized_tests
+        )
+
+    def __enter__(self):
+        common_device_type.instantiate_device_type_tests = DO_NOTHING
+        common_utils.instantiate_parametrized_tests = DO_NOTHING
+        if self.patch_test_case:
+            common_utils.TestCase = common_utils.NoTest
+        sys.path.extend(self.test_package)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        sys.path = self.original_path
+        common_device_type.instantiate_device_type_tests = (
+            self.instantiate_device_type_tests_fn
+        )
+        common_utils.instantiate_parametrized_tests = (
+            self.instantiate_parametrized_tests_fn
+        )
+        common_utils.TestCase = self.test_case_cls
+
+
 class XPUPatchForImport:
     def __init__(self, patch_test_case=True) -> None:
         test_dir = os.path.join(


### PR DESCRIPTION
Add a minimal alternative to XPUPatchForImport that only performs essential import mechanics:
- sys.path extension for upstream test module imports
- Suppresses instantiate_device_type_tests during import
- Suppresses instantiate_parametrized_tests during import
- Optional TestCase → NoTest replacement

Unlike XPUPatchForImport, this does NOT apply decorator remapping, op_db manipulation, or global state faking (TEST_CUDA, etc.). Test files using this rely on upstream's native XPU support.

This is a no-op change — no existing test files are modified.