### PR TITLE
Add diagonal_copy, expand_copy, slice_copy.Tensor to XPU yaml

### DIFF
--- a/yaml/native/native_functions.yaml
+++ b/yaml/native/native_functions.yaml
@@ -9051,6 +9051,27 @@
   tags: view_copy
   autogen: select_copy.int_out
 
+- func: diagonal_copy(Tensor self, int offset=0, int dim1=0, int dim2=1) -> Tensor
+  variants: function
+  dispatch:
+    CompositeExplicitAutogradNonFunctional: diagonal_copy
+  tags: view_copy
+  autogen: diagonal_copy.out
+
+- func: expand_copy(Tensor self, SymInt[] size, *, bool implicit=False) -> Tensor
+  variants: function
+  dispatch:
+    CompositeExplicitAutogradNonFunctional: expand_copy_symint
+  tags: view_copy
+  autogen: expand_copy.out
+
+- func: slice_copy.Tensor(Tensor self, int dim=0, SymInt? start=None, SymInt? end=None, SymInt step=1) -> Tensor
+  variants: function
+  dispatch:
+    CompositeExplicitAutogradNonFunctional: slice_copy_Tensor_symint
+  tags: view_copy
+  autogen: slice_copy.Tensor_out
+
 - func: select.int(Tensor(a) self, int dim, SymInt index) -> Tensor(a)
   variants: function, method
   device_check: NoCheck


### PR DESCRIPTION
These three _copy variants for core view ops (diagonal, expand, slice.Tensor) were missing from the XPU native functions yaml, while all other core view _copy variants (alias_copy, as_strided_copy, permute_copy, select_copy.int, split_with_sizes_copy, squeeze_copy, unsqueeze_copy, view_copy) were present.

This inconsistency caused test_views_op_having_view_copy to fail on XPU because torch.ops.aten.diagonal_copy, torch.ops.aten.expand_copy, and torch.ops.aten.slice_copy.Tensor were not properly available.

All three use CompositeExplicitAutogradNonFunctional dispatch (no XPU-specific kernel needed), matching the pattern of existing _copy variants in the XPU yaml.