### PR TITLE
Use if constexpr for compile-time-constant branches

### DIFF
--- a/src/ATen/native/sparse/xpu/sycl/SparseSoftmaxKernels.cpp
+++ b/src/ATen/native/sparse/xpu/sycl/SparseSoftmaxKernels.cpp
@@ -222,7 +222,7 @@ struct SparseCooSoftmaxFunctor {
           auto values_row = input_values_acc[i];
           auto out_values_row = output_values_acc[i];
 
-          if (LogSoftMax) {
+          if constexpr (LogSoftMax) {
             out_values_row[j] = values_row[j] - mx_row[j] - sycl::log(exp_sums);
           } else {
             out_values_row[j] *= 1.0 / exp_sums;
@@ -296,7 +296,7 @@ struct SparseCooSoftmaxbBackwardFunctor {
            */
           if (j < grad_nnz && (out_offsets[i] == grad_offsets[j])) {
             auto grad_values_row = grad_values_accessor[j];
-            if (LogSoftMax) {
+            if constexpr (LogSoftMax) {
               tmp_row -= grad_values_row[k];
             } else {
               tmp_row -= out_values_row[k] * grad_values_row[k];
@@ -312,7 +312,7 @@ struct SparseCooSoftmaxbBackwardFunctor {
           auto j = lower_bound_values[i];
           if (j < grad_nnz && (out_offsets[i] == grad_offsets[j])) {
             auto grad_values_row = grad_values_accessor[j];
-            if (LogSoftMax) {
+            if constexpr (LogSoftMax) {
               values_row[k] =
                   grad_values_row[k] + std::exp(out_values_row[k]) * tmp_row;
             } else {
@@ -320,7 +320,7 @@ struct SparseCooSoftmaxbBackwardFunctor {
                   out_values_row[k] * (grad_values_row[k] + tmp_row);
             }
           } else {
-            if (LogSoftMax) {
+            if constexpr (LogSoftMax) {
               values_row[k] = std::exp(out_values_row[k]) * tmp_row;
             } else {
               values_row[k] = out_values_row[k] * tmp_row;
@@ -519,7 +519,7 @@ void xpu_sparse_coo_softmax(
   out_indices.copy_(indices);
 
   if (dim >= sparse_dim) {
-    if (LogSoftMax) {
+    if constexpr (LogSoftMax) {
       auto new_values = _log_softmax(values, dim - sparse_dim + 1, false);
       out_values.set_(new_values);
     } else {
@@ -602,7 +602,7 @@ void xpu_sparse_coo_softmax_backward(
   /* when dim >= sparse_dim the dense backward is used */
   if (dim >= sparse_dim) {
     if (at::equal(out_offsets, grad_offsets) == true) {
-      if (LogSoftMax) {
+      if constexpr (LogSoftMax) {
         auto r = at::_log_softmax_backward_data(
             grad_values, out_values, dim - sparse_dim + 1, input_dtype);
         values.set_(r);
@@ -633,7 +633,7 @@ void xpu_sparse_coo_softmax_backward(
         */
         if (j < grad_nnz &&
             out_offsets_accessor[i] == grad_offsets_accessor[j]) {
-          if (LogSoftMax) {
+          if constexpr (LogSoftMax) {
             auto r = at::_log_softmax_backward_data(
                 grad_values[j], out_values[i], dim - sparse_dim, input_dtype);
             values[i].copy_(r);

--- a/src/ATen/native/xpu/sycl/FusedAdamUtils.h
+++ b/src/ATen/native/xpu/sycl/FusedAdamUtils.h
@@ -62,10 +62,6 @@ inline void adam_math(
     }
     opmath_t exp_avg = static_cast<opmath_t>(r_args[kExpAvgIdx][ii]);
     opmath_t exp_avg_sq = static_cast<opmath_t>(r_args[kExpAvgSqIdx][ii]);
-    opmath_t max_exp_avg_sq;
-    if (amsgrad) {
-      max_exp_avg_sq = static_cast<opmath_t>(r_args[kMaxExpAvgSqIdx][ii]);
-    }
     // Update param, grad, 1st and 2nd order momentum.
     if (weight_decay != 0) {
       if constexpr (adam_mode == ADAM_MODE::ORIGINAL) {
@@ -79,9 +75,11 @@ inline void adam_math(
     exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * grad * grad;
     const opmath_t step_size = lr / bias_correction1;
     opmath_t denom;
-    if (amsgrad) {
-      max_exp_avg_sq = std::max(max_exp_avg_sq, exp_avg_sq);
+    if constexpr (amsgrad) {
+      opmath_t max_exp_avg_sq = std::max(
+          static_cast<opmath_t>(r_args[kMaxExpAvgSqIdx][ii]), exp_avg_sq);
       denom = (sycl::sqrt(max_exp_avg_sq) / bias_correction2_sqrt) + eps;
+      r_args[kMaxExpAvgSqIdx][ii] = max_exp_avg_sq;
     } else {
       denom = (sycl::sqrt(exp_avg_sq) / bias_correction2_sqrt) + eps;
     }
@@ -94,9 +92,6 @@ inline void adam_math(
     }
     r_args[kExpAvgIdx][ii] = exp_avg;
     r_args[kExpAvgSqIdx][ii] = exp_avg_sq;
-    if (amsgrad) {
-      r_args[kMaxExpAvgSqIdx][ii] = max_exp_avg_sq;
-    }
   }
 }
 

--- a/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
+++ b/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
@@ -592,7 +592,7 @@ struct SoftmaxForwardKernelFunctor {
     }
     sum_value = sycl::reduce_over_group(
         item.get_group(), sum_value, sycl::plus<accscalar_t>());
-    if (LogSoftMax)
+    if constexpr (LogSoftMax)
       sum_value = sycl::log(sum_value);
     else
       sum_value = accscalar_t(1) / sum_value;
@@ -615,7 +615,7 @@ struct SoftmaxForwardKernelFunctor {
         for (int j = 0; j < vec_size; ++j) {
           IndexType linear_idx = i * vec_size + j - start;
           if (linear_idx >= 0 && linear_idx < dim_size_) {
-            if (LogSoftMax)
+            if constexpr (LogSoftMax)
               out_data_[group_offset + linear_idx] = static_cast<outscalar_t>(
                   in_data_[group_offset + linear_idx] - max_value - sum_value);
             else if (
@@ -635,7 +635,7 @@ struct SoftmaxForwardKernelFunctor {
         outscalar_t results[vec_size];
 #pragma unroll(vec_size)
         for (int j = 0; j < vec_size; ++j) {
-          if (LogSoftMax)
+          if constexpr (LogSoftMax)
             results[j] =
                 static_cast<outscalar_t>(in_val[j] - max_value - sum_value);
           else if (
@@ -799,7 +799,7 @@ struct SpatialSoftmaxForwardKernelFunctor
           [](accscalar_t a, accscalar_t b) { return a + b; });
 #pragma unroll(vec_size)
       for (int j = 0; j < vec_size; ++j) {
-        if (LogSoftMax)
+        if constexpr (LogSoftMax)
           sum_value[j] = sycl::log(local_data_[0][local_col_id][j]);
         else
           sum_value[j] = accscalar_t(1) / local_data_[0][local_col_id][j];
@@ -807,7 +807,7 @@ struct SpatialSoftmaxForwardKernelFunctor
     } else {
 #pragma unroll(vec_size)
       for (int j = 0; j < vec_size; ++j) {
-        if (LogSoftMax)
+        if constexpr (LogSoftMax)
           sum_value[j] = sycl::log(sum_value[j]);
         else
           sum_value[j] = accscalar_t(1) / sum_value[j];
@@ -824,7 +824,7 @@ struct SpatialSoftmaxForwardKernelFunctor
 #pragma unroll(vec_size)
         for (int j = 0; j < vec_size; ++j) {
           if constexpr (is_same_dtype) {
-            if (LogSoftMax)
+            if constexpr (LogSoftMax)
               in_val[j] = static_cast<inscalar_t>(
                   in_val[j] - max_value[j] - sum_value[j]);
             else if (
@@ -835,7 +835,7 @@ struct SpatialSoftmaxForwardKernelFunctor
               in_val[j] = static_cast<inscalar_t>(
                   sycl::exp(in_val[j] - max_value[j]) * sum_value[j]);
           } else {
-            if (LogSoftMax)
+            if constexpr (LogSoftMax)
               out_data_point[j] = static_cast<outscalar_t>(
                   in_val[j] - max_value[j] - sum_value[j]);
             else if (
@@ -1002,7 +1002,7 @@ struct DispatchSoftmaxBackwardKernelFunctor
 
 #pragma unroll(vec_size)
       for (int j = 0; j < vec_size; ++j) {
-        if (LogSoftMax) {
+        if constexpr (LogSoftMax) {
           sum_value += reg_gradout[i][j];
         } else {
           sum_value += reg_out[i][j] * reg_gradout[i][j];
@@ -1028,7 +1028,7 @@ struct DispatchSoftmaxBackwardKernelFunctor
       auto offset = group_offset + index;
 #pragma unroll(vec_size)
       for (int j = 0; j < vec_size; ++j) {
-        if (LogSoftMax) {
+        if constexpr (LogSoftMax) {
           auto exp_out = sycl::exp(static_cast<accscalar_t>(reg_out[i][j]));
           if constexpr (is_same_dtype) {
             reg_out[i][j] = static_cast<outscalar_t>(
@@ -1254,7 +1254,7 @@ struct SoftmaxBackwardKernelFunctor {
     auto sum_value = accscalar_t(0);
     for (int i = local_id; i < loops_end; i += local_size_) {
       auto gradout_val = vec_gradout_data_ptr[i];
-      if (LogSoftMax) {
+      if constexpr (LogSoftMax) {
 #pragma unroll(vec_size)
         for (int j = 0; j < vec_size; ++j) {
           int64_t linear_idx = i * vec_size + j - start;
@@ -1286,7 +1286,7 @@ struct SoftmaxBackwardKernelFunctor {
           auto linear_idx = i * vec_size + j - start;
           if (linear_idx >= 0 && linear_idx < dim_size_) {
             auto offset = group_offset + linear_idx;
-            if (LogSoftMax) {
+            if constexpr (LogSoftMax) {
               auto exp_out =
                   sycl::exp(static_cast<accscalar_t>(output_[offset]));
               gradInput_[offset] = gradOutput_[offset] - exp_out * sum_value;
@@ -1302,7 +1302,7 @@ struct SoftmaxBackwardKernelFunctor {
 #pragma unroll(vec_size)
         for (int j = 0; j < vec_size; ++j) {
           if constexpr (is_same_dtype) {
-            if (LogSoftMax) {
+            if constexpr (LogSoftMax) {
               auto exp_out = sycl::exp(static_cast<accscalar_t>(out_val[j]));
               out_val[j] = grad_val[j] - exp_out * sum_value;
             } else {
@@ -1310,7 +1310,7 @@ struct SoftmaxBackwardKernelFunctor {
             }
           } else {
             auto offset = group_offset - start + i * vec_size + j;
-            if (LogSoftMax) {
+            if constexpr (LogSoftMax) {
               auto exp_out = sycl::exp(static_cast<accscalar_t>(out_val[j]));
               gradInput_[offset] = grad_val[j] - exp_out * sum_value;
             } else {
@@ -1414,7 +1414,7 @@ struct SpatialSoftmaxBackwardKernelFunctor
       auto offset = i * inner_size_ + global_col * vec_size;
       vec_t gradout_val =
           *(reinterpret_cast<const vec_t*>(gradout_ptr + offset));
-      if (LogSoftMax) {
+      if constexpr (LogSoftMax) {
 #pragma unroll(vec_size)
         for (int j = 0; j < vec_size; ++j)
           sum_value[j] += gradout_val[j];
@@ -1448,7 +1448,7 @@ struct SpatialSoftmaxBackwardKernelFunctor
 #pragma unroll(vec_size)
         for (int j = 0; j < vec_size; ++j) {
           if constexpr (is_same_dtype) {
-            if (LogSoftMax) {
+            if constexpr (LogSoftMax) {
               auto exp_out = sycl::exp(static_cast<accscalar_t>(out_val[j]));
               out_val[j] = static_cast<outscalar_t>(
                   gradout_val[j] - exp_out * sum_value[j]);
@@ -1457,7 +1457,7 @@ struct SpatialSoftmaxBackwardKernelFunctor
                   out_val[j] * (gradout_val[j] - sum_value[j]));
             }
           } else {
-            if (LogSoftMax) {
+            if constexpr (LogSoftMax) {
               auto exp_out = sycl::exp(static_cast<accscalar_t>(out_val[j]));
               gradin_ptr[offset + j] = static_cast<inscalar_t>(
                   gradout_val[j] - exp_out * sum_value[j]);


### PR DESCRIPTION
`amsgrad` (fused Adam) and `LogSoftMax` (softmax) are `bool` template parameters, so branching on them with a runtime `if` can be `if constexpr`. This drops the branch at compile time and removes the dead branch from codegen — including a compiled-but-unreachable out-of-bounds `r_args[kMaxExpAvgSqIdx]` access in the depth-4 (non-amsgrad) Adam path. It also makes `SoftMaxKernels.cpp` consistent, which already used `if constexpr` for `LogSoftMax` in a few spots.

 
Authored with the assistance of an AI agent.