### PR TITLE
Add linalg_polar.out to XPU CPU fallback list

### DIFF
--- a/src/ATen/native/xpu/XPUFallback.cpp
+++ b/src/ATen/native/xpu/XPUFallback.cpp
@@ -361,6 +361,7 @@ TORCH_LIBRARY_IMPL(aten, XPU, m) {
       "linalg_lstsq.out",
       "linalg_lu.out",
       "linalg_matrix_exp",
+      "linalg_polar.out",
       "linalg_qr.out",
       "_linalg_svd.U",
       "lu_unpack.out",


### PR DESCRIPTION
Part of the fix for pytorch/pytorch#188238

`linalg_polar` was added to PyTorch in pytorch/pytorch#185837 with only CPU/CUDA dispatch. Add it to the XPU fallback list so XPU falls back to CPU instead of hitting a missing dispatch error.

The corresponding pytorch/pytorch fix (trace_rules.py + lowering.py) is in pytorch/pytorch#188537. Issue pytorch/pytorch#188238 will be fully resolved once both PRs are merged and the pin in xpu.txt is updated.

Test:
```
python test/inductor/test_torchinductor_opinfo.py \\
    TestInductorOpInfoXPU.test_comprehensive_linalg_polar_xpu_float64
# Ran 1 test in 11.728s  OK

python test/test_ops.py \\
    TestCommonXPU.test_compare_cpu_linalg_polar_xpu_float32
# Ran 1 test in 0.034s  OK
```