### PR TITLE
Require @torchxpubot at start of comment to trigger bot

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -25,7 +25,7 @@ jobs:
     if: >-
       github.event_name == 'issue_comment'
       && github.event.issue.pull_request
-      && contains(github.event.comment.body, '@torchxpubot')
+      && startsWith(github.event.comment.body, '@torchxpubot')
     permissions:
       pull-requests: read
       issues: read
@@ -62,7 +62,7 @@ jobs:
             const prNumber = context.payload.issue.number;
 
             // Extract the @torchxpubot command line
-            const match = body.match(/@torchxpubot\s+(\S+)(.*)/i);
+            const match = body.match(/^@torchxpubot\s+(\S+)(.*)/i);
             if (!match) {
               core.setOutput('command', '');
               core.setFailed('No valid command found after @torchxpubot');


### PR DESCRIPTION
## Summary

- Change trigger condition from `contains` to `startsWith` so the bot
  only responds when a comment begins with `@torchxpubot`
- Anchor the parse regex with `^` to match the stricter trigger

This prevents false triggers from comments that mention `@torchxpubot`
mid-sentence or quote a previous bot command.