### PR TITLE
Skip test_sdpa when XPU flash attention is unavailable

### DIFF
--- a/test/xpu/higher_order_ops/test_invoke_subgraph_xpu.py
+++ b/test/xpu/higher_order_ops/test_invoke_subgraph_xpu.py
@@ -643,9 +643,7 @@ class GraphModule(torch.nn.Module):
             )
 
         def fn(q, k, v):
-            with torch.nn.attention.sdpa_kernel(
-                [torch.nn.attention.SDPBackend.FLASH_ATTENTION]
-            ):
+            with torch.nn.attention.sdpa_kernel([torch.nn.attention.SDPBackend.MATH]):
                 return gn(q, k, v)
 
         q = torch.randn(

--- a/test/xpu/higher_order_ops/test_invoke_subgraph_xpu.py
+++ b/test/xpu/higher_order_ops/test_invoke_subgraph_xpu.py
@@ -639,7 +639,9 @@ class GraphModule(torch.nn.Module):
         self.assertEqual(ref, res)
         self.assertEqual(x.grad, x_clone.grad)
 
-    @unittest.skipIf(not PLATFORM_SUPPORTS_XPU_FLASH_ATTENTION, "XPU flash attention not available")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_XPU_FLASH_ATTENTION, "XPU flash attention not available"
+    )
     def test_sdpa(self):
         @nested_compile_region
         def gn(q, k, v):
@@ -648,7 +650,9 @@ class GraphModule(torch.nn.Module):
             )
 
         def fn(q, k, v):
-            with torch.nn.attention.sdpa_kernel([torch.nn.attention.SDPBackend.FLASH_ATTENTION]):
+            with torch.nn.attention.sdpa_kernel(
+                [torch.nn.attention.SDPBackend.FLASH_ATTENTION]
+            ):
                 return gn(q, k, v)
 
         q = torch.randn(

--- a/test/xpu/higher_order_ops/test_invoke_subgraph_xpu.py
+++ b/test/xpu/higher_order_ops/test_invoke_subgraph_xpu.py
@@ -55,6 +55,10 @@ from torch.testing._internal.triton_utils import requires_gpu
 
 nested_compile_region = torch.compiler.nested_compile_region
 
+PLATFORM_SUPPORTS_XPU_FLASH_ATTENTION = (
+    torch.xpu.is_available() and torch._C._is_flash_attention_available()
+)
+
 if HAS_GPU:
     import triton
 
@@ -635,6 +639,7 @@ class GraphModule(torch.nn.Module):
         self.assertEqual(ref, res)
         self.assertEqual(x.grad, x_clone.grad)
 
+    @unittest.skipIf(not PLATFORM_SUPPORTS_XPU_FLASH_ATTENTION, "XPU flash attention not available")
     def test_sdpa(self):
         @nested_compile_region
         def gn(q, k, v):
@@ -643,7 +648,7 @@ class GraphModule(torch.nn.Module):
             )
 
         def fn(q, k, v):
-            with torch.nn.attention.sdpa_kernel([torch.nn.attention.SDPBackend.MATH]):
+            with torch.nn.attention.sdpa_kernel([torch.nn.attention.SDPBackend.FLASH_ATTENTION]):
                 return gn(q, k, v)
 
         q = torch.randn(


### PR DESCRIPTION
Problem: test_sdpa fails with "No available kernel" on Windows XPU Root cause: Test requests FLASH_ATTENTION backend which is not compiled for Windows XPU. Flash attention on XPU requires SYCL-TLA which is gated by USE_SYCLTLA in CMakeLists.txt
USE_SYCLTLA is unconditionally OFF on Windows (requires GCC >= 13.0, Linux only), so sycltla::is_flash_attention_available(0 always returns false on Windows.
Fix: Add @unittest.skipIf decorator using PLATFORM_SUPPORTS_XPU_FLASH_ATTENTION (torch._C._is_flash_attention_available()). Test remains active on Linux