### PR TITLE
Fix bot cost tracking 403 and review max-turns limit

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -694,6 +694,7 @@ jobs:
   review:
     needs: parse-command
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: >-
       needs.parse-command.outputs.command == 'review'
       && needs.parse-command.outputs.authorized == 'true'
@@ -707,7 +708,8 @@ jobs:
         with:
           use_bedrock: "true"
           github_token: ${{ secrets.MERGE_TOKEN }}
-          claude_args: "--model ${{ env.BEDROCK_MODEL }} --max-turns 10 --allowedTools Bash,Read,Glob,Grep,WebFetch --disallowedTools \"Edit,Write,NotebookEdit,Bash(git push:*),Bash(git add:*),Bash(git commit:*),Bash(git rm:*)\""
+          settings: '{"alwaysThinkingEnabled": true}'
+          claude_args: "--model ${{ env.BEDROCK_MODEL }} --max-turns 30 --allowedTools Bash,Read,Glob,Grep,WebFetch --disallowedTools \"Edit,Write,NotebookEdit,Bash(git push:*),Bash(git add:*),Bash(git commit:*),Bash(git rm:*)\""
           prompt: |
             Use the /pr-review skill to review PR #${{ needs.parse-command.outputs.pr_number }}
             in the ${{ github.repository }} repository.
@@ -775,6 +777,7 @@ jobs:
   ut-check:
     needs: parse-command
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: >-
       needs.parse-command.outputs.command == 'ut-check'
       && needs.parse-command.outputs.authorized == 'true'
@@ -799,7 +802,8 @@ jobs:
         with:
           use_bedrock: "true"
           github_token: ${{ secrets.MERGE_TOKEN }}
-          claude_args: "--model ${{ env.BEDROCK_MODEL }} --max-turns 5 --allowedTools Bash,Read,Glob,Grep,WebFetch --disallowedTools \"Edit,Write,NotebookEdit,Bash(git push:*),Bash(git add:*),Bash(git commit:*),Bash(git rm:*)\""
+          settings: '{"alwaysThinkingEnabled": true}'
+          claude_args: "--model ${{ env.BEDROCK_MODEL }} --max-turns 15 --allowedTools Bash,Read,Glob,Grep,WebFetch --disallowedTools \"Edit,Write,NotebookEdit,Bash(git push:*),Bash(git add:*),Bash(git commit:*),Bash(git rm:*)\""
           prompt: |
             Read the file /tmp/ut_data.json which contains UT (unit test) results
             for PR #${{ needs.parse-command.outputs.pr_number }} on intel/torch-xpu-ops.


### PR DESCRIPTION
## Summary

- Fix cost tracking 403 error: MERGE_TOKEN lacks `issues:write`, so cost
  tracking steps now use default GITHUB_TOKEN with job-level permissions
  (`issues: write`, `actions: read`)
- Fix review `error_max_turns`: increase `--max-turns` from 10 to 30 for
  review and from 5 to 15 for ut-check, since the pr-review skill needs
  multiple turns to read diffs, check upstream code, and write the review

## Root Cause

1. **403 on cost tracking**: `MERGE_TOKEN` is a fine-grained PAT with
   `pull_requests: write` but not `issues: write`. Commenting on issue
   #4251 (cost tracker) requires `issues: write`. The `listJobsForWorkflowRun`
   API also needs `actions: read`.

2. **Review error_max_turns**: Claude hit the 10-turn limit before finishing
   the review on PR #4232 ($0.95 spent, 488K in / 10K out, `is_error: true`).
   The pr-review skill involves reading diff, fetching upstream files, analyzing
   each changed file, and posting the review — 10 turns is insufficient.

Co-authored-by: Claude Code (AI assistant)