### PR TITLE
Add recording call to ProcessGroupXCCL::wait()

### DIFF
--- a/src/xccl/ProcessGroupXCCL.cpp
+++ b/src/xccl/ProcessGroupXCCL.cpp
@@ -224,6 +224,8 @@ std::vector<at::Tensor>& TensorShelf::get() {
 }
 
 ProcessGroupXCCL::WorkXCCL::WorkXCCL(
+    std::string pgUID,
+    std::string pgDesc,
     at::Device& device,
     int rank,
     OpType opType,
@@ -234,6 +236,8 @@ ProcessGroupXCCL::WorkXCCL::WorkXCCL(
     bool enableTiming,
     bool xpuEventCacheEnabled)
     : Work(rank, opType, profilingTitle, inputs),
+      pgUID_(pgUID),
+      pgDesc_(pgDesc),
       device_(device),
       workStartTime_(std::chrono::steady_clock::now()),
       seq_(seq),
@@ -255,6 +259,8 @@ ProcessGroupXCCL::WorkXCCL::WorkXCCL(
 
 ProcessGroupXCCL::WorkXCCL::WorkXCCL(const WorkXCCL& w)
     : Work(w.rank_, w.opType_),
+      pgUID_(w.pgUID_),
+      pgDesc_(w.pgDesc_),
       device_(w.device_),
       xcclStartEvent_(w.xcclStartEvent_),
       xcclEndEvent_(w.xcclEndEvent_),
@@ -292,7 +298,7 @@ void ProcessGroupXCCL::WorkXCCL::synchronizeStream() {
 bool ProcessGroupXCCL::WorkXCCL::wait(std::chrono::milliseconds timeout) {
   RECORD_PARAM_COMMS(
       std::make_tuple(static_cast<int64_t>(this->seq_), this->isP2P_), // seq
-      std::make_tuple(pg_uid_, pg_desc_), // PG name tuple
+      std::make_tuple(pgUID_, pgDesc_), // PG name tuple
       rank_, // rank
       "wait", // collective name
       0, // inNelems
@@ -510,6 +516,8 @@ c10::intrusive_ptr<ProcessGroupXCCL::WorkXCCL> ProcessGroupXCCL::initWork(
     const std::vector<at::Tensor>& outputs,
     bool record) {
   auto r = c10::make_intrusive<ProcessGroupXCCL::WorkXCCL>(
+      pg_uid_,
+      pg_desc_,
       device,
       rank,
       opType,

--- a/src/xccl/ProcessGroupXCCL.cpp
+++ b/src/xccl/ProcessGroupXCCL.cpp
@@ -290,6 +290,20 @@ void ProcessGroupXCCL::WorkXCCL::synchronizeStream() {
 }
 
 bool ProcessGroupXCCL::WorkXCCL::wait(std::chrono::milliseconds timeout) {
+  RECORD_PARAM_COMMS(
+      std::make_tuple(static_cast<int64_t>(this->seq_), this->isP2P_), // seq
+      std::make_tuple(std::string(), std::string()), // PG name tuple
+      rank_, // rank
+      "wait", // collective name
+      0, // inNelems
+      0, // outNelems
+      at::kByte, // dType
+      std::vector<int64_t>(), // inSplitSizes
+      std::vector<int64_t>(), // outSplitSizes
+      -1,
+      -1,
+      static_cast<int>(1)); // number of device?
+
   synchronize();
 
   if (blockingWait_ || timeout != kNoTimeout) {

--- a/src/xccl/ProcessGroupXCCL.cpp
+++ b/src/xccl/ProcessGroupXCCL.cpp
@@ -292,7 +292,7 @@ void ProcessGroupXCCL::WorkXCCL::synchronizeStream() {
 bool ProcessGroupXCCL::WorkXCCL::wait(std::chrono::milliseconds timeout) {
   RECORD_PARAM_COMMS(
       std::make_tuple(static_cast<int64_t>(this->seq_), this->isP2P_), // seq
-      std::make_tuple(std::string(), std::string()), // PG name tuple
+      std::make_tuple(pg_uid_, pg_desc_), // PG name tuple
       rank_, // rank
       "wait", // collective name
       0, // inNelems

--- a/src/xccl/ProcessGroupXCCL.hpp
+++ b/src/xccl/ProcessGroupXCCL.hpp
@@ -87,6 +87,8 @@ class TORCH_API ProcessGroupXCCL : public Backend {
   class WorkXCCL : public Work {
    public:
     WorkXCCL(
+        std::string pgUID,
+        std::string pgDesc,
         at::Device& device,
         int rank,
         OpType opType,
@@ -130,6 +132,8 @@ class TORCH_API ProcessGroupXCCL : public Backend {
     }
 
    protected:
+    std::string pgUID_;
+    std::string pgDesc_;
     at::Device device_;
     std::shared_ptr<at::xpu::XPUEvent> xcclStartEvent_;
     std::shared_ptr<at::xpu::XPUEvent> xcclEndEvent_;


### PR DESCRIPTION
Fixes #3767

Add a call to ProcessGroupXCCL::wait() to record the op within the profiler trace, to match PGNCCL and pass the test.