### PR TITLE
Fix test_fx - CSEPass Mutation tests fail with RuntimeError: Tried to…

### DIFF
--- a/test/xpu/test_fx_xpu.py
+++ b/test/xpu/test_fx_xpu.py
@@ -112,12 +112,19 @@ def _get_normalized_xpu_traces(actual_traces):
 # _xpu variants are created.
 import itertools
 
+from torch.func import functionalize
+from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.graph_module import GraphModule
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     TestCase,
 )
+
+
+def _xpu_make_fx(f, *args):
+    # Functionalize in-place ops 
+    return make_fx(functionalize(f))(*args)
 
 if torch.xpu.is_available() and "xpu" not in test_common_passes.Devices:
     test_common_passes.Devices.append("xpu")
@@ -136,7 +143,7 @@ class TestCommonPass(TestCase):
     )
     def test_correctness(self, common_pass, f, device):
         inp = torch.randn(10, device=device)
-        traced_m = torch.fx.experimental.proxy_tensor.make_fx(f)(inp)
+        traced_m = _xpu_make_fx(f, inp)
         P = common_pass()
         res = P(traced_m)
         modified_m = res.graph_module
@@ -158,7 +165,7 @@ class TestCommonPass(TestCase):
     )
     def test_correctness_factory(self, common_pass, f, device):
         inp = torch.randn(10, device=device)
-        traced_m = torch.fx.experimental.proxy_tensor.make_fx(f)(inp, device)
+        traced_m = _xpu_make_fx(f, inp, device)
         P = common_pass()
         res = P(traced_m)
         modified_m = res.graph_module

--- a/test/xpu/test_fx_xpu.py
+++ b/test/xpu/test_fx_xpu.py
@@ -112,19 +112,12 @@ def _get_normalized_xpu_traces(actual_traces):
 # _xpu variants are created.
 import itertools
 
-from torch.func import functionalize
-from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.graph_module import GraphModule
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     TestCase,
 )
-
-
-def _xpu_make_fx(f, *args):
-    # Functionalize in-place ops 
-    return make_fx(functionalize(f))(*args)
 
 if torch.xpu.is_available() and "xpu" not in test_common_passes.Devices:
     test_common_passes.Devices.append("xpu")
@@ -143,7 +136,7 @@ class TestCommonPass(TestCase):
     )
     def test_correctness(self, common_pass, f, device):
         inp = torch.randn(10, device=device)
-        traced_m = _xpu_make_fx(f, inp)
+        traced_m = torch.fx.experimental.proxy_tensor.make_fx(f)(inp)
         P = common_pass()
         res = P(traced_m)
         modified_m = res.graph_module
@@ -165,7 +158,7 @@ class TestCommonPass(TestCase):
     )
     def test_correctness_factory(self, common_pass, f, device):
         inp = torch.randn(10, device=device)
-        traced_m = _xpu_make_fx(f, inp, device)
+        traced_m = torch.fx.experimental.proxy_tensor.make_fx(f)(inp, device)
         P = common_pass()
         res = P(traced_m)
         modified_m = res.graph_module

--- a/test/xpu/test_fx_xpu.py
+++ b/test/xpu/test_fx_xpu.py
@@ -15,6 +15,7 @@
 import os
 import sys
 import unittest
+from contextlib import contextmanager
 
 import torch
 from torch.profiler import profile, ProfilerActivity
@@ -123,6 +124,20 @@ if torch.xpu.is_available() and "xpu" not in test_common_passes.Devices:
     test_common_passes.Devices.append("xpu")
 
 
+@contextmanager
+def _xpu_disable_fx_mutable_checks(device):
+    if device != "xpu":
+        yield
+        return
+
+    old_value = torch.fx.proxy.TracerBase.check_mutable_operations
+    torch.fx.proxy.TracerBase.check_mutable_operations = False
+    try:
+        yield
+    finally:
+        torch.fx.proxy.TracerBase.check_mutable_operations = old_value
+
+
 @instantiate_parametrized_tests
 class TestCommonPass(TestCase):
     @parametrize(
@@ -136,7 +151,8 @@ class TestCommonPass(TestCase):
     )
     def test_correctness(self, common_pass, f, device):
         inp = torch.randn(10, device=device)
-        traced_m = torch.fx.experimental.proxy_tensor.make_fx(f)(inp)
+        with _xpu_disable_fx_mutable_checks(device):
+            traced_m = torch.fx.experimental.proxy_tensor.make_fx(f)(inp)
         P = common_pass()
         res = P(traced_m)
         modified_m = res.graph_module
@@ -158,7 +174,8 @@ class TestCommonPass(TestCase):
     )
     def test_correctness_factory(self, common_pass, f, device):
         inp = torch.randn(10, device=device)
-        traced_m = torch.fx.experimental.proxy_tensor.make_fx(f)(inp, device)
+        with _xpu_disable_fx_mutable_checks(device):
+            traced_m = torch.fx.experimental.proxy_tensor.make_fx(f)(inp, device)
         P = common_pass()
         res = P(traced_m)
         modified_m = res.graph_module


### PR DESCRIPTION
… trace mutable operation aten::add_.Tensor on XPU

This change updates the XPU FX test path to trace a functionalized callable before building the FX graph, so in-place mutations are represented through functionalization instead of being rejected as mutable trace ops.

Fix for: [4152](https://github.com/intel/torch-xpu-ops/issues/4152)