### PR TITLE
Update build flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,8 @@ endif()
 set(BUILD_SEPARATE_OPS $ENV{BUILD_SEPARATE_OPS})
 if(CMAKE_BUILD_TYPE MATCHES "(Debug|RelWithDebInfo)")
   set(BUILD_SEPARATE_OPS TRUE)
+  set(USE_SYCLTLA OFF)
+  message(STATUS "SYCL-TLA disabled in ${CMAKE_BUILD_TYPE} build (excessive memory usage with debug info)")
 endif()
 add_subdirectory(${TORCH_XPU_OPS_ROOT}/src)
 

--- a/cmake/BuildFlags.cmake
+++ b/cmake/BuildFlags.cmake
@@ -130,10 +130,18 @@ macro(set_build_flags)
     endif()
   endif()
 
-  if(CMAKE_BUILD_TYPE MATCHES Debug)
+  # -- Device debug flags (aligned with CUDA behavior)
+  # XPU_DEVICE_DEBUG=1: full device debug, disables optimization (like CUDA's -g -G)
+  #   Orthogonal to build type, always forces device debug.
+  # DEBUG_XPU=1: line-table-only debug info (like CUDA's -lineinfo)
+  #   Only effective in Debug/RelWithDebInfo builds.
+  # DEBUG=1 alone: does NOT affect device code (same as CUDA).
+  if(DEFINED ENV{XPU_DEVICE_DEBUG} AND "$ENV{XPU_DEVICE_DEBUG}" STREQUAL "1")
     set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -g -O0 -Rno-debug-disables-optimization)
-  elseif(CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
-    set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -gline-tables-only -O2)
+  elseif(DEFINED ENV{DEBUG_XPU} AND "$ENV{DEBUG_XPU}" STREQUAL "1")
+    if(CMAKE_BUILD_TYPE MATCHES "Debug|RelWithDebInfo")
+      set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} -gline-tables-only -O2)
+    endif()
   endif()
 
   CHECK_SYCL_FLAG("-fsycl-fp64-conv-emu" SUPPORTS_FP64_CONV_EMU)


### PR DESCRIPTION
This pull request updates the build configuration to better handle device debugging flags for SYCL builds, aligning their behavior with CUDA, and disables SYCL-TLA in debug builds to prevent excessive memory usage. The changes clarify the effect of various debug-related environment variables and ensure that device debug options are set more explicitly.

**Build configuration and debug flag handling:**

* Updated `macro(set_build_flags)` in `cmake/BuildFlags.cmake` to clarify and align device debug flags (`XPU_DEVICE_DEBUG`, `DEBUG_XPU`, `DEBUG`) with CUDA conventions, ensuring that device debug options are only set when appropriate environment variables are defined and with the correct optimization and debug info flags.

* Added logic to disable SYCL-TLA (`USE_SYCLTLA OFF`) in Debug and RelWithDebInfo builds within `CMakeLists.txt`, accompanied by a status message explaining the reason (excessive memory usage with debug info).