### PR TITLE
Align XPU test golden strings with upstream `print_readable` formatting

### DIFF
--- a/test/xpu/functorch/test_control_flow_xpu.py
+++ b/test/xpu/functorch/test_control_flow_xpu.py
@@ -9002,6 +9002,7 @@ class GraphModule(torch.nn.Module):
         while_loop_stack_output = torch.ops.higher_order.while_loop_stack_output(while_loop_cond_graph_0, while_loop_body_graph_0, (primals_1,), (primals_3, primals_2));  while_loop_cond_graph_0 = while_loop_body_graph_0 = None
         getitem: "f32[u2, 3, 3]" = while_loop_stack_output[0];  while_loop_stack_output = None
         select: "f32[3, 3]" = torch.ops.aten.select.int(getitem, 0, -1)
+
         unsqueeze: "f32[1, 3, 3]" = torch.ops.aten.unsqueeze.default(primals_1, 0);  primals_1 = None
         slice_1: "f32[u2 - 1, 3, 3]" = torch.ops.aten.slice.Tensor(getitem, 0, 0, -1);  getitem = None
         cat: "f32[u2, 3, 3]" = torch.ops.aten.cat.default([unsqueeze, slice_1]);  unsqueeze = slice_1 = None

--- a/test/xpu/higher_order_ops/test_invoke_subgraph_xpu.py
+++ b/test/xpu/higher_order_ops/test_invoke_subgraph_xpu.py
@@ -2030,6 +2030,7 @@ class GraphModule(torch.nn.Module):
 
         getitem: "f32[8, 8]" = invoke_subgraph_2[0];  invoke_subgraph_2 = None
         sin: "f32[8, 8]" = torch.ops.aten.sin.default(getitem)
+
         cos: "f32[8, 8]" = torch.ops.aten.cos.default(getitem);  getitem = None
         return (sin, getitem_6, getitem_5, getitem_4, cos)
 


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/4170

Upstream PyTorch PR [#185067](https://github.com/pytorch/pytorch/pull/185067) (*Mark AOT backward stack comments in `print_readable`*) changed how `GraphModule.print_readable()` formats node output: it now inserts a blank line after each "output-producing" node before the next independent node, producing slightly different graph text.

Two XPU test files that contain `assertExpectedInline` golden strings were not updated to match this format:

- test_control_flow_xpu.py — `TestControlFlowTraced::test_while_loop_autograd_simple`
- test_invoke_subgraph_xpu.py — `TestInvokeSubgraphCompile::test_bwd_partitioning`

Both tests fail with an `AssertionError` reporting a single missing blank line (`+`) in the expected string.

This PR adds the missing blank lines so the golden strings match current `print_readable` output, identical to what the upstream versions already have.

**Root cause**: upstream formatting-only change in `print_readable` not yet synced into XPU test port.

**Test Plan**:
```bash
pytest -v \
  test/xpu/functorch/test_control_flow_xpu.py::TestControlFlowTraced::test_while_loop_autograd_simple \
  test/xpu/higher_order_ops/test_invoke_subgraph_xpu.py::TestInvokeSubgraphCompile::test_bwd_partitioning
# 2 passed
```