### PR TITLE
Simplify map_options via c10::CppTypeToScalarType

### DIFF
--- a/src/comm/TensorOptions.h
+++ b/src/comm/TensorOptions.h
@@ -15,59 +15,9 @@
 namespace at {
 template <typename T>
 static inline TensorOptions map_options() {
-  if (std::is_same<T, uint8_t>::value)
-    return at::TensorOptions().dtype(kByte).device(kXPU).memory_format(
-        LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  else if (std::is_same<T, int8_t>::value)
-    return at::TensorOptions().dtype(kChar).device(kXPU).memory_format(
-        LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  else if (std::is_same<T, int16_t>::value)
-    return at::TensorOptions().dtype(kShort).device(kXPU).memory_format(
-        LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  else if (std::is_same<T, int32_t>::value)
-    return at::TensorOptions().dtype(kInt).device(kXPU).memory_format(
-        LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  else if (std::is_same<T, int64_t>::value)
-    return at::TensorOptions().dtype(kLong).device(kXPU).memory_format(
-        LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  else if (std::is_same<T, float>::value)
-    return at::TensorOptions().dtype(kFloat).device(kXPU).memory_format(
-        LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  else if (std::is_same<T, double>::value)
-    return at::TensorOptions().dtype(kDouble).device(kXPU).memory_format(
-        LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  else if (std::is_same<T, at::Half>::value)
-    return at::TensorOptions().dtype(kHalf).device(kXPU).memory_format(
-        LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  else if (std::is_same<T, at::BFloat16>::value)
-    return at::TensorOptions().dtype(kBFloat16).device(kXPU).memory_format(
-        LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  else if (std::is_same<T, bool>::value)
-    return at::TensorOptions().dtype(kBool).device(kXPU).memory_format(
-        LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  else if (std::is_same<T, c10::complex<float>>::value)
-    return at::TensorOptions()
-        .dtype(kComplexFloat)
-        .device(kXPU)
-        .memory_format(LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  else if (std::is_same<T, c10::complex<double>>::value)
-    return at::TensorOptions()
-        .dtype(kComplexDouble)
-        .device(kXPU)
-        .memory_format(LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  else if (std::is_same<T, uint16_t>::value)
-    return at::TensorOptions().dtype(kUInt16).device(kXPU).memory_format(
-        LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  else if (std::is_same<T, uint32_t>::value)
-    return at::TensorOptions().dtype(kUInt32).device(kXPU).memory_format(
-        LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  else if (std::is_same<T, uint64_t>::value)
-    return at::TensorOptions().dtype(kUInt64).device(kXPU).memory_format(
-        LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  else {
-    TORCH_CHECK(
-        false, "PSTLFunctions: data type cannot be mapped to tensor's dtype.");
-  }
-  return at::TensorOptions();
+  return at::TensorOptions()
+      .dtype(c10::CppTypeToScalarType<T>::value)
+      .device(kXPU)
+      .memory_format(LEGACY_CONTIGUOUS_MEMORY_FORMAT);
 }
 } // namespace at


### PR DESCRIPTION
c10::CppTypeToScalarType can replace the if-else chain in map_options.