### PR TITLE
Fix exception type in linalg.cond error handling

### DIFF
--- a/test/xpu/test_linalg_xpu.py
+++ b/test/xpu/test_linalg_xpu.py
@@ -789,7 +789,7 @@ def cond_errors_and_warnings(self, device, dtype):
     a = torch.ones(3, 3, dtype=dtype, device=device)
     for p in ["wrong_norm", 5]:
         with self.assertRaisesRegex(
-            RuntimeError, f"linalg.cond got an invalid norm type: {p}"
+            ValueError, f"linalg.cond got an invalid norm type: {p}"
         ):
             torch.linalg.cond(a, p)
 


### PR DESCRIPTION
Fixes intel/torch-xpu-ops#4216

PyTorch PR pytorch/pytorch#188591 (commit e356f51370f) changed the validation in `linalg.cond` from `TORCH_CHECK` to `TORCH_CHECK_VALUE`, which raises `ValueError` instead of `RuntimeError` for invalid norm types. Updated the XPU test override to expect the correct exception type.

Test Plan:
```bash
pytest test/xpu/test_linalg_xpu.py -k "test_cond_errors_and_warnings" -xvs