### PR TITLE
Add test class to `test_init.py`

### DIFF
--- a/test/xpu/nn/test_init_xpu.py
+++ b/test/xpu/nn/test_init_xpu.py
@@ -8,6 +8,7 @@
 
 # Owner(s): ["module: intel"]
 
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import run_tests
 
 try:
@@ -16,7 +17,12 @@ except Exception as e:
     from ..xpu_test_utils import XPUPatchForImport
 
 with XPUPatchForImport(False):
-    from test_init import TestNNInit  # noqa: F401
+    from test_init import TestNNInit, TestNNInitDeviceType  # noqa: F401
+
+
+instantiate_device_type_tests(
+    TestNNInitDeviceType, globals(), only_for="xpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The upstream `nn/test_init.py` file also contains the `TestNNInitDeviceType`
class which is not tested against XPU. This commit updates the thin
wrapper to also execute tests on XPU.

Before: 31 passed, 28 subtests passed (6.66s)
After:  53 passed, 56 subtests passed (9.26s)