### PR TITLE
XPU: isolate gamma Philox subsequences to fix Chi2 sampling bias

### DIFF
--- a/src/ATen/native/xpu/sycl/DistributionTemplates.h
+++ b/src/ATen/native/xpu/sycl/DistributionTemplates.h
@@ -25,6 +25,7 @@
 #include <ATen/native/xpu/sycl/TensorApplyUtils.h>
 #include <ATen/ops/empty.h>
 #include <ATen/xpu/PhiloxXpuState.h>
+#include <ATen/xpu/XPUGeneratorImpl.h>
 #include <comm/DeviceProperties.h>
 #include <comm/Runtime.h>
 
@@ -189,6 +190,11 @@ void distribution_nullary_kernel(
 }
 
 // Unary kernel
+enum class DistributionRngInitMode {
+  Default,
+  OffsetAsSubsequence,
+};
+
 template <
     typename scalar1_t,
     typename scalar2_t,
@@ -203,7 +209,15 @@ struct DistributionUnaryElementwiseKernelFunctor {
 
     auto seeds = at::xpu::philox::unpack(philox_args_);
     randStatePhilox4_32_10_t state;
-    rand_init(std::get<0>(seeds), global_idx, std::get<1>(seeds), &state);
+    if (rng_init_mode_ == DistributionRngInitMode::OffsetAsSubsequence) {
+      rand_init(
+          std::get<0>(seeds),
+          static_cast<unsigned long long>(global_idx) + std::get<1>(seeds),
+          0,
+          &state);
+    } else {
+      rand_init(std::get<0>(seeds), global_idx, std::get<1>(seeds), &state);
+    }
 
     for (int i = global_idx; i < numel_; i += global_size) {
       auto in_offsets = inp_calc_.get(i);
@@ -218,14 +232,16 @@ struct DistributionUnaryElementwiseKernelFunctor {
       scalar1_t* output_data,
       const scalar2_t* input_data,
       inp_offset_calc_t input_offset_calculator,
-      out_offset_calc_t output_offset_calculator)
+      out_offset_calc_t output_offset_calculator,
+      DistributionRngInitMode rng_init_mode)
       : numel_(numel),
         f_(f),
         philox_args_(philox_args),
         output_data_(output_data),
         input_data_(input_data),
         inp_calc_(input_offset_calculator),
-        out_calc_(output_offset_calculator) {}
+        out_calc_(output_offset_calculator),
+        rng_init_mode_(rng_init_mode) {}
 
  private:
   int numel_;
@@ -235,17 +251,25 @@ struct DistributionUnaryElementwiseKernelFunctor {
   const scalar2_t* input_data_;
   inp_offset_calc_t inp_calc_;
   out_offset_calc_t out_calc_;
+  DistributionRngInitMode rng_init_mode_;
 };
 
-template <typename scalar1_t, typename scalar2_t, typename func_t>
+template <
+    typename scalar1_t,
+    typename scalar2_t,
+    typename func_t,
+    DistributionRngInitMode rng_init_mode = DistributionRngInitMode::Default>
 void distribution_unary_kernel(
     TensorIterator& iter,
     PhiloxXpuState philox_args,
     func_t f) {
   if (!iter.can_use_32bit_indexing()) {
     for (auto& sub_iter : iter.with_32bit_indexing()) {
-      distribution_unary_kernel<scalar1_t, scalar2_t, decltype(f)>(
-          sub_iter, philox_args, f);
+      distribution_unary_kernel<
+          scalar1_t,
+          scalar2_t,
+          decltype(f),
+          rng_init_mode>(sub_iter, philox_args, f);
     }
     return;
   }
@@ -274,7 +298,8 @@ void distribution_unary_kernel(
         output_data,
         input_data,
         input_offset_calculator,
-        output_offset_calculator);
+        output_offset_calculator,
+        rng_init_mode);
     sycl_kernel_submit(
         num_groups * group_size, group_size, getCurrentSYCLQueue(), caller);
   } else {
@@ -287,10 +312,57 @@ void distribution_unary_kernel(
         output_data,
         input_data,
         input_offset_calculator,
-        output_offset_calculator);
+        output_offset_calculator,
+        rng_init_mode);
     sycl_kernel_submit(
         num_groups * group_size, group_size, getCurrentSYCLQueue(), caller);
   }
