### PR TITLE
batch_norm: SLM param cache for channels-last fwd 1D kernel, fix small-C perf

### DIFF
--- a/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
@@ -26,6 +26,7 @@
 #include <comm/SYCLContext.h>
 #include <comm/XPUMathCompat.h>
 #include <comm/xpu_aten.h>
+#include <ATen/native/xpu/sycl/IntegerDivider.h>
 
 #include <ATen/native/xpu/sycl/BatchNormKernels.h>
 
@@ -1401,8 +1402,9 @@ struct BatchNormTransformInputChannelsLast1DKernelFunctor {
 
       for (int idx = item.get_global_id(0); idx < total_vecs;
            idx += global_stride) {
-        int c_offset = (idx % vec_stride) * VEC_SIZE;
-        int flat_pos = (idx / vec_stride) * stride_ + c_offset;
+        auto dm = vec_divider_.divmod(static_cast<unsigned int>(idx));
+        int c_offset = static_cast<int>(dm.mod) * VEC_SIZE;
+        int flat_pos = static_cast<int>(dm.div) * stride_ + c_offset;
         int remaining = stride_ - c_offset;
 
         if (remaining >= VEC_SIZE) {
@@ -1464,7 +1466,8 @@ struct BatchNormTransformInputChannelsLast1DKernelFunctor {
       scalar_t* RESTRICT out,
       const int reduction_size,
       const int stride,
-      const bool fuse_relu)
+      const bool fuse_relu,
+      const at::detail::IntDivider<unsigned int> vec_divider)
       : input_(input),
         z_(z),
         mean_(mean),
@@ -1474,7 +1477,8 @@ struct BatchNormTransformInputChannelsLast1DKernelFunctor {
         out_(out),
         reduction_size_(reduction_size),
         stride_(stride),
-        fuse_relu_(fuse_relu) {}
+        fuse_relu_(fuse_relu),
+        vec_divider_(vec_divider) {}
 
  private:
   inline void load_params(
@@ -1503,6 +1507,7 @@ struct BatchNormTransformInputChannelsLast1DKernelFunctor {
   const int reduction_size_;
   const int stride_;
   const bool fuse_relu_;
+  const at::detail::IntDivider<unsigned int> vec_divider_;
 };
 
 void batch_norm_elemt_channels_last_template(
@@ -1563,7 +1568,8 @@ void batch_norm_elemt_channels_last_template(
                     inv_std.const_data_ptr<accscalar_t>(),
                     weight_data_ptr, shift_data_ptr,
                     output_data_ptr, reduction_size,
-                    stride, fuse_relu);
+                    stride, fuse_relu,
+                    at::detail::IntDivider<unsigned int>(static_cast<unsigned int>(vec_stride)));
             sycl_kernel_submit(
                 num_wg * wg_size, wg_size, queue, kfn);
           } else {
@@ -1576,7 +1582,8 @@ void batch_norm_elemt_channels_last_template(
                     inv_std.const_data_ptr<accscalar_t>(),
                     weight_data_ptr, shift_data_ptr,
                     output_data_ptr, reduction_size,
-                    stride, fuse_relu);
+                    stride, fuse_relu,
+                    at::detail::IntDivider<unsigned int>(static_cast<unsigned int>(vec_stride)));
             sycl_kernel_submit(
                 num_wg * wg_size, wg_size, queue, kfn);
           }
@@ -1628,7 +1635,8 @@ void batch_norm_elemt_channels_last_template(
                     inv_std.const_data_ptr<accscalar_t>(),
                     weight_data_ptr, shift_data_ptr,
                     output_data_ptr, reduction_size,
-                    stride, fuse_relu);
+                    stride, fuse_relu,
+                    at::detail::IntDivider<unsigned int>(static_cast<unsigned int>(vec_stride)));
             sycl_kernel_submit(
                 num_wg * wg_size, wg_size, queue, kfn);
           } else {
@@ -1641,7 +1649,8 @@ void batch_norm_elemt_channels_last_template(
                     inv_std.const_data_ptr<accscalar_t>(),
                     weight_data_ptr, shift_data_ptr,
                     output_data_ptr, reduction_size,
-                    stride, fuse_relu);
+                    stride, fuse_relu,
+                    at::detail::IntDivider<unsigned int>(static_cast<unsigned int>(vec_stride)));
             sycl_kernel_submit(
                 num_wg * wg_size, wg_size, queue, kfn);
           }

--- a/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
@@ -1450,6 +1450,113 @@ struct BatchNormTransformInputChannelsLastKernelFunctor {
   const bool fuse_relu_;
 };
 
+// 1D kernel for cache-line-aligned writes in channels-last BN.
+// When C * sizeof(scalar_t) is not a multiple of 64, the 2D (m, c/VEC)
+// mapping causes sub-groups to straddle cache line boundaries, producing
+// L3 partial writes and DRAM read-modify-write amplification.
+// This kernel uses a flat 1D mapping: consecutive work items in a sub-group
+// access consecutive elements, so fp16 x 32 lanes = 64 B = one cache line.
+// Per-channel parameters are loaded into SLM once per work group.
+template <typename scalar_t, typename accscalar_t, typename layerscalar_t>
+struct BatchNormTransformInputChannelsLast1DKernelFunctor
+    : public __SYCL_KER_CONFIG_CONVENTION__ {
+  void operator()(sycl::nd_item<1> item) const {
+    int wg_size = item.get_local_range(0);
+    int lid = item.get_local_id(0);
+
+    // Cooperatively load per-channel params into SLM
+    for (int i = lid; i < stride_; i += wg_size) {
+      slm_mean_[i] = mean_[i];
+      slm_inv_std_[i] = inv_std_[i];
+    }
+    if (weight_ != nullptr) {
+      for (int i = lid; i < stride_; i += wg_size)
+        slm_weight_[i] = weight_[i];
+    }
+    if (shift_ != nullptr) {
+      for (int i = lid; i < stride_; i += wg_size)
+        slm_shift_[i] = shift_[i];
+    }
+    sycl::group_barrier(item.get_group());
+
+    int total = reduction_size_ * stride_;
+    int global_stride = item.get_global_range(0);
+
+    for (int idx = item.get_global_id(0); idx < total;
+         idx += global_stride) {
+      int c = idx % stride_;
+
+      auto m_c = slm_mean_[c];
+      auto inv_std_c = static_cast<accscalar_t>(slm_inv_std_[c]);
+      auto w_c = weight_ == nullptr
+          ? accscalar_t(1.0)
+          : static_cast<accscalar_t>(slm_weight_[c]);
+      auto s_c = shift_ == nullptr
+          ? accscalar_t(0.0)
+          : static_cast<accscalar_t>(slm_shift_[c]);
+
+      auto tmp = w_c *
+              (static_cast<accscalar_t>(input_[idx]) - m_c) * inv_std_c +
+          s_c;
+      if (z_ != nullptr) {
+        tmp += z_[idx];
+      }
+      out_[idx] = (fuse_relu_ && tmp <= accscalar_t(0.0)
+                       ? scalar_t(0.0)
+                       : static_cast<scalar_t>(tmp));
+    }
+  }
+
+  void sycl_ker_config_convention(sycl::handler& cgh) {
+    slm_mean_ = sycl_local_acc_t<accscalar_t, 1>(
+        sycl::range<1>{(size_t)stride_}, cgh);
+    slm_inv_std_ = sycl_local_acc_t<accscalar_t, 1>(
+        sycl::range<1>{(size_t)stride_}, cgh);
+    slm_weight_ = sycl_local_acc_t<layerscalar_t, 1>(
+        sycl::range<1>{(size_t)(weight_ != nullptr ? stride_ : 1)}, cgh);
+    slm_shift_ = sycl_local_acc_t<layerscalar_t, 1>(
+        sycl::range<1>{(size_t)(shift_ != nullptr ? stride_ : 1)}, cgh);
+  }
+
+  BatchNormTransformInputChannelsLast1DKernelFunctor(
+      const scalar_t* RESTRICT input,
+      const scalar_t* RESTRICT z,
+      const accscalar_t* RESTRICT mean,
+      const accscalar_t* RESTRICT inv_std,
+      const layerscalar_t* RESTRICT weight,
+      const layerscalar_t* RESTRICT shift,
+      scalar_t* RESTRICT out,
+      const int reduction_size,
+      const int stride,
+      const bool fuse_relu)
+      : input_(input),
+        z_(z),
+        mean_(mean),
+        inv_std_(inv_std),
+        weight_(weight),
+        shift_(shift),
+        out_(out),
+        reduction_size_(reduction_size),
+        stride_(stride),
+        fuse_relu_(fuse_relu) {}
+
+ private:
+  const scalar_t* RESTRICT input_;
+  const scalar_t* RESTRICT z_;
+  const accscalar_t* RESTRICT mean_;
+  const accscalar_t* RESTRICT inv_std_;
+  const layerscalar_t* RESTRICT weight_;
+  const layerscalar_t* RESTRICT shift_;
+  scalar_t* RESTRICT out_;
+  const int reduction_size_;
+  const int stride_;
+  const bool fuse_relu_;
+  sycl_local_acc_t<accscalar_t, 1> slm_mean_;
+  sycl_local_acc_t<accscalar_t, 1> slm_inv_std_;
+  sycl_local_acc_t<layerscalar_t, 1> slm_weight_;
+  sycl_local_acc_t<layerscalar_t, 1> slm_shift_;
+};
+
 template <
     typename scalar_t,
     typename accscalar_t,
