### PR TITLE
Fix test_misc_xpu: Update for upstream dynamo refactoring

### DIFF
--- a/test/xpu/dynamo/test_misc_xpu.py
+++ b/test/xpu/dynamo/test_misc_xpu.py
@@ -12722,13 +12722,13 @@ fn
         from torch._dynamo.variables.user_defined import InspectVariable
 
         redirected_attrs = []
-        original_var_getattr = InspectVariable.var_getattr
+        original_getattro_impl = InspectVariable.getattro_impl
 
-        def tracking_var_getattr(self, tx, name):
+        def tracking_getattro_impl(self, tx, name):
             redirects = self._PROPERTY_REDIRECTS.get(type(self.value), {})
             if name in redirects:
                 redirected_attrs.append(name)
-            return original_var_getattr(self, tx, name)
+            return original_getattro_impl(self, tx, name)
 
         def fn(x, gn):
             sig = inspect.signature(gn)
@@ -12740,7 +12740,7 @@ fn
             return a + b
 
         x = torch.randn(2, 3)
-        with patch.object(InspectVariable, "var_getattr", tracking_var_getattr):
+        with patch.object(InspectVariable, "getattro_impl", tracking_getattro_impl):
             opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
             result = opt_fn(x, gn)
 
@@ -13124,7 +13124,7 @@ fn
         self.assertEqual(cnts.frame_count, 1)
 
     def test_getattrvariable_as_python_constant(self):
-        from torch._dynamo.variables.misc import GetAttrVariable
+        from torch._dynamo.variables.misc import CallMethodVariable as CMV
 
         @torch.compile(backend="eager")
         def fn(x, rand1):
@@ -13140,7 +13140,7 @@ fn
         x = torch.randn(3, 3)
         expected = fn.__wrapped__(x, get_rng())
 
-        with patch.object(GetAttrVariable, "as_python_constant", autospec=True) as po:
+        with patch.object(CMV, "as_python_constant", autospec=True) as po:
             actual = fn(x, get_rng())
 
         self.assertEqual(expected, actual)


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/4217
Fixes two test failures in `test/xpu/dynamo/test_misc_xpu.py` caused by upstream PyTorch dynamo refactoring that renamed methods but weren't reflected in the XPU test file.

## Root Cause

Two upstream refactoring PRs landed between the good and bad commits:

1. **PR #186013**: Renamed `var_getattr` → `getattro_impl` across all `VariableTracker` subclasses
2. **PR #187196**: Moved `as_python_constant` call path from `GetAttrVariable` to `CallMethodVariable`

The XPU test file wasn't updated to match, causing `AttributeError` and assertion failures.

## Changes

- **`test_inspect_variable_redirect`**: Updated all references from `var_getattr` to `getattro_impl`
- **`test_getattrvariable_as_python_constant`**: Changed import and patch target from `GetAttrVariable` to `CallMethodVariable as CMV`

These changes mirror upstream `test/dynamo/test_misc.py` (PR #188591). Pure test porting fix — no XPU operator code involved.

## Test Plan

```bash
pytest test/xpu/dynamo/test_misc_xpu.py::MiscTests::test_inspect_variable_redirect -xvs
pytest test/xpu/dynamo/test_misc_xpu.py::MiscTests::test_getattrvariable_as_python_constant -xvs
```
Both tests now pass.