### PR TITLE
[Benchmark] Enable emulate_precision_casts for 3 timm bf16 training models

### DIFF
--- a/.ci/benchmarks/timm_models.yaml
+++ b/.ci/benchmarks/timm_models.yaml
@@ -88,6 +88,9 @@ require_larger_multiplier_for_smaller_tensor:
 # small natural gradient magnitudes (e.g. LayerScale init=1e-5).
 emulate_precision_casts:
   - vit_base_patch14_dinov2.lvd142m
+  - fbnetv3_b
+  - levit_128
+  - convnextv2_nano.fcmae_ft_in22k_in1k
 
 
 dtype:


### PR DESCRIPTION
Hi @mengfei25, @chuanqi129

Three timm models started failing the bf16 training accuracy check (`fbnetv3_b`, `levit_128`, `convnextv2_nano.fcmae_ft_in22k_in1k`). I think something changed slightly between the two PyTorch pin versions, but the main reason looks like a bf16 rounding difference between eager and inductor rather than a wrong kernel:

- eager rounds back to bf16 after every op
- inductor (default) fuses a chain of ops, keeps the intermediates in fp32, and rounds to bf16 once at the end

Setting `emulate_precision_casts=True` makes inductor round after every op, so it matches eager mode. The mechanism was added upstream in pytorch/pytorch#185676, which resolved a very similar issue for `vit_base_patch14_dinov2`.

This PR just adds the three models to the `emulate_precision_casts` list in `.ci/benchmarks/timm_models.yaml`. Verified locally on Max 1100: all three pass with the flag set and fail without it.
