### PR TITLE
Fix Bedrock model ID and add error detection to bot token-permission-test

### DIFF
--- a/.claude/skills/auto-label/SKILL.md
+++ b/.claude/skills/auto-label/SKILL.md
@@ -49,7 +49,7 @@ Rules are evaluated top-to-bottom; use the FIRST matching rule set.
 - If modifying `_linux_e2e.yml` or e2e-related actions/scripts → keep linux-e2e running: `disable_ut,disable_distributed,disable_win`
 - If modifying `_windows_*.yml` → keep windows jobs running, add `windows_ci`: `disable_ut,disable_e2e,disable_distributed`
 - If modifying `pull.yml` only (trigger/condition/concurrency changes) → `disable_all`
-- If modifying only non-functional workflows (`auto_label.yml`, `auto_merge_by_comment.yml`, `issue_operator.yml`) → `disable_all`
+- If modifying only non-functional workflows (`auto_label.yml`, `auto_merge_by_comment.yml`, `issue_operator.yml`, `bot.yml`) or bot scripts (`.github/scripts/bot_*.py`) → `disable_all`
 - If modifying MULTIPLE workflow areas or unclear scope → run full CI: `none`
 
 **Additional:** If no `src/`, `cmake/`, `CMakeLists.txt` files changed, add `disable_build`.

