### PR TITLE
Extract `XPUImportCtx` base class from `XPUPatchForImport`

### DIFF
--- a/test/xpu/xpu_test_utils.py
+++ b/test/xpu/xpu_test_utils.py
@@ -983,7 +983,20 @@ def get_dtypesIf_mock(src_device_type: str):
     return dtypesIfXPUMock
 
 
-class XPUPatchForImport:
+class XPUImportCtx:
+    """Minimal context manager for importing upstream test modules on XPU.
+
+    Only performs the essential import mechanics:
+    - Extends sys.path so upstream test modules can be imported
+    - Suppresses instantiate_device_type_tests during import
+    - Suppresses instantiate_parametrized_tests during import
+    - Optionally replaces TestCase with NoTest to hide upstream classes from pytest
+
+    Does NOT apply any decorator remapping, op_db manipulation, or global state
+    faking. Test files using this are expected to work with upstream decorators
+    as-is, relying on upstream's native XPU support.
+    """
+
     def __init__(self, patch_test_case=True) -> None:
         test_dir = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), "../../../../test"
@@ -997,16 +1010,39 @@ class XPUPatchForImport:
         self.patch_test_case = patch_test_case
         self.original_path = sys.path.copy()
         self.test_case_cls = common_utils.TestCase
-        self.only_cuda_fn = common_device_type.onlyCUDA
-        self.dtypes_if_cuda_fn = common_device_type.dtypesIfCUDA
-        self.dtypes_if_xpu_fn = common_device_type.dtypesIfXPU
-        self.only_native_device_types_fn = common_device_type.onlyNativeDeviceTypes
         self.instantiate_device_type_tests_fn = (
             common_device_type.instantiate_device_type_tests
         )
         self.instantiate_parametrized_tests_fn = (
             common_utils.instantiate_parametrized_tests
         )
+
+    def __enter__(self):
+        common_device_type.instantiate_device_type_tests = DO_NOTHING
+        common_utils.instantiate_parametrized_tests = DO_NOTHING
+        if self.patch_test_case:
+            common_utils.TestCase = common_utils.NoTest
+        sys.path.extend(self.test_package)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        sys.path = self.original_path
+        common_device_type.instantiate_device_type_tests = (
+            self.instantiate_device_type_tests_fn
+        )
+        common_utils.instantiate_parametrized_tests = (
+            self.instantiate_parametrized_tests_fn
+        )
+        common_utils.TestCase = self.test_case_cls
+
+
+class XPUPatchForImport(XPUImportCtx):
+    def __init__(self, patch_test_case=True) -> None:
+        super().__init__(patch_test_case)
+        self.only_cuda_fn = common_device_type.onlyCUDA
+        self.dtypes_if_cuda_fn = common_device_type.dtypesIfCUDA
+        self.dtypes_if_xpu_fn = common_device_type.dtypesIfXPU
+        self.only_native_device_types_fn = common_device_type.onlyNativeDeviceTypes
         self.largeTensorTest = common_device_type.largeTensorTest
         self.TEST_CUDA = common_cuda.TEST_CUDA
         self.TEST_CUDNN = common_cuda.TEST_CUDNN
@@ -1166,19 +1202,13 @@ class XPUPatchForImport:
                         opinfo.reference_inputs_func = reference_inputs_cat_nofp64
 
     def __enter__(self):
-        # Monkey patch until we have a fancy way
+        super().__enter__()
 
         common_device_type.onlyCUDA = common_device_type.onlyXPU
-
         common_device_type.skipXPU = _skipXPU
         common_device_type.dtypesIfCUDA = get_dtypesIf_mock("cuda")
         common_device_type.dtypesIfXPU = get_dtypesIf_mock("xpu")
-
         common_device_type.onlyNativeDeviceTypes = common_device_type.onlyXPU
-        if self.patch_test_case:
-            common_utils.TestCase = common_utils.NoTest
-        common_device_type.instantiate_device_type_tests = DO_NOTHING
-        common_utils.instantiate_parametrized_tests = DO_NOTHING
         common_device_type.largeTensorTest = (
             lambda size, device=None: self.largeTensorTest(
                 size, device if device and device != "cuda" else "xpu"
@@ -1204,23 +1234,13 @@ class XPUPatchForImport:
         torch.cuda.is_tf32_supported = is_tf32_supported
         torch.cuda.get_device_capability = torch.xpu.get_device_capability
 
-        sys.path.extend(self.test_package)
-
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        sys.path = self.original_path
         common_device_type.onlyCUDA = self.only_cuda_fn
         common_device_type.dtypesIfCUDA = self.dtypes_if_cuda_fn
         common_device_type.dtypesIfXPU = self.dtypes_if_xpu_fn
         common_device_type.onlyNativeDeviceTypes = self.only_native_device_types_fn
-        common_device_type.instantiate_device_type_tests = (
-            self.instantiate_device_type_tests_fn
-        )
-        common_utils.instantiate_parametrized_tests = (
-            self.instantiate_parametrized_tests_fn
-        )
-        common_utils.TestCase = self.test_case_cls
         common_device_type.largeTensorTest = self.largeTensorTest
         common_cuda.TEST_CUDA = self.TEST_CUDA
         common_cuda.TEST_CUDNN = self.TEST_CUDNN
@@ -1228,6 +1248,7 @@ class XPUPatchForImport:
         torch.cuda.is_tf32_supported = self.cuda_is_tf32_supported
         torch.cuda.get_device_capability = self.cuda_get_device_capability
         common_device_type.skipXPU = self.skipXPU
+        super().__exit__(exc_type, exc_value, traceback)
 
 
 # Copy the test cases from generic_base_class to generic_test_class.


### PR DESCRIPTION
Minimal import-only context manager that handles sys.path, suppresses `instantiate_device_type_tests`, and optionally replaces TestCase — without op-db rewrites or CUDA->XPU decorator translation.