+}
+
+template <
+    typename scalar1_t,
+    typename scalar2_t,
+    typename func_t,
+    DistributionRngInitMode rng_init_mode = DistributionRngInitMode::Default>
+void distribution_unary_kernel(
+    TensorIterator& iter,
+    XPUGeneratorImpl* gen,
+    func_t f) {
+  if (!iter.can_use_32bit_indexing()) {
+    for (auto& sub_iter : iter.with_32bit_indexing()) {
+      distribution_unary_kernel<
+          scalar1_t,
+          scalar2_t,
+          decltype(f),
+          rng_init_mode>(sub_iter, gen, f);
+    }
+    return;
+  }
+
+  int64_t numel = iter.numel();
+  if (numel == 0) {
+    return;
+  }
+
+  PhiloxXpuState rng_engine_inputs;
+  auto execution_policy = calc_execution_policy(numel);
+  if constexpr (rng_init_mode == DistributionRngInitMode::OffsetAsSubsequence) {
+    auto num_groups = std::get<1>(execution_policy);
+    auto group_size = std::get<2>(execution_policy);
+    {
+      std::lock_guard<std::mutex> lock(gen->mutex_);
+      rng_engine_inputs = gen->philox_xpu_state(num_groups * group_size);
+    }
+  } else {
+    auto counter_offset = std::get<0>(execution_policy);
+    {
+      std::lock_guard<std::mutex> lock(gen->mutex_);
+      rng_engine_inputs = gen->philox_xpu_state(counter_offset);
+    }
+  }
+
+  distribution_unary_kernel<scalar1_t, scalar2_t, decltype(f), rng_init_mode>(
+      iter, rng_engine_inputs, f);
 }
 
 // Binary kernel

--- a/src/ATen/native/xpu/sycl/Distributions.cpp
+++ b/src/ATen/native/xpu/sycl/Distributions.cpp
@@ -131,19 +131,11 @@ void launch_binomial_kernel(TensorIteratorBase& iter, XPUGeneratorImpl* gen) {
 }
 
 template <typename scalar_t, typename accscalar_t>
-struct GammaTensorApplyFunctor {
+struct GammaKernelFunctor {
   void operator()(
-      sycl::nd_item<1> item,
+      randStatePhilox4_32_10_t& state,
       scalar_t& ret_val,
       const scalar_t& alpha) const {
-    auto seeds = at::xpu::philox::unpack(philox_args_);
-    randStatePhilox4_32_10_t state;
-    rand_init(
-        std::get<0>(seeds),
-        item.get_group(0) * item.get_local_range(0) + item.get_local_id(0),
-        std::get<1>(seeds),
-        &state);
-
     auto uniform_lambda = [&state]() { return rand_uniform(&state); };
     BaseSampler<accscalar_t, decltype(uniform_lambda)> standard_uniform(
         uniform_lambda);
@@ -160,52 +152,33 @@ struct GammaTensorApplyFunctor {
     auto min_value = std::numeric_limits<scalar_t>::min();
     ret_val = (min_value > sample) ? min_value : sample;
   }
-
-  GammaTensorApplyFunctor(PhiloxXpuState philox_args)
-      : philox_args_(philox_args) {}
-
- private:
-  PhiloxXpuState philox_args_;
 };
 
 template <typename scalar_t>
-void gamma_kernel(
-    const at::TensorBase& ret,
-    const at::TensorBase& alpha,
-    PhiloxXpuState philox_args) {
+void gamma_kernel(TensorIterator& iter, XPUGeneratorImpl* gen) {
   using accscalar_t = at::acc_type_device<scalar_t, kXPU>;
-  GammaTensorApplyFunctor<scalar_t, accscalar_t> functor(philox_args);
-  at::native::xpu::tensor_apply2<
+  GammaKernelFunctor<scalar_t, accscalar_t> f;
+  at::native::xpu::distribution_unary_kernel<
       scalar_t,
       scalar_t,
-      decltype(functor),
-      /*max_threads_per_block=*/256>(
-      const_cast<at::TensorBase&>(ret),
-      const_cast<at::TensorBase&>(alpha),
-      functor);
+      decltype(f),
+      at::native::xpu::DistributionRngInitMode::OffsetAsSubsequence>(
+      iter, gen, f);
 }
 
 void launch_gamma_kernel(
     Tensor& ret,
     const Tensor& alpha,
     XPUGeneratorImpl* gen) {
-  PhiloxXpuState rng_engine_inputs;
-  {
-    // See Note [Acquire lock when using random generators]
-    std::lock_guard<std::mutex> lock(gen->mutex_);
-    // Using a seed value of 10 for the Philox random engine initialization.
-    // This seed was chosen to ensure consistent random number generation
-    // behavior for this specific kernel. Modify with caution as it affects
-    // reproducibility of results.
-    rng_engine_inputs = gen->philox_xpu_state(10);
-  }
+  auto iter =
+      at::TensorIteratorConfig().add_output(ret).add_input(alpha).build();
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::Half,
       at::ScalarType::BFloat16,
       ret.scalar_type(),
       "gamma_xpu",
-      [&] { gamma_kernel<scalar_t>(ret, alpha, rng_engine_inputs); });
+      [&] { gamma_kernel<scalar_t>(iter, gen); });
 }
 
 template <typename scalar_t, typename accscalar_t>


### PR DESCRIPTION
This PR applies a minimal XPU runtime fix for gamma/chi2 sampling correctness.

Gamma sampling now uses an opt-in RNG init mode that maps launch threads to distinct Philox subsequences (offset-as-subsequence) with per-launch reservation from XPUGenerator.

The default unary RNG path remains unchanged; behavior change is isolated to gamma. 