### PR TITLE
Replace enable_if SFINAE with C++20 requires-clauses

### DIFF
--- a/src/ATen/native/xpu/sycl/MathExtensions.h
+++ b/src/ATen/native/xpu/sycl/MathExtensions.h
@@ -31,7 +31,8 @@ namespace at::native::xpu {
  * "ATen/native/Math.h".
  */
 template <typename T>
-inline std::enable_if_t<std::is_floating_point_v<T>, T> calc_erfinv(T y) {
+  requires std::is_floating_point_v<T>
+inline T calc_erfinv(T y) {
   /* Function to calculate inverse error function. Rational approximation is
    * used to generate an initial approximation, which is then improved to full
    * accuracy by two steps of Newton's method.
@@ -1014,9 +1015,8 @@ static inline C10_HOST_DEVICE scalar_t calc_i0(scalar_t _x) {
 }
 
 template <typename T>
-C10_HOST_DEVICE inline typename std::enable_if<
-    std::is_same<double, T>::value,
-    std::tuple<const T*, size_t>>::type
+  requires std::is_same_v<double, T>
+C10_HOST_DEVICE inline std::tuple<const T*, size_t>
 chebyshev_coefficients_i1e_A() {
   /* Chebyshev coefficients for exp(-x) I1(x)
    * in the interval [0,8].
@@ -1044,9 +1044,9 @@ chebyshev_coefficients_i1e_A() {
 }
 
 template <typename T>
-C10_HOST_DEVICE inline typename std::
-    enable_if<std::is_same<float, T>::value, std::tuple<const T*, size_t>>::type
-    chebyshev_coefficients_i1e_A() {
+  requires std::is_same_v<float, T>
+C10_HOST_DEVICE inline std::tuple<const T*, size_t>
+chebyshev_coefficients_i1e_A() {
   /* Chebyshev coefficients for exp(-x) I1(x)
    * in the interval [0,8].
    *
@@ -1074,9 +1074,8 @@ C10_HOST_DEVICE inline typename std::
 };
 
 template <typename T>
-C10_HOST_DEVICE inline typename std::enable_if<
-    std::is_same<double, T>::value,
-    std::tuple<const T*, size_t>>::type
+  requires std::is_same_v<double, T>
+C10_HOST_DEVICE inline std::tuple<const T*, size_t>
 chebyshev_coefficients_i1e_B() {
   /* Chebyshev coefficients for exp(-x) sqrt(x) I1(x)
    * in the inverted interval [8,infinity].
@@ -1102,9 +1101,9 @@ chebyshev_coefficients_i1e_B() {
 }
 
 template <typename T>
-C10_HOST_DEVICE inline typename std::
-    enable_if<std::is_same<float, T>::value, std::tuple<const T*, size_t>>::type
-    chebyshev_coefficients_i1e_B() {
+  requires std::is_same_v<float, T>
+C10_HOST_DEVICE inline std::tuple<const T*, size_t>
+chebyshev_coefficients_i1e_B() {
   /* Chebyshev coefficients for exp(-x) sqrt(x) I1(x)
    * in the inverted interval [8,infinity].
    *

--- a/src/ATen/native/xpu/sycl/Pow.h
+++ b/src/ATen/native/xpu/sycl/Pow.h
@@ -38,12 +38,10 @@ static inline at::BFloat16 pow_(at::BFloat16 base, at::BFloat16 exp) {
 }
 // pow (floating, floating/int)
 template <typename Base_type, typename Exp_type>
-static inline typename std::enable_if<
-    std::is_floating_point<Base_type>::value &&
-        (std::is_same<Base_type, Exp_type>::value ||
-         std::is_same<Exp_type, int>::value),
-    Base_type>::type
-pow_(Base_type base, Exp_type exp) {
+  requires(
+      std::is_floating_point_v<Base_type> &&
+      (std::is_same_v<Base_type, Exp_type> || std::is_same_v<Exp_type, int>))
+static inline Base_type pow_(Base_type base, Exp_type exp) {
   if constexpr (std::is_same_v<Exp_type, int>) {
     return sycl::pown(base, exp);
   } else {
@@ -52,11 +50,9 @@ pow_(Base_type base, Exp_type exp) {
 }
 // pow (Otherwise)
 template <typename Base_type, typename Exp_type>
-static inline typename std::enable_if<
-    !std::is_same<Base_type, Exp_type>::value &&
-        !std::is_same<Exp_type, int>::value,
-    Base_type>::type
-pow_(Base_type base, Exp_type exp) {
+  requires(
+      !std::is_same_v<Base_type, Exp_type> && !std::is_same_v<Exp_type, int>)
+static inline Base_type pow_(Base_type base, Exp_type exp) {
   return static_cast<Base_type>(
       sycl::pow(static_cast<double>(base), static_cast<double>(exp)));
 }
@@ -78,9 +74,8 @@ static inline Base_type pow_(Base_type base, Exp_type exp) {
 #endif
 
 template <typename T>
-static inline std::enable_if_t<std::is_integral<T>::value, T> pow_(
-    T base,
-    T exp) {
+  requires std::is_integral_v<T>
+static inline T pow_(T base, T exp) {
   return at::native::powi(base, exp);
 }
 

--- a/src/ATen/native/xpu/sycl/PowKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PowKernels.cpp
@@ -42,9 +42,8 @@ static inline Base_type pow_(Base_type base, Exp_type exp) {
 }
 
 template <typename T>
-static inline std::enable_if_t<std::is_integral<T>::value, T> pow_(
-    T base,
-    T exp) {
+  requires std::is_integral_v<T>
+static inline T pow_(T base, T exp) {
   return at::native::powi(base, exp);
 }
 

--- a/src/ATen/native/xpu/sycl/Reduce.h
+++ b/src/ATen/native/xpu/sycl/Reduce.h
@@ -858,10 +858,10 @@ struct ReduceOp {
   }
 
   template <int output_vec_size, bool can_acc>
+    requires can_acc
   at::detail::Array<arg_t, output_vec_size> accumulate_in_output(
       at::detail::Array<out_scalar_t*, output_vec_size> out,
-      at::detail::Array<arg_t, output_vec_size> value,
-      typename std::enable_if<can_acc>::type* = nullptr) const {
+      at::detail::Array<arg_t, output_vec_size> value) const {
     at::detail::Array<arg_t, output_vec_size> ret;
 #pragma unroll(output_vec_size)
     for (int i = 0; i < output_vec_size; ++i) {
@@ -871,10 +871,8 @@ struct ReduceOp {
   }
 
   template <bool can_acc>
-  out_scalar_t get_accumulated_output(
-      out_scalar_t* out,
-      arg_t value,
-      typename std::enable_if<can_acc>::type* = nullptr) const {
+    requires can_acc
+  out_scalar_t get_accumulated_output(out_scalar_t* out, arg_t value) const {
     assert(!final_output);
     return (out_scalar_t)value;
   }
@@ -883,10 +881,10 @@ struct ReduceOp {
   // It's the version of `accumulate_in_output`
   // when accumulation in the output is not possible.
   template <int output_vec_size, bool can_acc>
+    requires(!can_acc)
   at::detail::Array<arg_t, output_vec_size> accumulate_in_output(
       at::detail::Array<out_scalar_t*, output_vec_size>,
-      at::detail::Array<arg_t, output_vec_size>,
-      typename std::enable_if<!can_acc>::type* = nullptr) const {
+      at::detail::Array<arg_t, output_vec_size>) const {
     assert(false);
     return arg_t{};
   }
@@ -895,10 +893,8 @@ struct ReduceOp {
   // it's the version of `get_accumulated_output`
   // when accumulation in the output is not possible.
   template <bool can_acc>
-  out_scalar_t get_accumulated_output(
-      out_scalar_t* out,
-      arg_t value,
-      typename std::enable_if<!can_acc>::type* = nullptr) const {
+    requires(!can_acc)
+  out_scalar_t get_accumulated_output(out_scalar_t* out, arg_t value) const {
     assert(false);
     return *out;
   }

--- a/src/comm/SYCLHelpers.h
+++ b/src/comm/SYCLHelpers.h
@@ -79,10 +79,8 @@ static inline void sycl_kernel_submit(
 struct __SYCL_KER_CONFIG_CONVENTION__ {};
 
 template <typename ker_t, int dim>
-static inline typename std::enable_if<
-    std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
-    void>::type
-sycl_kernel_submit(
+  requires std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>
+static inline void sycl_kernel_submit(
     ::sycl::range<dim> global_range,
     ::sycl::range<dim> local_range,
     ::sycl::queue q,
@@ -96,10 +94,8 @@ sycl_kernel_submit(
 }
 
 template <typename ker_t, int dim>
-static inline typename std::enable_if<
-    !std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
-    void>::type
-sycl_kernel_submit(
+  requires(!std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>)
+static inline void sycl_kernel_submit(
     ::sycl::range<dim> global_range,
     ::sycl::range<dim> local_range,
     ::sycl::queue q,
@@ -112,10 +108,8 @@ sycl_kernel_submit(
 }
 
 template <typename ker_t>
-static inline typename std::enable_if<
-    std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
-    void>::type
-sycl_kernel_submit(
+  requires std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>
+static inline void sycl_kernel_submit(
     int64_t global_range,
     int64_t local_range,
     ::sycl::queue q,
@@ -131,10 +125,8 @@ sycl_kernel_submit(
 }
 
 template <typename ker_t>
-static inline typename std::enable_if<
-    !std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
-    void>::type
-sycl_kernel_submit(
+  requires(!std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>)
+static inline void sycl_kernel_submit(
     int64_t global_range,
     int64_t local_range,
     ::sycl::queue q,
@@ -169,10 +161,8 @@ struct __SyclKernelWithProps__ {
 };
 
 template <typename ker_t, typename Props, int dim>
-static inline typename std::enable_if<
-    std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
-    void>::type
-sycl_kernel_submit(
+  requires std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>
+static inline void sycl_kernel_submit(
     ::sycl::range<dim> global_range,
     ::sycl::range<dim> local_range,
     ::sycl::queue q,
@@ -189,10 +179,8 @@ sycl_kernel_submit(
 }
 
 template <typename ker_t, typename Props, int dim>
-static inline typename std::enable_if<
-    !std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
-    void>::type
-sycl_kernel_submit(
+  requires(!std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>)
+static inline void sycl_kernel_submit(
     ::sycl::range<dim> global_range,
     ::sycl::range<dim> local_range,
     ::sycl::queue q,
@@ -208,10 +196,8 @@ sycl_kernel_submit(
 }
 
 template <typename ker_t, typename Props>
-static inline typename std::enable_if<
-    std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
-    void>::type
-sycl_kernel_submit(
+  requires std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>
+static inline void sycl_kernel_submit(
     int64_t global_range,
     int64_t local_range,
     ::sycl::queue q,
@@ -230,10 +216,8 @@ sycl_kernel_submit(
 }
 
 template <typename ker_t, typename Props>
-static inline typename std::enable_if<
-    !std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>,
-    void>::type
-sycl_kernel_submit(
+  requires(!std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, ker_t>)
+static inline void sycl_kernel_submit(
     int64_t global_range,
     int64_t local_range,
     ::sycl::queue q,


### PR DESCRIPTION
The project compiles as C++20, so std::enable_if return-type SFINAE under src/ can be rewritten as requires-clauses, which read more clearly and keep the return type unobscured. Constraints are preserved exactly, so overload selection is unchanged. In Reduce.h the dummy `enable_if<...>::type* = nullptr` parameter is dropped (all call sites relied on its default).

Authored with assistance from an AI coding agent.