### PR TITLE
Extract ut-check into a standalone skill

### DIFF
--- a/.claude/skills/ut-check/SKILL.md
+++ b/.claude/skills/ut-check/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: ut-check
+description: Analyze UT (unit test) results for a torch-xpu-ops PR. Use when asked to check test results, analyze CI failures, or evaluate test coverage for a PR. Produces a structured report of new failures, failure relevance, and new test coverage.
+---
+
+# UT Result Check Skill
+
+Analyze unit test results for a torch-xpu-ops PR: identify new failures, assess
+whether they relate to the PR changes, and verify new test coverage.
+
+## Input
+
+The UT data is provided as a JSON file (typically `/tmp/ut_data.json`) produced
+by `.github/scripts/bot_ut_check.py`. The JSON contains:
+
+```json
+{
+  "pr_number": 1234,
+  "run_id": 56789,
+  "failures": [
+    {"category": "...", "class": "TestFoo", "test": "test_bar", "status": "FAILED", "message": "..."}
+  ],
+  "changed_files": {
+    "operator_source": ["src/ATen/native/xpu/Foo.cpp"],
+    "test_files": ["test/xpu/test_foo.py"],
+    "skip_lists": [],
+    "other": []
+  },
+  "new_tests": ["TestFoo::test_bar"],
+  "new_tests_passed": ["TestFoo::test_bar"],
+  "new_tests_not_run": [],
+  "passed_tests_count": 12345
+}
+```
+
+## Analysis Workflow
+
+### Step 1: Read the Data
+
+Read the JSON file. Understand the scope: how many failures, which files the PR
+changed, which new tests were added.
+
+### Step 2: Classify Failures
+
+For each new failure, determine relevance to the PR:
+
+- **Related** -- the failure is in a test module that directly tests an operator
+  modified by this PR (e.g., PR changes `src/ATen/native/xpu/sycl/FooKernels.cpp`
+  and `test_foo_xpu` fails).
+- **Possibly related** -- the failure is in a related subsystem or could be
+  caused by a side effect of the change.
+- **Unrelated** -- the failure is in an unrelated test module and is likely a
+  pre-existing flaky test or infrastructure issue.
+
+Use the `changed_files.operator_source` list to map operator files to test
+modules. Common mappings:
+- `src/ATen/native/xpu/sycl/<Op>Kernels.cpp` -> `test/xpu/test_<op>_xpu.py`
+- `src/ATen/native/xpu/<Op>.cpp` -> same test file
+
+### Step 3: Evaluate New Test Coverage
+
+If the PR adds or modifies test files, check:
+- Which new tests ran and passed (`new_tests_passed`)
+- Which new tests failed (cross-reference with `failures`)
+- Which new tests were NOT RUN (`new_tests_not_run`) -- this is a concern
+
+### Step 4: Produce the Report
+
+Follow the output format below. Apply the truncation rules strictly.
+
+## Truncation Rules
+
+When lists are long, showing every item clutters the report without adding value.
+Apply these limits:
+
+- **New failures**: If more than 20, show the first 20 in the table, then add:
+  `... and N more. See CI logs for the full list.`
+- **New/modified tests**: If more than 20, show the first 20 in the table, then
+  add: `... and N more new tests (M passed, K failed, J not run).`
+- **Changed files**: List individual files only if <= 10 per category. Otherwise
+  summarize as counts (e.g., "42 operator source files changed").
+
+Always include the total count so the reader knows the full scope.
+
+## Output Format
+
+```markdown
+## UT Result Check: PR #<number>
+
+### New Failures
+<count> new failure(s) detected. / No new failures detected.
+
+| Test | Category | Status | Related to PR? |
+|------|----------|--------|----------------|
+| `ClassName::test_name` | category | FAILED | Related / Possibly related / Unrelated |
+...
+
+### Failure Relevance Analysis
+Brief explanation of why each failure is classified as it is. Group related
+failures together rather than repeating the same reasoning per test.
+
+### New Test Coverage
+| New/Modified Test | Status |
+|-------------------|--------|
+| `ClassName::test_name` | PASSED / FAILED / NOT RUN |
+...
+
+### Summary
+One-sentence verdict: safe to merge, needs investigation, or blocked by failures.
+```
+
+**Omit sections that have no content.** If there are no new failures, omit the
+"Failure Relevance Analysis" section. If the PR adds no tests, omit "New Test
+Coverage."
+
+If a calling workflow explicitly requires a skill marker, append this exact
+literal final line:
+Custom skills applied: ut-check.
+
+Otherwise, keep the reply in the requested report format and do not force an
+extra trailing sentence.

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -827,28 +827,9 @@ jobs:
           settings: '{"alwaysThinkingEnabled": true}'
           claude_args: "--model ${{ env.BEDROCK_MODEL }} --max-turns 15 --allowedTools ${{ env.CLAUDE_ALLOWED_TOOLS }}"
           prompt: |
-            Read the file /tmp/ut_data.json which contains UT (unit test) results
-            for PR #${{ needs.parse-command.outputs.pr_number }} on intel/torch-xpu-ops.
-
-            Produce a report in this markdown format and post it as a PR comment:
-
-            ## UT Result Check
-
-            ### New Failures
-            <count> new failure(s) or "No new failures detected."
-            If there are failures, include a table:
-            | Test | Category | Status | Related to PR? |
-
-            ### Failure Relevance Analysis
-            For each failure, classify as Related, Possibly related, or Unrelated
-            to the PR changes. Map operator source files to test modules.
-
-            ### New Test Coverage
-            If the PR adds/modifies test files, report which new tests ran and
-            passed, which failed, and which were NOT RUN.
-
-            ### Summary
-            One-sentence verdict.
+            Use the /ut-check skill to analyze UT results for
+            PR #${{ needs.parse-command.outputs.pr_number }} on ${{ github.repository }}.
+            The UT data JSON file is at /tmp/ut_data.json.
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}


### PR DESCRIPTION
## Summary

Move the inline ut-check prompt from `bot.yml` into `.claude/skills/ut-check/SKILL.md`, mirroring how `/pr-review` is structured as a standalone skill.

The skill defines:
- Input format (JSON schema from `bot_ut_check.py`)
- Analysis workflow: read data, classify failures by PR relevance, evaluate new test coverage
- **Truncation rules**: when new failures or new test cases exceed 20, show the first 20 and summarize the rest to keep PR comments readable
- Output format and omit-empty-sections rule

`bot.yml` now references the skill with a one-liner prompt (`Use the /ut-check skill to analyze UT results for PR #...`), same pattern as the review job.

Test: none (skill file and workflow change only, no runtime code modified)