### PR TITLE
Use aminmax and align index_put with upstream CUDA

### DIFF
--- a/src/ATen/native/xpu/sycl/IndexingUtils.h
+++ b/src/ATen/native/xpu/sycl/IndexingUtils.h
@@ -25,8 +25,9 @@ static Tensor wrapIndexOnce(
   // we don't need to check range in backward - if there were out of bounds
   // indices forward should already have errored out
   if (index.numel() != 0 && check_range) {
-    auto max_idx = index.max().item<int64_t>();
-    auto min_idx = index.min().item<int64_t>();
+    auto [min_idx_tensor, max_idx_tensor] = index.aminmax();
+    auto max_idx = max_idx_tensor.item<int64_t>();
+    auto min_idx = min_idx_tensor.item<int64_t>();
     if (max_idx >= dim_size) {
       TORCH_CHECK_INDEX(
           false,

--- a/src/ATen/native/xpu/sycl/IndexingUtils.h
+++ b/src/ATen/native/xpu/sycl/IndexingUtils.h
@@ -14,40 +14,22 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/native/IndexingUtils.h>
 #include <ATen/native/TensorIterator.h>
+#include <ATen/ops/_assert_async.h>
+#include <ATen/ops/aminmax.h>
 
 namespace at::native::xpu {
 
 static Tensor wrapIndexOnce(
     const Tensor& index,
-    int64_t dim,
+    [[maybe_unused]] int64_t dim,
     int64_t dim_size,
     bool check_range = true) {
   // we don't need to check range in backward - if there were out of bounds
   // indices forward should already have errored out
   if (index.numel() != 0 && check_range) {
-    auto [min_idx_tensor, max_idx_tensor] = index.aminmax();
-    auto max_idx = max_idx_tensor.item<int64_t>();
-    auto min_idx = min_idx_tensor.item<int64_t>();
-    if (max_idx >= dim_size) {
-      TORCH_CHECK_INDEX(
-          false,
-          "index ",
-          max_idx,
-          " is out of bounds for dimension ",
-          dim,
-          " with size ",
-          dim_size);
-    }
-    if (min_idx < -dim_size) {
-      TORCH_CHECK_INDEX(
-          false,
-          "index ",
-          min_idx,
-          " is out of bounds for dimension ",
-          dim,
-          " with size ",
-          dim_size);
-    }
+    auto [index_min, index_max] = at::aminmax(index);
+    at::_assert_async(index_max < dim_size);
+    at::_assert_async(index_min >= -dim_size);
   }
   return index.remainder(dim_size);
 }
@@ -153,12 +135,12 @@ makeLinearIndex(Tensor self, IOptTensorListRef orig, bool check_range) {
        dims_before,
        dims_indexed] = computeLinearIndex(self, indices, check_range);
   return std::make_tuple(
-      linearIndex,
-      self,
+      std::move(linearIndex),
+      std::move(self),
       nElemBefore,
       strideBefore,
       nElemAfter,
-      inversePerm,
+      std::move(inversePerm),
       dims_before,
       dims_indexed);
 }

--- a/src/ATen/native/xpu/sycl/SummaryOpsKernels.cpp
+++ b/src/ATen/native/xpu/sycl/SummaryOpsKernels.cpp
@@ -15,6 +15,7 @@ DISABLE_RETURN_TYPE_WARNING_BEGIN
 
 #include <ATen/AccumulateType.h>
 #include <ATen/native/xpu/sycl/Atomics.h>
+#include <ATen/ops/aminmax.h>
 #include <comm/Runtime.h>
 #include <comm/SYCLHelpers.h>
 #include <comm/TensorInfo.h>
@@ -225,8 +226,9 @@ Tensor _histc_template(
   bounds_t maxvalue = max;
 
   if (min == max && self.numel() > 0) {
-    minvalue = *self.min().cpu().const_data_ptr<input_t>();
-    maxvalue = *self.max().cpu().const_data_ptr<input_t>();
+    auto [min_tensor, max_tensor] = self.aminmax();
+    minvalue = min_tensor.item<input_t>();
+    maxvalue = max_tensor.item<input_t>();
   }
   if (minvalue == maxvalue) {
     minvalue = minvalue - 1;
@@ -273,19 +275,24 @@ Tensor bincount_template(
   if (self.dim() == 1 && self.numel() == 0) {
     return at::zeros({minlength}, device(kXPU).dtype(kLong));
   }
-  if (self.dim() != 1 ||
-      (!std::is_same<input_t, uint8_t>::value &&
-       *self.min().cpu().data_ptr<input_t>() < 0)) {
-    TORCH_CHECK(0, "bincount only supports 1-d non-negative integral inputs.");
-  }
+  TORCH_CHECK(
+      self.dim() == 1,
+      "bincount only supports 1-d non-negative integral inputs.");
 
   bool has_weights = weights.defined();
   if (has_weights && (weights.dim() != 1 || weights.size(0) != self.size(0))) {
     TORCH_CHECK(0, "weights should be 1-d and have the same length as input");
   }
 
+  auto [self_min, self_max] = at::aminmax(self);
+  if constexpr (!std::is_same_v<input_t, uint8_t>) {
+    TORCH_CHECK(
+        *self_min.cpu().const_data_ptr<input_t>() >= 0,
+        "bincount only supports 1-d non-negative integral inputs.");
+  }
+
   const int64_t nbins =
-      std::max(self.max().item<input_t>() + (int64_t)1, minlength);
+      std::max(self_max.item<input_t>() + (int64_t)1, minlength);
   using bounds_t = at::acc_type_device<input_t, kXPU>;
   const bounds_t min_value = 0;
   const bounds_t max_value = nbins;
@@ -307,10 +314,8 @@ Tensor bincount_template(
         std::nullopt /* layout */,
         DeviceType::XPU,
         std::nullopt /* pin_memory */);
-    tensor_histogram<
-        typename c10::impl::ScalarTypeToCPPType<kLong>::type,
-        input_t,
-        false>(output, self, weights, nbins, min_value, max_value);
+    tensor_histogram<int64_t, input_t, false>(
+        output, self, weights, nbins, min_value, max_value);
   }
   return output;
 }


### PR DESCRIPTION
Aligns XPU summary/indexing kernels with upstream CUDA where XPU lagged:

- SummaryOps (histc/bincount): `.min()+.max()` -> `aminmax()`; `int64_t`
  instead of `ScalarTypeToCPPType<kLong>::type`; bincount dim/negativity
  check as `TORCH_CHECK` + `if constexpr`. (matches `cuda/SummaryOps.cu`)
- IndexingUtils `wrapIndexOnce`: `at::aminmax` + `at::_assert_async` (no
  host sync) instead of `.item()`+`TORCH_CHECK_INDEX`; `std::move`
  `makeLinearIndex`'s tuple args. (matches `cuda/Indexing.cu`)

Behavior change: `wrapIndexOnce` out-of-bounds indices now report via an
async, generic device assert instead of an immediate, detailed host-side
error. Indices are still wrapped via `remainder(dim_size)`, so there is no
out-of-bounds memory access — only the diagnostic UX changes. This matches
upstream CUDA's trade-off.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
