### PR TITLE
add exp cache for softmax fast path

### DIFF
--- a/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
+++ b/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
@@ -319,7 +319,7 @@ struct DispatchSoftmaxForwardKernelFunctor
     else if (sum_value != 0)
       sum_value = accscalar_t(1) / sum_value;
 
-    // update result
+      // update result
 #pragma unroll(outer_loop)
     for (int i = 0; i < outer_loop; ++i) {
       auto index = i * local_stride + lid_offset;

--- a/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
+++ b/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
@@ -241,6 +241,11 @@ struct DispatchSoftmaxForwardKernelFunctor
     }
     vec_t reg_in[outer_loop];
     vec_t reg_mask[outer_loop];
+    // Softmax needs exp(x - max) in both the sum and output passes. Since exp
+    // is an expensive math operation, cache the first result to avoid issuing a
+    // second math exp per element. LogSoftMax does not use this cache, hence
+    // maybe_unused.
+    [[maybe_unused]] accscalar_t reg_exp[outer_loop][vec_size];
     auto lid_offset = lid_col * vec_size;
     auto local_stride = local_size_ * vec_size;
 
@@ -292,7 +297,11 @@ struct DispatchSoftmaxForwardKernelFunctor
          ++i) {
 #pragma unroll(vec_size)
       for (int j = 0; j < vec_size; ++j) {
-        sum_value += sycl::exp(reg_in[i][j] - max_value);
+        auto exp_value = sycl::exp(reg_in[i][j] - max_value);
+        if constexpr (!LogSoftMax) {
+          reg_exp[i][j] = exp_value;
+        }
+        sum_value += exp_value;
       }
     }
     if (local_size_ > 1) {
@@ -310,7 +319,7 @@ struct DispatchSoftmaxForwardKernelFunctor
     else if (sum_value != 0)
       sum_value = accscalar_t(1) / sum_value;
 
-      // update result
+    // update result
 #pragma unroll(outer_loop)
     for (int i = 0; i < outer_loop; ++i) {
       auto index = i * local_stride + lid_offset;
@@ -331,8 +340,7 @@ struct DispatchSoftmaxForwardKernelFunctor
           } else if (sum_value == 0) {
             reg_in[i][j] = nan_;
           } else {
-            reg_in[i][j] = static_cast<outscalar_t>(
-                sycl::exp(reg_in[i][j] - max_value) * sum_value);
+            reg_in[i][j] = static_cast<outscalar_t>(reg_exp[i][j] * sum_value);
           }
         } else {
           if constexpr (LogSoftMax) {
@@ -345,8 +353,8 @@ struct DispatchSoftmaxForwardKernelFunctor
           } else if (sum_value == 0) {
             out_data_point[j] = static_cast<outscalar_t>(nan_);
           } else {
-            out_data_point[j] = static_cast<outscalar_t>(
-                sycl::exp(reg_in[i][j] - max_value) * sum_value);
+            out_data_point[j] =
+                static_cast<outscalar_t>(reg_exp[i][j] * sum_value);
           }
         }
       }


### PR DESCRIPTION
## Summary

This PR optimizes XPU softmax forward by caching `exp(x - max)` in the fast-path `DispatchSoftmaxForwardKernelFunctor`.

For softmax, the current implementation computes `exp(x - max)` twice per element:

1. Once while accumulating `sum`
2. Again while writing normalized output

Since `exp` is an expensive math operation and shows up as pipe/dist stalls in profiling, this PR stores the first result in registers and reuses it during the output pass. `LogSoftMax` does not use this cache.

## Motivation

The motivating case is fp16 softmax with shape roughly: (401408, 49), dtype=fp16, dim=-1

This shape uses the fast-path dispatch kernel:
```
DispatchSoftmaxForwardKernelFunctor<
  ..., c10::Half, c10::Half, float, ..., outer_loop=32, vec_size=1
>
```

Profiling showed that this kernel has two important costs:
- Global load dependency: load consumers wait on load results.
- Exp math pressure: exp(x - max) is computed in both the sum pass and output pass.

The store path for this shape is also not ideal because fp16 scalar stores do not naturally fill 64B cache lines. This can cause partial-write/RMW behavior. However, vectorizing or staging stores was evaluated separately and was not kept in this PR because it caused broader regressions. This PR only addresses the repeated exp work.

## Change
Before:
```
sum_value += sycl::exp(reg_in[i][j] - max_value);
...
reg_in[i][j] = static_cast<outscalar_t>(
    sycl::exp(reg_in[i][j] - max_value) * sum_value);
```
After:
```
auto exp_value = sycl::exp(reg_in[i][j] - max_value);
reg_exp[i][j] = exp_value;
sum_value += exp_value;
...
reg_in[i][j] = static_cast<outscalar_t>(reg_exp[i][j] * sum_value);
```
## Performance
Measured with unitrace on B70.
For the motivating fp16 shape:
```
shape=(401408, 49), dtype=fp16
baseline:  335.104 us
after:     294.270 us
speedup:   1.14x
improvement: 12.2%
```

Across the full collected  OOB softmax shape set:
```
geomean speedup: 1.128x
median improvement: 5.55%
faster cases: 170 / 211
slower cases: 40 / 211
By dtype:
fp16 geomean speedup: 1.126x
fp32 geomean speedup: 1.133x
```

## Profiling Notes
For (401408, 49) fp16, stall sampling before the change showed significant pipe/dist stall around the exp path. After caching exp, pipe stalls dropped substantially and the remaining top stall shifted back to load dependency on the fp16 global load consumer.
This indicates the duplicate exp computation was a real contributor, while the remaining bottleneck is mostly memory/load dependency and fp16 store behavior.