### PR TITLE
Fix off-by-one in deform_conv2d 32/64-bit indexing threshold

### DIFF
--- a/src/ATen/native/xpu/sycl/DeformConv2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/DeformConv2dKernels.cpp
@@ -73,6 +73,8 @@
  *  https://github.com/open-mmlab/mmdetection/blob/master/mmdet/ops/dcn/src/deform_conv_cuda.cpp
  */
 
+#include <limits>
+
 #include <comm/Macros.h>
 // clang-format off
 DISABLE_RETURN_TYPE_WARNING_BEGIN
@@ -289,11 +291,11 @@ void deformable_im2col(
   // https://github.com/pytorch/vision/issues/4269
   bool use_64bits_indexing = false;
   // Checks if num_kernels or columns numel larger than 2 ** 31
-  use_64bits_indexing |= num_kernels > ((int64_t)1 << 31);
+  use_64bits_indexing |= num_kernels > std::numeric_limits<int32_t>::max();
   use_64bits_indexing |=
       ((int64_t)n_in_channels * weight_h * weight_w * parallel_imgs * out_h *
            out_w >
-       ((int64_t)1 << 31));
+       std::numeric_limits<int32_t>::max());
 
   if (use_64bits_indexing) {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
@@ -537,7 +539,7 @@ void compute_grad_input(
   // https://github.com/pytorch/vision/issues/4269
   bool use_64bits_indexing = false;
   // Checks if num_kernels or columns numel larger than 2 ** 31
-  use_64bits_indexing |= num_kernels > (1 << 31);
+  use_64bits_indexing |= num_kernels > std::numeric_limits<int32_t>::max();
 
   at::globalContext().alertNotDeterministic("compute_grad_input");
 
@@ -847,10 +849,10 @@ void compute_grad_offset_and_mask(
   // https://github.com/pytorch/vision/issues/4269
   bool use_64bits_indexing = false;
   // Checks if columns numel is larger than 2 ** 31
-  use_64bits_indexing |= num_kernels > ((int64_t)1 << 31);
+  use_64bits_indexing |= num_kernels > std::numeric_limits<int32_t>::max();
   use_64bits_indexing |=
       ((int64_t)channels * weight_h * weight_w * parallel_imgs * out_h * out_w >
-       ((int64_t)1 << 31));
+       std::numeric_limits<int32_t>::max());
 
   if (use_64bits_indexing) {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(


### PR DESCRIPTION
Aligns the deform_conv2d 32/64-bit indexing threshold with upstream torchvision: gate on `> std::numeric_limits<int32_t>::max()` instead of `> ((int64_t)1 << 31)`.

CUDA uses `> std::numeric_limits<int32_t>::max()`; the XPU port diverged by one (used `2**31`). With the XPU check, a count of exactly `2**31` stays on the 32-bit path, narrows to `INT_MIN` in the kernel's `int` launch parameter, and the strided loop `index < n` never runs — silent wrong gradient/output. Also drops the bare `(1 << 31)` sign-bit UB at `compute_grad_input`.

