### PR TITLE
Add linalg_matrix_sqrth and linalg_polar.out to XPU CPU fallback list

### DIFF
--- a/src/ATen/native/xpu/XPUFallback.cpp
+++ b/src/ATen/native/xpu/XPUFallback.cpp
@@ -361,6 +361,7 @@ TORCH_LIBRARY_IMPL(aten, XPU, m) {
       "linalg_lstsq.out",
       "linalg_lu.out",
       "linalg_matrix_exp",
+      "linalg_matrix_sqrth",
       "linalg_qr.out",
       "_linalg_svd.U",
       "lu_unpack.out",

--- a/src/ATen/native/xpu/XPUFallback.cpp
+++ b/src/ATen/native/xpu/XPUFallback.cpp
@@ -362,6 +362,7 @@ TORCH_LIBRARY_IMPL(aten, XPU, m) {
       "linalg_lu.out",
       "linalg_matrix_exp",
       "linalg_matrix_sqrth",
+      "linalg_polar.out",
       "linalg_qr.out",
       "_linalg_svd.U",
       "lu_unpack.out",

--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -65,8 +65,6 @@ skip_dict = {
     "test_autograd_xpu.py": (
         # skipped due to #2536, torch._C._scatter or torch._C._gather
         "test_profiler_emit_nvtx_xpu",
-        # kineto profiler propagation via JIT fork/wait is not supported on XPU
-        "test_profiler_propagation",
         "test_checkpointing_without_reentrant_dataparallel",
         "test_dataparallel_saved_tensors_hooks",
         # CUDA-specific bogus autograd registration tests, not applicable to XPU

--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -65,6 +65,8 @@ skip_dict = {
     "test_autograd_xpu.py": (
         # skipped due to #2536, torch._C._scatter or torch._C._gather
         "test_profiler_emit_nvtx_xpu",
+        # kineto profiler propagation via JIT fork/wait is not supported on XPU
+        "test_profiler_propagation",
         "test_checkpointing_without_reentrant_dataparallel",
         "test_dataparallel_saved_tensors_hooks",
         # CUDA-specific bogus autograd registration tests, not applicable to XPU


### PR DESCRIPTION
Related to pytorch/pytorch#188393
Related to pytorch/pytorch#188392
Related to pytorch/pytorch#188391
Part of the fix for pytorch/pytorch#188238

`linalg_matrix_sqrth` and `linalg_polar` were added to PyTorch ([#187987](https://github.com/pytorch/pytorch/pull/187987), [#185837](https://github.com/pytorch/pytorch/pull/185837)) with only `CPU, CUDA` dispatch keys. Without XPU entries, calling them on XPU raises `NotImplementedError`. This adds both to the CPU fallback list in `XPUFallback.cpp`, consistent with other linalg ops that lack a native XPU kernel.

Note: the CI failures in pytorch/pytorch will be resolved after this PR merges and pytorch/pytorch updates the xpu.txt pin.

**Tests in pytorch/pytorch:**

```bash
python test/inductor/test_torchinductor_opinfo.py \
  TestInductorOpInfoXPU.test_comprehensive_linalg_matrix_sqrth_xpu_float32 \
  TestInductorOpInfoXPU.test_comprehensive_linalg_matrix_sqrth_xpu_float64
python test/test_ops.py \
  TestCommonXPU.test_compare_cpu_linalg_matrix_sqrth_xpu_float32
python test/inductor/test_torchinductor_opinfo.py \
  TestInductorOpInfoXPU.test_comprehensive_linalg_polar_xpu_float64
python test/test_ops.py \
  TestCommonXPU.test_compare_cpu_linalg_polar_xpu_float32
```
All tests pass locally (source build, Intel Data Center GPU Max 1100).

This PR was authored with AI assistance.