### PR TITLE
Fix bot review and ut-check comment posting

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   BEDROCK_MODEL: global.anthropic.claude-opus-4-6-v1
+  CLAUDE_ALLOWED_TOOLS: Bash,Read,Glob,Grep,WebFetch,Skill
   COST_TRACKING_ISSUE: 4251
 
 permissions:
@@ -709,13 +710,34 @@ jobs:
           use_bedrock: "true"
           github_token: ${{ secrets.MERGE_TOKEN }}
           settings: '{"alwaysThinkingEnabled": true}'
-          claude_args: "--model ${{ env.BEDROCK_MODEL }} --max-turns 30 --allowedTools Bash,Read,Glob,Grep,WebFetch --disallowedTools \"Edit,Write,NotebookEdit,Bash(git push:*),Bash(git add:*),Bash(git commit:*),Bash(git rm:*)\""
+          claude_args: "--model ${{ env.BEDROCK_MODEL }} --max-turns 30 --allowedTools ${{ env.CLAUDE_ALLOWED_TOOLS }}"
           prompt: |
             Use the /pr-review skill to review PR #${{ needs.parse-command.outputs.pr_number }}
             in the ${{ github.repository }} repository.
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+
+      - name: Post review comment
+        if: steps.ai-review.outputs.execution_file
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const file = '${{ steps.ai-review.outputs.execution_file }}';
+            if (!file || !fs.existsSync(file)) return;
+            const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+            const result = data.filter(e => e.type === 'result').pop();
+            if (!result || result.is_error || !result.result) return;
+            const trigger = context.payload.comment;
+            const header = `> Replying to [this comment](${trigger.html_url}) by @${trigger.user.login}\n\n`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.parse-command.outputs.pr_number }},
+              body: header + result.result
+            });
 
       - name: "Verify: AI review succeeded"
         uses: actions/github-script@v7
@@ -803,7 +825,7 @@ jobs:
           use_bedrock: "true"
           github_token: ${{ secrets.MERGE_TOKEN }}
           settings: '{"alwaysThinkingEnabled": true}'
-          claude_args: "--model ${{ env.BEDROCK_MODEL }} --max-turns 15 --allowedTools Bash,Read,Glob,Grep,WebFetch --disallowedTools \"Edit,Write,NotebookEdit,Bash(git push:*),Bash(git add:*),Bash(git commit:*),Bash(git rm:*)\""
+          claude_args: "--model ${{ env.BEDROCK_MODEL }} --max-turns 15 --allowedTools ${{ env.CLAUDE_ALLOWED_TOOLS }}"
           prompt: |
             Read the file /tmp/ut_data.json which contains UT (unit test) results
             for PR #${{ needs.parse-command.outputs.pr_number }} on intel/torch-xpu-ops.
@@ -830,6 +852,27 @@ jobs:
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+
+      - name: Post analysis comment
+        if: steps.collect.outputs.has_data == 'true' && steps.ai-analysis.outputs.execution_file
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const file = '${{ steps.ai-analysis.outputs.execution_file }}';
+            if (!file || !fs.existsSync(file)) return;
+            const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+            const result = data.filter(e => e.type === 'result').pop();
+            if (!result || result.is_error || !result.result) return;
+            const trigger = context.payload.comment;
+            const header = `> Replying to [this comment](${trigger.html_url}) by @${trigger.user.login}\n\n`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.parse-command.outputs.pr_number }},
+              body: header + result.result
+            });
 
       - name: "Verify: AI analysis succeeded"
         if: steps.collect.outputs.has_data == 'true'


### PR DESCRIPTION
## Summary

- Replace `--disallowedTools` with `--allowedTools` whitelist
  (`Bash,Read,Glob,Grep,WebFetch,Skill`) via global `CLAUDE_ALLOWED_TOOLS` env
- Add explicit "Post review/analysis comment" steps that read Claude result
  from the execution output and post it as a reply to the triggering comment

## Root Cause

The bot completed reviews successfully but never posted comments to the PR.
Two issues:

1. **Automation mode has no auto-reply**: Our workflow uses `@torchxpubot`
   (not `@claude`) with a `prompt` parameter, which puts `claude-code-action`
   in automation mode. Per the [docs](https://code.claude.com/docs/en/github-actions),
   when `prompt` is provided the action does NOT auto-post Claude response —
   unlike the standard `@claude` interactive flow.

2. **Previous `--allowedTools` blocked MCP tools**: The earlier whitelist
   (`Bash,Read,Glob,Grep,WebFetch`) excluded both `Skill` and the MCP GitHub
   tools. Adding `Skill` allows Claude to load the `/pr-review` skill.

Evidence: Claude completed the review ($0.87, 9 turns, `is_error: false`) but
the action logged `No buffered inline comments` and no PR comment appeared.
https://github.com/intel/torch-xpu-ops/actions/runs/28852076728/job/85624506291

## Changes

| Before | After |
|--------|-------|
| `--disallowedTools "Edit,Write,..."` | `--allowedTools $CLAUDE_ALLOWED_TOOLS` |
| No comment posting step | Explicit step reads `result.result` and posts as reply |
| Tools list hardcoded per job | Global `CLAUDE_ALLOWED_TOOLS` env var |