--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -158,8 +158,9 @@ jobs:
                   test/xpu/skip_list_common.py|test/xpu/expect/*|test/xpu/test_decomp_xpu.py|test/xpu/extended/skip_list_*.py) ;;
                   *) ONLY_SKIP_EXPECT=false ;;
                 esac ;;
-              .github/workflows/auto_label.yml|.github/workflows/auto_merge_by_comment.yml|.github/workflows/issue_operator.yml) HAS_GITHUB_META=true ;;
+              .github/workflows/auto_label.yml|.github/workflows/auto_merge_by_comment.yml|.github/workflows/issue_operator.yml|.github/workflows/bot.yml) HAS_GITHUB_META=true ;;
               .github/workflows/*) HAS_WORKFLOW=true ;;
+              .github/scripts/bot_*.py) HAS_GITHUB_META=true ;;
               .github/actions/*|.github/scripts/*) HAS_CI_SCRIPTS=true ;;
               .github/*) HAS_GITHUB_META=true ;;
               .claude/*) HAS_GITHUB_META=true ;;

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -8,6 +8,9 @@ on:
       - '.github/workflows/bot.yml'
       - '.github/scripts/bot_*.py'
 
+env:
+  BEDROCK_MODEL: global.anthropic.claude-opus-4-6-v1
+
 permissions:
   contents: read
 
@@ -698,17 +701,42 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run AI review
+        id: ai-review
         uses: anthropics/claude-code-action@v1
         with:
           use_bedrock: "true"
           github_token: ${{ secrets.MERGE_TOKEN }}
-          claude_args: "--model us.anthropic.claude-opus-4-6-20250617-v1:0 --max-turns 10"
+          claude_args: "--model ${{ env.BEDROCK_MODEL }} --max-turns 10"
           prompt: |
             Use the /pr-review skill to review PR #${{ needs.parse-command.outputs.pr_number }}
             in the ${{ github.repository }} repository.
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+
+      - name: "Verify: AI review succeeded"
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const file = '${{ steps.ai-review.outputs.execution_file }}';
+            let ok = false;
+            if (file && fs.existsSync(file)) {
+              const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+              const result = data.filter(e => e.type === 'result').pop();
+              console.log('Result:', JSON.stringify(result, null, 2));
+              ok = result && !result.is_error && result.total_cost_usd > 0;
+            }
+            if (!ok) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: ${{ needs.parse-command.outputs.pr_number }},
+                body: '@chuanqi129 `@torchxpubot review` failed: Bedrock returned an error or no output. Please check AWS token validity.'
+              });
+              core.setFailed('AI review failed.');
+            }
 
   ut-check:
     needs: parse-command
@@ -731,12 +759,13 @@ jobs:
             --output /tmp/ut_data.json
 
       - name: AI analysis
+        id: ai-analysis
         if: steps.collect.outputs.has_data == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           use_bedrock: "true"
           github_token: ${{ secrets.MERGE_TOKEN }}
-          claude_args: "--model us.anthropic.claude-opus-4-6-20250617-v1:0 --max-turns 5"
+          claude_args: "--model ${{ env.BEDROCK_MODEL }} --max-turns 5"
           prompt: |
             Read the file /tmp/ut_data.json which contains UT (unit test) results
             for PR #${{ needs.parse-command.outputs.pr_number }} on intel/torch-xpu-ops.
@@ -763,6 +792,31 @@ jobs:
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+
+      - name: "Verify: AI analysis succeeded"
+        if: steps.collect.outputs.has_data == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const file = '${{ steps.ai-analysis.outputs.execution_file }}';
+            let ok = false;
+            if (file && fs.existsSync(file)) {
+              const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+              const result = data.filter(e => e.type === 'result').pop();
+              console.log('Result:', JSON.stringify(result, null, 2));
+              ok = result && !result.is_error && result.total_cost_usd > 0;
+            }
+            if (!ok) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: ${{ needs.parse-command.outputs.pr_number }},
+                body: '@chuanqi129 `@torchxpubot ut-check` failed: Bedrock returned an error or no output. Please check AWS token validity.'
+              });
+              core.setFailed('AI analysis failed.');
+            }
 
       - name: Deterministic fallback
         if: steps.collect.outputs.has_data == 'true' && failure()
@@ -840,15 +894,43 @@ jobs:
             }
 
       - name: "Test: AWS Bedrock connectivity via Claude Code Action"
+        id: bedrock-test
         uses: anthropics/claude-code-action@v1
         with:
           use_bedrock: "true"
           github_token: ${{ secrets.MERGE_TOKEN }}
-          claude_args: "--model us.anthropic.claude-opus-4-6-20250617-v1:0 --max-turns 1"
+          claude_args: "--model ${{ env.BEDROCK_MODEL }} --max-turns 1"
           use_sticky_comment: "true"
+          show_full_output: "true"
           prompt: |
             Reply with exactly: "Bedrock connectivity test passed."
             Do not do anything else.
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+
+      - name: "Verify: Bedrock test actually succeeded"
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const file = '${{ steps.bedrock-test.outputs.execution_file }}';
+            let ok = false;
+            if (file && fs.existsSync(file)) {
+              const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+              const result = data.filter(e => e.type === 'result').pop();
+              console.log('Result:', JSON.stringify(result, null, 2));
+              ok = result && !result.is_error && result.total_cost_usd > 0;
+            }
+            if (!ok) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: '@chuanqi129 Bedrock connectivity test failed. Please check AWS token validity.'
+              });
+              core.setFailed('Bedrock test failed.');
+            } else {
+              console.log('Bedrock connectivity verified.');
+            }


### PR DESCRIPTION
## Summary

Fixes issues discovered during Bedrock integration testing of PR #4243:

1. **Invalid model ID**: `us.anthropic.claude-opus-4-6-20250617-v1:0` is rejected by Bedrock. Updated to `global.anthropic.claude-opus-4-6-v1` and extracted into a workflow-level `env.BEDROCK_MODEL` variable (single source of truth for all 3 jobs).

2. **Silent Bedrock failures**: `claude-code-action` returns exit code 0 even when `is_error: true` (e.g. invalid model ID, auth failure), and does NOT expose an `execution_output` step output. Added a verification step after every `claude-code-action` usage (review, ut-check, token-permission-test) that reads the `execution_file` JSON, checks `is_error` and `total_cost_usd`, and posts a PR comment `@chuanqi129` to check token validity on failure.

3. **Auto-label**: Added `bot.yml` and `.github/scripts/bot_*.py` to the non-functional file list in both the auto-label skill and the workflow fallback logic, so bot-related PRs get `disable_all`.

### Changes
- `.github/workflows/bot.yml`: Extract `BEDROCK_MODEL` env var, fix model ID, add verification steps with `@chuanqi129` notification, enable `show_full_output` in token-permission-test.
- `.github/workflows/auto_label.yml`: Add bot files to metadata pattern matching.
- `.claude/skills/auto-label/SKILL.md`: Update Rule 2 non-functional workflow list.

Test: `token-permission-test` job on this PR passes (Bedrock call succeeds, verification step confirms `is_error: false` and `total_cost_usd > 0`). `auto-label` correctly applies `disable_all`.

Co-authored-by: AI assistant
