### PR TITLE
ci: read live PR labels instead of stale event snapshot

### DIFF
--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -32,8 +32,6 @@ jobs:
       contents: read
       pull-requests: write
     timeout-minutes: 5
-    outputs:
-      labels_changed: ${{ steps.apply-labels.outputs.labels_changed || 'false' }}
     steps:
       - name: Get existing labels
         id: existing-labels
@@ -240,7 +238,6 @@ jobs:
 
           if [ -z "$TO_ADD" ]; then
             echo "All labels already present, no changes needed"
-            echo "labels_changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -253,65 +250,9 @@ jobs:
 
           gh pr edit ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} "${ARGS[@]}"
-          echo "labels_changed=true" >> "$GITHUB_OUTPUT"
           echo "Applied new labels: $TO_ADD (total: $ALL_LABELS)"
 
       - name: Dry-run output (pull_request trigger)
         if: ${{ github.event_name == 'pull_request' }}
-        id: dry-run
         run: |
           echo "::notice::DRY-RUN: Would apply labels: ${{ steps.determine-labels.outputs.labels }}"
-          echo "labels_changed=false" >> "$GITHUB_OUTPUT"
-
-  retrigger-pull:
-    needs: [auto-label]
-    if: ${{ github.event_name == 'pull_request_target' && needs.auto-label.outputs.labels_changed == 'true' }}
-    runs-on: ubuntu-24.04
-    # All API calls use MERGE_TOKEN PAT; no GITHUB_TOKEN write permissions needed.
-    permissions:
-      contents: read
-    timeout-minutes: 5
-    steps:
-      - name: Cancel in-flight pull workflow and retrigger via draft toggle
-        env:
-          # MERGE_TOKEN (PAT) required: GITHUB_TOKEN events don't trigger other workflows
-          GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
-        run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          REPO=${{ github.repository }}
-          HEAD_SHA=${{ github.event.pull_request.head.sha }}
-
-          echo "Looking for 'pull' workflow runs to cancel..."
-
-          # Wait briefly for pull workflow to register (race condition mitigation)
-          sleep 5
-
-          # Find all pull workflow runs for this SHA (any status)
-          ALL_RUNS=$(gh api "repos/${REPO}/actions/workflows/pull.yml/runs?head_sha=${HEAD_SHA}" \
-            --jq '[.workflow_runs[] | select(.status != "completed")] | .[].id' 2>/dev/null || true)
-
-          if [ -n "$ALL_RUNS" ]; then
-            for RUN_ID in $ALL_RUNS; do
-              echo "Cancelling workflow run: $RUN_ID"
-              gh api "repos/${REPO}/actions/runs/${RUN_ID}/cancel" --method POST 2>/dev/null || true
-            done
-            echo "Waiting for cancellation..."
-            sleep 5
-          else
-            echo "No in-flight 'pull' workflow runs found"
-          fi
-
-          # Retrigger by converting to draft then back to ready_for_review
-          # This creates a fresh pull_request event with updated labels
-          IS_DRAFT=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json isDraft --jq '.isDraft')
-
-          if [ "$IS_DRAFT" = "true" ]; then
-            echo "PR is a draft — skipping retrigger (labels will take effect when PR is marked ready)"
-          else
-            echo "Converting PR to draft..."
-            gh pr ready "$PR_NUMBER" --repo "$REPO" --undo
-            sleep 2
-            echo "Converting PR back to ready..."
-            gh pr ready "$PR_NUMBER" --repo "$REPO"
-            echo "Done — pull workflow will be re-triggered with updated labels"
-          fi

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -25,8 +25,15 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: read
     outputs:
       pr_body_cmd: ${{ steps.reproducer-check.outputs.pr_cmd }}
+      skip_all: ${{ steps.live-labels.outputs.skip_all }}
+      skip_ut: ${{ steps.live-labels.outputs.skip_ut }}
+      skip_e2e: ${{ steps.live-labels.outputs.skip_e2e }}
+      skip_distributed: ${{ steps.live-labels.outputs.skip_distributed }}
+      skip_win: ${{ steps.live-labels.outputs.skip_win }}
+      force_win_ut: ${{ steps.live-labels.outputs.force_win_ut }}
     steps:
       - name: Checkout torch-xpu-ops
         uses: actions/checkout@v4
