### PR TITLE
bot: implement @torchxpubot PR bot

### DIFF
--- a/.github/scripts/bot_revert.py
+++ b/.github/scripts/bot_revert.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Copyright 2024-2025 Intel Corporation
+# Licensed under the Apache License, Version 2.0
+
+"""Create a revert PR for a merged pull request.
+
+Usage:
+    python bot_revert.py --pr-number 123 --reason "broke nightly" --repo owner/repo
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def run(cmd, check=True, capture=True):
+    """Run a shell command and return stdout."""
+    result = subprocess.run(
+        cmd, shell=True, capture_output=capture, text=True, check=False
+    )
+    if check and result.returncode != 0:
+        print(f"Command failed: {cmd}", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        sys.exit(1)
+    return result.stdout.strip() if capture else None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create a revert PR")
+    parser.add_argument("--pr-number", type=int, required=True)
+    parser.add_argument("--reason", type=str, required=True)
+    parser.add_argument("--repo", type=str, required=True)
+    args = parser.parse_args()
+
+    # Get PR info
+    pr_json = run(
+        f"gh pr view {args.pr_number} --repo {args.repo} "
+        f"--json title,mergeCommit,merged,baseRefName,headRefName"
+    )
+    pr = json.loads(pr_json)
+
+    if not pr["merged"]:
+        print(f"::error::PR #{args.pr_number} is not merged. Cannot revert.")
+        # Post comment via gh
+        run(
+            f"gh pr comment {args.pr_number} --repo {args.repo} "
+            f'--body "Cannot revert: PR #{args.pr_number} is not merged."'
+        )
+        sys.exit(1)
+
+    merge_sha = pr["mergeCommit"]["oid"]
+    base_branch = pr["baseRefName"]
+    original_title = pr["title"]
+    revert_branch = f"revert-pr-{args.pr_number}"
+
+    # Configure git identity
+    run('git config user.name "torchxpubot"')
+    run('git config user.email "torchxpubot@users.noreply.github.com"')
+
+    # Fetch and create revert branch
+    run(f"git fetch origin {base_branch}")
+    run(f"git checkout -b {revert_branch} origin/{base_branch}")
+
+    # Revert the merge commit
+    # -m 1 is needed for merge commits to specify the mainline parent
+    revert_result = subprocess.run(
+        f"git revert --no-edit -m 1 {merge_sha}",
+        shell=True,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if revert_result.returncode != 0:
+        # Try without -m 1 (for squash merges which are not merge commits)
+        revert_result = subprocess.run(
+            f"git revert --no-edit {merge_sha}",
+            shell=True,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if revert_result.returncode != 0:
+            print(f"::error::git revert failed: {revert_result.stderr}")
+            run(
+                f"gh pr comment {args.pr_number} --repo {args.repo} "
+                f'--body "Failed to revert merge commit `{merge_sha[:10]}`. '
+                f'Manual revert may be needed."'
+            )
+            sys.exit(1)
+
+    # Push the revert branch
+    run(f"git push origin {revert_branch}")
+
+    # Create the revert PR
+    revert_title = f'Revert "{original_title}"'
+    revert_body = (
+        f"Reverts #{args.pr_number}\n\n"
+        f"**Reason:** {args.reason}\n\n"
+        f"Original PR: #{args.pr_number}"
+    )
+    pr_url = run(
+        f"gh pr create --repo {args.repo} "
+        f"--base {base_branch} --head {revert_branch} "
+        f'--title "{revert_title}" '
+        f'--body "{revert_body}"'
+    )
+
+    # Comment on the original PR
+    run(
+        f"gh pr comment {args.pr_number} --repo {args.repo} "
+        f'--body "Revert PR created: {pr_url}\nReason: {args.reason}"'
+    )
+    print(f"Revert PR created: {pr_url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/bot_review.py
+++ b/.github/scripts/bot_review.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# Copyright 2024-2025 Intel Corporation
+# Licensed under the Apache License, Version 2.0
+
+"""AI-powered PR review using Claude via Anthropic API.
+
+Usage:
+    ANTHROPIC_API_KEY=... python bot_review.py --pr-number 123 --repo owner/repo
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SKILL_DIR = Path(__file__).resolve().parent.parent / ".claude" / "skills" / "pr-review"
+
+SYSTEM_PROMPT = """You are a code reviewer for the intel/torch-xpu-ops repository.
+This repository provides XPU (Intel GPU) operator implementations for PyTorch ATen.
+
+Review philosophy:
+1. Only report problems. Do NOT mention things done correctly.
+2. Focus on what CI cannot check: correctness against CPU/CUDA semantics,
+   XPU-specific risks (synchronization, indexing, precision), test adequacy.
+3. Be specific and actionable. Reference file paths and line numbers.
+4. Assume the reader has PyTorch familiarity.
+5. Use SYCL programming model terms (subgroup size, work-group, work-item),
+   not hardware terms, in code review.
+
+Output format:
+## PR Review: #<number>
+### Summary
+What the PR does (1 sentence), then overall verdict.
+### Correctness
+[Problems only]
+### XPU-Specific Risks
+[Problems only]
+### Testing
+[Problems only]
+### Recommendation
+**Approve** / **Request Changes** / **Needs Discussion**
+
+Omit sections with no problems."""
+
+
+def run(cmd, check=True):
+    result = subprocess.run(
+        cmd, shell=True, capture_output=True, text=True, check=False
+    )
+    if check and result.returncode != 0:
+        print(f"Command failed: {cmd}", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        sys.exit(1)
+    return result.stdout.strip()
+
+
+def call_claude(system_prompt, user_prompt, api_key):
+    """Call the Anthropic API with the given prompts."""
+    import urllib.request
+
+    url = "https://api.anthropic.com/v1/messages"
+    headers = {
+        "Content-Type": "application/json",
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+    }
+    data = json.dumps(
+        {
+            "model": "claude-opus-4-20250514",
+            "max_tokens": 8192,
+            "system": system_prompt,
+            "messages": [{"role": "user", "content": user_prompt}],
+        }
+    ).encode("utf-8")
+
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+            return result["content"][0]["text"]
+    except Exception as e:
+        print(f"::error::Anthropic API call failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="AI-powered PR review")
+    parser.add_argument("--pr-number", type=int, required=True)
+    parser.add_argument("--repo", type=str, required=True)
+    args = parser.parse_args()
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("::error::ANTHROPIC_API_KEY is not set", file=sys.stderr)
+        sys.exit(1)
+
+    # Fetch PR metadata
+    pr_json = run(
+        f"gh pr view {args.pr_number} --repo {args.repo} "
+        f"--json title,body,author,baseRefName,headRefName,files,additions,deletions"
+    )
+    pr = json.loads(pr_json)
+
+    # Fetch PR diff
+    diff = run(f"gh pr diff {args.pr_number} --repo {args.repo}")
+
+    # Build file list
+    file_list = "\n".join(
+        f"  {f['path']} (+{f.get('additions', '?')}/-{f.get('deletions', '?')})"
+        for f in pr.get("files", [])
+    )
+
+    # Construct user prompt
+    user_prompt = f"""Review this PR.
+
+Title: {pr["title"]}
+Author: {pr["author"]["login"]}
+Base: {pr["baseRefName"]} <- Head: {pr["headRefName"]}
+Total: +{pr["additions"]}/-{pr["deletions"]}
+
+Files changed:
+{file_list}
+
+PR description:
+{pr.get("body", "(no description)")}
+
+Diff:
+{diff}"""
+
+    # Truncate if too large (Claude context limit)
+    max_chars = 180000
+    if len(user_prompt) > max_chars:
+        user_prompt = user_prompt[:max_chars] + "\n\n[Diff truncated due to size]"
+
+    review = call_claude(SYSTEM_PROMPT, user_prompt, api_key)
+
+    # Post the review as a PR comment
+    # Write to temp file to avoid shell escaping issues
+    with open("/tmp/review_body.md", "w") as f:
+        f.write(review)
+    run(
+        f"gh pr comment {args.pr_number} --repo {args.repo} "
+        f"--body-file /tmp/review_body.md"
+    )
+    print(f"Review posted to PR #{args.pr_number}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/bot_ut_check.py
+++ b/.github/scripts/bot_ut_check.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+# Copyright 2024-2025 Intel Corporation
+# Licensed under the Apache License, Version 2.0
+
+"""Analyze UT results from CI: new failures, relevance to PR, new-test coverage.
+
+Usage:
+    ANTHROPIC_API_KEY=... python bot_ut_check.py \
+        --pr-number 123 --repo owner/repo --run-id 12345
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run(cmd, check=True):
+    result = subprocess.run(
+        cmd, shell=True, capture_output=True, text=True, check=False
+    )
+    if check and result.returncode != 0:
+        print(f"Command failed: {cmd}", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        sys.exit(1)
+    return result.stdout.strip()
+
+
+def find_latest_run(repo, pr_number):
+    """Find the latest 'pull' workflow run for this PR."""
+    pr_json = run(f"gh pr view {pr_number} --repo {repo} --json headRefOid")
+    head_sha = json.loads(pr_json)["headRefOid"]
+
+    runs_json = run(
+        f"gh run list --repo {repo} --workflow pull.yml "
+        f"--commit {head_sha} --limit 1 --json databaseId,status"
+    )
+    runs = json.loads(runs_json)
+    if not runs:
+        return None, None
+    return runs[0]["databaseId"], runs[0]["status"]
+
+
+def download_artifacts(repo, run_id, download_dir):
+    """Download UT-related artifacts from the workflow run."""
+    artifacts_json = run(f"gh run view {run_id} --repo {repo} --json jobs")
+
+    # Download all matching artifacts
+    run(f"mkdir -p {download_dir}", check=False)
+
+    # Try downloading new failures artifact
+    result = subprocess.run(
+        f"gh run download {run_id} --repo {repo} --dir {download_dir} "
+        f'--pattern "New-UT-Failures-*"',
+        shell=True,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    has_new_failures_artifact = result.returncode == 0
+
+    # Download UT data artifacts (for passed logs)
+    subprocess.run(
+        f"gh run download {run_id} --repo {repo} --dir {download_dir} "
+        f'--pattern "Inductor-XPU-UT-Data-*"',
+        shell=True,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    return has_new_failures_artifact
+
+
+def parse_new_failures(download_dir):
+    """Parse new_ut_failure_list.csv files from downloaded artifacts."""
+    failures = []
+    for csv_file in Path(download_dir).rglob("new_ut_failure_list.csv"):
+        with open(csv_file) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("Category"):
+                    continue
+                # CSV format: Category | Class name | Test name | Status | Message | Source
+                parts = [p.strip() for p in line.split("|")]
+                if len(parts) >= 4:
+                    failures.append(
+                        {
+                            "category": parts[0],
+                            "class": parts[1],
+                            "test": parts[2],
+                            "status": parts[3],
+                            "message": parts[4] if len(parts) > 4 else "",
+                        }
+                    )
+    return failures
+
+
+def parse_passed_tests(download_dir):
+    """Parse passed_*.log files to get set of passed test names."""
+    passed = set()
+    for log_file in Path(download_dir).rglob("passed_*.log"):
+        with open(log_file) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    # Format: category,class_name,test_name
+                    parts = line.split(",")
+                    if len(parts) >= 3:
+                        passed.add(f"{parts[1]}::{parts[2]}")
+    return passed
+
+
+def get_pr_changed_files(repo, pr_number):
+    """Get list of changed files in the PR, classified by category."""
+    files_json = run(f"gh pr view {pr_number} --repo {repo} --json files")
+    files = json.loads(files_json).get("files", [])
+
+    classified = {
+        "operator_source": [],
+        "test_files": [],
+        "skip_lists": [],
+        "other": [],
+    }
+    for f in files:
+        path = f["path"]
+        if re.match(r"src/ATen/native/xpu/", path):
+            classified["operator_source"].append(path)
+        elif re.match(r"test/(xpu|regressions)/", path):
+            if "skip_list" in path:
+                classified["skip_lists"].append(path)
+            else:
+                classified["test_files"].append(path)
+        else:
+            classified["other"].append(path)
+
+    return classified
+
+
+def extract_new_test_names(repo, pr_number, test_files):
+    """Extract new/modified test method names from the PR diff for test files."""
+    if not test_files:
+        return []
+
+    diff = run(f"gh pr diff {pr_number} --repo {repo}")
+    new_tests = []
+
+    # Match added lines that look like test method definitions
+    current_file = None
+    current_class = None
+    for line in diff.split("\n"):
+        if line.startswith("+++ b/"):
+            current_file = line[6:]
+            current_class = None
+        elif current_file in test_files:
+            # Track class context
+            class_match = re.match(r"[+ ]class\s+(\w+)", line)
+            if class_match:
+                current_class = class_match.group(1)
+            # Match added test methods
+            if line.startswith("+") and not line.startswith("+++"):
+                test_match = re.match(r"\+\s+def\s+(test_\w+)", line)
+                if test_match:
+                    test_name = test_match.group(1)
+                    if current_class:
+                        new_tests.append(f"{current_class}::{test_name}")
+                    else:
+                        new_tests.append(test_name)
+
+    return new_tests
+
+
+def call_claude(prompt, api_key):
+    """Call Claude API for analysis."""
+    import urllib.request
+
+    url = "https://api.anthropic.com/v1/messages"
+    headers = {
+        "Content-Type": "application/json",
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+    }
+    data = json.dumps(
+        {
+            "model": "claude-opus-4-20250514",
+            "max_tokens": 4096,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+    ).encode("utf-8")
+
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+            return result["content"][0]["text"]
+    except Exception as e:
+        print(f"Warning: Claude API call failed: {e}", file=sys.stderr)
+        return None
+
+
+def build_deterministic_report(failures, changed_files, new_tests, passed_tests):
+    """Build a report without LLM -- deterministic fallback."""
+    lines = ["## UT Result Check\n"]
+
+    # New failures section
+    lines.append("### New Failures")
+    if not failures:
+        lines.append("No new failures detected.\n")
+    else:
+        lines.append(
+            f"{len(failures)} new failure(s) detected (not in known issues).\n"
+        )
+        lines.append("| Test | Category | Status |")
+        lines.append("|------|----------|--------|")
+        for f in failures[:20]:
+            lines.append(
+                f"| `{f['class']}::{f['test']}` | {f['category']} | {f['status']} |"
+            )
+        if len(failures) > 20:
+            lines.append(f"\n... and {len(failures) - 20} more\n")
+
+    # Changed files summary
+    lines.append("\n### PR Changes")
+    if changed_files["operator_source"]:
+        lines.append(
+            f"- Operator source: {len(changed_files['operator_source'])} file(s)"
+        )
+    if changed_files["test_files"]:
+        lines.append(f"- Test files: {len(changed_files['test_files'])} file(s)")
+    if changed_files["skip_lists"]:
+        lines.append(f"- Skip lists: {len(changed_files['skip_lists'])} file(s)")
+    lines.append("")
+
+    # New test coverage
+    if new_tests:
+        lines.append("### New Test Coverage")
+        lines.append(
+            "PR adds/modifies tests in: "
+            + ", ".join(f"`{f}`" for f in changed_files["test_files"])
+        )
+        lines.append("")
+        lines.append("| New/Modified Test | Found in Results? | Status |")
+        lines.append("|-------------------|-------------------|--------|")
+        for t in new_tests:
+            if t in passed_tests:
+                lines.append(f"| `{t}` | Yes | PASSED |")
+            else:
+                # Check if it failed
+                failed_match = any(f"{f['class']}::{f['test']}" == t for f in failures)
+                if failed_match:
+                    lines.append(f"| `{t}` | Yes | FAILED |")
+                else:
+                    lines.append(f"| `{t}` | No | NOT RUN |")
+        lines.append("")
+
+    # Summary
+    lines.append("### Summary")
+    if not failures and all(t in passed_tests for t in new_tests):
+        lines.append("All new tests passed and no new failures detected.")
+    elif failures:
+        lines.append(
+            f"{len(failures)} new failure(s) detected. "
+            "Please investigate before merging."
+        )
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def build_llm_report(failures, changed_files, new_tests, passed_tests, api_key):
+    """Build a report using Claude for relevance analysis."""
+    # Prepare data for Claude
+    failures_text = json.dumps(failures[:30], indent=2) if failures else "[]"
+    changed_text = json.dumps(changed_files, indent=2)
+    new_tests_text = json.dumps(new_tests, indent=2) if new_tests else "[]"
+    passed_list = [t for t in new_tests if t in passed_tests]
+    not_run_list = [
+        t
+        for t in new_tests
+        if t not in passed_tests
+        and not any(f"{f['class']}::{f['test']}" == t for f in failures)
+    ]
+
+    prompt = f"""Analyze these UT (unit test) results for a PR on intel/torch-xpu-ops.
+
+## New Failures (not in known issues)
+{failures_text}
+
+## PR Changed Files
+{changed_text}
+
+## New/Modified Test Methods in PR
+{new_tests_text}
+
+## New Tests That Passed
+{json.dumps(passed_list)}
+
+## New Tests Not Found in Results
+{json.dumps(not_run_list)}
+
+Produce a report in this exact markdown format:
+
+## UT Result Check
+
+### New Failures
+<count> new failure(s) or "No new failures detected."
+
+If there are failures, include a table:
+| Test | Category | Status | Related to PR? |
+|------|----------|--------|----------------|
+
+### Failure Relevance Analysis
+For each new failure, explain whether it is Related, Possibly related, or Unrelated
+to the PR changes. Map operator source files to test modules.
+- Related: changes to src/ATen/native/xpu/sycl/FooKernels.cpp and failure in test_foo
+- Unrelated: failure in a completely different area
+
+### New Test Coverage
+If the PR adds/modifies test files, report which new tests ran and passed,
+which failed, and which were NOT RUN.
+
+### Summary
+One-sentence verdict."""
+
+    return call_claude(prompt, api_key)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="UT result analysis")
+    parser.add_argument("--pr-number", type=int, required=True)
+    parser.add_argument("--repo", type=str, required=True)
+    parser.add_argument(
+        "--run-id", type=int, default=0, help="Workflow run ID (auto-detected if 0)"
+    )
+    args = parser.parse_args()
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+
+    # Find the latest run
+    if args.run_id:
+        run_id = args.run_id
+        status = "completed"
+    else:
+        run_id, status = find_latest_run(args.repo, args.pr_number)
+        if not run_id:
+            run(
+                f"gh pr comment {args.pr_number} --repo {args.repo} "
+                f'--body "No CI workflow run found for this PR. '
+                f'Please wait for CI to complete and try again."'
+            )
+            return
+
+    if status != "completed":
+        run(
+            f"gh pr comment {args.pr_number} --repo {args.repo} "
+            f'--body "CI is still running (status: {status}). '
+            f'Please wait for CI to complete and try again."'
+        )
+        return
+
+    # Download artifacts
+    download_dir = "/tmp/ut_artifacts"
+    run(f"rm -rf {download_dir}", check=False)
+    has_new_failures = download_artifacts(args.repo, run_id, download_dir)
+
+    # Parse results
+    failures = parse_new_failures(download_dir) if has_new_failures else []
+    passed_tests = parse_passed_tests(download_dir)
+
+    # Get PR changes
+    changed_files = get_pr_changed_files(args.repo, args.pr_number)
+    new_tests = extract_new_test_names(
+        args.repo, args.pr_number, changed_files["test_files"]
+    )
+
+    # Build report
+    if api_key:
+        report = build_llm_report(
+            failures, changed_files, new_tests, passed_tests, api_key
+        )
+    else:
+        report = None
+
+    if not report:
+        # Fallback to deterministic report
+        report = build_deterministic_report(
+            failures, changed_files, new_tests, passed_tests
+        )
+
+    # Post report
+    with open("/tmp/ut_check_body.md", "w") as f:
+        f.write(report)
+    run(
+        f"gh pr comment {args.pr_number} --repo {args.repo} "
+        f"--body-file /tmp/ut_check_body.md"
+    )
+    print(f"UT check report posted to PR #{args.pr_number}")
+
+    # Fail the job if there are new failures
+    if failures:
+        print(f"::warning::{len(failures)} new UT failure(s) detected")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/auto_merge_by_comment.yml
+++ b/.github/workflows/auto_merge_by_comment.yml
@@ -35,6 +35,18 @@ jobs:
               content: '+1'
             });
 
+      - name: Post Deprecation Notice
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: '**Note:** The `/merge` command is deprecated. Please use `@torchxpubot merge` instead. See `@torchxpubot help` for all available commands.'
+            });
+
       - name: Get PR Info
         uses: actions/github-script@v7
         id: prinfo

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1,0 +1,776 @@
+name: bot
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    paths:
+      - '.github/workflows/bot.yml'
+      - '.github/scripts/bot_*.py'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bot-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  parse-command:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'issue_comment'
+      && github.event.issue.pull_request
+      && contains(github.event.comment.body, '@torchxpubot')
+    permissions:
+      pull-requests: read
+      issues: read
+    outputs:
+      command: ${{ steps.parse.outputs.command }}
+      force: ${{ steps.parse.outputs.force }}
+      rerun_mode: ${{ steps.parse.outputs.rerun_mode }}
+      pytorch_ref: ${{ steps.parse.outputs.pytorch_ref }}
+      revert_reason: ${{ steps.parse.outputs.revert_reason }}
+      pr_number: ${{ steps.parse.outputs.pr_number }}
+      actor: ${{ steps.parse.outputs.actor }}
+      authorized: ${{ steps.parse.outputs.authorized }}
+    steps:
+      - name: Acknowledge Command
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '+1'
+            });
+
+      - name: Parse Command
+        id: parse
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.comment.body;
+            const actor = context.payload.comment.user.login;
+            const assoc = context.payload.comment.author_association;
+            const prNumber = context.payload.issue.number;
+
+            // Extract the @torchxpubot command line
+            const match = body.match(/@torchxpubot\s+(\S+)(.*)/i);
+            if (!match) {
+              core.setOutput('command', '');
+              core.setFailed('No valid command found after @torchxpubot');
+              return;
+            }
+
+            const command = match[1].toLowerCase();
+            const args = (match[2] || '').trim();
+            const validCommands = ['merge', 'revert', 'rebase', 'lint', 'rerun', 'review', 'ut-check', 'help'];
+
+            if (!validCommands.includes(command)) {
+              core.setOutput('command', 'invalid');
+              core.setOutput('pr_number', prNumber);
+              core.setOutput('actor', actor);
+              core.setOutput('authorized', 'false');
+              return;
+            }
+
+            // Permission check
+            const privileged = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            const maintainerOnly = ['OWNER', 'MEMBER'];
+            let authorized = true;
+
+            if (command === 'help') {
+              authorized = true; // anyone
+            } else if (!privileged.includes(assoc)) {
+              authorized = false;
+            }
+
+            // Parse command-specific args
+            let force = 'false';
+            let rerunMode = 'all';
+            let pytorchRef = '';
+            let revertReason = '';
+
+            if (command === 'merge') {
+              if (args.includes('-f')) {
+                force = 'true';
+                if (!maintainerOnly.includes(assoc)) {
+                  authorized = false;
+                }
+              }
+            } else if (command === 'revert') {
+              const reasonMatch = args.match(/-m\s+["']([^"']+)["']/);
+              if (reasonMatch) {
+                revertReason = reasonMatch[1];
+              } else {
+                const reasonMatchUnquoted = args.match(/-m\s+(.+)/);
+                if (reasonMatchUnquoted) {
+                  revertReason = reasonMatchUnquoted[1].trim();
+                }
+              }
+            } else if (command === 'rerun') {
+              if (args.toLowerCase().includes('failed')) {
+                rerunMode = 'failed';
+              }
+              const branchMatch = args.match(/-b\s+(\S+)/);
+              if (branchMatch) {
+                pytorchRef = branchMatch[1];
+              }
+            }
+
+            core.setOutput('command', command);
+            core.setOutput('force', force);
+            core.setOutput('rerun_mode', rerunMode);
+            core.setOutput('pytorch_ref', pytorchRef);
+            core.setOutput('revert_reason', revertReason);
+            core.setOutput('pr_number', prNumber);
+            core.setOutput('actor', actor);
+            core.setOutput('authorized', String(authorized));
+
+  invalid-command:
+    needs: parse-command
+    runs-on: ubuntu-latest
+    if: needs.parse-command.outputs.command == 'invalid'
+    steps:
+      - name: Post invalid command message
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.parse-command.outputs.pr_number }},
+              body: 'Unknown command. Use `@torchxpubot help` to see available commands.'
+            });
+
+  permission-denied:
+    needs: parse-command
+    runs-on: ubuntu-latest
+    if: >-
+      needs.parse-command.outputs.command != 'invalid'
+      && needs.parse-command.outputs.command != 'help'
+      && needs.parse-command.outputs.command != ''
+      && needs.parse-command.outputs.authorized == 'false'
+    steps:
+      - name: Post permission denied message
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const cmd = '${{ needs.parse-command.outputs.command }}';
+            const force = '${{ needs.parse-command.outputs.force }}';
+            let msg = `You do not have permission to use \`@torchxpubot ${cmd}\`. `;
+            msg += 'This command requires OWNER, MEMBER, or COLLABORATOR association.';
+            if (cmd === 'merge' && force === 'true') {
+              msg = 'Only OWNER or MEMBER can use `@torchxpubot merge -f` (force merge).';
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.parse-command.outputs.pr_number }},
+              body: msg
+            });
+
+  help:
+    needs: parse-command
+    runs-on: ubuntu-latest
+    if: needs.parse-command.outputs.command == 'help'
+    steps:
+      - name: Post help message
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const helpText = `## @torchxpubot Commands
+
+            | Command | Description |
+            |---------|-------------|
+            | \`@torchxpubot merge\` | Merge PR (requires 2 approvals + CI pass) |
+            | \`@torchxpubot merge -f\` | Force merge (maintainers only, skips CI check) |
+            | \`@torchxpubot revert -m "reason"\` | Create a revert PR |
+            | \`@torchxpubot rebase\` | Rebase onto latest main |
+            | \`@torchxpubot lint\` | Auto-fix lint errors and push |
+            | \`@torchxpubot rerun\` | Re-trigger full CI |
+            | \`@torchxpubot rerun failed\` | Re-run only failed CI jobs |
+            | \`@torchxpubot rerun -b <branch_or_commit>\` | Rerun CI against a pytorch ref |
+            | \`@torchxpubot review\` | AI-powered PR code review |
+            | \`@torchxpubot ut-check\` | Analyze UT results: new failures, relevance, coverage |
+            | \`@torchxpubot help\` | Show this help message |`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.parse-command.outputs.pr_number }},
+              body: helpText.replace(/^ +/gm, '')
+            });
+
+  merge:
+    needs: parse-command
+    runs-on: ubuntu-latest
+    if: >-
+      needs.parse-command.outputs.command == 'merge'
+      && needs.parse-command.outputs.authorized == 'true'
+    permissions:
+      checks: read
+      issues: read
+      pull-requests: read
+      statuses: read
+    steps:
+      - name: Get PR Info
+        uses: actions/github-script@v7
+        id: prinfo
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ needs.parse-command.outputs.pr_number }}
+            });
+            core.setOutput('head_sha', pr.data.head.sha);
+            core.setOutput('mergeable', String(pr.data.mergeable));
+
+      - name: Check Reviews
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const prNumber = ${{ needs.parse-command.outputs.pr_number }};
+            const reviews = await github.paginate(
+              github.rest.pulls.listReviews,
+              { owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber }
+            );
+            const latestByUser = new Map();
+            for (const r of reviews) {
+              if (r.state === 'COMMENTED') continue;
+              latestByUser.set(r.user.login, r);
+            }
+            const approvals = [...latestByUser.values()].filter(r => r.state === 'APPROVED');
+            if (approvals.length < 2) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber,
+                body: `Not enough approvals (${approvals.length}/2). At least 2 approvals are required to merge.`
+              });
+              core.setFailed(`Not enough approvals: ${approvals.length}/2`);
+            }
+
+      - name: Check CI Status
+        if: needs.parse-command.outputs.force != 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const prNumber = ${{ needs.parse-command.outputs.pr_number }};
+            const sha = '${{ steps.prinfo.outputs.head_sha }}';
+            const [checks, statuses] = await Promise.all([
+              github.rest.checks.listForRef({
+                owner: context.repo.owner, repo: context.repo.repo, ref: sha, per_page: 100
+              }),
+              github.rest.repos.getCombinedStatusForRef({
+                owner: context.repo.owner, repo: context.repo.repo, ref: sha
+              })
+            ]);
+            const latestByName = new Map();
+            for (const c of checks.data.check_runs) {
+              const existing = latestByName.get(c.name);
+              if (!existing || new Date(c.started_at) > new Date(existing.started_at)) {
+                latestByName.set(c.name, c);
+              }
+            }
+            const latestChecks = [...latestByName.values()];
+            const pending = latestChecks.filter(c => c.status !== 'completed');
+            if (pending.length > 0) {
+              const names = pending.map(c => c.name).join(', ');
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber,
+                body: `Some checks are still running: ${names}. Please wait for them to complete.`
+              });
+              core.setFailed(`Checks still in progress: ${names}`);
+              return;
+            }
+            const acceptable = new Set(['success', 'skipped', 'neutral']);
+            const failedChecks = latestChecks.filter(c => !acceptable.has(c.conclusion));
+            const statusFailed = statuses.data.state !== 'success' && statuses.data.total_count > 0;
+            if (failedChecks.length > 0 || statusFailed) {
+              const failedNames = failedChecks.map(c => `${c.name}: ${c.conclusion}`).join(', ');
+              const msg = [
+                failedChecks.length > 0 ? `Failed checks: ${failedNames}` : '',
+                statusFailed ? `Combined commit status: ${statuses.data.state}` : ''
+              ].filter(Boolean).join('\n');
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber,
+                body: `CI checks have not passed.\n${msg}\n\nUse \`@torchxpubot merge -f\` to force merge (maintainers only).`
+              });
+              core.setFailed('CI checks failed.');
+            }
+
+      - name: Check Merge Conflicts
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const prNumber = ${{ needs.parse-command.outputs.pr_number }};
+            let mergeable = '${{ steps.prinfo.outputs.mergeable }}';
+            if (mergeable === 'null') {
+              await new Promise(r => setTimeout(r, 5000));
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber
+              });
+              mergeable = String(pr.data.mergeable);
+            }
+            if (mergeable === 'false') {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber,
+                body: 'This PR has conflicts with the target branch. Please resolve the conflicts before merging.'
+              });
+              core.setFailed('PR has merge conflicts.');
+            }
+
+      - name: Merge PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const prNumber = ${{ needs.parse-command.outputs.pr_number }};
+            const actor = '${{ needs.parse-command.outputs.actor }}';
+            const force = '${{ needs.parse-command.outputs.force }}' === 'true';
+            try {
+              await github.rest.pulls.merge({
+                owner: context.repo.owner, repo: context.repo.repo,
+                pull_number: prNumber, merge_method: 'squash'
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber,
+                body: `PR has been successfully merged by @${actor}${force ? ' (force merge)' : ''}.`
+              });
+            } catch (e) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber,
+                body: `Failed to merge PR: ${e.message}`
+              });
+              core.setFailed(`Failed to merge PR: ${e.message}`);
+            }
+
+  revert:
+    needs: parse-command
+    runs-on: ubuntu-latest
+    if: >-
+      needs.parse-command.outputs.command == 'revert'
+      && needs.parse-command.outputs.authorized == 'true'
+    steps:
+      - name: Validate revert reason
+        if: needs.parse-command.outputs.revert_reason == ''
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: ${{ needs.parse-command.outputs.pr_number }},
+              body: 'Missing revert reason. Usage: `@torchxpubot revert -m "reason for revert"`'
+            });
+            core.setFailed('Missing revert reason');
+
+      - name: Checkout repository
+        if: needs.parse-command.outputs.revert_reason != ''
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.MERGE_TOKEN }}
+          fetch-depth: 0
+
+      - name: Run revert script
+        if: needs.parse-command.outputs.revert_reason != ''
+        env:
+          GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
+        run: |
+          python .github/scripts/bot_revert.py \
+            --pr-number ${{ needs.parse-command.outputs.pr_number }} \
+            --reason "${{ needs.parse-command.outputs.revert_reason }}" \
+            --repo ${{ github.repository }}
+
+  rebase:
+    needs: parse-command
+    runs-on: ubuntu-latest
+    if: >-
+      needs.parse-command.outputs.command == 'rebase'
+      && needs.parse-command.outputs.authorized == 'true'
+    steps:
+      - name: Check fork status and rebase
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const prNumber = ${{ needs.parse-command.outputs.pr_number }};
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+            const isFork = pr.data.head.repo.full_name !== pr.data.base.repo.full_name;
+            if (isFork && !pr.data.maintainer_can_modify) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber,
+                body: 'Cannot rebase: this PR is from a fork and "Allow edits from maintainers" is not enabled. Please enable it in your PR settings and try again.'
+              });
+              core.setFailed('Fork PR without maintainer_can_modify');
+              return;
+            }
+            // Export PR info for subsequent steps
+            core.exportVariable('PR_HEAD_REF', pr.data.head.ref);
+            core.exportVariable('PR_HEAD_REPO', pr.data.head.repo.clone_url);
+            core.exportVariable('PR_IS_FORK', String(isFork));
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.MERGE_TOKEN }}
+          fetch-depth: 0
+
+      - name: Rebase and push
+        env:
+          GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
+        run: |
+          git config user.name "torchxpubot"
+          git config user.email "torchxpubot@users.noreply.github.com"
+
+          if [ "$PR_IS_FORK" = "true" ]; then
+            git remote add fork "$PR_HEAD_REPO"
+            git fetch fork "$PR_HEAD_REF"
+            git checkout -b "$PR_HEAD_REF" "fork/$PR_HEAD_REF"
+          else
+            git fetch origin "$PR_HEAD_REF"
+            git checkout "$PR_HEAD_REF"
+          fi
+
+          git fetch origin main
+          git rebase origin/main
+
+          if [ "$PR_IS_FORK" = "true" ]; then
+            git push --force-with-lease fork "$PR_HEAD_REF"
+          else
+            git push --force-with-lease origin "$PR_HEAD_REF"
+          fi
+
+      - name: Post success
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: ${{ needs.parse-command.outputs.pr_number }},
+              body: 'Successfully rebased onto latest `main`.'
+            });
+
+      - name: Post failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: ${{ needs.parse-command.outputs.pr_number }},
+              body: 'Rebase failed. There may be conflicts that need manual resolution.'
+            });
+
+  lint:
+    needs: parse-command
+    runs-on: ubuntu-latest
+    if: >-
+      needs.parse-command.outputs.command == 'lint'
+      && needs.parse-command.outputs.authorized == 'true'
+    steps:
+      - name: Check fork status
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const prNumber = ${{ needs.parse-command.outputs.pr_number }};
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+            const isFork = pr.data.head.repo.full_name !== pr.data.base.repo.full_name;
+            if (isFork && !pr.data.maintainer_can_modify) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber,
+                body: 'Cannot fix lint: this PR is from a fork and "Allow edits from maintainers" is not enabled. Please enable it in your PR settings and try again.'
+              });
+              core.setFailed('Fork PR without maintainer_can_modify');
+              return;
+            }
+            core.exportVariable('PR_HEAD_REF', pr.data.head.ref);
+            core.exportVariable('PR_HEAD_REPO', pr.data.head.repo.clone_url);
+            core.exportVariable('PR_IS_FORK', String(isFork));
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.MERGE_TOKEN }}
+          fetch-depth: 0
+          ref: ${{ needs.parse-command.outputs.pr_number && format('refs/pull/{0}/head', needs.parse-command.outputs.pr_number) || '' }}
+
+      - name: Checkout correct branch for push
+        run: |
+          git config user.name "torchxpubot"
+          git config user.email "torchxpubot@users.noreply.github.com"
+          if [ "$PR_IS_FORK" = "true" ]; then
+            git remote add fork "$PR_HEAD_REPO"
+            git fetch fork "$PR_HEAD_REF"
+            git checkout -b "$PR_HEAD_REF" FETCH_HEAD
+          else
+            git fetch origin "$PR_HEAD_REF"
+            git checkout "$PR_HEAD_REF"
+          fi
+
+      - name: Run lintrunner
+        run: |
+          # CLANGFORMAT excluded: requires PyTorch headers checkout.
+          # PR CI handles clang formatting; bot only fixes Python linters.
+          export ADDITIONAL_LINTRUNNER_ARGS="--take RUFF,PYFMT,NEWLINE -a --all-files"
+          bash .github/scripts/lintrunner.sh || true
+
+      - name: Commit and push lint fixes
+        id: push
+        run: |
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            git add -A
+            git commit -m "[torchxpubot] Fix lint"
+            if [ "$PR_IS_FORK" = "true" ]; then
+              git push fork "$PR_HEAD_REF"
+            else
+              git push origin "$PR_HEAD_REF"
+            fi
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post result
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const hasChanges = '${{ steps.push.outputs.has_changes }}' === 'true';
+            const msg = hasChanges
+              ? 'Lint fixes have been applied and pushed.'
+              : 'No lint issues found. Code is clean.';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: ${{ needs.parse-command.outputs.pr_number }},
+              body: msg
+            });
+
+  rerun:
+    needs: parse-command
+    runs-on: ubuntu-latest
+    if: >-
+      needs.parse-command.outputs.command == 'rerun'
+      && needs.parse-command.outputs.authorized == 'true'
+    steps:
+      - name: Rerun CI
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const prNumber = ${{ needs.parse-command.outputs.pr_number }};
+            const mode = '${{ needs.parse-command.outputs.rerun_mode }}';
+            const pytorchRef = '${{ needs.parse-command.outputs.pytorch_ref }}';
+
+            // Get PR head SHA
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber
+            });
+            const headSha = pr.data.head.sha;
+
+            // Handle rerun -b (workflow_dispatch mode)
+            if (pytorchRef) {
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: 'pull.yml',
+                  ref: pr.data.base.ref,
+                  inputs: {
+                    pytorch_ref: pytorchRef,
+                    pr_number: String(prNumber)
+                  }
+                });
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber,
+                  body: `CI triggered with pytorch ref: \`${pytorchRef}\`. A new workflow run will appear shortly.`
+                });
+              } catch (e) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber,
+                  body: `Failed to trigger CI with pytorch ref \`${pytorchRef}\`: ${e.message}`
+                });
+                core.setFailed(e.message);
+              }
+              return;
+            }
+
+            // Find the latest 'pull' workflow run for this PR's head SHA
+            const workflows = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner, repo: context.repo.repo,
+              workflow_id: 'pull.yml', head_sha: headSha, per_page: 5
+            });
+
+            if (workflows.data.total_count === 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber,
+                body: 'No workflow runs found for the current PR head. Push a new commit or wait for CI to start.'
+              });
+              core.setFailed('No workflow runs found');
+              return;
+            }
+
+            const latestRun = workflows.data.workflow_runs[0];
+            const runId = latestRun.id;
+
+            try {
+              if (mode === 'failed') {
+                // Get failed jobs for the comment
+                const jobs = await github.rest.actions.listJobsForWorkflowRun({
+                  owner: context.repo.owner, repo: context.repo.repo, run_id: runId
+                });
+                const failedJobs = jobs.data.jobs.filter(j => j.conclusion === 'failure');
+                const failedNames = failedJobs.map(j => j.name).join(', ') || 'none found';
+
+                await github.rest.actions.reRunWorkflowFailedJobs({
+                  owner: context.repo.owner, repo: context.repo.repo, run_id: runId
+                });
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber,
+                  body: `Re-running failed jobs: ${failedNames}\nWorkflow run: ${latestRun.html_url}`
+                });
+              } else {
+                await github.rest.actions.reRunWorkflow({
+                  owner: context.repo.owner, repo: context.repo.repo, run_id: runId
+                });
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber,
+                  body: `Full CI re-run triggered.\nWorkflow run: ${latestRun.html_url}`
+                });
+              }
+            } catch (e) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber,
+                body: `Failed to re-run CI: ${e.message}`
+              });
+              core.setFailed(e.message);
+            }
+
+  review:
+    needs: parse-command
+    runs-on: ubuntu-latest
+    if: >-
+      needs.parse-command.outputs.command == 'review'
+      && needs.parse-command.outputs.authorized == 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run review script
+        env:
+          GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python .github/scripts/bot_review.py \
+            --pr-number ${{ needs.parse-command.outputs.pr_number }} \
+            --repo ${{ github.repository }}
+
+  ut-check:
+    needs: parse-command
+    runs-on: ubuntu-latest
+    if: >-
+      needs.parse-command.outputs.command == 'ut-check'
+      && needs.parse-command.outputs.authorized == 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run UT check script
+        env:
+          GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python .github/scripts/bot_ut_check.py \
+            --pr-number ${{ needs.parse-command.outputs.pr_number }} \
+            --repo ${{ github.repository }}
+
+  token-permission-test:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: "Test: MERGE_TOKEN has PR read/write access"
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+            console.log(`pulls.get OK - PR #${pr.data.number}`);
+
+            const reviews = await github.rest.pulls.listReviews({
+              owner: context.repo.owner, repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+            console.log(`pulls.listReviews OK - ${reviews.data.length} reviews`);
+
+            const checks = await github.rest.checks.listForRef({
+              owner: context.repo.owner, repo: context.repo.repo,
+              ref: context.payload.pull_request.head.sha
+            });
+            console.log(`checks.listForRef OK - ${checks.data.total_count} checks`);
+
+            // Test comment create + delete
+            const comment = await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: 'Bot token permission test -- this comment will be deleted.'
+            });
+            console.log(`issues.createComment OK`);
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              comment_id: comment.data.id, content: '+1'
+            });
+            console.log(`reactions.createForIssueComment OK`);
+            await github.rest.issues.deleteComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              comment_id: comment.data.id
+            });
+            console.log(`issues.deleteComment OK`);
+
+            // Test merge permission (dry-run with wrong SHA)
+            try {
+              await github.rest.pulls.merge({
+                owner: context.repo.owner, repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                merge_method: 'squash',
+                sha: '0000000000000000000000000000000000000000'
+              });
+            } catch (e) {
+              if (e.status === 409 || e.status === 422 || e.status === 405) {
+                console.log(`pulls.merge permission OK (got ${e.status})`);
+              } else {
+                core.setFailed(`pulls.merge permission DENIED: ${e.status}`);
+              }
+            }
+
+      - name: "Test: ANTHROPIC_API_KEY is set"
+        run: |
+          if [ -z "${{ secrets.ANTHROPIC_API_KEY }}" ]; then
+            echo "::warning::ANTHROPIC_API_KEY is not set. Review and ut-check commands will not work."
+          else
+            echo "ANTHROPIC_API_KEY is configured."
+          fi

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -10,11 +10,21 @@ on:
     branches:
       - main
       - release/*
+  workflow_dispatch:
+    inputs:
+      pytorch_ref:
+        description: 'PyTorch branch or commit to build against'
+        required: false
+        default: ''
+      pr_number:
+        description: 'PR number to checkout (for bot-triggered reruns)'
+        required: false
+        default: ''
 
 permissions: read-all
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.event_name == 'workflow_dispatch' && format('pull-rerun-{0}', github.event.inputs.pr_number) || format('{0}-{1}', github.workflow, github.event.pull_request.number) }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

Implement a GitHub Actions-based PR bot (`@torchxpubot`) for intel/torch-xpu-ops. The bot is triggered by `@torchxpubot <command>` comments on pull requests and supports the following commands:

| Command | Description |
|---------|-------------|
| `@torchxpubot merge` | Merge PR (requires 2 approvals + CI pass, squash merge) |
| `@torchxpubot merge -f` | Force merge (maintainers only, skips CI check) |
| `@torchxpubot revert -m "reason"` | Create a revert PR for a merged PR |
| `@torchxpubot rebase` | Rebase onto latest main (supports fork PRs) |
| `@torchxpubot lint` | Auto-fix Python lint errors and push (supports fork PRs) |
| `@torchxpubot rerun` | Re-trigger full CI |
| `@torchxpubot rerun failed` | Re-run only failed CI jobs |
| `@torchxpubot rerun -b <branch_or_commit>` | Rerun CI against a specific pytorch ref |
| `@torchxpubot review` | AI-powered PR code review (Claude) |
| `@torchxpubot ut-check` | Analyze UT results: new failures, relevance to PR, coverage |
| `@torchxpubot help` | Show command reference |

## Architecture

- **Single workflow** (`bot.yml`): `issue_comment` trigger → `parse-command` job fans out to conditional handler jobs
- **Python scripts** for complex operations: `bot_revert.py`, `bot_review.py`, `bot_ut_check.py`
- **Permission model**: `help` open to anyone, privileged commands require OWNER/MEMBER/COLLABORATOR, force merge requires OWNER/MEMBER only
- **Fork support**: `rebase` and `lint` commands check `maintainer_can_modify` for fork PRs
- **Deprecation**: Existing `/merge` flow gets a deprecation notice pointing to `@torchxpubot merge`
- **Rerun -b**: `pull.yml` gains `workflow_dispatch` trigger with isolated concurrency group

## Files Changed

**Created:**
- `.github/workflows/bot.yml` — Main bot workflow (12 jobs, 775 lines)
- `.github/scripts/bot_revert.py` — Revert PR creation via `gh` CLI
- `.github/scripts/bot_review.py` — AI review via Anthropic Claude API
- `.github/scripts/bot_ut_check.py` — UT analysis with Claude-enhanced + deterministic fallback

**Modified:**
- `.github/workflows/auto_merge_by_comment.yml` — Added deprecation notice
- `.github/workflows/pull.yml` — Added `workflow_dispatch` trigger for `rerun -b`

## Required Secrets

- `MERGE_TOKEN`: PAT for @torchxpubot with PR read/write, checks, issues, reactions, actions permissions
- `ANTHROPIC_API_KEY`: For `review` and `ut-check` commands (optional — ut-check falls back to deterministic report)

Test: The bot.yml includes a `token-permission-test` job that validates MERGE_TOKEN permissions on PRs modifying bot files. All YAML files validated with `yaml.safe_load()`, all Python scripts pass `py_compile` and `lintrunner`.

Co-authored-by: AI Assistant (Claude)