### PR TITLE
Implementation of Empty/Zeros with nested tensors for XPU

### DIFF
--- a/src/ATen/native/xpu/TensorFactories.cpp
+++ b/src/ATen/native/xpu/TensorFactories.cpp
@@ -23,6 +23,7 @@ DISABLE_SYCL_DEPRECATED_WARNING_END
 #include <ATen/ops/_efficientzerotensor_native.h>
 #include <ATen/ops/empty_native.h>
 #include <ATen/ops/empty_strided_native.h>
+#include <ATen/EmptyTensor.h>
 
 #include <ATen/native/xpu/sycl/ComplexKernels.h>
 #include <ATen/native/xpu/sycl/RandpermKernel.h>
@@ -53,6 +54,72 @@ Tensor& eye_out_xpu(int64_t n, int64_t m, Tensor& result) {
 
 Tensor& eye_out_xpu(int64_t n, Tensor& result) {
   return eye_out_xpu(n, n, result);
+}
+
+Tensor empty_xpu_symint(
+    c10::SymIntArrayRef size,
+    std::optional<ScalarType> dtype_opt,
+    std::optional<Layout> layout_opt,
+    std::optional<Device> device_opt,
+    std::optional<bool> pin_memory_opt,
+    std::optional<c10::MemoryFormat> memory_format_opt) {
+  TORCH_CHECK(
+      !pin_memory_opt.has_value() || !*pin_memory_opt,
+      "Only dense CPU tensors can be pinned");
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      layout_or_default(layout_opt) == Layout::Strided);
+
+  const auto dtype = dtype_or_default(dtype_opt);
+  at::globalContext().lazyInitDevice(kXPU);
+  const auto device = device_or_default(device_opt);
+  TORCH_INTERNAL_ASSERT(device.is_xpu());
+  const c10::DeviceGuard device_guard(device);
+  auto* allocator = c10::GetAllocator(kXPU);
+  constexpr c10::DispatchKeySet xpu_dks(c10::DispatchKey::XPU);
+
+  Tensor result = at::detail::empty_generic_symint(
+      size, allocator, xpu_dks, dtype, memory_format_opt);
+
+  // See Note [Enabling Deterministic Operations]
+  if (C10_UNLIKELY(
+          at::globalContext().deterministicAlgorithms() &&
+          at::globalContext().deterministicFillUninitializedMemory())) {
+    at::native::fill_empty_deterministic_(result);
+  }
+  return result;
+}
+
+Tensor empty_strided_xpu_symint(
+    c10::SymIntArrayRef size,
+    c10::SymIntArrayRef stride,
+    std::optional<ScalarType> dtype_opt,
+    std::optional<Layout> layout_opt,
+    std::optional<Device> device_opt,
+    std::optional<bool> pin_memory_opt) {
+  TORCH_CHECK(
+      !pin_memory_opt.has_value() || !*pin_memory_opt,
+      "Only dense CPU tensors can be pinned");
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      layout_or_default(layout_opt) == Layout::Strided);
+
+  const auto dtype = dtype_or_default(dtype_opt);
+  at::globalContext().lazyInitDevice(kXPU);
+  const auto device = device_or_default(device_opt);
+  TORCH_INTERNAL_ASSERT(device.is_xpu());
+  const c10::DeviceGuard device_guard(device);
+  auto* allocator = c10::GetAllocator(kXPU);
+  constexpr c10::DispatchKeySet xpu_dks(c10::DispatchKey::XPU);
+
+  Tensor result = at::detail::empty_strided_symint_generic(
+      size, stride, allocator, xpu_dks, dtype);
+
+  // See Note [Enabling Deterministic Operations]
+  if (C10_UNLIKELY(
+          at::globalContext().deterministicAlgorithms() &&
+          at::globalContext().deterministicFillUninitializedMemory())) {
+    at::native::fill_empty_deterministic_(result);
+  }
+  return result;
 }
 
 Tensor empty_xpu(

--- a/test/xpu/test_nestedtensor_xpu.py
+++ b/test/xpu/test_nestedtensor_xpu.py
@@ -8622,14 +8622,6 @@ BACKWARD_SKIPS_AND_XFAILS = [
         sample_match_fn=lambda device, sample: ("ragged dim" in sample.name),
         name="broken_min_max_reduction_with_dim_backward_on_ragged_dim",
     ),
-    # copysign(): formula is broken for (T, NT) broadcasting
-    XFailRule(
-        error_type=RuntimeError,
-        error_msg="SymIntArrayRef expected to contain only concrete integers",
-        op_match_fn=lambda device, op: (op.full_name == "copysign"),
-        sample_match_fn=lambda device, sample: ("(T, NT)" in sample.name),
-        name="broken_copysign_backward",
-    ),
     # amin() / amax(): broken in a host of ways I don't think it's a good use of time
     # to try to sift through
     SkipRule(

--- a/yaml/native/native_functions.yaml
+++ b/yaml/native/native_functions.yaml
@@ -1252,7 +1252,7 @@
 
 - func: empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   dispatch:
-    XPU: empty_xpu
+    XPU: empty_xpu_symint
     SparseXPU: empty_sparse
     SparseCsrXPU: empty_sparse_compressed
   tags: core
@@ -1275,7 +1275,7 @@
 
 - func: empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   dispatch:
-    XPU: empty_strided_xpu
+    XPU: empty_strided_xpu_symint
   autogen: empty_strided.out
   tags: core
 


### PR DESCRIPTION
This is a fix for issues discovered here:
https://github.com/intel/torch-xpu-ops/issues/4042

For RuntimeErrors: `SymIntArrayRef expected to contain only concrete integers`

Changed "empty.memory_format" to use "empty_xpu_symint", which is needed for nested tensors case. 