### PR TITLE
Skip very long tests from pull workflows.

### DIFF
--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -90,6 +90,14 @@ skip_dict = {
         "test_quick_core_backward_baddbmm_xpu_float64",
         # Slow test case: it takes more than 10 minutes to run on XPU.
         "test_quick_core_backward__unsafe_masked_index_put_accumulate_xpu_float64",
+        # Slow test cases: it takes more than 10 minutes to run on XPU.
+        "test_comprehensive_grid_sampler_2d_xpu_float32",
+        "test_comprehensive_grid_sampler_2d_xpu_float64",
+        # Slow test cases: it takes more than 10 minutes to run on XPU.
+        "test_quick_core_backward_clamp_max_xpu_float64",
+        "test_quick_core_backward_clamp_min_xpu_float64",
+        # Slow test case: it takes more than 10 minutes to run on XPU.
+        "test_quick_core_backward__unsafe_masked_index_xpu_float64",
     ),
     "test_distributions_xpu.py": None,
     "test_dynamic_shapes_xpu.py": None,


### PR DESCRIPTION
There are several test cases in #4116 that were randomly failing in the pull workflows.
I checked the logs and launched those tests locally and it seems like the problem was that they are taking too much time to finish and the pull workflows have timeout set to 10 minutes. Depending on the XPU usage, execution time was probably slightly below 10 minutes and with high XPU occupancy it was more than 10 minutes. That is why it was failing randomly.

This PR moves those very slow test cases to skip list, so they are not launched in every pull workflow, but they are launched in Nightly tests under `skipped_ut` suite with timeout time increased to 60 minutes.

I launched the On-demand workflow with `skipped_ut` to verify if they pass. All those 5 test cases passed when launched with higher timeout in `skipped_ut` suite.
Here is the workflow: [WORKFLOW URL](https://github.com/intel/torch-xpu-ops/actions/runs/28028219483/job/82980750141#step:5:101)