### PR TITLE
[2/N] Replace shift_group_left with reduce_over_group in Reduce Sum

### DIFF
--- a/src/ATen/native/xpu/sycl/Reduce.h
+++ b/src/ATen/native/xpu/sycl/Reduce.h
@@ -178,7 +178,7 @@ inline at::detail::Array<arg_t, out_vec_sz> group_x_reduce(
   }
 
   // sub-group reduction
-  // when dim_x < sg_size, a single sub-group may spans multiple rows
+  // when dim_x < sg_size, a single sub-group may span multiple rows
   // and each row needs an independent x-direction reduction
   for (int offset = 1; offset < dim_x; offset <<= 1) {
 #pragma unroll(out_vec_sz)

--- a/src/ATen/native/xpu/sycl/Reduce.h
+++ b/src/ATen/native/xpu/sycl/Reduce.h
@@ -121,13 +121,9 @@ inline at::detail::Array<arg_t, out_vec_sz> group_reduce(
       for (int i = 0; i < out_vec_sz; ++i) {
         value[i] = (sg_lid < sg_range) ? shared_[sg_lid][i] : ident;
       }
-      for (int offset = 1; offset < sg_size; offset <<= 1) {
-#pragma unroll(out_vec_sz)
-        for (int i = 0; i < out_vec_sz; ++i) {
-          value[i] =
-              combine(value[i], sycl::shift_group_left(sg, value[i], offset));
-        }
-      }
+      // subgroup tree reduce
+      subgroup_tree_reduce<arg_t, CombineFunc, NativeOp, out_vec_sz>(
+          sg, value, combine);
     }
   } else {
     // work item tree reduce
@@ -182,6 +178,8 @@ inline at::detail::Array<arg_t, out_vec_sz> group_x_reduce(
   }
 
   // sub-group reduction
+  // when dim_x < sg_size, a single sub-group may spans multiple rows
+  // and each row needs an independent x-direction reduction
   for (int offset = 1; offset < dim_x; offset <<= 1) {
 #pragma unroll(out_vec_sz)
     for (int i = 0; i < out_vec_sz; ++i) {


### PR DESCRIPTION
This PR refactors the subgroup reduction logic in the `Reduce.h` file to use a more modular and reusable approach for tree reductions, and improves code clarity with additional comments.

Refactoring and code reuse:

* Replaced the manual subgroup reduction loop in `group_reduce` with a call to `subgroup_tree_reduce`, making the code more modular and easier to maintain.

Code clarity:

* Added a clarifying comment to the subgroup reduction loop in `group_x_reduce` explaining the behavior when the sub-group size exceeds the dimension size.

Speedup on B60:

| Shape (batch=1024, dim) | FP32 | FP16 | BF16 |
|----------------------|------------|------------|-------------|
| (1024, 16384)          | 1.00x        | 1.08x        | 1.10x         |

