### PR TITLE
Use if constexpr for compile-time-constant branches 

### DIFF
--- a/src/ATen/native/xpu/sycl/FusedSgdKernels.cpp
+++ b/src/ATen/native/xpu/sycl/FusedSgdKernels.cpp
@@ -47,7 +47,7 @@ void sgd_math(
     if (weight_decay != 0) {
       g += weight_decay * p;
     }
-    if (depth > 2) {
+    if constexpr (depth > 2) {
       const auto momentum_buffer = is_first_step
           ? g
           : (momentum * static_cast<opmath_t>(r_args[2][ii]) +
@@ -130,7 +130,7 @@ struct FusedSgdMathFunctor {
         if (grad_scale_ptr) {
           load_store(args[1], r_args[1], i_start, 0);
         }
-        if (depth > 2) {
+        if constexpr (depth > 2) {
           load_store(args[2], r_args[2], i_start, 0);
         }
       }
@@ -156,7 +156,7 @@ struct FusedSgdMathFunctor {
           store_args(
               args[1], r_args[1], i_start, chunk_size, n, item_id, local_range);
         }
-        if (depth > 2) {
+        if constexpr (depth > 2) {
           store_args(
               args[2], r_args[2], i_start, chunk_size, n, item_id, local_range);
         }

--- a/src/ATen/native/xpu/sycl/LogAddExpKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LogAddExpKernels.cpp
@@ -35,7 +35,7 @@ c10::complex<scalar_t> _logaddexp_minmax(
     return y;
   } else if (sycl::isnan(xr) || (sycl::isnan(std::imag(x)))) {
     return x;
-  } else if (min) {
+  } else if constexpr (min) {
     return (xr < yr) ? x : y;
   } else {
     return (xr >= yr) ? x : y;

--- a/src/ATen/native/xpu/sycl/LogcumsumexpKernel.cpp
+++ b/src/ATen/native/xpu/sycl/LogcumsumexpKernel.cpp
@@ -33,7 +33,7 @@ c10::complex<scalar_t> _logcumsumexp_minmax(
     return y;
   } else if (at::_isnan(xr) || (at::_isnan(std::imag(x)))) {
     return x;
-  } else if (min) { // min
+  } else if constexpr (min) { // min
     return (xr < yr) ? x : y;
   } else { // max
     return (xr >= yr) ? x : y;

--- a/src/ATen/native/xpu/sycl/MaxUnpoolingKernels.cpp
+++ b/src/ATen/native/xpu/sycl/MaxUnpoolingKernels.cpp
@@ -39,7 +39,7 @@ struct MaxUnpooling2dForwardKernelFunctor {
           ? n * numChannels_ * outputHeight_ * outputWidth_ + c
           : (n * numChannels_ + c) * outputHeight_ * outputWidth_;
       output += offset;
-      if (is_channels_last_) {
+      if constexpr (is_channels_last_) {
         output[maxind * numChannels_] = input_data_[linearIndex];
       } else {
         output[maxind] = input_data_[linearIndex];

--- a/src/ATen/native/xpu/sycl/SortingRadixSelect.h
+++ b/src/ATen/native/xpu/sycl/SortingRadixSelect.h
@@ -481,7 +481,7 @@ void radixSelect(
 
     // All threads participate in the comparisons below to know the
     // final result
-    if (Order) {
+    if constexpr (Order) {
       // Process in descending order
       for (int i = RADIX_SIZE - 1; i >= 0; --i) {
         int count = counts[i];


### PR DESCRIPTION
Converts runtime `if` checks on compile-time-constant template parameters to `if constexpr`, so the dead branch is discarded at compile time instead of emitted.

- `FusedSgdKernels.cpp`: `depth > 2`
- `LogAddExpKernels.cpp`: `min`
- `LogcumsumexpKernel.cpp`: `min`
- `MaxUnpoolingKernels.cpp`: `is_channels_last_`
- `SortingRadixSelect.h`: `Order`