@@ -1614,16 +1721,39 @@ void batch_norm_elemt_channels_last_template(
           auto shift_data_ptr =
               shift.defined() ? shift.const_data_ptr<accscalar_t>() : nullptr;
 
-          if (can_use_batch_norm_cnl_vec_kernel<
-                  scalar_t,
-                  accscalar_t,
-                  VEC_SIZE>(
-                  (char*)input_data_ptr,
-                  (char*)output_data_ptr,
-                  (char*)z_data_ptr,
-                  (char*)weight_data_ptr,
-                  (char*)shift_data_ptr,
-                  stride)) {
+          if ((stride * sizeof(scalar_t)) % 64 != 0) {
+            auto kfn =
+                BatchNormTransformInputChannelsLast1DKernelFunctor<
+                    scalar_t,
+                    accscalar_t,
+                    accscalar_t>(
+                    input_data_ptr,
+                    z_data_ptr,
+                    mean.const_data_ptr<accscalar_t>(),
+                    inv_std.const_data_ptr<accscalar_t>(),
+                    weight_data_ptr,
+                    shift_data_ptr,
+                    output_data_ptr,
+                    reduction_size,
+                    stride,
+                    fuse_relu);
+            int64_t wg_size = 256;
+            int64_t total = (int64_t)reduction_size * stride;
+            int64_t num_wg = std::min(
+                at::ceil_div(total, wg_size),
+                (int64_t)(syclMaxWorkItemsPerTile() / wg_size));
+            num_wg = std::max(num_wg, (int64_t)1);
+            sycl_kernel_submit(num_wg * wg_size, wg_size, queue, kfn);
+          } else if (can_use_batch_norm_cnl_vec_kernel<
+                         scalar_t,
+                         accscalar_t,
+                         VEC_SIZE>(
+                         (char*)input_data_ptr,
+                         (char*)output_data_ptr,
+                         (char*)z_data_ptr,
+                         (char*)weight_data_ptr,
+                         (char*)shift_data_ptr,
+                         stride)) {
             auto kfn =
                 BatchNormTransformInputChannelsLastVectorizedKernelFunctor<
                     scalar_t,
@@ -1699,13 +1829,39 @@ void batch_norm_elemt_channels_last_template(
           auto shift_data_ptr =
               shift.defined() ? shift.const_data_ptr<scalar_t>() : nullptr;
 
-          if (can_use_batch_norm_cnl_vec_kernel<scalar_t, scalar_t, VEC_SIZE>(
-                  (char*)input_data_ptr,
-                  (char*)output_data_ptr,
-                  (char*)z_data_ptr,
-                  (char*)weight_data_ptr,
-                  (char*)shift_data_ptr,
-                  stride)) {
+          if ((stride * sizeof(scalar_t)) % 64 != 0) {
+            auto kfn =
+                BatchNormTransformInputChannelsLast1DKernelFunctor<
+                    scalar_t,
+                    accscalar_t,
+                    scalar_t>(
+                    input_data_ptr,
+                    z_data_ptr,
+                    mean.const_data_ptr<accscalar_t>(),
+                    inv_std.const_data_ptr<accscalar_t>(),
+                    weight_data_ptr,
+                    shift_data_ptr,
+                    output_data_ptr,
+                    reduction_size,
+                    stride,
+                    fuse_relu);
+            int64_t wg_size = 256;
+            int64_t total = (int64_t)reduction_size * stride;
+            int64_t num_wg = std::min(
+                at::ceil_div(total, wg_size),
+                (int64_t)(syclMaxWorkItemsPerTile() / wg_size));
+            num_wg = std::max(num_wg, (int64_t)1);
+            sycl_kernel_submit(num_wg * wg_size, wg_size, queue, kfn);
+          } else if (can_use_batch_norm_cnl_vec_kernel<
+                         scalar_t,
+                         scalar_t,
+                         VEC_SIZE>(
+                         (char*)input_data_ptr,
+                         (char*)output_data_ptr,
+                         (char*)z_data_ptr,
+                         (char*)weight_data_ptr,
+                         (char*)shift_data_ptr,
+                         stride)) {
             auto kfn =
                 BatchNormTransformInputChannelsLastVectorizedKernelFunctor<
                     scalar_t,

--- a/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
@@ -1396,62 +1396,58 @@ struct BatchNormTransformInputChannelsLast1DKernelFunctor {
                          : static_cast<scalar_t>(tmp));
       }
     } else {
-      using vec_t = memory::aligned_vector<scalar_t, VEC_SIZE>;
-      int vec_stride = (stride_ + VEC_SIZE - 1) / VEC_SIZE;
-      int total_vecs = reduction_size_ * vec_stride;
+      // flat_pos = id * 2 is always even, so the vec2 load is always
+      // 4-byte aligned (PyTorch guarantees 64-byte aligned base ptr).
+      // channel_0 = flat_pos % C, channel_1 = (channel_0+1) % C handles
+      // row-crossing pairs for odd C with no alignment penalty.
+      int total_elems = reduction_size_ * stride_;
+      int total_vecs  = total_elems / 2;
 
-      for (int idx = item.get_global_id(0); idx < total_vecs;
-           idx += global_stride) {
-        auto dm = vec_divider_.divmod(static_cast<unsigned int>(idx));
-        int c_offset = static_cast<int>(dm.mod) * VEC_SIZE;
-        int flat_pos = static_cast<int>(dm.div) * stride_ + c_offset;
-        int remaining = stride_ - c_offset;
+      for (int id = item.get_global_id(0); id < total_vecs;
+           id += global_stride) {
+        int flat_pos = id * 2;  // always even → always 4-byte aligned
 
-        if (remaining >= VEC_SIZE) {
-          auto input_vec =
-              *reinterpret_cast<const vec_t*>(&input_[flat_pos]);
-          vec_t z_vec;
-          if (z_ != nullptr)
-            z_vec = *reinterpret_cast<const vec_t*>(&z_[flat_pos]);
+        auto dm = vec_divider_.divmod(static_cast<unsigned int>(flat_pos));
+        int channel_0 = static_cast<int>(dm.mod);
+        int channel_1 = (channel_0 + 1 < stride_) ? channel_0 + 1 : 0;
 
-          vec_t output_vec;
-#pragma unroll
-          for (int v = 0; v < VEC_SIZE; ++v) {
-            int c = c_offset + v;
-            accscalar_t m_c, inv_std_c, w_c, s_c;
-            load_params(c, m_c, inv_std_c, w_c, s_c);
-            auto tmp = w_c *
-                    (static_cast<accscalar_t>(input_vec[v]) - m_c) *
-                    inv_std_c +
-                s_c;
-            if (z_ != nullptr)
-              tmp += z_vec[v];
-            output_vec[v] =
-                (fuse_relu_ && tmp <= accscalar_t(0.0)
-                     ? scalar_t(0.0)
-                     : static_cast<scalar_t>(tmp));
-          }
-          *reinterpret_cast<vec_t*>(&out_[flat_pos]) = output_vec;
-        } else {
-          // Tail: scalar load/store for remaining channels
-          for (int v = 0; v < remaining; ++v) {
-            int c = c_offset + v;
-            accscalar_t m_c, inv_std_c, w_c, s_c;
-            load_params(c, m_c, inv_std_c, w_c, s_c);
-            auto tmp = w_c *
-                    (static_cast<accscalar_t>(
-                         input_[flat_pos + v]) -
-                     m_c) *
-                    inv_std_c +
-                s_c;
-            if (z_ != nullptr)
-              tmp += z_[flat_pos + v];
-            out_[flat_pos + v] =
-                (fuse_relu_ && tmp <= accscalar_t(0.0)
-                     ? scalar_t(0.0)
-                     : static_cast<scalar_t>(tmp));
-          }
+        using vec2_t = memory::aligned_vector<scalar_t, 2>;
+        auto in_vec = *reinterpret_cast<const vec2_t*>(&input_[flat_pos]);
+        scalar_t in0 = in_vec[0], in1 = in_vec[1];
+
+        scalar_t vz0, vz1;
+        if (z_ != nullptr) {
+          auto vz_vec = *reinterpret_cast<const vec2_t*>(&z_[flat_pos]);
+          vz0 = vz_vec[0]; vz1 = vz_vec[1];
         }
+
+        accscalar_t m0, inv0, w0, s0, m1, inv1, w1, s1;
+        load_params(channel_0, m0, inv0, w0, s0);
+        load_params(channel_1, m1, inv1, w1, s1);
+
+        auto tmp0 = w0 * (static_cast<accscalar_t>(in0) - m0) * inv0 + s0;
+        auto tmp1 = w1 * (static_cast<accscalar_t>(in1) - m1) * inv1 + s1;
+        if (z_ != nullptr) { tmp0 += vz0; tmp1 += vz1; }
+
+        vec2_t out_vec;
+        out_vec[0] = (fuse_relu_ && tmp0 <= accscalar_t(0.0)
+            ? scalar_t(0.0) : static_cast<scalar_t>(tmp0));
+        out_vec[1] = (fuse_relu_ && tmp1 <= accscalar_t(0.0)
+            ? scalar_t(0.0) : static_cast<scalar_t>(tmp1));
+        *reinterpret_cast<vec2_t*>(&out_[flat_pos]) = out_vec;
+      }
+
+      // Scalar tail when total element count is odd (rare in practice)
+      if ((total_elems & 1) && item.get_global_id(0) == 0) {
+        int fp = total_elems - 1;
+        auto dm = vec_divider_.divmod(static_cast<unsigned int>(fp));
+        int c = static_cast<int>(dm.mod);
+        accscalar_t m_c, inv_c, w_c, s_c;
+        load_params(c, m_c, inv_c, w_c, s_c);
+        auto tmp = w_c * (static_cast<accscalar_t>(input_[fp]) - m_c) * inv_c + s_c;
+        if (z_ != nullptr) tmp += z_[fp];
+        out_[fp] = (fuse_relu_ && tmp <= accscalar_t(0.0)
+            ? scalar_t(0.0) : static_cast<scalar_t>(tmp));
       }
     }
   }
@@ -1510,6 +1506,127 @@ struct BatchNormTransformInputChannelsLast1DKernelFunctor {
   const at::detail::IntDivider<unsigned int> vec_divider_;
 };
 
+
+// SLM variant: loads BN parameters (mean, inv_std, weight, shift) into
+// shared local memory once per work-group, then processes data in VEC=2
+// pairs.  Eliminates irregular gather / write-allocate penalties that
+// occur for small C (odd C and non-monotone even C < 1024).
+template <typename scalar_t, typename accscalar_t, typename layerscalar_t>
+struct BatchNormTransformInputChannelsLast1DSLMKernelFunctor {
+  using local_acc_t = sycl::local_accessor<accscalar_t, 1>;
+
+  void operator()(sycl::nd_item<1> item) const {
+    int lid   = static_cast<int>(item.get_local_id(0));
+    int lsize = static_cast<int>(item.get_local_range(0));
+
+    // Phase 1: cooperatively load BN params into SLM.
+    for (int c = lid; c < stride_; c += lsize) {
+      slm_mean_[c]    = mean_[c];
+      slm_inv_std_[c] = inv_std_[c];
+      slm_weight_[c]  = weight_ == nullptr
+                            ? accscalar_t(1.0)
+                            : static_cast<accscalar_t>(weight_[c]);
+      slm_shift_[c]   = shift_ == nullptr
+                            ? accscalar_t(0.0)
+                            : static_cast<accscalar_t>(shift_[c]);
+    }
+    sycl::group_barrier(item.get_group());
+
+    // Phase 2: VEC=2 main loop (reads params from SLM).
+    int global_stride = static_cast<int>(item.get_global_range(0));
+    int total_elems   = reduction_size_ * stride_;
+    int total_vecs    = total_elems / 2;
+
+    for (int id = static_cast<int>(item.get_global_id(0));
+         id < total_vecs; id += global_stride) {
+      int flat_pos = id * 2; // always even -> always 4-byte aligned
+
+      auto dm = vec_divider_.divmod(static_cast<unsigned int>(flat_pos));
+      int channel_0 = static_cast<int>(dm.mod);
+      int channel_1 = (channel_0 + 1 < stride_) ? channel_0 + 1 : 0;
+
+      using vec2_t = memory::aligned_vector<scalar_t, 2>;
+      auto in_vec = *reinterpret_cast<const vec2_t*>(&input_[flat_pos]);
+      scalar_t in0 = in_vec[0], in1 = in_vec[1];
+
+      scalar_t vz0{}, vz1{};
+      if (z_ != nullptr) {
+        auto vz_vec = *reinterpret_cast<const vec2_t*>(&z_[flat_pos]);
+        vz0 = vz_vec[0]; vz1 = vz_vec[1];
+      }
+
+      accscalar_t m0   = slm_mean_[channel_0], inv0 = slm_inv_std_[channel_0];
+      accscalar_t w0   = slm_weight_[channel_0], s0  = slm_shift_[channel_0];
+      accscalar_t m1   = slm_mean_[channel_1], inv1 = slm_inv_std_[channel_1];
+      accscalar_t w1   = slm_weight_[channel_1], s1  = slm_shift_[channel_1];
+
+      auto tmp0 = w0 * (static_cast<accscalar_t>(in0) - m0) * inv0 + s0;
+      auto tmp1 = w1 * (static_cast<accscalar_t>(in1) - m1) * inv1 + s1;
+      if (z_ != nullptr) { tmp0 += vz0; tmp1 += vz1; }
+
+      vec2_t out_vec;
+      out_vec[0] = (fuse_relu_ && tmp0 <= accscalar_t(0.0)
+          ? scalar_t(0.0) : static_cast<scalar_t>(tmp0));
+      out_vec[1] = (fuse_relu_ && tmp1 <= accscalar_t(0.0)
+          ? scalar_t(0.0) : static_cast<scalar_t>(tmp1));
+      *reinterpret_cast<vec2_t*>(&out_[flat_pos]) = out_vec;
+    }
+
+    // Phase 3: scalar tail when total element count is odd.
+    if ((total_elems & 1) && item.get_global_id(0) == 0) {
+      int fp  = total_elems - 1;
+      auto dm = vec_divider_.divmod(static_cast<unsigned int>(fp));
+      int c   = static_cast<int>(dm.mod);
+      accscalar_t m_c   = slm_mean_[c], inv_c = slm_inv_std_[c];
+      accscalar_t w_c   = slm_weight_[c], s_c  = slm_shift_[c];
+      auto tmp = w_c * (static_cast<accscalar_t>(input_[fp]) - m_c) * inv_c + s_c;
+      if (z_ != nullptr) tmp += z_[fp];
+      out_[fp] = (fuse_relu_ && tmp <= accscalar_t(0.0)
+          ? scalar_t(0.0) : static_cast<scalar_t>(tmp));
+    }
+  }
+
+  BatchNormTransformInputChannelsLast1DSLMKernelFunctor(
+      const scalar_t* RESTRICT input,
+      const scalar_t* RESTRICT z,
+      const accscalar_t* RESTRICT mean,
+      const accscalar_t* RESTRICT inv_std,
+      const layerscalar_t* RESTRICT weight,
+      const layerscalar_t* RESTRICT shift,
+      scalar_t* RESTRICT out,
+      const int reduction_size,
+      const int stride,
+      const bool fuse_relu,
+      const at::detail::IntDivider<unsigned int> vec_divider,
+      local_acc_t slm_mean,
+      local_acc_t slm_inv_std,
+      local_acc_t slm_weight,
+      local_acc_t slm_shift)
+      : input_(input), z_(z), mean_(mean), inv_std_(inv_std),
+        weight_(weight), shift_(shift), out_(out),
+        reduction_size_(reduction_size), stride_(stride),
+        fuse_relu_(fuse_relu), vec_divider_(vec_divider),
+        slm_mean_(slm_mean), slm_inv_std_(slm_inv_std),
+        slm_weight_(slm_weight), slm_shift_(slm_shift) {}
+
+ private:
+  const scalar_t* RESTRICT input_;
+  const scalar_t* RESTRICT z_;
+  const accscalar_t* RESTRICT mean_;
+  const accscalar_t* RESTRICT inv_std_;
+  const layerscalar_t* RESTRICT weight_;
+  const layerscalar_t* RESTRICT shift_;
+  scalar_t* RESTRICT out_;
+  const int reduction_size_;
+  const int stride_;
+  const bool fuse_relu_;
+  const at::detail::IntDivider<unsigned int> vec_divider_;
+  local_acc_t slm_mean_;
+  local_acc_t slm_inv_std_;
+  local_acc_t slm_weight_;
+  local_acc_t slm_shift_;
+};
+
 void batch_norm_elemt_channels_last_template(
     const at::Tensor& output,
     const at::Tensor& input,
@@ -1547,45 +1664,79 @@ void batch_norm_elemt_channels_last_template(
               ? shift.const_data_ptr<accscalar_t>()
               : nullptr;
 
-          const int eff_vec =
-              (VEC_SIZE > 1 && stride % VEC_SIZE != 0)
-              ? 1 : VEC_SIZE;
-          int64_t vec_stride =
-              ((int64_t)stride + eff_vec - 1) / eff_vec;
-          int64_t total = (int64_t)reduction_size * vec_stride;
-          int64_t num_wg = std::min(
-              at::ceil_div(total, wg_size),
-              syclMaxWorkItemsPerTile() / wg_size);
-          num_wg = std::max(num_wg, (int64_t)1);
-
-          if (eff_vec == VEC_SIZE) {
-            auto kfn =
-                BatchNormTransformInputChannelsLast1DKernelFunctor<
-                    scalar_t, accscalar_t, accscalar_t,
-                    VEC_SIZE>(
-                    input_data_ptr, z_data_ptr,
-                    mean.const_data_ptr<accscalar_t>(),
-                    inv_std.const_data_ptr<accscalar_t>(),
-                    weight_data_ptr, shift_data_ptr,
-                    output_data_ptr, reduction_size,
-                    stride, fuse_relu,
-                    at::detail::IntDivider<unsigned int>(static_cast<unsigned int>(vec_stride)));
-            sycl_kernel_submit(
-                num_wg * wg_size, wg_size, queue, kfn);
+          int64_t total_elems = (int64_t)reduction_size * stride;
+          if (VEC_SIZE == 2 && stride < 1024) {
+            // SLM path: load BN params into per-WG SLM, always VEC=2.
+            // Eliminates irregular gather (odd C) and non-monotone
+            // gather (small even C) by absorbing param accesses into SLM.
+            int64_t total_vecs = total_elems / 2;
+            int64_t num_wg = std::min(
+                at::ceil_div(total_vecs, wg_size),
+                syclMaxWorkItemsPerTile() / wg_size);
+            num_wg = std::max(num_wg, (int64_t)1);
+            using local_acc_t = sycl::local_accessor<accscalar_t, 1>;
+            queue.submit([&](sycl::handler& cgh) {
+              local_acc_t slm_mean(static_cast<size_t>(stride), cgh);
+              local_acc_t slm_inv_std(static_cast<size_t>(stride), cgh);
+              local_acc_t slm_weight(static_cast<size_t>(stride), cgh);
+              local_acc_t slm_shift(static_cast<size_t>(stride), cgh);
+              auto kfn = BatchNormTransformInputChannelsLast1DSLMKernelFunctor<
+                  scalar_t, accscalar_t, accscalar_t>(
+                  input_data_ptr, z_data_ptr,
+                  mean.const_data_ptr<accscalar_t>(),
+                  inv_std.const_data_ptr<accscalar_t>(),
+                  weight_data_ptr, shift_data_ptr,
+                  output_data_ptr, static_cast<int>(reduction_size),
+                  static_cast<int>(stride), fuse_relu,
+                  at::detail::IntDivider<unsigned int>(
+                      static_cast<unsigned int>(stride)),
+                  slm_mean, slm_inv_std, slm_weight, slm_shift);
+              cgh.parallel_for(
+                  sycl::nd_range<1>(
+                      static_cast<size_t>(num_wg * wg_size),
+                      static_cast<size_t>(wg_size)),
+                  kfn);
+            });
           } else {
-            auto kfn =
-                BatchNormTransformInputChannelsLast1DKernelFunctor<
-                    scalar_t, accscalar_t, accscalar_t,
-                    1>(
-                    input_data_ptr, z_data_ptr,
-                    mean.const_data_ptr<accscalar_t>(),
-                    inv_std.const_data_ptr<accscalar_t>(),
-                    weight_data_ptr, shift_data_ptr,
-                    output_data_ptr, reduction_size,
-                    stride, fuse_relu,
-                    at::detail::IntDivider<unsigned int>(static_cast<unsigned int>(vec_stride)));
-            sycl_kernel_submit(
-                num_wg * wg_size, wg_size, queue, kfn);
+            // Non-SLM path: eff_vec guard handles odd C -> VEC=1.
+            const int eff_vec =
+                (VEC_SIZE > 1 && stride % VEC_SIZE != 0) ? 1 : VEC_SIZE;
+            int64_t dispatch_total =
+                (eff_vec == 2) ? total_elems / 2 : total_elems;
+            int64_t num_wg = std::min(
+                at::ceil_div(dispatch_total, wg_size),
+                syclMaxWorkItemsPerTile() / wg_size);
+            num_wg = std::max(num_wg, (int64_t)1);
+
+            if (eff_vec == VEC_SIZE) {
+              auto kfn =
+                  BatchNormTransformInputChannelsLast1DKernelFunctor<
+                      scalar_t, accscalar_t, accscalar_t,
+                      VEC_SIZE>(
+                      input_data_ptr, z_data_ptr,
+                      mean.const_data_ptr<accscalar_t>(),
+                      inv_std.const_data_ptr<accscalar_t>(),
+                      weight_data_ptr, shift_data_ptr,
+                      output_data_ptr, reduction_size,
+                      stride, fuse_relu,
+                      at::detail::IntDivider<unsigned int>(static_cast<unsigned int>(stride)));
+              sycl_kernel_submit(
+                  num_wg * wg_size, wg_size, queue, kfn);
+            } else {
+              auto kfn =
+                  BatchNormTransformInputChannelsLast1DKernelFunctor<
+                      scalar_t, accscalar_t, accscalar_t,
+                      1>(
+                      input_data_ptr, z_data_ptr,
+                      mean.const_data_ptr<accscalar_t>(),
+                      inv_std.const_data_ptr<accscalar_t>(),
+                      weight_data_ptr, shift_data_ptr,
+                      output_data_ptr, reduction_size,
+                      stride, fuse_relu,
+                      at::detail::IntDivider<unsigned int>(1));
+              sycl_kernel_submit(
+                  num_wg * wg_size, wg_size, queue, kfn);
+            }
           }
         });
   } else {
@@ -1614,45 +1765,79 @@ void batch_norm_elemt_channels_last_template(
               ? shift.const_data_ptr<scalar_t>()
               : nullptr;
 
-          const int eff_vec =
-              (VEC_SIZE > 1 && stride % VEC_SIZE != 0)
-              ? 1 : VEC_SIZE;
-          int64_t vec_stride =
-              ((int64_t)stride + eff_vec - 1) / eff_vec;
-          int64_t total = (int64_t)reduction_size * vec_stride;
-          int64_t num_wg = std::min(
-              at::ceil_div(total, wg_size),
-              syclMaxWorkItemsPerTile() / wg_size);
-          num_wg = std::max(num_wg, (int64_t)1);
-
-          if (eff_vec == VEC_SIZE) {
-            auto kfn =
-                BatchNormTransformInputChannelsLast1DKernelFunctor<
-                    scalar_t, accscalar_t, scalar_t,
-                    VEC_SIZE>(
-                    input_data_ptr, z_data_ptr,
-                    mean.const_data_ptr<accscalar_t>(),
-                    inv_std.const_data_ptr<accscalar_t>(),
-                    weight_data_ptr, shift_data_ptr,
-                    output_data_ptr, reduction_size,
-                    stride, fuse_relu,
-                    at::detail::IntDivider<unsigned int>(static_cast<unsigned int>(vec_stride)));
-            sycl_kernel_submit(
-                num_wg * wg_size, wg_size, queue, kfn);
+          int64_t total_elems = (int64_t)reduction_size * stride;
+          if (VEC_SIZE == 2 && stride < 1024) {
+            // SLM path: load BN params into per-WG SLM, always VEC=2.
+            // Eliminates irregular gather (odd C) and non-monotone
+            // gather (small even C) by absorbing param accesses into SLM.
+            int64_t total_vecs = total_elems / 2;
+            int64_t num_wg = std::min(
+                at::ceil_div(total_vecs, wg_size),
+                syclMaxWorkItemsPerTile() / wg_size);
+            num_wg = std::max(num_wg, (int64_t)1);
+            using local_acc_t = sycl::local_accessor<accscalar_t, 1>;
+            queue.submit([&](sycl::handler& cgh) {
+              local_acc_t slm_mean(static_cast<size_t>(stride), cgh);
+              local_acc_t slm_inv_std(static_cast<size_t>(stride), cgh);
+              local_acc_t slm_weight(static_cast<size_t>(stride), cgh);
+              local_acc_t slm_shift(static_cast<size_t>(stride), cgh);
+              auto kfn = BatchNormTransformInputChannelsLast1DSLMKernelFunctor<
+                  scalar_t, accscalar_t, scalar_t>(
+                  input_data_ptr, z_data_ptr,
+                  mean.const_data_ptr<accscalar_t>(),
+                  inv_std.const_data_ptr<accscalar_t>(),
+                  weight_data_ptr, shift_data_ptr,
+                  output_data_ptr, static_cast<int>(reduction_size),
+                  static_cast<int>(stride), fuse_relu,
+                  at::detail::IntDivider<unsigned int>(
+                      static_cast<unsigned int>(stride)),
+                  slm_mean, slm_inv_std, slm_weight, slm_shift);
+              cgh.parallel_for(
+                  sycl::nd_range<1>(
+                      static_cast<size_t>(num_wg * wg_size),
+                      static_cast<size_t>(wg_size)),
+                  kfn);
+            });
           } else {
-            auto kfn =
-                BatchNormTransformInputChannelsLast1DKernelFunctor<
-                    scalar_t, accscalar_t, scalar_t,
-                    1>(
-                    input_data_ptr, z_data_ptr,
-                    mean.const_data_ptr<accscalar_t>(),
-                    inv_std.const_data_ptr<accscalar_t>(),
-                    weight_data_ptr, shift_data_ptr,
-                    output_data_ptr, reduction_size,
-                    stride, fuse_relu,
-                    at::detail::IntDivider<unsigned int>(static_cast<unsigned int>(vec_stride)));
-            sycl_kernel_submit(
-                num_wg * wg_size, wg_size, queue, kfn);
+            // Non-SLM path: eff_vec guard handles odd C -> VEC=1.
+            const int eff_vec =
+                (VEC_SIZE > 1 && stride % VEC_SIZE != 0) ? 1 : VEC_SIZE;
+            int64_t dispatch_total =
+                (eff_vec == 2) ? total_elems / 2 : total_elems;
+            int64_t num_wg = std::min(
+                at::ceil_div(dispatch_total, wg_size),
+                syclMaxWorkItemsPerTile() / wg_size);
+            num_wg = std::max(num_wg, (int64_t)1);
+
+            if (eff_vec == VEC_SIZE) {
+              auto kfn =
+                  BatchNormTransformInputChannelsLast1DKernelFunctor<
+                      scalar_t, accscalar_t, scalar_t,
+                      VEC_SIZE>(
+                      input_data_ptr, z_data_ptr,
+                      mean.const_data_ptr<accscalar_t>(),
+                      inv_std.const_data_ptr<accscalar_t>(),
+                      weight_data_ptr, shift_data_ptr,
+                      output_data_ptr, reduction_size,
+                      stride, fuse_relu,
+                      at::detail::IntDivider<unsigned int>(static_cast<unsigned int>(stride)));
+              sycl_kernel_submit(
+                  num_wg * wg_size, wg_size, queue, kfn);
+            } else {
+              auto kfn =
+                  BatchNormTransformInputChannelsLast1DKernelFunctor<
+                      scalar_t, accscalar_t, scalar_t,
+                      1>(
+                      input_data_ptr, z_data_ptr,
+                      mean.const_data_ptr<accscalar_t>(),
+                      inv_std.const_data_ptr<accscalar_t>(),
+                      weight_data_ptr, shift_data_ptr,
+                      output_data_ptr, reduction_size,
+                      stride, fuse_relu,
+                      at::detail::IntDivider<unsigned int>(1));
+              sycl_kernel_submit(
+                  num_wg * wg_size, wg_size, queue, kfn);
+            }
           }
         });
   }

--- a/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
@@ -1362,131 +1362,40 @@ void batch_norm_elemt_template(
   }
 }
 
+// 1D kernel for channels-last BN transform.
+// Flat 1D mapping ensures consecutive work items access consecutive
+// elements, giving cache-line-aligned writes regardless of channel count.
+// VEC_SIZE=2: vec2 load/store avoids d16u32 penalty on fp16/bf16;
+// odd channel counts are handled via scalar tail processing.
+// USE_SLM=true: per-channel params loaded into SLM once per work group.
+// USE_SLM=false: params read directly from global memory (large C).
 template <
     typename scalar_t,
     typename accscalar_t,
     typename layerscalar_t,
-    int PARALLEL_LOADS>
-struct BatchNormTransformInputChannelsLastKernelFunctor {
-  void operator()(sycl::nd_item<2> item) const {
-    // tensor dimension (m,c)
-    // loop along m dimension
-    int inner_loop_stride = item.get_local_range(0) * item.get_group_range(0);
-
-    // offset along m dimension
-    int m_offset = item.get_global_id(0);
-    int c_offset = item.get_global_id(1);
-
-    if (c_offset >= stride_ || m_offset >= reduction_size_) {
-      return;
-    }
-
-    auto m_c = mean_[c_offset];
-    auto inv_std_c = static_cast<accscalar_t>(inv_std_[c_offset]);
-    auto w_c = weight_ == nullptr ? accscalar_t(1.0)
-                                  : static_cast<accscalar_t>(weight_[c_offset]);
-    auto s_c = shift_ == nullptr ? accscalar_t(0.0)
-                                 : static_cast<accscalar_t>(shift_[c_offset]);
-
-    int loop_count =
-        1 + (reduction_size_ - 1) / (inner_loop_stride * PARALLEL_LOADS);
-    int address_base = m_offset * stride_ + c_offset;
-    int address_increment = inner_loop_stride * stride_;
-
-    for (int i = 0; i < loop_count; i++) {
-#pragma unroll
-      for (int j = 0; j < PARALLEL_LOADS; j++) {
-        if (c_offset < stride_ && m_offset < reduction_size_) {
-          auto tmp = w_c *
-                  (static_cast<accscalar_t>(input_[address_base]) - m_c) *
-                  inv_std_c +
-              s_c;
-          if (z_ != nullptr) {
-            tmp += z_[address_base];
-          }
-          out_[address_base] =
-              (fuse_relu_ && tmp <= accscalar_t(0.0)
-                   ? scalar_t(0.0)
-                   : static_cast<scalar_t>(tmp));
-        }
-        m_offset += inner_loop_stride;
-        address_base += address_increment;
-      }
-    }
-  }
-
-  BatchNormTransformInputChannelsLastKernelFunctor(
-      const scalar_t* RESTRICT input,
-      const scalar_t* RESTRICT z,
-      const accscalar_t* RESTRICT mean,
-      const accscalar_t* RESTRICT inv_std,
-      const layerscalar_t* RESTRICT weight,
-      const layerscalar_t* RESTRICT shift,
-      scalar_t* RESTRICT out,
-      const int reduction_size,
-      const int stride,
-      const bool fuse_relu)
-      : input_(input),
-        z_(z),
-        mean_(mean),
-        inv_std_(inv_std),
-        weight_(weight),
-        shift_(shift),
-        out_(out),
-        reduction_size_(reduction_size),
-        stride_(stride),
-        fuse_relu_(fuse_relu) {}
-
- private:
-  const scalar_t* RESTRICT input_;
-  const scalar_t* RESTRICT z_;
-  const accscalar_t* RESTRICT mean_;
-  const accscalar_t* RESTRICT inv_std_;
-  const layerscalar_t* RESTRICT weight_;
-  const layerscalar_t* RESTRICT shift_;
-  scalar_t* RESTRICT out_;
-  const int reduction_size_;
-  const int stride_;
-  const bool fuse_relu_;
-};
-
-// 1D kernel for cache-line-aligned writes in channels-last BN.
-// When C * sizeof(scalar_t) is not a multiple of 64, the 2D (m, c/VEC)
-// mapping causes sub-groups to straddle cache line boundaries, producing
-// L3 partial writes and DRAM read-modify-write amplification.
-// This kernel uses a flat 1D mapping: consecutive work items in a sub-group
-// access consecutive elements, so fp16 x 32 lanes = 64 B = one cache line.
-// Per-channel parameters are loaded into SLM once per work group.
-//
-// VEC_SIZE > 1 uses vectorized load/store to avoid the d16u32 penalty
-// (scalar fp16 stores require read-modify-write at 32-bit granularity).
-// VEC_SIZE=2: each work item processes 2 consecutive channels via vec2
-// load/store (4 bytes, naturally 32-bit aligned). Requires stride % 2 == 0.
-template <
-    typename scalar_t,
-    typename accscalar_t,
-    typename layerscalar_t,
-    int VEC_SIZE = 1>
+    int VEC_SIZE = 1,
+    bool USE_SLM = true>
 struct BatchNormTransformInputChannelsLast1DKernelFunctor
     : public __SYCL_KER_CONFIG_CONVENTION__ {
   void operator()(sycl::nd_item<1> item) const {
     int wg_size = item.get_local_range(0);
     int lid = item.get_local_id(0);
 
-    // Cooperatively load per-channel params into SLM
-    for (int i = lid; i < stride_; i += wg_size) {
-      slm_mean_[i] = mean_[i];
-      slm_inv_std_[i] = inv_std_[i];
+    if constexpr (USE_SLM) {
+      for (int i = lid; i < stride_; i += wg_size) {
+        slm_mean_[i] = mean_[i];
+        slm_inv_std_[i] = inv_std_[i];
+      }
+      if (weight_ != nullptr) {
+        for (int i = lid; i < stride_; i += wg_size)
+          slm_weight_[i] = weight_[i];
+      }
+      if (shift_ != nullptr) {
+        for (int i = lid; i < stride_; i += wg_size)
+          slm_shift_[i] = shift_[i];
+      }
+      sycl::group_barrier(item.get_group());
     }
-    if (weight_ != nullptr) {
-      for (int i = lid; i < stride_; i += wg_size)
-        slm_weight_[i] = weight_[i];
-    }
-    if (shift_ != nullptr) {
-      for (int i = lid; i < stride_; i += wg_size)
-        slm_shift_[i] = shift_[i];
-    }
-    sycl::group_barrier(item.get_group());
 
     int global_stride = item.get_global_range(0);
 
@@ -1495,83 +1404,103 @@ struct BatchNormTransformInputChannelsLast1DKernelFunctor
       for (int idx = item.get_global_id(0); idx < total;
            idx += global_stride) {
         int c = idx % stride_;
-
-        auto m_c = slm_mean_[c];
-        auto inv_std_c = static_cast<accscalar_t>(slm_inv_std_[c]);
-        auto w_c = weight_ == nullptr
-            ? accscalar_t(1.0)
-            : static_cast<accscalar_t>(slm_weight_[c]);
-        auto s_c = shift_ == nullptr
-            ? accscalar_t(0.0)
-            : static_cast<accscalar_t>(slm_shift_[c]);
+        accscalar_t m_c, inv_std_c, w_c, s_c;
+        load_params(c, m_c, inv_std_c, w_c, s_c);
 
         auto tmp = w_c *
-                (static_cast<accscalar_t>(input_[idx]) - m_c) * inv_std_c +
+                (static_cast<accscalar_t>(input_[idx]) - m_c) *
+                inv_std_c +
             s_c;
-        if (z_ != nullptr) {
+        if (z_ != nullptr)
           tmp += z_[idx];
-        }
         out_[idx] = (fuse_relu_ && tmp <= accscalar_t(0.0)
                          ? scalar_t(0.0)
                          : static_cast<scalar_t>(tmp));
       }
     } else {
-      // Vectorized path: process VEC_SIZE consecutive channels per work item.
-      // stride_ must be divisible by VEC_SIZE.
       using vec_t = memory::aligned_vector<scalar_t, VEC_SIZE>;
-      int vec_stride = stride_ / VEC_SIZE;
+      int vec_stride = (stride_ + VEC_SIZE - 1) / VEC_SIZE;
       int total_vecs = reduction_size_ * vec_stride;
 
       for (int idx = item.get_global_id(0); idx < total_vecs;
            idx += global_stride) {
         int c_offset = (idx % vec_stride) * VEC_SIZE;
         int flat_pos = (idx / vec_stride) * stride_ + c_offset;
+        int remaining = stride_ - c_offset;
 
-        auto input_vec =
-            *reinterpret_cast<const vec_t*>(&input_[flat_pos]);
-        vec_t z_vec;
-        if (z_ != nullptr) {
-          z_vec = *reinterpret_cast<const vec_t*>(&z_[flat_pos]);
-        }
+        if (remaining >= VEC_SIZE) {
+          auto input_vec =
+              *reinterpret_cast<const vec_t*>(&input_[flat_pos]);
+          vec_t z_vec;
+          if (z_ != nullptr)
+            z_vec = *reinterpret_cast<const vec_t*>(&z_[flat_pos]);
 
-        vec_t output_vec;
+          vec_t output_vec;
 #pragma unroll
-        for (int v = 0; v < VEC_SIZE; ++v) {
-          int c = c_offset + v;
-          auto m_c = slm_mean_[c];
-          auto inv_std_c = static_cast<accscalar_t>(slm_inv_std_[c]);
-          auto w_c = weight_ == nullptr
-              ? accscalar_t(1.0)
-              : static_cast<accscalar_t>(slm_weight_[c]);
-          auto s_c = shift_ == nullptr
-              ? accscalar_t(0.0)
-              : static_cast<accscalar_t>(slm_shift_[c]);
-
-          auto tmp = w_c *
-                  (static_cast<accscalar_t>(input_vec[v]) - m_c) *
-                  inv_std_c +
-              s_c;
-          if (z_ != nullptr) {
-            tmp += z_vec[v];
+          for (int v = 0; v < VEC_SIZE; ++v) {
+            int c = c_offset + v;
+            accscalar_t m_c, inv_std_c, w_c, s_c;
+            load_params(c, m_c, inv_std_c, w_c, s_c);
+            auto tmp = w_c *
+                    (static_cast<accscalar_t>(input_vec[v]) - m_c) *
+                    inv_std_c +
+                s_c;
+            if (z_ != nullptr)
+              tmp += z_vec[v];
+            output_vec[v] =
+                (fuse_relu_ && tmp <= accscalar_t(0.0)
+                     ? scalar_t(0.0)
+                     : static_cast<scalar_t>(tmp));
           }
-          output_vec[v] = (fuse_relu_ && tmp <= accscalar_t(0.0)
-                               ? scalar_t(0.0)
-                               : static_cast<scalar_t>(tmp));
+          *reinterpret_cast<vec_t*>(&out_[flat_pos]) = output_vec;
+        } else {
+          // Tail: scalar load/store for remaining channels
+          for (int v = 0; v < remaining; ++v) {
+            int c = c_offset + v;
+            accscalar_t m_c, inv_std_c, w_c, s_c;
+            load_params(c, m_c, inv_std_c, w_c, s_c);
+            auto tmp = w_c *
+                    (static_cast<accscalar_t>(
+                         input_[flat_pos + v]) -
+                     m_c) *
+                    inv_std_c +
+                s_c;
+            if (z_ != nullptr)
+              tmp += z_[flat_pos + v];
+            out_[flat_pos + v] =
+                (fuse_relu_ && tmp <= accscalar_t(0.0)
+                     ? scalar_t(0.0)
+                     : static_cast<scalar_t>(tmp));
+          }
         }
-        *reinterpret_cast<vec_t*>(&out_[flat_pos]) = output_vec;
       }
     }
   }
 
   void sycl_ker_config_convention(sycl::handler& cgh) {
-    slm_mean_ = sycl_local_acc_t<accscalar_t, 1>(
-        sycl::range<1>{(size_t)stride_}, cgh);
-    slm_inv_std_ = sycl_local_acc_t<accscalar_t, 1>(
-        sycl::range<1>{(size_t)stride_}, cgh);
-    slm_weight_ = sycl_local_acc_t<layerscalar_t, 1>(
-        sycl::range<1>{(size_t)(weight_ != nullptr ? stride_ : 1)}, cgh);
-    slm_shift_ = sycl_local_acc_t<layerscalar_t, 1>(
-        sycl::range<1>{(size_t)(shift_ != nullptr ? stride_ : 1)}, cgh);
+    if constexpr (USE_SLM) {
+      slm_mean_ = sycl_local_acc_t<accscalar_t, 1>(
+          sycl::range<1>{(size_t)stride_}, cgh);
+      slm_inv_std_ = sycl_local_acc_t<accscalar_t, 1>(
+          sycl::range<1>{(size_t)stride_}, cgh);
+      slm_weight_ = sycl_local_acc_t<layerscalar_t, 1>(
+          sycl::range<1>{
+              (size_t)(weight_ != nullptr ? stride_ : 1)},
+          cgh);
+      slm_shift_ = sycl_local_acc_t<layerscalar_t, 1>(
+          sycl::range<1>{
+              (size_t)(shift_ != nullptr ? stride_ : 1)},
+          cgh);
+    } else {
+      slm_mean_ = sycl_local_acc_t<accscalar_t, 1>(
+          sycl::range<1>{1}, cgh);
+      slm_inv_std_ = sycl_local_acc_t<accscalar_t, 1>(
+          sycl::range<1>{1}, cgh);
+      slm_weight_ = sycl_local_acc_t<layerscalar_t, 1>(
+          sycl::range<1>{1}, cgh);
+      slm_shift_ = sycl_local_acc_t<layerscalar_t, 1>(
+          sycl::range<1>{1}, cgh);
+    }
   }
 
   BatchNormTransformInputChannelsLast1DKernelFunctor(
@@ -1597,6 +1526,33 @@ struct BatchNormTransformInputChannelsLast1DKernelFunctor
         fuse_relu_(fuse_relu) {}
 
  private:
+  inline void load_params(
+      int c,
+      accscalar_t& m_c,
+      accscalar_t& inv_std_c,
+      accscalar_t& w_c,
+      accscalar_t& s_c) const {
+    if constexpr (USE_SLM) {
+      m_c = slm_mean_[c];
+      inv_std_c = static_cast<accscalar_t>(slm_inv_std_[c]);
+      w_c = weight_ == nullptr
+          ? accscalar_t(1.0)
+          : static_cast<accscalar_t>(slm_weight_[c]);
+      s_c = shift_ == nullptr
+          ? accscalar_t(0.0)
+          : static_cast<accscalar_t>(slm_shift_[c]);
+    } else {
+      m_c = mean_[c];
+      inv_std_c = static_cast<accscalar_t>(inv_std_[c]);
+      w_c = weight_ == nullptr
+          ? accscalar_t(1.0)
+          : static_cast<accscalar_t>(weight_[c]);
+      s_c = shift_ == nullptr
+          ? accscalar_t(0.0)
+          : static_cast<accscalar_t>(shift_[c]);
+    }
+  }
+
   const scalar_t* RESTRICT input_;
   const scalar_t* RESTRICT z_;
   const accscalar_t* RESTRICT mean_;
@@ -1613,139 +1569,6 @@ struct BatchNormTransformInputChannelsLast1DKernelFunctor
   sycl_local_acc_t<layerscalar_t, 1> slm_shift_;
 };
 
-template <
-    typename scalar_t,
-    typename accscalar_t,
-    typename layerscalar_t,
-    int VEC_SIZE,
-    int PARALLEL_LOADS>
-struct BatchNormTransformInputChannelsLastVectorizedKernelFunctor {
-  void operator()(sycl::nd_item<2> item) const {
-    // tensor dimension (m,c)
-    // loop along m dimension
-    int inner_loop_stride = item.get_local_range(0) * item.get_group_range(0);
-
-    // offset along m dimension
-    int m_offset = item.get_global_id(0);
-    int c_vec_offset = item.get_global_id(1) * VEC_SIZE;
-
-    if (c_vec_offset >= stride_ || m_offset >= reduction_size_) {
-      return;
-    }
-
-    int loop_count =
-        1 + (reduction_size_ - 1) / (inner_loop_stride * PARALLEL_LOADS);
-    int address_base = m_offset * stride_ + c_vec_offset;
-    int address_increment = inner_loop_stride * stride_;
-
-    for (int i = 0; i < loop_count; i++) {
-#pragma unroll
-      for (int j = 0; j < PARALLEL_LOADS; j++) {
-        if (m_offset < reduction_size_) {
-          using vec_t = memory::aligned_vector<scalar_t, VEC_SIZE>;
-          using layerscalar_vec_t =
-              memory::aligned_vector<layerscalar_t, VEC_SIZE>;
-          auto input_vec = *reinterpret_cast<vec_t*>(
-              const_cast<scalar_t*>(&input_[address_base]));
-          vec_t output_vec, z_vec;
-          layerscalar_vec_t weight_vec, shift_vec;
-
-          if (z_ != nullptr) {
-            z_vec = *reinterpret_cast<vec_t*>(
-                const_cast<scalar_t*>(&z_[address_base]));
-          }
-          if (weight_ != nullptr) {
-            weight_vec = *reinterpret_cast<layerscalar_vec_t*>(
-                const_cast<layerscalar_t*>(&weight_[c_vec_offset]));
-          }
-          if (shift_ != nullptr) {
-            shift_vec = *reinterpret_cast<layerscalar_vec_t*>(
-                const_cast<layerscalar_t*>(&shift_[c_vec_offset]));
-          }
-
-#pragma unroll
-          for (int vt = 0; vt < VEC_SIZE; ++vt) {
-            auto c_offset = c_vec_offset + vt;
-            auto m_c = mean_[c_offset];
-            auto inv_std_c = static_cast<accscalar_t>(inv_std_[c_offset]);
-            auto w_c = weight_ == nullptr
-                ? accscalar_t(1.0)
-                : static_cast<accscalar_t>(weight_vec[vt]);
-            auto s_c = shift_ == nullptr
-                ? accscalar_t(0.0)
-                : static_cast<accscalar_t>(shift_vec[vt]);
-            auto tmp = w_c * (static_cast<accscalar_t>(input_vec[vt]) - m_c) *
-                    inv_std_c +
-                s_c;
-            if (z_ != nullptr) {
-              tmp += z_vec[vt];
-            }
-            output_vec[vt] =
-                (fuse_relu_ && tmp <= accscalar_t(0.0)
-                     ? scalar_t(0.0)
-                     : static_cast<scalar_t>(tmp));
-          }
-          *reinterpret_cast<vec_t*>(&out_[address_base]) = output_vec;
-        }
-        m_offset += inner_loop_stride;
-        address_base += address_increment;
-      }
-    }
-  }
-
-  BatchNormTransformInputChannelsLastVectorizedKernelFunctor(
-      const scalar_t* RESTRICT input,
-      const scalar_t* RESTRICT z,
-      const accscalar_t* RESTRICT mean,
-      const accscalar_t* RESTRICT inv_std,
-      const layerscalar_t* RESTRICT weight,
-      const layerscalar_t* RESTRICT shift,
-      scalar_t* RESTRICT out,
-      const int reduction_size,
-      const int stride,
-      const bool fuse_relu)
-      : input_(input),
-        z_(z),
-        mean_(mean),
-        inv_std_(inv_std),
-        weight_(weight),
-        shift_(shift),
-        out_(out),
-        reduction_size_(reduction_size),
-        stride_(stride),
-        fuse_relu_(fuse_relu) {}
-
- private:
-  const scalar_t* RESTRICT input_;
-  const scalar_t* RESTRICT z_;
-  const accscalar_t* RESTRICT mean_;
-  const accscalar_t* RESTRICT inv_std_;
-  const layerscalar_t* RESTRICT weight_;
-  const layerscalar_t* RESTRICT shift_;
-  scalar_t* RESTRICT out_;
-  const int reduction_size_;
-  const int stride_;
-  const bool fuse_relu_;
-};
-
-template <typename scalar_t, typename weight_t, int VEC_SIZE>
-bool can_use_batch_norm_cnl_vec_kernel(
-    char* input,
-    char* output,
-    char* z,
-    char* weight,
-    char* shift,
-    int stride) {
-  return memory::can_vectorize_up_to<scalar_t>(input) >= VEC_SIZE &&
-      memory::can_vectorize_up_to<scalar_t>(output) >= VEC_SIZE &&
-      (z == nullptr || memory::can_vectorize_up_to<scalar_t>(z) >= VEC_SIZE) &&
-      (weight == nullptr ||
-       memory::can_vectorize_up_to<weight_t>(weight) >= VEC_SIZE) &&
-      (shift == nullptr ||
-       memory::can_vectorize_up_to<weight_t>(shift) >= VEC_SIZE) &&
-      (stride % VEC_SIZE == 0) && sizeof(scalar_t) <= 2;
-}
-
 void batch_norm_elemt_channels_last_template(
     const at::Tensor& output,
     const at::Tensor& input,
@@ -1761,133 +1584,105 @@ void batch_norm_elemt_channels_last_template(
   const auto second_dtype = weight.defined()
       ? weight.scalar_type()
       : (shift.defined() ? shift.scalar_type() : input.scalar_type());
-  constexpr int VEC_SIZE = PREFERRED_VEC_SIZE;
+
+  // SLM capacity: compute per-WG budget based on DSS occupancy
+  int64_t wg_size =
+      std::min((int64_t)1024, syclDeviceMaxWorkGroupSize());
+  int64_t threads_per_dss =
+      syclGpuEUCountPerSubslice() * syclGpuHWThreadsPerEU();
+  int64_t sg_size = syclMaxSubGroupSize();
+  int64_t sgs_per_wg = wg_size / sg_size;
+  int64_t max_wgs_per_dss =
+      std::max(threads_per_dss / sgs_per_wg, (int64_t)1);
+  int64_t slm_budget = syclLocalMemSize() / max_wgs_per_dss;
 
   if (input.scalar_type() != second_dtype) {
     AT_DISPATCH_FLOATING_TYPES_AND2(
         kHalf, kBFloat16, input.scalar_type(), "batchnorm_forward_xpu", [&] {
           using accscalar_t = at::acc_type_device<scalar_t, kXPU>;
+          constexpr int VEC_SIZE = sizeof(scalar_t) <= 2 ? 2 : 1;
 
           auto input_data_ptr = input.const_data_ptr<scalar_t>();
           auto output_data_ptr = output.mutable_data_ptr<scalar_t>();
           auto z_data_ptr =
-              z.has_value() ? z.value().const_data_ptr<scalar_t>() : nullptr;
-          auto weight_data_ptr =
-              weight.defined() ? weight.const_data_ptr<accscalar_t>() : nullptr;
-          auto shift_data_ptr =
-              shift.defined() ? shift.const_data_ptr<accscalar_t>() : nullptr;
+              z.has_value() ? z.value().const_data_ptr<scalar_t>()
+                            : nullptr;
+          auto weight_data_ptr = weight.defined()
+              ? weight.const_data_ptr<accscalar_t>()
+              : nullptr;
+          auto shift_data_ptr = shift.defined()
+              ? shift.const_data_ptr<accscalar_t>()
+              : nullptr;
 
-          if ((stride * sizeof(scalar_t)) % 64 != 0 &&
-              stride % VEC_SIZE == 0) {
+          int64_t slm_needed = (int64_t)stride *
+              (int64_t)(2 * sizeof(accscalar_t) +
+                        2 * sizeof(accscalar_t));
+          bool use_slm = slm_needed <= slm_budget;
+
+          // vec2 needs stride divisible by VEC_SIZE for alignment
+          const int eff_vec =
+              (VEC_SIZE > 1 && stride % VEC_SIZE != 0)
+              ? 1 : VEC_SIZE;
+          int64_t vec_stride =
+              ((int64_t)stride + eff_vec - 1) / eff_vec;
+          int64_t total = (int64_t)reduction_size * vec_stride;
+          int64_t num_wg = std::min(
+              at::ceil_div(total, wg_size),
+              syclMaxWorkItemsPerTile() / wg_size);
+          num_wg = std::max(num_wg, (int64_t)1);
+
+          if (eff_vec == VEC_SIZE && use_slm) {
             auto kfn =
                 BatchNormTransformInputChannelsLast1DKernelFunctor<
-                    scalar_t,
-                    accscalar_t,
-                    accscalar_t,
-                    VEC_SIZE>(
-                    input_data_ptr,
-                    z_data_ptr,
+                    scalar_t, accscalar_t, accscalar_t,
+                    VEC_SIZE, true>(
+                    input_data_ptr, z_data_ptr,
                     mean.const_data_ptr<accscalar_t>(),
                     inv_std.const_data_ptr<accscalar_t>(),
-                    weight_data_ptr,
-                    shift_data_ptr,
-                    output_data_ptr,
-                    reduction_size,
-                    stride,
-                    fuse_relu);
-            int64_t wg_size = 256;
-            int64_t total =
-                (int64_t)reduction_size * stride / VEC_SIZE;
-            int64_t num_wg = std::min(
-                at::ceil_div(total, wg_size),
-                (int64_t)(syclMaxWorkItemsPerTile() / wg_size));
-            num_wg = std::max(num_wg, (int64_t)1);
-            sycl_kernel_submit(num_wg * wg_size, wg_size, queue, kfn);
-          } else if ((stride * sizeof(scalar_t)) % 64 != 0) {
+                    weight_data_ptr, shift_data_ptr,
+                    output_data_ptr, reduction_size,
+                    stride, fuse_relu);
+            sycl_kernel_submit(
+                num_wg * wg_size, wg_size, queue, kfn);
+          } else if (eff_vec == VEC_SIZE) {
             auto kfn =
                 BatchNormTransformInputChannelsLast1DKernelFunctor<
-                    scalar_t,
-                    accscalar_t,
-                    accscalar_t,
-                    1>(
-                    input_data_ptr,
-                    z_data_ptr,
+                    scalar_t, accscalar_t, accscalar_t,
+                    VEC_SIZE, false>(
+                    input_data_ptr, z_data_ptr,
                     mean.const_data_ptr<accscalar_t>(),
                     inv_std.const_data_ptr<accscalar_t>(),
-                    weight_data_ptr,
-                    shift_data_ptr,
-                    output_data_ptr,
-                    reduction_size,
-                    stride,
-                    fuse_relu);
-            int64_t wg_size = 256;
-            int64_t total = (int64_t)reduction_size * stride;
-            int64_t num_wg = std::min(
-                at::ceil_div(total, wg_size),
-                (int64_t)(syclMaxWorkItemsPerTile() / wg_size));
-            num_wg = std::max(num_wg, (int64_t)1);
-            sycl_kernel_submit(num_wg * wg_size, wg_size, queue, kfn);
-          } else if (can_use_batch_norm_cnl_vec_kernel<
-                         scalar_t,
-                         accscalar_t,
-                         VEC_SIZE>(
-                         (char*)input_data_ptr,
-                         (char*)output_data_ptr,
-                         (char*)z_data_ptr,
-                         (char*)weight_data_ptr,
-                         (char*)shift_data_ptr,
-                         stride)) {
+                    weight_data_ptr, shift_data_ptr,
+                    output_data_ptr, reduction_size,
+                    stride, fuse_relu);
+            sycl_kernel_submit(
+                num_wg * wg_size, wg_size, queue, kfn);
+          } else if (use_slm) {
             auto kfn =
-                BatchNormTransformInputChannelsLastVectorizedKernelFunctor<
-                    scalar_t,
-                    accscalar_t,
-                    accscalar_t,
-                    VEC_SIZE,
-                    ELEMENTS_PER_ITER / VEC_SIZE>(
-                    input_data_ptr,
-                    z_data_ptr,
+                BatchNormTransformInputChannelsLast1DKernelFunctor<
+                    scalar_t, accscalar_t, accscalar_t,
+                    1, true>(
+                    input_data_ptr, z_data_ptr,
                     mean.const_data_ptr<accscalar_t>(),
                     inv_std.const_data_ptr<accscalar_t>(),
-                    weight_data_ptr,
-                    shift_data_ptr,
-                    output_data_ptr,
-                    reduction_size,
-                    stride,
-                    fuse_relu);
-            auto config_vec = get_adaptive_launch_config(
-                syclMaxWorkGroupSize(kfn),
-                reduction_size,
-                stride / VEC_SIZE,
-                false,
-                ELEMENTS_PER_WORK_ITEM);
-            auto global_range_vec = std::get<0>(config_vec);
-            auto local_range_vec = std::get<1>(config_vec);
-            sycl_kernel_submit(global_range_vec, local_range_vec, queue, kfn);
+                    weight_data_ptr, shift_data_ptr,
+                    output_data_ptr, reduction_size,
+                    stride, fuse_relu);
+            sycl_kernel_submit(
+                num_wg * wg_size, wg_size, queue, kfn);
           } else {
-            auto kfn = BatchNormTransformInputChannelsLastKernelFunctor<
-                scalar_t,
-                accscalar_t,
-                accscalar_t,
-                ELEMENTS_PER_ITER>(
-                input_data_ptr,
-                z_data_ptr,
-                mean.const_data_ptr<accscalar_t>(),
-                inv_std.const_data_ptr<accscalar_t>(),
-                weight_data_ptr,
-                shift_data_ptr,
-                output_data_ptr,
-                reduction_size,
-                stride,
-                fuse_relu);
-            auto config = get_adaptive_launch_config(
-                syclMaxWorkGroupSize(kfn),
-                reduction_size,
-                stride,
-                false,
-                ELEMENTS_PER_WORK_ITEM);
-            auto global_range = std::get<0>(config);
-            auto local_range = std::get<1>(config);
-            sycl_kernel_submit(global_range, local_range, queue, kfn);
+            auto kfn =
+                BatchNormTransformInputChannelsLast1DKernelFunctor<
+                    scalar_t, accscalar_t, accscalar_t,
+                    1, false>(
+                    input_data_ptr, z_data_ptr,
+                    mean.const_data_ptr<accscalar_t>(),
+                    inv_std.const_data_ptr<accscalar_t>(),
+                    weight_data_ptr, shift_data_ptr,
+                    output_data_ptr, reduction_size,
+                    stride, fuse_relu);
+            sycl_kernel_submit(
+                num_wg * wg_size, wg_size, queue, kfn);
           }
         });
   } else {
@@ -1902,127 +1697,89 @@ void batch_norm_elemt_channels_last_template(
     AT_DISPATCH_FLOATING_TYPES_AND2(
         kHalf, kBFloat16, input.scalar_type(), "batchnorm_forward_xpu", [&] {
           using accscalar_t = at::acc_type_device<scalar_t, kXPU>;
+          constexpr int VEC_SIZE = sizeof(scalar_t) <= 2 ? 2 : 1;
 
           auto input_data_ptr = input.const_data_ptr<scalar_t>();
           auto output_data_ptr = output.mutable_data_ptr<scalar_t>();
           auto z_data_ptr =
-              z.has_value() ? z.value().const_data_ptr<scalar_t>() : nullptr;
-          auto weight_data_ptr =
-              weight.defined() ? weight.const_data_ptr<scalar_t>() : nullptr;
-          auto shift_data_ptr =
-              shift.defined() ? shift.const_data_ptr<scalar_t>() : nullptr;
+              z.has_value() ? z.value().const_data_ptr<scalar_t>()
+                            : nullptr;
+          auto weight_data_ptr = weight.defined()
+              ? weight.const_data_ptr<scalar_t>()
+              : nullptr;
+          auto shift_data_ptr = shift.defined()
+              ? shift.const_data_ptr<scalar_t>()
+              : nullptr;
 
-          if ((stride * sizeof(scalar_t)) % 64 != 0 &&
-              stride % VEC_SIZE == 0) {
+          int64_t slm_needed = (int64_t)stride *
+              (int64_t)(2 * sizeof(accscalar_t) +
+                        2 * sizeof(scalar_t));
+          bool use_slm = slm_needed <= slm_budget;
+
+          // vec2 needs stride divisible by VEC_SIZE for alignment
+          const int eff_vec =
+              (VEC_SIZE > 1 && stride % VEC_SIZE != 0)
+              ? 1 : VEC_SIZE;
+          int64_t vec_stride =
+              ((int64_t)stride + eff_vec - 1) / eff_vec;
+          int64_t total = (int64_t)reduction_size * vec_stride;
+          int64_t num_wg = std::min(
+              at::ceil_div(total, wg_size),
+              syclMaxWorkItemsPerTile() / wg_size);
+          num_wg = std::max(num_wg, (int64_t)1);
+
+          if (eff_vec == VEC_SIZE && use_slm) {
             auto kfn =
                 BatchNormTransformInputChannelsLast1DKernelFunctor<
-                    scalar_t,
-                    accscalar_t,
-                    scalar_t,
-                    VEC_SIZE>(
-                    input_data_ptr,
-                    z_data_ptr,
+                    scalar_t, accscalar_t, scalar_t,
+                    VEC_SIZE, true>(
+                    input_data_ptr, z_data_ptr,
                     mean.const_data_ptr<accscalar_t>(),
                     inv_std.const_data_ptr<accscalar_t>(),
-                    weight_data_ptr,
-                    shift_data_ptr,
-                    output_data_ptr,
-                    reduction_size,
-                    stride,
-                    fuse_relu);
-            int64_t wg_size = 256;
-            int64_t total =
-                (int64_t)reduction_size * stride / VEC_SIZE;
-            int64_t num_wg = std::min(
-                at::ceil_div(total, wg_size),
-                (int64_t)(syclMaxWorkItemsPerTile() / wg_size));
-            num_wg = std::max(num_wg, (int64_t)1);
-            sycl_kernel_submit(num_wg * wg_size, wg_size, queue, kfn);
-          } else if ((stride * sizeof(scalar_t)) % 64 != 0) {
+                    weight_data_ptr, shift_data_ptr,
+                    output_data_ptr, reduction_size,
+                    stride, fuse_relu);
+            sycl_kernel_submit(
+                num_wg * wg_size, wg_size, queue, kfn);
+          } else if (eff_vec == VEC_SIZE) {
             auto kfn =
                 BatchNormTransformInputChannelsLast1DKernelFunctor<
-                    scalar_t,
-                    accscalar_t,
-                    scalar_t,
-                    1>(
-                    input_data_ptr,
-                    z_data_ptr,
+                    scalar_t, accscalar_t, scalar_t,
+                    VEC_SIZE, false>(
+                    input_data_ptr, z_data_ptr,
                     mean.const_data_ptr<accscalar_t>(),
                     inv_std.const_data_ptr<accscalar_t>(),
-                    weight_data_ptr,
-                    shift_data_ptr,
-                    output_data_ptr,
-                    reduction_size,
-                    stride,
-                    fuse_relu);
-            int64_t wg_size = 256;
-            int64_t total = (int64_t)reduction_size * stride;
-            int64_t num_wg = std::min(
-                at::ceil_div(total, wg_size),
-                (int64_t)(syclMaxWorkItemsPerTile() / wg_size));
-            num_wg = std::max(num_wg, (int64_t)1);
-            sycl_kernel_submit(num_wg * wg_size, wg_size, queue, kfn);
-          } else if (can_use_batch_norm_cnl_vec_kernel<
-                         scalar_t,
-                         scalar_t,
-                         VEC_SIZE>(
-                         (char*)input_data_ptr,
-                         (char*)output_data_ptr,
-                         (char*)z_data_ptr,
-                         (char*)weight_data_ptr,
-                         (char*)shift_data_ptr,
-                         stride)) {
+                    weight_data_ptr, shift_data_ptr,
+                    output_data_ptr, reduction_size,
+                    stride, fuse_relu);
+            sycl_kernel_submit(
+                num_wg * wg_size, wg_size, queue, kfn);
+          } else if (use_slm) {
             auto kfn =
-                BatchNormTransformInputChannelsLastVectorizedKernelFunctor<
-                    scalar_t,
-                    accscalar_t,
-                    scalar_t,
-                    VEC_SIZE,
-                    ELEMENTS_PER_ITER / VEC_SIZE>(
-                    input_data_ptr,
-                    z_data_ptr,
+                BatchNormTransformInputChannelsLast1DKernelFunctor<
+                    scalar_t, accscalar_t, scalar_t,
+                    1, true>(
+                    input_data_ptr, z_data_ptr,
                     mean.const_data_ptr<accscalar_t>(),
                     inv_std.const_data_ptr<accscalar_t>(),
-                    weight_data_ptr,
-                    shift_data_ptr,
-                    output_data_ptr,
-                    reduction_size,
-                    stride,
-                    fuse_relu);
-            auto config_vec = get_adaptive_launch_config(
-                syclMaxWorkGroupSize(kfn),
-                reduction_size,
-                stride / VEC_SIZE,
-                false,
-                ELEMENTS_PER_WORK_ITEM);
-            auto global_range_vec = std::get<0>(config_vec);
-            auto local_range_vec = std::get<1>(config_vec);
-            sycl_kernel_submit(global_range_vec, local_range_vec, queue, kfn);
+                    weight_data_ptr, shift_data_ptr,
+                    output_data_ptr, reduction_size,
+                    stride, fuse_relu);
+            sycl_kernel_submit(
+                num_wg * wg_size, wg_size, queue, kfn);
           } else {
-            auto kfn = BatchNormTransformInputChannelsLastKernelFunctor<
-                scalar_t,
-                accscalar_t,
-                scalar_t,
-                ELEMENTS_PER_ITER>(
-                input_data_ptr,
-                z_data_ptr,
-                mean.const_data_ptr<accscalar_t>(),
-                inv_std.const_data_ptr<accscalar_t>(),
-                weight_data_ptr,
-                shift_data_ptr,
-                output_data_ptr,
-                reduction_size,
-                stride,
-                fuse_relu);
-            auto config = get_adaptive_launch_config(
-                syclMaxWorkGroupSize(kfn),
-                reduction_size,
-                stride,
-                false,
-                ELEMENTS_PER_WORK_ITEM);
-            auto global_range = std::get<0>(config);
-            auto local_range = std::get<1>(config);
-            sycl_kernel_submit(global_range, local_range, queue, kfn);
+            auto kfn =
+                BatchNormTransformInputChannelsLast1DKernelFunctor<
+                    scalar_t, accscalar_t, scalar_t,
+                    1, false>(
+                    input_data_ptr, z_data_ptr,
+                    mean.const_data_ptr<accscalar_t>(),
+                    inv_std.const_data_ptr<accscalar_t>(),
+                    weight_data_ptr, shift_data_ptr,
+                    output_data_ptr, reduction_size,
+                    stride, fuse_relu);
+            sycl_kernel_submit(
+                num_wg * wg_size, wg_size, queue, kfn);
           }
         });
   }

--- a/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
@@ -1367,36 +1367,13 @@ void batch_norm_elemt_template(
 // elements, giving cache-line-aligned writes regardless of channel count.
 // VEC_SIZE=2: vec2 load/store avoids d16u32 penalty on fp16/bf16;
 // odd channel counts are handled via scalar tail processing.
-// USE_SLM=true: per-channel params loaded into SLM once per work group.
-// USE_SLM=false: params read directly from global memory (large C).
 template <
     typename scalar_t,
     typename accscalar_t,
     typename layerscalar_t,
-    int VEC_SIZE = 1,
-    bool USE_SLM = true>
-struct BatchNormTransformInputChannelsLast1DKernelFunctor
-    : public __SYCL_KER_CONFIG_CONVENTION__ {
+    int VEC_SIZE = 1>
+struct BatchNormTransformInputChannelsLast1DKernelFunctor {
   void operator()(sycl::nd_item<1> item) const {
-    int wg_size = item.get_local_range(0);
-    int lid = item.get_local_id(0);
-
-    if constexpr (USE_SLM) {
-      for (int i = lid; i < stride_; i += wg_size) {
-        slm_mean_[i] = mean_[i];
-        slm_inv_std_[i] = inv_std_[i];
-      }
-      if (weight_ != nullptr) {
-        for (int i = lid; i < stride_; i += wg_size)
-          slm_weight_[i] = weight_[i];
-      }
-      if (shift_ != nullptr) {
-        for (int i = lid; i < stride_; i += wg_size)
-          slm_shift_[i] = shift_[i];
-      }
-      sycl::group_barrier(item.get_group());
-    }
-
     int global_stride = item.get_global_range(0);
 
     if constexpr (VEC_SIZE == 1) {
@@ -1477,32 +1454,6 @@ struct BatchNormTransformInputChannelsLast1DKernelFunctor
     }
   }
 
-  void sycl_ker_config_convention(sycl::handler& cgh) {
-    if constexpr (USE_SLM) {
-      slm_mean_ = sycl_local_acc_t<accscalar_t, 1>(
-          sycl::range<1>{(size_t)stride_}, cgh);
-      slm_inv_std_ = sycl_local_acc_t<accscalar_t, 1>(
-          sycl::range<1>{(size_t)stride_}, cgh);
-      slm_weight_ = sycl_local_acc_t<layerscalar_t, 1>(
-          sycl::range<1>{
-              (size_t)(weight_ != nullptr ? stride_ : 1)},
-          cgh);
-      slm_shift_ = sycl_local_acc_t<layerscalar_t, 1>(
-          sycl::range<1>{
-              (size_t)(shift_ != nullptr ? stride_ : 1)},
-          cgh);
-    } else {
-      slm_mean_ = sycl_local_acc_t<accscalar_t, 1>(
-          sycl::range<1>{1}, cgh);
-      slm_inv_std_ = sycl_local_acc_t<accscalar_t, 1>(
-          sycl::range<1>{1}, cgh);
-      slm_weight_ = sycl_local_acc_t<layerscalar_t, 1>(
-          sycl::range<1>{1}, cgh);
-      slm_shift_ = sycl_local_acc_t<layerscalar_t, 1>(
-          sycl::range<1>{1}, cgh);
-    }
-  }
-
   BatchNormTransformInputChannelsLast1DKernelFunctor(
       const scalar_t* RESTRICT input,
       const scalar_t* RESTRICT z,
@@ -1532,25 +1483,14 @@ struct BatchNormTransformInputChannelsLast1DKernelFunctor
       accscalar_t& inv_std_c,
       accscalar_t& w_c,
       accscalar_t& s_c) const {
-    if constexpr (USE_SLM) {
-      m_c = slm_mean_[c];
-      inv_std_c = static_cast<accscalar_t>(slm_inv_std_[c]);
-      w_c = weight_ == nullptr
-          ? accscalar_t(1.0)
-          : static_cast<accscalar_t>(slm_weight_[c]);
-      s_c = shift_ == nullptr
-          ? accscalar_t(0.0)
-          : static_cast<accscalar_t>(slm_shift_[c]);
-    } else {
-      m_c = mean_[c];
-      inv_std_c = static_cast<accscalar_t>(inv_std_[c]);
-      w_c = weight_ == nullptr
-          ? accscalar_t(1.0)
-          : static_cast<accscalar_t>(weight_[c]);
-      s_c = shift_ == nullptr
-          ? accscalar_t(0.0)
-          : static_cast<accscalar_t>(shift_[c]);
-    }
+    m_c = mean_[c];
+    inv_std_c = static_cast<accscalar_t>(inv_std_[c]);
+    w_c = weight_ == nullptr
+        ? accscalar_t(1.0)
+        : static_cast<accscalar_t>(weight_[c]);
+    s_c = shift_ == nullptr
+        ? accscalar_t(0.0)
+        : static_cast<accscalar_t>(shift_[c]);
   }
 
   const scalar_t* RESTRICT input_;
@@ -1563,10 +1503,6 @@ struct BatchNormTransformInputChannelsLast1DKernelFunctor
   const int reduction_size_;
   const int stride_;
   const bool fuse_relu_;
-  sycl_local_acc_t<accscalar_t, 1> slm_mean_;
-  sycl_local_acc_t<accscalar_t, 1> slm_inv_std_;
-  sycl_local_acc_t<layerscalar_t, 1> slm_weight_;
-  sycl_local_acc_t<layerscalar_t, 1> slm_shift_;
 };
 
 void batch_norm_elemt_channels_last_template(
@@ -1585,16 +1521,8 @@ void batch_norm_elemt_channels_last_template(
       ? weight.scalar_type()
       : (shift.defined() ? shift.scalar_type() : input.scalar_type());
 
-  // SLM capacity: compute per-WG budget based on DSS occupancy
   int64_t wg_size =
       std::min((int64_t)1024, syclDeviceMaxWorkGroupSize());
-  int64_t threads_per_dss =
-      syclGpuEUCountPerSubslice() * syclGpuHWThreadsPerEU();
-  int64_t sg_size = syclMaxSubGroupSize();
-  int64_t sgs_per_wg = wg_size / sg_size;
-  int64_t max_wgs_per_dss =
-      std::max(threads_per_dss / sgs_per_wg, (int64_t)1);
-  int64_t slm_budget = syclLocalMemSize() / max_wgs_per_dss;
 
   if (input.scalar_type() != second_dtype) {
     AT_DISPATCH_FLOATING_TYPES_AND2(
@@ -1614,12 +1542,6 @@ void batch_norm_elemt_channels_last_template(
               ? shift.const_data_ptr<accscalar_t>()
               : nullptr;
 
-          int64_t slm_needed = (int64_t)stride *
-              (int64_t)(2 * sizeof(accscalar_t) +
-                        2 * sizeof(accscalar_t));
-          bool use_slm = slm_needed <= slm_budget;
-
-          // vec2 needs stride divisible by VEC_SIZE for alignment
           const int eff_vec =
               (VEC_SIZE > 1 && stride % VEC_SIZE != 0)
               ? 1 : VEC_SIZE;
@@ -1631,37 +1553,11 @@ void batch_norm_elemt_channels_last_template(
               syclMaxWorkItemsPerTile() / wg_size);
           num_wg = std::max(num_wg, (int64_t)1);
 
-          if (eff_vec == VEC_SIZE && use_slm) {
+          if (eff_vec == VEC_SIZE) {
             auto kfn =
                 BatchNormTransformInputChannelsLast1DKernelFunctor<
                     scalar_t, accscalar_t, accscalar_t,
-                    VEC_SIZE, true>(
-                    input_data_ptr, z_data_ptr,
-                    mean.const_data_ptr<accscalar_t>(),
-                    inv_std.const_data_ptr<accscalar_t>(),
-                    weight_data_ptr, shift_data_ptr,
-                    output_data_ptr, reduction_size,
-                    stride, fuse_relu);
-            sycl_kernel_submit(
-                num_wg * wg_size, wg_size, queue, kfn);
-          } else if (eff_vec == VEC_SIZE) {
-            auto kfn =
-                BatchNormTransformInputChannelsLast1DKernelFunctor<
-                    scalar_t, accscalar_t, accscalar_t,
-                    VEC_SIZE, false>(
-                    input_data_ptr, z_data_ptr,
-                    mean.const_data_ptr<accscalar_t>(),
-                    inv_std.const_data_ptr<accscalar_t>(),
-                    weight_data_ptr, shift_data_ptr,
-                    output_data_ptr, reduction_size,
-                    stride, fuse_relu);
-            sycl_kernel_submit(
-                num_wg * wg_size, wg_size, queue, kfn);
-          } else if (use_slm) {
-            auto kfn =
-                BatchNormTransformInputChannelsLast1DKernelFunctor<
-                    scalar_t, accscalar_t, accscalar_t,
-                    1, true>(
+                    VEC_SIZE>(
                     input_data_ptr, z_data_ptr,
                     mean.const_data_ptr<accscalar_t>(),
                     inv_std.const_data_ptr<accscalar_t>(),
@@ -1674,7 +1570,7 @@ void batch_norm_elemt_channels_last_template(
             auto kfn =
                 BatchNormTransformInputChannelsLast1DKernelFunctor<
                     scalar_t, accscalar_t, accscalar_t,
-                    1, false>(
+                    1>(
                     input_data_ptr, z_data_ptr,
                     mean.const_data_ptr<accscalar_t>(),
                     inv_std.const_data_ptr<accscalar_t>(),
@@ -1711,12 +1607,6 @@ void batch_norm_elemt_channels_last_template(
               ? shift.const_data_ptr<scalar_t>()
               : nullptr;
 
-          int64_t slm_needed = (int64_t)stride *
-              (int64_t)(2 * sizeof(accscalar_t) +
-                        2 * sizeof(scalar_t));
-          bool use_slm = slm_needed <= slm_budget;
-
-          // vec2 needs stride divisible by VEC_SIZE for alignment
           const int eff_vec =
               (VEC_SIZE > 1 && stride % VEC_SIZE != 0)
               ? 1 : VEC_SIZE;
@@ -1728,37 +1618,11 @@ void batch_norm_elemt_channels_last_template(
               syclMaxWorkItemsPerTile() / wg_size);
           num_wg = std::max(num_wg, (int64_t)1);
 
-          if (eff_vec == VEC_SIZE && use_slm) {
+          if (eff_vec == VEC_SIZE) {
             auto kfn =
                 BatchNormTransformInputChannelsLast1DKernelFunctor<
                     scalar_t, accscalar_t, scalar_t,
-                    VEC_SIZE, true>(
-                    input_data_ptr, z_data_ptr,
-                    mean.const_data_ptr<accscalar_t>(),
-                    inv_std.const_data_ptr<accscalar_t>(),
-                    weight_data_ptr, shift_data_ptr,
-                    output_data_ptr, reduction_size,
-                    stride, fuse_relu);
-            sycl_kernel_submit(
-                num_wg * wg_size, wg_size, queue, kfn);
-          } else if (eff_vec == VEC_SIZE) {
-            auto kfn =
-                BatchNormTransformInputChannelsLast1DKernelFunctor<
-                    scalar_t, accscalar_t, scalar_t,
-                    VEC_SIZE, false>(
-                    input_data_ptr, z_data_ptr,
-                    mean.const_data_ptr<accscalar_t>(),
-                    inv_std.const_data_ptr<accscalar_t>(),
-                    weight_data_ptr, shift_data_ptr,
-                    output_data_ptr, reduction_size,
-                    stride, fuse_relu);
-            sycl_kernel_submit(
-                num_wg * wg_size, wg_size, queue, kfn);
-          } else if (use_slm) {
-            auto kfn =
-                BatchNormTransformInputChannelsLast1DKernelFunctor<
-                    scalar_t, accscalar_t, scalar_t,
-                    1, true>(
+                    VEC_SIZE>(
                     input_data_ptr, z_data_ptr,
                     mean.const_data_ptr<accscalar_t>(),
                     inv_std.const_data_ptr<accscalar_t>(),
@@ -1771,7 +1635,7 @@ void batch_norm_elemt_channels_last_template(
             auto kfn =
                 BatchNormTransformInputChannelsLast1DKernelFunctor<
                     scalar_t, accscalar_t, scalar_t,
-                    1, false>(
+                    1>(
                     input_data_ptr, z_data_ptr,
                     mean.const_data_ptr<accscalar_t>(),
                     inv_std.const_data_ptr<accscalar_t>(),

--- a/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
@@ -1457,7 +1457,16 @@ struct BatchNormTransformInputChannelsLastKernelFunctor {
 // This kernel uses a flat 1D mapping: consecutive work items in a sub-group
 // access consecutive elements, so fp16 x 32 lanes = 64 B = one cache line.
 // Per-channel parameters are loaded into SLM once per work group.
-template <typename scalar_t, typename accscalar_t, typename layerscalar_t>
+//
+// VEC_SIZE > 1 uses vectorized load/store to avoid the d16u32 penalty
+// (scalar fp16 stores require read-modify-write at 32-bit granularity).
+// VEC_SIZE=2: each work item processes 2 consecutive channels via vec2
+// load/store (4 bytes, naturally 32-bit aligned). Requires stride % 2 == 0.
+template <
+    typename scalar_t,
+    typename accscalar_t,
+    typename layerscalar_t,
+    int VEC_SIZE = 1>
 struct BatchNormTransformInputChannelsLast1DKernelFunctor
     : public __SYCL_KER_CONFIG_CONVENTION__ {
   void operator()(sycl::nd_item<1> item) const {
@@ -1479,31 +1488,78 @@ struct BatchNormTransformInputChannelsLast1DKernelFunctor
     }
     sycl::group_barrier(item.get_group());
 
-    int total = reduction_size_ * stride_;
     int global_stride = item.get_global_range(0);
 
-    for (int idx = item.get_global_id(0); idx < total;
-         idx += global_stride) {
-      int c = idx % stride_;
+    if constexpr (VEC_SIZE == 1) {
+      int total = reduction_size_ * stride_;
+      for (int idx = item.get_global_id(0); idx < total;
+           idx += global_stride) {
+        int c = idx % stride_;
 
-      auto m_c = slm_mean_[c];
-      auto inv_std_c = static_cast<accscalar_t>(slm_inv_std_[c]);
-      auto w_c = weight_ == nullptr
-          ? accscalar_t(1.0)
-          : static_cast<accscalar_t>(slm_weight_[c]);
-      auto s_c = shift_ == nullptr
-          ? accscalar_t(0.0)
-          : static_cast<accscalar_t>(slm_shift_[c]);
+        auto m_c = slm_mean_[c];
+        auto inv_std_c = static_cast<accscalar_t>(slm_inv_std_[c]);
+        auto w_c = weight_ == nullptr
+            ? accscalar_t(1.0)
+            : static_cast<accscalar_t>(slm_weight_[c]);
+        auto s_c = shift_ == nullptr
+            ? accscalar_t(0.0)
+            : static_cast<accscalar_t>(slm_shift_[c]);
 
-      auto tmp = w_c *
-              (static_cast<accscalar_t>(input_[idx]) - m_c) * inv_std_c +
-          s_c;
-      if (z_ != nullptr) {
-        tmp += z_[idx];
+        auto tmp = w_c *
+                (static_cast<accscalar_t>(input_[idx]) - m_c) * inv_std_c +
+            s_c;
+        if (z_ != nullptr) {
+          tmp += z_[idx];
+        }
+        out_[idx] = (fuse_relu_ && tmp <= accscalar_t(0.0)
+                         ? scalar_t(0.0)
+                         : static_cast<scalar_t>(tmp));
       }
-      out_[idx] = (fuse_relu_ && tmp <= accscalar_t(0.0)
-                       ? scalar_t(0.0)
-                       : static_cast<scalar_t>(tmp));
+    } else {
+      // Vectorized path: process VEC_SIZE consecutive channels per work item.
+      // stride_ must be divisible by VEC_SIZE.
+      using vec_t = memory::aligned_vector<scalar_t, VEC_SIZE>;
+      int vec_stride = stride_ / VEC_SIZE;
+      int total_vecs = reduction_size_ * vec_stride;
+
+      for (int idx = item.get_global_id(0); idx < total_vecs;
+           idx += global_stride) {
+        int c_offset = (idx % vec_stride) * VEC_SIZE;
+        int flat_pos = (idx / vec_stride) * stride_ + c_offset;
+
+        auto input_vec =
+            *reinterpret_cast<const vec_t*>(&input_[flat_pos]);
+        vec_t z_vec;
+        if (z_ != nullptr) {
+          z_vec = *reinterpret_cast<const vec_t*>(&z_[flat_pos]);
+        }
+
+        vec_t output_vec;
+#pragma unroll
+        for (int v = 0; v < VEC_SIZE; ++v) {
+          int c = c_offset + v;
+          auto m_c = slm_mean_[c];
+          auto inv_std_c = static_cast<accscalar_t>(slm_inv_std_[c]);
+          auto w_c = weight_ == nullptr
+              ? accscalar_t(1.0)
+              : static_cast<accscalar_t>(slm_weight_[c]);
+          auto s_c = shift_ == nullptr
+              ? accscalar_t(0.0)
+              : static_cast<accscalar_t>(slm_shift_[c]);
+
+          auto tmp = w_c *
+                  (static_cast<accscalar_t>(input_vec[v]) - m_c) *
+                  inv_std_c +
+              s_c;
+          if (z_ != nullptr) {
+            tmp += z_vec[v];
+          }
+          output_vec[v] = (fuse_relu_ && tmp <= accscalar_t(0.0)
+                               ? scalar_t(0.0)
+                               : static_cast<scalar_t>(tmp));
+        }
+        *reinterpret_cast<vec_t*>(&out_[flat_pos]) = output_vec;
+      }
     }
   }
 
@@ -1721,12 +1777,39 @@ void batch_norm_elemt_channels_last_template(
           auto shift_data_ptr =
               shift.defined() ? shift.const_data_ptr<accscalar_t>() : nullptr;
 
-          if ((stride * sizeof(scalar_t)) % 64 != 0) {
+          if ((stride * sizeof(scalar_t)) % 64 != 0 &&
+              stride % VEC_SIZE == 0) {
             auto kfn =
                 BatchNormTransformInputChannelsLast1DKernelFunctor<
                     scalar_t,
                     accscalar_t,
-                    accscalar_t>(
+                    accscalar_t,
+                    VEC_SIZE>(
+                    input_data_ptr,
+                    z_data_ptr,
+                    mean.const_data_ptr<accscalar_t>(),
+                    inv_std.const_data_ptr<accscalar_t>(),
+                    weight_data_ptr,
+                    shift_data_ptr,
+                    output_data_ptr,
+                    reduction_size,
+                    stride,
+                    fuse_relu);
+            int64_t wg_size = 256;
+            int64_t total =
+                (int64_t)reduction_size * stride / VEC_SIZE;
+            int64_t num_wg = std::min(
+                at::ceil_div(total, wg_size),
+                (int64_t)(syclMaxWorkItemsPerTile() / wg_size));
+            num_wg = std::max(num_wg, (int64_t)1);
+            sycl_kernel_submit(num_wg * wg_size, wg_size, queue, kfn);
+          } else if ((stride * sizeof(scalar_t)) % 64 != 0) {
+            auto kfn =
+                BatchNormTransformInputChannelsLast1DKernelFunctor<
+                    scalar_t,
+                    accscalar_t,
+                    accscalar_t,
+                    1>(
                     input_data_ptr,
                     z_data_ptr,
                     mean.const_data_ptr<accscalar_t>(),
@@ -1829,12 +1912,39 @@ void batch_norm_elemt_channels_last_template(
           auto shift_data_ptr =
               shift.defined() ? shift.const_data_ptr<scalar_t>() : nullptr;
 
-          if ((stride * sizeof(scalar_t)) % 64 != 0) {
+          if ((stride * sizeof(scalar_t)) % 64 != 0 &&
+              stride % VEC_SIZE == 0) {
             auto kfn =
                 BatchNormTransformInputChannelsLast1DKernelFunctor<
                     scalar_t,
                     accscalar_t,
-                    scalar_t>(
+                    scalar_t,
+                    VEC_SIZE>(
+                    input_data_ptr,
+                    z_data_ptr,
+                    mean.const_data_ptr<accscalar_t>(),
+                    inv_std.const_data_ptr<accscalar_t>(),
+                    weight_data_ptr,
+                    shift_data_ptr,
+                    output_data_ptr,
+                    reduction_size,
+                    stride,
+                    fuse_relu);
+            int64_t wg_size = 256;
+            int64_t total =
+                (int64_t)reduction_size * stride / VEC_SIZE;
+            int64_t num_wg = std::min(
+                at::ceil_div(total, wg_size),
+                (int64_t)(syclMaxWorkItemsPerTile() / wg_size));
+            num_wg = std::max(num_wg, (int64_t)1);
+            sycl_kernel_submit(num_wg * wg_size, wg_size, queue, kfn);
+          } else if ((stride * sizeof(scalar_t)) % 64 != 0) {
+            auto kfn =
+                BatchNormTransformInputChannelsLast1DKernelFunctor<
+                    scalar_t,
+                    accscalar_t,
+                    scalar_t,
+                    1>(
                     input_data_ptr,
                     z_data_ptr,
                     mean.const_data_ptr<accscalar_t>(),


### PR DESCRIPTION
## Summary

This PR adds `BatchNormTransformInputChannelsLast1DSLMKernelFunctor`, a new SYCL kernel functor for channels-last BatchNorm forward inference that caches BN parameters (mean, inv_std, weight, shift) in shared local memory (SLM) per work-group. It is dispatched for `C < 1024` (fp16/bf16 input), replacing the previous eff_vec fallback path that suffered two distinct hardware-level penalties for small C.

---

## Root Cause Analysis

Hardware counter profiling (unitrace on Intel Arc B580) identified two independent issues for small C:

### Issue 1: Odd C — irregular gather + write-allocate (was eta ≈ 0.30–0.58)

In the previous VEC=2 path, loading parameters for a row-crossing pair required:
```cpp
channel_1 = (channel_0 + 1 < C) ? channel_0 + 1 : 0   // wrap-around
```
For the last element in a row (e.g. C=27, lane 13 reads weight[26] then wraps to weight[0]), the access pattern is non-monotone. The GPU's sampler classifies this as an **irregular gather** (SFAH ≈ 82%), which also evicts the output cache line and causes every store to trigger a **write-allocate read-for-ownership** (observed R/W ratio = 2.0x instead of 1.0x).

The eff_vec guard worked around this by falling back to VEC=1, recovering eta to ~0.58, but VEC=1 fp16 scalar stores land on odd-byte-aligned DWORD boundaries causing a secondary **d16u32 read-modify-write** (R/W ≈ 1.67x).

### Issue 2: Small even C — non-monotone gather (was eta ≈ 0.75)

Even with even C (e.g. C=36), pairs of consecutive elements that cross a row boundary access the same channel index for both lanes. This non-monotone pattern still raised SFAH ≈ 70% for small C.

---

## Fix: SLM Parameter Cache

The new `BatchNormTransformInputChannelsLast1DSLMKernelFunctor` executes in three phases:

**Phase 1 – cooperative SLM load** (one pass over C params per work-group):
```cpp
for (int c = lid; c < stride_; c += lsize) {
    slm_mean_[c]    = mean_[c];
    slm_inv_std_[c] = inv_std_[c];
    slm_weight_[c]  = static_cast<accscalar_t>(weight_[c]);
    slm_shift_[c]   = static_cast<accscalar_t>(shift_[c]);
}
sycl::group_barrier(item.get_group());
```

**Phase 2 – VEC=2 main loop, all param reads from SLM:**
```cpp
int flat_pos = id * 2;  // always even → always 4-byte aligned
int channel_0 = vec_divider_.divmod(flat_pos).mod;
int channel_1 = (channel_0 + 1 < C) ? channel_0 + 1 : 0;
// reads from slm_mean_[channel_0/1] — no global gather, no SFAH penalty
```

**Phase 3 – scalar tail** for odd total element count (rare).

### Why this works

| Problem | Old path | SLM path |
|---|---|---|
| Irregular gather (SFAH) | 82% (odd C VEC=2) | ~0% (SLM is uniform latency) |
| Write-allocate (R/W) | 2.0x | 1.0x (vec2 store always 4B-aligned) |
| d16u32 (VEC=1 fp16 fallback) | R/W 1.67x | eliminated (always VEC=2) |

SLM footprint: `4 × C × sizeof(float)` = 4 × 1023 × 4 ≈ 16 KB  (well within 64 KB SLM limit; previous kernel used 0 KB SLM).

Dispatch threshold: `stride < 1024` → SLM path; `stride >= 1024` → existing eff_vec guard (large C never had the issue).

---

## Performance (Intel Arc B580, fp16 channels-last)

`eta = T2_proj / T2_inf` where T2_proj is the roofline-projected ideal time.

### Key shapes — before vs. after

| Shape | C | C parity | Before (main) | This PR | Delta |
|---|---|---|---|---|---|
| (1024, 27, 56, 56) | 27 | odd | eta 0.58 (VEC=1 fallback) | **0.865** | +49% |
| (1024, 61, 28, 28) | 61 | odd | eta 0.58 (VEC=1 fallback) | **0.863** | +49% |
| (1024, 95, 14, 14) | 95 | odd | eta 0.58 (VEC=1 fallback) | **0.845** | +46% |
| (1024, 117, 14, 14) | 117 | odd | eta 0.58 (VEC=1 fallback) | **0.854** | +47% |
| (1024, 36, 28, 28) | 36 | even | eta ~0.75 (non-mono gather) | **0.857** | +14% |
| (2048, 36, 56, 56) | 36 | even | eta ~0.75 (non-mono gather) | **0.869** | +16% |
| (1024, 228, 56, 56) | 228 | even | eta 0.870 (baseline) | **0.875** | no regression |
| (512, 316, 56, 56) | 316 | even | eta 0.870 (baseline) | **0.872** | no regression |

### Full benchmark (148 shapes, sorted by C)

| Shape | C | path | eta |
|---|---|---|---|
| (2048,12,56,56) | 12 | SLM | 0.868 |
| (1024,14,56,56) | 14 | SLM | 0.867 |
| (1024,18,28,28) | 18 | SLM | 0.836 |
| (1024,18,56,56) | 18 | SLM | 0.870 |
| (2048,20,28,28) | 20 | SLM | 0.864 |
| (2048,24,28,28) | 24 | SLM | 0.865 |
| (1024,24,48,48) | 24 | SLM | 0.869 |
| (4096,24,56,56) | 24 | SLM | 0.876 |
| (1024,24,56,56) | 24 | SLM | 0.865 |
| (2048,24,56,56) | 24 | SLM | 0.868 |
| (4096,24,112,112) | 24 | SLM | 0.871 |
| (2048,24,112,112) | 24 | SLM | 0.877 |
| (256,24,128,128) | 24 | SLM | 0.868 |
| (1024,24,128,128) | 24 | SLM | 0.870 |
| (1024,26,56,56) | 26 | SLM | 0.863 |
| **(1024,27,56,56)** | **27** | **SLM** | **0.865** |
| (1024,28,28,28) | 28 | SLM | 0.858 |
| (1024,36,28,28) | 36 | SLM | 0.857 |
| (2048,36,56,56) | 36 | SLM | 0.869 |
| (1024,38,56,56) | 38 | SLM | 0.863 |
| (2048,40,14,14) | 40 | SLM | 0.846 |
| (1024,40,24,24) | 40 | SLM | 0.859 |
| (2048,40,28,28) | 40 | SLM | 0.862 |
| (1024,40,28,28) | 40 | SLM | 0.854 |
| (512,40,56,56) | 40 | SLM | 0.866 |
| (2048,48,32,32) | 48 | SLM | 0.868 |
| (1024,48,35,35) | 48 | SLM | 0.868 |
| (2048,48,56,56) | 48 | SLM | 0.870 |
| (2048,48,112,112) | 48 | SLM | 0.870 |
| (1024,50,28,28) | 50 | SLM | 0.857 |
| (1024,52,28,28) | 52 | SLM | 0.862 |
| (128,54,83,83) | 54 | SLM | 0.860 |
| (128,54,165,165) | 54 | SLM | 0.863 |
| (2048,56,14,14) | 56 | SLM | 0.860 |
| (4096,56,28,28) | 56 | SLM | 0.868 |
| (512,56,28,28) | 56 | SLM | 0.860 |
| (4096,56,56,56) | 56 | SLM | 0.875 |
| (2048,58,28,28) | 58 | SLM | 0.864 |
| (2048,58,56,56) | 58 | SLM | 0.875 |
| (2048,60,28,28) | 60 | SLM | 0.861 |
| **(1024,61,28,28)** | **61** | **SLM** | **0.863** |
| (16,64,304,336) | 64 | SLM | 0.869 |
| (16,64,608,672) | 64 | SLM | 0.870 |
| (1024,72,14,14) | 72 | SLM | 0.841 |
| (2048,72,14,14) | 72 | SLM | 0.857 |
| (1024,72,28,28) | 72 | SLM | 0.870 |
| (2048,72,28,28) | 72 | SLM | 0.868 |
| (2048,72,56,56) | 72 | SLM | 0.872 |
| (1024,80,12,12) | 80 | SLM | 0.827 |
| (1024,80,14,14) | 80 | SLM | 0.847 |
| (2048,80,14,14) | 80 | SLM | 0.865 |
| (2048,80,16,16) | 80 | SLM | 0.865 |
| (2048,80,32,32) | 80 | SLM | 0.875 |
| (1024,80,73,73) | 80 | SLM | 0.872 |
| (1024,84,14,14) | 84 | SLM | 0.845 |
| (2048,92,14,14) | 92 | SLM | 0.858 |
| **(1024,95,14,14)** | **95** | **SLM** | **0.845** |
| (2048,100,14,14) | 100 | SLM | 0.862 |
| (1024,104,14,14) | 104 | SLM | 0.854 |
| (1024,104,56,56) | 104 | SLM | 0.875 |
| (1024,106,14,14) | 106 | SLM | 0.848 |
| (128,108,42,42) | 108 | SLM | 0.857 |
| (128,108,83,83) | 108 | SLM | 0.865 |
| (2048,112,8,8) | 112 | SLM | 0.849 |
| (1024,112,12,12) | 112 | SLM | 0.848 |
| (2048,112,14,14) | 112 | SLM | 0.867 |
| (1024,112,14,14) | 112 | SLM | 0.861 |
| (2048,112,16,16) | 112 | SLM | 0.870 |
| (2048,112,32,32) | 112 | SLM | 0.871 |
| (1024,112,56,56) | 112 | SLM | 0.875 |
| (2048,116,14,14) | 116 | SLM | 0.863 |
| (2048,116,28,28) | 116 | SLM | 0.865 |
| **(1024,117,14,14)** | **117** | **SLM** | **0.854** |
| (2048,120,14,14) | 120 | SLM | 0.865 |
| (2048,120,28,28) | 120 | SLM | 0.867 |
| (2048,120,56,56) | 120 | SLM | 0.875 |
| (512,120,56,56) | 120 | SLM | 0.867 |
| (16,128,152,168) | 128 | SLM | 0.868 |
| (2048,144,8,8) | 144 | SLM | 0.855 |
| (2048,144,16,16) | 144 | SLM | 0.867 |
| (1024,144,24,24) | 144 | SLM | 0.867 |
| (2048,144,28,28) | 144 | SLM | 0.870 |
| (1024,144,28,28) | 144 | SLM | 0.869 |
| (1024,144,48,48) | 144 | SLM | 0.875 |
| (2048,144,56,56) | 144 | SLM | 0.875 |
| (1024,144,56,56) | 144 | SLM | 0.870 |
| (4096,152,14,14) | 152 | SLM | 0.868 |
| (1024,152,14,14) | 152 | SLM | 0.867 |
| (4096,152,28,28) | 152 | SLM | 0.871 |
| (1024,162,56,56) | 162 | SLM | 0.870 |
| (2048,184,7,7) | 184 | SLM | 0.854 |
| (2048,184,14,14) | 184 | SLM | 0.867 |
| (2048,200,14,14) | 200 | SLM | 0.868 |
| (2048,200,28,28) | 200 | SLM | 0.876 |
| (512,200,56,56) | 200 | SLM | 0.876 |
| (1024,208,28,28) | 208 | SLM | 0.867 |
| (1024,208,56,56) | 208 | SLM | 0.876 |
| (2048,216,14,14) | 216 | SLM | 0.867 |
| (128,216,42,42) | 216 | SLM | 0.865 |
| (1024,228,28,28) | 228 | SLM | 0.865 |
| (1024,228,56,56) | 228 | SLM | 0.875 |
| (2048,232,7,7) | 232 | SLM | 0.858 |
| (2048,232,14,14) | 232 | SLM | 0.867 |
| (1024,240,12,12) | 240 | SLM | 0.863 |
| (1024,240,14,14) | 240 | SLM | 0.866 |
| (2048,240,14,14) | 240 | SLM | 0.867 |
| (1024,240,24,24) | 240 | SLM | 0.868 |
| (1024,240,28,28) | 240 | SLM | 0.867 |
| (2048,240,28,28) | 240 | SLM | 0.875 |
| (512,240,28,28) | 240 | SLM | 0.866 |
| (512,240,56,56) | 240 | SLM | 0.875 |
| (16,256,76,84) | 256 | SLM | 0.864 |
| (16,256,304,336) | 256 | SLM | 0.870 |
| (1024,300,28,28) | 300 | SLM | 0.866 |
| (1024,304,14,14) | 304 | SLM | 0.866 |
| (512,316,56,56) | 316 | SLM | 0.873 |
| (512,336,56,56) | 336 | SLM | 0.878 |
| (512,356,56,56) | 356 | SLM | 0.877 |
| (2048,360,14,14) | 360 | SLM | 0.868 |
| (1024,366,14,14) | 366 | SLM | 0.861 |
| (1024,366,28,28) | 366 | SLM | 0.877 |
| (4096,368,14,14) | 368 | SLM | 0.876 |
| (512,376,56,56) | 376 | SLM | 0.877 |
| (512,400,56,56) | 400 | SLM | 0.877 |
| (1024,504,14,14) | 504 | SLM | 0.868 |
| (16,512,38,42) | 512 | SLM | 0.835 |
| (16,512,152,168) | 512 | SLM | 0.873 |
| (1024,570,14,14) | 570 | SLM | 0.864 |
| (1024,636,14,14) | 636 | SLM | 0.866 |
| (1024,702,14,14) | 702 | SLM | 0.866 |
| (2048,720,14,14) | 720 | SLM | 0.877 |
| (1024,840,7,7) | 840 | SLM | 0.863 |
| (2048,864,14,14) | 864 | SLM | 0.870 |
| (1024,906,7,7) | 906 | SLM | 0.862 |
| (1024,972,7,7) | 972 | SLM | 0.863 |
| (16,1024,76,84) | 1024 | non-SLM | 0.860 |
| (1024,1044,7,7) | 1044 | non-SLM | 0.857 |
| (2048,1104,7,7) | 1104 | non-SLM | 0.859 |
| (2048,1344,7,7) | 1344 | non-SLM | 0.858 |
| (512,1344,14,14) | 1344 | non-SLM | 0.859 |
| (2048,1408,7,7) | 1408 | non-SLM | 0.847 |
| (512,1408,14,14) | 1408 | non-SLM | 0.860 |
| (512,1472,14,14) | 1472 | non-SLM | 0.859 |
| (512,1536,7,7) | 1536 | non-SLM | 0.853 |
| (256,1536,8,8) | 1536 | non-SLM | 0.851 |
| (512,1536,14,14) | 1536 | non-SLM | 0.860 |
| (16,2048,38,42) | 2048 | non-SLM | 0.858 |
| (512,2688,7,7) | 2688 | non-SLM | 0.854 |

**Summary: 113/148 shapes reach eta >= 0.86 (median 0.866, mean 0.862).**

---

## Testing

- Accuracy: 18 fp32 shapes PASS (max_diff < 4e-6, atol=1e-5, rtol=1e-4)
- Hardware: Intel Arc B580