@@ -166,9 +173,26 @@ jobs:
             echo "::error::${FAIL_MSG}"
             exit 1
           fi
+      - name: Read live PR labels
+        if: ${{ !cancelled() }}
+        id: live-labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LABELS=$(gh pr view ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+          echo "Live PR labels: $LABELS"
+          has() { echo "$LABELS" | tr ',' '\n' | grep -qx "$1" && echo "true" || echo "false"; }
+          echo "skip_all=$(has disable_all)" >> "$GITHUB_OUTPUT"
+          echo "skip_ut=$(has disable_ut)" >> "$GITHUB_OUTPUT"
+          echo "skip_e2e=$(has disable_e2e)" >> "$GITHUB_OUTPUT"
+          echo "skip_distributed=$(has disable_distributed)" >> "$GITHUB_OUTPUT"
+          echo "skip_win=$(has disable_win)" >> "$GITHUB_OUTPUT"
+          echo "force_win_ut=$(has windows_ci)" >> "$GITHUB_OUTPUT"
 
   conditions-filter-win:
-    if: ${{ github.repository_owner == 'intel' && github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'disable_all') }}
+    if: ${{ github.repository_owner == 'intel' && github.event.pull_request.draft == false }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     outputs:
@@ -191,7 +215,7 @@ jobs:
 
   linux-build:
     needs: preci-lint-check
-    if: ${{ github.repository_owner == 'intel' && github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'disable_all') }}
+    if: ${{ github.repository_owner == 'intel' && github.event.pull_request.draft == false && needs.preci-lint-check.outputs.skip_all != 'true' }}
     secrets: inherit
     strategy:
       fail-fast: false
@@ -204,7 +228,7 @@ jobs:
 
   reproducer-test:
     needs: [linux-build, preci-lint-check]
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'disable_all') }}
+    if: ${{ needs.preci-lint-check.outputs.skip_all != 'true' }}
     secrets: inherit
     permissions:
       contents: read
@@ -218,8 +242,8 @@ jobs:
       pr_body_cmd: ${{ needs.preci-lint-check.outputs.pr_body_cmd }}
 
   linux-ut:
-    needs: [linux-build, reproducer-test]
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'disable_all') && !contains(github.event.pull_request.labels.*.name, 'disable_ut') }}
+    needs: [linux-build, reproducer-test, preci-lint-check]
+    if: ${{ needs.preci-lint-check.outputs.skip_all != 'true' && needs.preci-lint-check.outputs.skip_ut != 'true' }}
     secrets: inherit
     permissions:
       contents: read
@@ -237,8 +261,8 @@ jobs:
       ut: ${{ matrix.ut_name }}
 
   linux-distributed:
-    needs: [linux-build, reproducer-test]
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'disable_all') && !contains(github.event.pull_request.labels.*.name, 'disable_distributed') }}
+    needs: [linux-build, reproducer-test, preci-lint-check]
+    if: ${{ needs.preci-lint-check.outputs.skip_all != 'true' && needs.preci-lint-check.outputs.skip_distributed != 'true' }}
     secrets: inherit
     permissions:
       contents: read
@@ -257,8 +281,8 @@ jobs:
 
   linux-e2e:
     name: linux-e2e
-    needs: [linux-build, reproducer-test]
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'disable_all') && !contains(github.event.pull_request.labels.*.name, 'disable_e2e') }}
+    needs: [linux-build, reproducer-test, preci-lint-check]
+    if: ${{ needs.preci-lint-check.outputs.skip_all != 'true' && needs.preci-lint-check.outputs.skip_e2e != 'true' }}
     secrets: inherit
     strategy:
       fail-fast: false
@@ -274,8 +298,8 @@ jobs:
       scenario: ${{ matrix.scenario }}
   linux-e2e-summary:
     name: linux-e2e-summary
