### PR TITLE
Add kBComplex32 regression tests for Indexing, Cat, and Scatter/Gather

### DIFF
--- a/test/regressions/test_cat.py
+++ b/test/regressions/test_cat.py
@@ -280,6 +280,16 @@ class TestTorchMethod(TestCase):
                     res_xpu.is_contiguous(memory_format=torch.channels_last), False
                 )
 
+    def test_cat_bcomplex32(self):
+        # bcomplex32 CPU support is limited; compare XPU results directly
+        a = torch.randn(3, 4).to(torch.bcomplex32).to(xpu_device)
+        b = torch.randn(2, 4).to(torch.bcomplex32).to(xpu_device)
+        result = torch.cat([a, b], dim=0)
+        self.assertEqual(result.shape, torch.Size([5, 4]))
+        self.assertEqual(result.dtype, torch.bcomplex32)
+        self.assertEqual(result[:3], a)
+        self.assertEqual(result[3:], b)
+
 
 instantiate_device_type_tests(
     TestTorchMethod, globals(), only_for="xpu", allow_xpu=True

--- a/test/regressions/test_copy.py
+++ b/test/regressions/test_copy.py
@@ -64,6 +64,14 @@ class TestSimpleCopy(TestCase):
         b_xpu = a_xpu.clone(memory_format=torch.channels_last)
         self.assertEqual(b_cpu, b_xpu.view(torch.uint8).to(cpu_device))
 
+    def test_copy_kernel_bcomplex32(self):
+        x_xpu = torch.tensor(
+            [1 + 2j, 3 + 4j, -5 - 6j], dtype=torch.bcomplex32, device="xpu"
+        )
+        y_xpu = torch.empty_like(x_xpu)
+        y_xpu.copy_(x_xpu)
+        self.assertEqual(y_xpu, x_xpu)
+
 
 instantiate_device_type_tests(TestSimpleCopy, globals(), only_for="xpu", allow_xpu=True)
 

--- a/test/regressions/test_index_and_index_put.py
+++ b/test/regressions/test_index_and_index_put.py
@@ -180,3 +180,30 @@ class TestTorchMethod(TestCase):
                 v_xpu, i_xpu = op(x.xpu(), dim)
                 self.assertEqual(v_xpu.cpu(), v_cpu)
                 self.assertEqual(i_xpu.cpu(), i_cpu)
+
+    def test_index_bcomplex32(self):
+        # bcomplex32 CPU support is limited; compare XPU results directly
+        x = torch.randn(8, 4).to(torch.bcomplex32).to(xpu_device)
+        idx = torch.tensor([0, 3, 5], device=xpu_device)
+        result = x[idx]
+        self.assertEqual(result.dtype, torch.bcomplex32)
+        self.assertEqual(result, torch.stack([x[0], x[3], x[5]]))
+
+    def test_masked_fill_bcomplex32(self):
+        x = torch.randn(4, 8).to(torch.bcomplex32).to(xpu_device)
+        mask = torch.zeros(4, 8, dtype=torch.bool, device=xpu_device)
+        mask[1] = True
+        x.masked_fill_(mask, 0)
+        self.assertEqual(x.dtype, torch.bcomplex32)
+        self.assertEqual(
+            x[1], torch.zeros(8, dtype=torch.bcomplex32, device=xpu_device)
+        )
+
+    def test_index_put_bcomplex32(self):
+        x = torch.zeros(4, 8, dtype=torch.bcomplex32, device=xpu_device)
+        idx = torch.tensor([1, 3], device=xpu_device)
+        vals = torch.randn(2, 8).to(torch.bcomplex32).to(xpu_device)
+        x.index_put_([idx], vals)
+        self.assertEqual(x.dtype, torch.bcomplex32)
+        self.assertEqual(x[1], vals[0])
+        self.assertEqual(x[3], vals[1])

--- a/test/regressions/test_scatter_gather.py
+++ b/test/regressions/test_scatter_gather.py
@@ -1,0 +1,38 @@
+# Copyright 2020-2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Owner(s): ["module: intel"]
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+xpu_device = torch.device("xpu")
+
+
+class TestScatterGatherBComplex32(TestCase):
+    def test_gather_bcomplex32(self):
+        # bcomplex32 CPU support is limited; compare XPU results directly
+        x = torch.randn(4, 8).to(dtype=torch.bcomplex32, device=xpu_device)
+        # gather column 0 from all rows via a (4, 1) index tensor
+        idx = torch.zeros(4, 1, dtype=torch.long, device=xpu_device)
+        result = torch.gather(x, 1, idx)
+        self.assertEqual(result.dtype, torch.bcomplex32)
+        self.assertEqual(result[:, 0], x[:, 0])
+
+    def test_scatter_bcomplex32(self):
+        x = torch.zeros(4, 8, dtype=torch.bcomplex32, device=xpu_device)
+        idx = torch.tensor([[0, 2, 4]], dtype=torch.long, device=xpu_device)
+        src = torch.randn(1, 3).to(dtype=torch.bcomplex32, device=xpu_device)
+        x.scatter_(1, idx, src)
+        self.assertEqual(x.dtype, torch.bcomplex32)
+        self.assertEqual(x[0, 0], src[0, 0])
+        self.assertEqual(x[0, 2], src[0, 1])
+        self.assertEqual(x[0, 4], src[0, 2])
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/4083
### Summary
 
Add regression tests verifying `kBComplex32` dtype support for the core operators updated in #4125. Those kernel dispatch changes are already on `main`; these tests provide explicit coverage for the acceptance criteria in #4083.
 
### Changes
 
| File | Tests Added |
|------|-------------|
| `test/regressions/test_index_and_index_put.py` | `test_index_bcomplex32`, `test_masked_fill_bcomplex32`, `test_index_put_bcomplex32` |
| `test/regressions/test_cat.py` | `test_cat_bcomplex32` |
| `test/regressions/test_copy.py` | Adds a `bcomplex32` copy-kernel regression test |
| `test/regressions/test_scatter_gather.py` (new) | `test_gather_bcomplex32`, `test_scatter_bcomplex32` |
 
All tests run XPU-only and compare XPU tensor results directly, since CPU support for `bcomplex32` is limited (matching the pattern established in `test_copy` from #4125).

### Test Plan
 
 ```bash
# Indexing + masked_fill + index_put
pytest test/regressions/test_index_and_index_put.py -v -k "bcomplex32"

# Cat / Shape
pytest test/regressions/test_cat.py -v -k "bcomplex32"

# Copy
pytest test/regressions/test_copy.py -v -k "bcomplex32"

# Scatter / Gather
pytest test/regressions/test_scatter_gather.py -v