### PR TITLE
Fix test_decomp_xpu.py in-place op detection for overloaded ops

### DIFF
--- a/test/xpu/test_decomp_xpu.py
+++ b/test/xpu/test_decomp_xpu.py
@@ -834,7 +834,7 @@ def forward(self, scores_1, mask_1, value_1):
             # Stuff we shouldn't bother testing
             # (TODO: remove detach from the decomp table?)
             # N.b. Testing in-place ops would need dedicated logic
-            in_place = func.name()[-1] == "_"
+            in_place = func._schema.name.endswith("_")
             ignored_ops = [
                 torch.ops.aten.detach.default,
                 # non-deterministic ops


### PR DESCRIPTION
Fixes #4218

## Summary

Fixes gradcheck failure in `test_quick_core_backward_linalg_vector_norm_xpu_float64` by correcting the in-place operation detection logic in `DecompCrossRefMode.__torch_dispatch__`.

## Root Cause

The test harness in `test_decomp_xpu.py` used `func.name()[-1] == "_"` to detect in-place operations, which fails for overloaded in-place ops:

```python
>>> torch.ops.aten.pow_.Scalar.name()
"aten::pow_.Scalar"
>>> "aten::pow_.Scalar"[-1]
"r"              # ❌ last char is "r", not "_"

>>> torch.ops.aten.pow_.Scalar._schema.name
"aten::pow_"
>>> "aten::pow_".endswith("_")
True             # ✅ correctly detects in-place
```

When `linalg_vector_norm` was added to the core decomposition table (PyTorch PR #185735), the `test_quick_core_backward` test began exercising the backward pass through the decomposed op. During backward, `norm_backward` calls `self.abs().pow_(p - 1)` — an in-place `aten::pow_.Scalar` operation.

The XPU test's incorrect check failed to detect this as in-place, causing `DecompCrossRefMode` to:
1. Run the decomposed `pow_.Scalar` → mutates the tensor in-place
2. Run the real `pow_.Scalar` → **double-mutates** the already-corrupted tensor
3. Compare outputs → corrupted gradient buffers

Result: analytical Jacobian ~`3e-10` instead of `-1.0`, causing gradcheck to fail.

## The Fix

Align with upstream `test_decomp.py` (fixed in PyTorch PR #185735, commit `db9d1d7e8df`):

```python
# Before (broken):
in_place = func.name()[-1] == "_"

# After (correct):
in_place = func._schema.name.endswith("_")
```

This is a one-line porting fix that correctly detects all in-place operations, including overloaded variants.

## Test Plan

**Before fix:**
```bash
cd third_party/torch-xpu-ops/test/xpu
python -m pytest -sxv test_decomp_xpu.py -k "test_quick_core_backward_linalg_vector_norm_xpu_float64"
# Result: FAILED - GradcheckError: Jacobian mismatch
#   numerical:  tensor([[-1.0000]], device='xpu:0', dtype=torch.float64)
#   analytical: tensor([[-3.2369e-10]], device='xpu:0', dtype=torch.float64)
```

**After fix:**
```bash
cd third_party/torch-xpu-ops/test/xpu
python -m pytest -sxv test_decomp_xpu.py -k "test_quick_core_backward_linalg_vector_norm_xpu_float64"
# Result: PASSED in 62.14s (1 passed, 9174 deselected)
```

**Broader validation (all quick_core_backward tests):**
```bash
cd third_party/torch-xpu-ops/test/xpu
python -m pytest -xv test_decomp_xpu.py -k "test_quick_core_backward"
# All tests pass with no regressions
```

## Additional Context

- **Why this wasn't caught earlier:** The test only started failing after PyTorch PR #185735 added `linalg_vector_norm` to the core decomposition table, exposing the latent bug in the XPU test harness.
- **CUDA/CPU unaffected:** The upstream `test_decomp.py` already has the correct fix from PR #185735.
- **Not a float32 fast-math issue:** The issue body mentioned commit `ba09082f036` (SYCL native fast-math) as a potential factor, but that only affects float32 and is not involved in this float64 gradcheck failure.

## Related

- PyTorch PR #185735: Added `linalg_vector_norm` to core decompositions + fixed the same bug in upstream `test_decomp.py`