### PR TITLE
Implement SYCL-compatible math functions in XPUMathCompat.h

### DIFF
--- a/src/comm/XPUMathCompat.h
+++ b/src/comm/XPUMathCompat.h
@@ -125,11 +125,14 @@ __MATH_FUNCTIONS_DECL__ double tanh(double x) {
   return sycl::tanh(x);
 }
 
+// https://github.com/intel/llvm/blob/HEAD/libc/include/llvm-libc-macros/math-macros.h
+constexpr double kSqrt1_2 = 0x1.6a09e667f3bcdp-1; // 1/sqrt(2) M_SQRT1_2
+
 __MATH_FUNCTIONS_DECL__ float normcdf(float x) {
-  return 0.5f * sycl::erfc(-x * static_cast<float>(M_SQRT1_2));
+  return 0.5f * sycl::erfc(-x * static_cast<float>(kSqrt1_2));
 }
 __MATH_FUNCTIONS_DECL__ double normcdf(double x) {
-  return 0.5 * sycl::erfc(-x * M_SQRT1_2);
+  return 0.5 * sycl::erfc(-x * kSqrt1_2);
 }
 
 // To walk around SYCL compiler optimization on data type promotion.

--- a/src/comm/XPUMathCompat.h
+++ b/src/comm/XPUMathCompat.h
@@ -18,18 +18,90 @@
 
 namespace c10::xpu::compat {
 
-__MATH_FUNCTIONS_DECL__ float exp(float x) {
-  return ::expf(x);
+__MATH_FUNCTIONS_DECL__ float abs(float x) {
+  return sycl::fabs(x);
 }
-__MATH_FUNCTIONS_DECL__ double exp(double x) {
-  return ::exp(x);
+__MATH_FUNCTIONS_DECL__ double abs(double x) {
+  return sycl::fabs(x);
 }
 
-__MATH_FUNCTIONS_DECL__ float tanh(float x) {
-  return ::tanhf(x);
+__MATH_FUNCTIONS_DECL__ float exp(float x) {
+  return sycl::exp(x);
 }
-__MATH_FUNCTIONS_DECL__ double tanh(double x) {
-  return ::tanh(x);
+__MATH_FUNCTIONS_DECL__ double exp(double x) {
+  return sycl::exp(x);
+}
+
+__MATH_FUNCTIONS_DECL__ float ceil(float x) {
+  return sycl::ceil(x);
+}
+__MATH_FUNCTIONS_DECL__ double ceil(double x) {
+  return sycl::ceil(x);
+}
+
+__MATH_FUNCTIONS_DECL__ float copysign(float x, float y) {
+  return sycl::copysign(x, y);
+}
+__MATH_FUNCTIONS_DECL__ double copysign(double x, double y) {
+  return sycl::copysign(x, y);
+}
+
+__MATH_FUNCTIONS_DECL__ float floor(float x) {
+  return sycl::floor(x);
+}
+__MATH_FUNCTIONS_DECL__ double floor(double x) {
+  return sycl::floor(x);
+}
+
+__MATH_FUNCTIONS_DECL__ float log(float x) {
+  return sycl::log(x);
+}
+__MATH_FUNCTIONS_DECL__ double log(double x) {
+  return sycl::log(x);
+}
+
+__MATH_FUNCTIONS_DECL__ float log1p(float x) {
+  return sycl::log1p(x);
+}
+__MATH_FUNCTIONS_DECL__ double log1p(double x) {
+  return sycl::log1p(x);
+}
+
+__MATH_FUNCTIONS_DECL__ float max(float x, float y) {
+  return sycl::fmax(x, y);
+}
+__MATH_FUNCTIONS_DECL__ double max(double x, double y) {
+  return sycl::fmax(x, y);
+}
+
+__MATH_FUNCTIONS_DECL__ float min(float x, float y) {
+  return sycl::fmin(x, y);
+}
+__MATH_FUNCTIONS_DECL__ double min(double x, double y) {
+  return sycl::fmin(x, y);
+}
+
+__MATH_FUNCTIONS_DECL__ float pow(float x, float y) {
+  return sycl::pow(x, y);
+}
+__MATH_FUNCTIONS_DECL__ double pow(double x, double y) {
+  return sycl::pow(x, y);
+}
+
+__MATH_FUNCTIONS_DECL__ void sincos(float x, float* sptr, float* cptr) {
+  *sptr = sycl::sin(x);
+  *cptr = sycl::cos(x);
+}
+__MATH_FUNCTIONS_DECL__ void sincos(double x, double* sptr, double* cptr) {
+  *sptr = sycl::sin(x);
+  *cptr = sycl::cos(x);
+}
+
+__MATH_FUNCTIONS_DECL__ float sqrt(float x) {
+  return sycl::sqrt(x);
+}
+__MATH_FUNCTIONS_DECL__ double sqrt(double x) {
+  return sycl::sqrt(x);
 }
 
 __MATH_FUNCTIONS_DECL__ float rsqrt(float x) {
@@ -37,6 +109,27 @@ __MATH_FUNCTIONS_DECL__ float rsqrt(float x) {
 }
 __MATH_FUNCTIONS_DECL__ double rsqrt(double x) {
   return sycl::rsqrt(x);
+}
+
+__MATH_FUNCTIONS_DECL__ float tan(float x) {
+  return sycl::tan(x);
+}
+__MATH_FUNCTIONS_DECL__ double tan(double x) {
+  return sycl::tan(x);
+}
+
+__MATH_FUNCTIONS_DECL__ float tanh(float x) {
+  return sycl::tanh(x);
+}
+__MATH_FUNCTIONS_DECL__ double tanh(double x) {
+  return sycl::tanh(x);
+}
+
+__MATH_FUNCTIONS_DECL__ float normcdf(float x) {
+  return 0.5f * sycl::erfc(-x * static_cast<float>(M_SQRT1_2));
+}
+__MATH_FUNCTIONS_DECL__ double normcdf(double x) {
+  return 0.5 * sycl::erfc(-x * M_SQRT1_2);
 }
 
 // To walk around SYCL compiler optimization on data type promotion.


### PR DESCRIPTION
This pull request significantly expands and refactors the math compatibility layer in `src/comm/XPUMathCompat.h` to use SYCL math functions instead of standard C/C++ math library calls. It introduces several new math function wrappers, ensuring consistent use of SYCL for device portability and improved support for various mathematical operations.

Key changes include:

**Migration to SYCL math functions:**
- Replaced previous math function implementations (such as `exp`, `tanh`) with their SYCL equivalents (e.g., `sycl::exp`, `sycl::tanh`) for both `float` and `double` types, improving compatibility with SYCL devices.

**Addition of new math wrappers:**
- Introduced new SYCL-based wrappers for functions including `abs`, `ceil`, `copysign`, `floor`, `log`, `log1p`, `max`, `min`, `pow`, `sincos`, `sqrt`, `tan`, and `tanh`, for both `float` and `double` types. 

**Specialized math functions:**
- Since SYCL does not offer a native normcdff function, we implement it via erfc based on their mathematical equivalence.

These changes make the math compatibility layer more robust and SYCL-centric, facilitating easier cross-platform development and improved numerical support for XPU targets.