### PR TITLE
Add BComplex32 support for XPU unary geometric ops

### DIFF
--- a/src/ATen/native/xpu/sycl/UnaryGeometricAcosKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricAcosKernel.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/OpMathType.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/xpu/sycl/Loops.h>
@@ -30,12 +31,17 @@ struct AcosFunctor {
 void acos_kernel(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
-    AT_DISPATCH_COMPLEX_TYPES_AND(
-        kComplexHalf, common_dtype, "acos_xpu", [&]() {
+    AT_DISPATCH_V2(
+        common_dtype,
+        "acos_xpu",
+        AT_WRAP([&]() {
           using opmath_t = at::opmath_type<scalar_t>;
           auto caller = AcosFunctor<scalar_t, opmath_t>();
           gpu_kernel(iter, caller);
-        });
+        }),
+        AT_EXPAND(AT_COMPLEX_TYPES),
+        kComplexHalf,
+        kBComplex32);
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(
         at::ScalarType::Half,

--- a/src/ATen/native/xpu/sycl/UnaryGeometricAcoshKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricAcoshKernel.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/OpMathType.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/xpu/sycl/Loops.h>
@@ -31,12 +32,17 @@ struct AcoshFunctor {
 void acosh_kernel(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
-    AT_DISPATCH_COMPLEX_TYPES_AND(
-        kComplexHalf, common_dtype, "acosh_xpu", [&]() {
+    AT_DISPATCH_V2(
+        common_dtype,
+        "acosh_xpu",
+        AT_WRAP([&]() {
           using opmath_t = at::opmath_type<scalar_t>;
           auto caller = AcoshFunctor<scalar_t, opmath_t>();
           gpu_kernel(iter, caller);
-        });
+        }),
+        AT_EXPAND(AT_COMPLEX_TYPES),
+        kComplexHalf,
+        kBComplex32);
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(
         at::ScalarType::Half,

--- a/src/ATen/native/xpu/sycl/UnaryGeometricAsinKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricAsinKernel.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/OpMathType.h>
 
 #include <ATen/native/xpu/sycl/Loops.h>
@@ -36,10 +37,13 @@ struct AsinFunctor {
 void asin_kernel(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
-    AT_DISPATCH_COMPLEX_TYPES_AND(
-        kComplexHalf, common_dtype, "asin_xpu", [&]() {
-          gpu_kernel(iter, AsinComplexFunctor<scalar_t>());
-        });
+    AT_DISPATCH_V2(
+        common_dtype,
+        "asin_xpu",
+        AT_WRAP([&]() { gpu_kernel(iter, AsinComplexFunctor<scalar_t>()); }),
+        AT_EXPAND(AT_COMPLEX_TYPES),
+        kComplexHalf,
+        kBComplex32);
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(
         ScalarType::Half,

--- a/src/ATen/native/xpu/sycl/UnaryGeometricAsinhKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricAsinhKernel.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/OpMathType.h>
 
 #include <ATen/native/xpu/sycl/Loops.h>
@@ -36,10 +37,13 @@ struct AsinhFunctor {
 void asinh_kernel(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
-    AT_DISPATCH_COMPLEX_TYPES_AND(
-        kComplexHalf, common_dtype, "asinh_xpu", [&]() {
-          gpu_kernel(iter, AsinhComplexFunctor<scalar_t>());
-        });
+    AT_DISPATCH_V2(
+        common_dtype,
+        "asinh_xpu",
+        AT_WRAP([&]() { gpu_kernel(iter, AsinhComplexFunctor<scalar_t>()); }),
+        AT_EXPAND(AT_COMPLEX_TYPES),
+        kComplexHalf,
+        kBComplex32);
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(
         ScalarType::Half,

--- a/src/ATen/native/xpu/sycl/UnaryGeometricAtanKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricAtanKernel.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/OpMathType.h>
 
 #include <ATen/native/xpu/sycl/Loops.h>
@@ -40,10 +41,13 @@ struct AtanFunctor {
 void atan_kernel(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
-    AT_DISPATCH_COMPLEX_TYPES_AND(
-        kComplexHalf, common_dtype, "atan_xpu", [&]() {
-          gpu_kernel(iter, AtanComplexFunctor<scalar_t>());
-        });
+    AT_DISPATCH_V2(
+        common_dtype,
+        "atan_xpu",
+        AT_WRAP([&]() { gpu_kernel(iter, AtanComplexFunctor<scalar_t>()); }),
+        AT_EXPAND(AT_COMPLEX_TYPES),
+        kComplexHalf,
+        kBComplex32);
   } else {
     AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
         ScalarType::Half,

--- a/src/ATen/native/xpu/sycl/UnaryGeometricAtanhKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricAtanhKernel.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/OpMathType.h>
 
 #include <ATen/native/xpu/sycl/Loops.h>
@@ -40,10 +41,13 @@ struct AtanhFunctor {
 void atanh_kernel(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
-    AT_DISPATCH_COMPLEX_TYPES_AND(
-        kComplexHalf, common_dtype, "atanh_xpu", [&]() {
-          gpu_kernel(iter, AtanhComplexFunctor<scalar_t>());
-        });
+    AT_DISPATCH_V2(
+        common_dtype,
+        "atanh_xpu",
+        AT_WRAP([&]() { gpu_kernel(iter, AtanhComplexFunctor<scalar_t>()); }),
+        AT_EXPAND(AT_COMPLEX_TYPES),
+        kComplexHalf,
+        kBComplex32);
   } else {
     AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
         ScalarType::Half,

--- a/src/ATen/native/xpu/sycl/UnaryGeometricCosKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricCosKernel.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/OpMathType.h>
 #include <ATen/native/TensorIterator.h>
 #include <c10/core/ScalarType.h>
@@ -34,10 +35,16 @@ struct CosFunctor {
 void cos_kernel(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
-    AT_DISPATCH_COMPLEX_TYPES_AND(kComplexHalf, common_dtype, "cos_xpu", [&]() {
-      using opmath_t = at::opmath_type<scalar_t>;
-      gpu_kernel(iter, CosFunctor<opmath_t>());
-    });
+    AT_DISPATCH_V2(
+        common_dtype,
+        "cos_xpu",
+        AT_WRAP([&]() {
+          using opmath_t = at::opmath_type<scalar_t>;
+          gpu_kernel(iter, CosFunctor<opmath_t>());
+        }),
+        AT_EXPAND(AT_COMPLEX_TYPES),
+        kComplexHalf,
+        kBComplex32);
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(
         ScalarType::Half, ScalarType::BFloat16, common_dtype, "cos_xpu", [&]() {

--- a/src/ATen/native/xpu/sycl/UnaryGeometricCoshKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricCoshKernel.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/OpMathType.h>
 
 #include <ATen/native/xpu/sycl/Loops.h>
@@ -36,10 +37,13 @@ struct CoshFunctor {
 void cosh_kernel(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
-    AT_DISPATCH_COMPLEX_TYPES_AND(
-        kComplexHalf, common_dtype, "cosh_xpu", [&]() {
-          gpu_kernel(iter, CoshComplexFunctor<scalar_t>());
-        });
+    AT_DISPATCH_V2(
+        common_dtype,
+        "cosh_xpu",
+        AT_WRAP([&]() { gpu_kernel(iter, CoshComplexFunctor<scalar_t>()); }),
+        AT_EXPAND(AT_COMPLEX_TYPES),
+        kComplexHalf,
+        kBComplex32);
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(
         ScalarType::Half,

--- a/src/ATen/native/xpu/sycl/UnaryGeometricSinKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricSinKernel.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/OpMathType.h>
 #include <ATen/native/TensorIterator.h>
 #include <c10/core/ScalarType.h>
@@ -34,10 +35,16 @@ struct SinFunctor {
 void sin_kernel(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
-    AT_DISPATCH_COMPLEX_TYPES_AND(kComplexHalf, common_dtype, "sin_xpu", [&]() {
-      using opmath_t = at::opmath_type<scalar_t>;
-      gpu_kernel(iter, SinFunctor<opmath_t>());
-    });
+    AT_DISPATCH_V2(
+        common_dtype,
+        "sin_xpu",
+        AT_WRAP([&]() {
+          using opmath_t = at::opmath_type<scalar_t>;
+          gpu_kernel(iter, SinFunctor<opmath_t>());
+        }),
+        AT_EXPAND(AT_COMPLEX_TYPES),
+        kComplexHalf,
+        kBComplex32);
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(
         ScalarType::Half, ScalarType::BFloat16, common_dtype, "sin_xpu", [&]() {

--- a/src/ATen/native/xpu/sycl/UnaryGeometricSinhKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricSinhKernel.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/OpMathType.h>
 
 #include <ATen/native/xpu/sycl/Loops.h>
@@ -36,10 +37,13 @@ struct SinhFunctor {
 void sinh_kernel(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
-    AT_DISPATCH_COMPLEX_TYPES_AND(
-        kComplexHalf, common_dtype, "sinh_xpu", [&]() {
-          gpu_kernel(iter, SinhComplexFunctor<scalar_t>());
-        });
+    AT_DISPATCH_V2(
+        common_dtype,
+        "sinh_xpu",
+        AT_WRAP([&]() { gpu_kernel(iter, SinhComplexFunctor<scalar_t>()); }),
+        AT_EXPAND(AT_COMPLEX_TYPES),
+        kComplexHalf,
+        kBComplex32);
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(
         ScalarType::Half,

--- a/src/ATen/native/xpu/sycl/UnaryGeometricTanKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricTanKernel.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/OpMathType.h>
 
 #include <ATen/native/xpu/sycl/Loops.h>
@@ -36,9 +37,13 @@ struct TanFunctor {
 void tan_kernel(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
-    AT_DISPATCH_COMPLEX_TYPES_AND(kComplexHalf, common_dtype, "tan_xpu", [&]() {
-      gpu_kernel(iter, TanComplexFunctor<scalar_t>());
-    });
+    AT_DISPATCH_V2(
+        common_dtype,
+        "tan_xpu",
+        AT_WRAP([&]() { gpu_kernel(iter, TanComplexFunctor<scalar_t>()); }),
+        AT_EXPAND(AT_COMPLEX_TYPES),
+        kComplexHalf,
+        kBComplex32);
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(
         ScalarType::Half, ScalarType::BFloat16, common_dtype, "tan_xpu", [&]() {

--- a/src/ATen/native/xpu/sycl/UnaryGeometricTanhKernel.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryGeometricTanhKernel.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/OpMathType.h>
 #include <ATen/native/TensorIterator.h>
 #include <c10/core/ScalarType.h>
@@ -34,11 +35,16 @@ struct TanhFunctor {
 void tanh_kernel(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
-    AT_DISPATCH_COMPLEX_TYPES_AND(
-        kComplexHalf, common_dtype, "tanh_xpu", [&]() {
+    AT_DISPATCH_V2(
+        common_dtype,
+        "tanh_xpu",
+        AT_WRAP([&]() {
           using opmath_t = at::opmath_type<scalar_t>;
           gpu_kernel(iter, TanhFunctor<opmath_t>());
-        });
+        }),
+        AT_EXPAND(AT_COMPLEX_TYPES),
+        kComplexHalf,
+        kBComplex32);
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(
         ScalarType::Half,

--- a/test/regressions/test_unary.py
+++ b/test/regressions/test_unary.py
@@ -102,3 +102,32 @@ class TestSimpleUnary(TestCase):
     @Dtypes(floating_and_complex_types)
     def test_reciprocal_out(self, dtype):
         self._test_unary_out_ops("reciprocal", dtype)
+
+    def test_unary_geometric_bcomplex32(self):
+        x_cpu = torch.randn(64, dtype=torch.complex64) * 0.1
+        x_xpu = x_cpu.to("xpu").to(torch.bcomplex32)
+        unary_geometric_ops = [
+            torch.acos,
+            torch.acosh,
+            torch.asin,
+            torch.asinh,
+            torch.atan,
+            torch.atanh,
+            torch.cos,
+            torch.cosh,
+            torch.sin,
+            torch.sinh,
+            torch.tan,
+            torch.tanh,
+        ]
+
+        for op in unary_geometric_ops:
+            with self.subTest(op=op.__name__):
+                out = op(x_xpu)
+                self.assertEqual(out.dtype, torch.bcomplex32)
+                self.assertEqual(out.shape, x_xpu.shape)
+
+                ref = op(x_cpu)
+                self.assertEqual(
+                    out.to(torch.complex64).cpu(), ref, rtol=3e-2, atol=3e-2
+                )


### PR DESCRIPTION
### Root cause
These XPU unary geometric kernels did not include BComplex32 in their complex dispatch path, which could lead to not implemented errors for BComplex32 inputs.

### What changed
1. Added BComplex32 support in 12 XPU unary geometric kernels.
2. Covered:
   1. acos, acosh, asin, asinh, atan, atanh
   2. cos, cosh, sin, sinh, tan, tanh
3. Kept changes scoped to dtype dispatch only (no algorithmic behavior changes).

Test plan
1. Rebuild PyTorch with XPU enabled.
2. Run targeted XPU unary/opinfo numerics tests for complex32 on the 12 operators above.
3. Confirm no not implemented for BComplex32 failures on those ops.

Issue linkage
Fixes #4086
Related: #4082