-    needs: [linux-e2e]
-    if: ${{ !cancelled() && !contains(github.event.pull_request.labels.*.name, 'disable_all') && !endsWith(needs.linux-e2e.result, 'ed') }}
+    needs: [linux-e2e, preci-lint-check]
+    if: ${{ !cancelled() && needs.preci-lint-check.outputs.skip_all != 'true' && !endsWith(needs.linux-e2e.result, 'ed') }}
     permissions:
       actions: read
       contents: read
@@ -290,8 +314,8 @@ jobs:
     needs: preci-lint-check
     if: >-
       ${{ github.repository_owner == 'intel' && github.event.pull_request.draft == false
-      && !contains(github.event.pull_request.labels.*.name, 'disable_all')
-      && !contains(github.event.pull_request.labels.*.name, 'disable_win') }}
+      && needs.preci-lint-check.outputs.skip_all != 'true'
+      && needs.preci-lint-check.outputs.skip_win != 'true' }}
     secrets: inherit
     uses: ./.github/workflows/_windows_build.yml
     with:
@@ -300,12 +324,12 @@ jobs:
 
   windows-ut:
     name: windows-ut
-    needs: [windows-build, conditions-filter-win]
+    needs: [windows-build, conditions-filter-win, preci-lint-check]
     if: >-
-      ${{ !contains(github.event.pull_request.labels.*.name, 'disable_all')
-      && !contains(github.event.pull_request.labels.*.name, 'disable_win')
-      && (contains(github.event.pull_request.labels.*.name, 'windows_ci')
-      || (!contains(github.event.pull_request.labels.*.name, 'disable_ut')
+      ${{ needs.preci-lint-check.outputs.skip_all != 'true'
+      && needs.preci-lint-check.outputs.skip_win != 'true'
+      && (needs.preci-lint-check.outputs.force_win_ut == 'true'
+      || (needs.preci-lint-check.outputs.skip_ut != 'true'
       && needs.conditions-filter-win.outputs.src_changed == 'true')) }}
     secrets: inherit
     uses: ./.github/workflows/_windows_ut.yml


### PR DESCRIPTION
## Summary

The `pull` workflow reads labels from `github.event.pull_request.labels`, which
is a snapshot taken at event creation time. Since `auto_label` runs concurrently
and applies labels *after* the event is created, `pull.yml` sees stale labels
and makes wrong skip decisions. The existing workaround is a `retrigger-pull`
job that cancels the in-flight workflow and re-triggers it via draft toggle --
wasteful and fragile.

This PR replaces that mechanism: a "Read live PR labels" step is added at the
end of `preci-lint-check` (which takes ~2-3 min, well after `auto_label`'s
~30-60s finishes). It calls `gh pr view` to read current labels and exports
skip decisions as job outputs. All downstream jobs now gate on these outputs
instead of the stale event snapshot.

### Changes

**`pull.yml`** (+42):
- New step in `preci-lint-check`: reads live labels via GitHub API, outputs 6 signals (`skip_all`, `skip_ut`, `skip_e2e`, `skip_distributed`, `skip_win`, `force_win_ut`)
- All downstream job `if` conditions replaced: `contains(github.event.pull_request.labels.*.name, ...)` → `needs.preci-lint-check.outputs.skip_xxx != 'true'`
- Jobs that didn't already depend on `preci-lint-check` (`linux-ut`, `linux-distributed`, `linux-e2e`, `linux-e2e-summary`, `windows-ut`) now include it in `needs`
- `conditions-filter-win` no longer checks `disable_all` (downstream jobs handle it)

**`auto_label.yml`** (-57):
- Removed `labels_changed` output and related echo statements
- Removed entire `retrigger-pull` job

**Unchanged:**
- `disable_build` checks in `with:` blocks stay on event snapshot (stale but harmless)
- `ai_generated` label checks stay (manual label, unaffected by auto_label race)

Test: none (CI workflow change -- validate by observing correct label-based gating on this PR)

Co-authored-by: AI assistant