### PR TITLE
Use if constexpr and constexpr in XPU kernels

### DIFF
--- a/src/ATen/native/xpu/UpSample.h
+++ b/src/ATen/native/xpu/UpSample.h
@@ -348,7 +348,7 @@ struct BilinearFilterFunctor {
     return 0;
   }
 
-  static const int size = 2;
+  static constexpr int size = 2;
 };
 
 // taken from
@@ -371,7 +371,7 @@ struct BicubicFilterFunctor {
     return 0;
   }
 
-  static const int size = 4;
+  static constexpr int size = 4;
 };
 
 template <typename accscalar_t>

--- a/src/ATen/native/xpu/sycl/DistributionTemplates.h
+++ b/src/ATen/native/xpu/sycl/DistributionTemplates.h
@@ -28,6 +28,8 @@
 #include <comm/DeviceProperties.h>
 #include <comm/Runtime.h>
 
+#include <concepts>
+
 namespace at {
 namespace native {
 namespace xpu {
@@ -510,10 +512,10 @@ void random_full_64_bits_range_kernel(TensorIteratorBase& iter, RNG gen) {
       iter.dtype(),
       "random_full_64_bits_range_kernel_xpu",
       [&] {
-        if (std::is_same<scalar_t, int64_t>::value ||
-            std::is_same<scalar_t, double>::value ||
-            std::is_same<scalar_t, float>::value ||
-            std::is_same<scalar_t, at::BFloat16>::value) {
+        if constexpr (
+            std::same_as<scalar_t, int64_t> || std::same_as<scalar_t, double> ||
+            std::same_as<scalar_t, float> ||
+            std::same_as<scalar_t, at::BFloat16>) {
           distribution_nullary_kernel<
               scalar_t,
               uint64_t,
@@ -546,8 +548,8 @@ void random_kernel(TensorIteratorBase& iter, RNG gen) {
       iter.dtype(),
       "random_kernel_xpu",
       [&] {
-        if (std::is_same<scalar_t, double>::value ||
-            std::is_same<scalar_t, int64_t>::value) {
+        if constexpr (
+            std::same_as<scalar_t, double> || std::same_as<scalar_t, int64_t>) {
           distribution_nullary_kernel<
               scalar_t,
               uint64_t,
@@ -591,7 +593,7 @@ void uniform_and_transform(
     RNG gen,
     transform_t transform) {
   // Distribution backbone only handle two accumulate type.
-  if (std::is_same<scalar_t, double>::value) {
+  if constexpr (std::same_as<scalar_t, double>) {
     Uniform2DistributionFunctor f;
     distribution_nullary_kernel<scalar_t, accscalar_t, engine_calls / 2>(
         iter, gen, f, transform);
@@ -624,7 +626,7 @@ void normal_and_transform(
     TensorIteratorBase& iter,
     RNG gen,
     transform_t transform) {
-  if (std::is_same<scalar_t, double>::value) {
+  if constexpr (std::same_as<scalar_t, double>) {
     Normal2DistributionFunctor f;
     distribution_nullary_kernel<scalar_t, accscalar_t, engine_calls / 2>(
         iter, gen, f, transform);
@@ -803,7 +805,7 @@ void bernoulli_kernel(const TensorBase& self, const TensorBase& p_, RNG gen) {
       self.scalar_type(),
       "bernoulli_tensor_xpu_self_",
       [&] {
-        if (std::is_same<scalar_t, double>::value) {
+        if constexpr (std::same_as<scalar_t, double>) {
           return bernoulli_tensor_kernel<double, double>(
               const_cast<TensorBase&>(self),
               const_cast<TensorBase&>(*p),

--- a/src/ATen/native/xpu/sycl/ForeachReduceKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ForeachReduceKernels.cpp
@@ -71,10 +71,10 @@ struct LpNormFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
           opmath_t next = static_cast<opmath_t>(r_x[ii]);
           if constexpr (norm_type == NormType::LInf) {
             vals[ii] = max_impl(vals[ii], sycl::fabs((opmath_t)next));
+          } else if constexpr (norm_type == NormType::L1) {
+            vals[ii] += static_cast<opmath_t>(sycl::fabs((opmath_t)next));
           } else {
-            vals[ii] += norm_type == NormType::L1
-                ? static_cast<opmath_t>(sycl::fabs((opmath_t)next))
-                : static_cast<opmath_t>(next * next);
+            vals[ii] += static_cast<opmath_t>(next * next);
           }
         }
       }
@@ -89,10 +89,10 @@ struct LpNormFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
             if constexpr (norm_type == NormType::LInf) {
               vals[ii] =
                   max_impl(vals[ii], sycl::fabs(sycl::fabs((opmath_t)next)));
+            } else if constexpr (norm_type == NormType::L1) {
+              vals[ii] += static_cast<opmath_t>(sycl::fabs((opmath_t)next));
             } else {
-              vals[ii] += norm_type == NormType::L1
-                  ? static_cast<opmath_t>(sycl::fabs((opmath_t)next))
-                  : static_cast<opmath_t>(next * next);
+              vals[ii] += static_cast<opmath_t>(next * next);
             }
           }
         }
@@ -108,9 +108,14 @@ struct LpNormFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
       }
     }
 
-    auto sum_val = norm_type == NormType::L1 || norm_type == NormType::L2
-        ? GroupReduceSumWithoutBroadcast<opmath_t, SIMD>(item_id, val, shared_)
-        : GroupReduceMaxWithoutBroadcast<opmath_t, SIMD>(item_id, val, shared_);
+    opmath_t sum_val;
+    if constexpr (norm_type == NormType::L1 || norm_type == NormType::L2) {
+      sum_val =
+          GroupReduceSumWithoutBroadcast<opmath_t, SIMD>(item_id, val, shared_);
+    } else {
+      sum_val =
+          GroupReduceMaxWithoutBroadcast<opmath_t, SIMD>(item_id, val, shared_);
+    }
 
     if (item_idx == 0) {
       output_per_tensor[tensor_loc * max_chunks_per_tensor + chunk_idx] =
@@ -143,14 +148,20 @@ struct lpnormChunkReduceKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
         val += output_this_tensor[i];
       }
     }
-    auto sum_val = norm_type == NormType::L1 || norm_type == NormType::L2
-        ? GroupReduceSumWithoutBroadcast<opmath_t, SIMD>(item_id, val, shared_)
-        : GroupReduceMaxWithoutBroadcast<opmath_t, SIMD>(item_id, val, shared_);
+    opmath_t sum_val;
+    if constexpr (norm_type == NormType::L1 || norm_type == NormType::L2) {
+      sum_val =
+          GroupReduceSumWithoutBroadcast<opmath_t, SIMD>(item_id, val, shared_);
+    } else {
+      sum_val =
+          GroupReduceMaxWithoutBroadcast<opmath_t, SIMD>(item_id, val, shared_);
+    }
     if (lid == 0) {
-      *(ret_per_tensor_[group_id]) =
-          norm_type == NormType::L1 || norm_type == NormType::LInf
-          ? sum_val
-          : sycl::sqrt((opmath_t)sum_val);
+      if constexpr (norm_type == NormType::L1 || norm_type == NormType::LInf) {
+        *(ret_per_tensor_[group_id]) = sum_val;
+      } else {
+        *(ret_per_tensor_[group_id]) = sycl::sqrt((opmath_t)sum_val);
+      }
     }
   }
   void sycl_ker_config_convention(sycl::handler& cgh) {

--- a/src/ATen/native/xpu/sycl/HistogramddKernels.cpp
+++ b/src/ATen/native/xpu/sycl/HistogramddKernels.cpp
@@ -421,7 +421,7 @@ void histogramdd_xpu_contiguous(
   Tensor num_bin_edges_xpu =
       at::tensor(num_bin_edges, hist_strides_xpu.options());
 
-  if (algorithm == PARALLEL_SEARCH) {
+  if constexpr (algorithm == PARALLEL_SEARCH) {
     histogramdd_template<input_t>(
         accessor_in,
         reinterpret_cast<const input_t* const*>(

--- a/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
@@ -664,7 +664,10 @@ void layer_norm_kernel_impl(
   const T* gamma_data = gamma.defined() ? gamma.const_data_ptr<T>() : nullptr;
   const T* beta_data = beta.defined() ? beta.const_data_ptr<T>() : nullptr;
   T* Y_data = Y->data_ptr<T>();
-  T_ACC* mean_data = !rms_norm ? mean->data_ptr<T_ACC>() : nullptr;
+  T_ACC* mean_data = nullptr;
+  if constexpr (!rms_norm) {
+    mean_data = mean->data_ptr<T_ACC>();
+  }
   T_ACC* rstd_data = rstd->data_ptr<T_ACC>();
 
   constexpr int num_vec_elems = vec_size;

--- a/src/ATen/native/xpu/sycl/RreluWithNoiseKernels.cpp
+++ b/src/ATen/native/xpu/sycl/RreluWithNoiseKernels.cpp
@@ -17,6 +17,8 @@
 
 #include <ATen/native/xpu/sycl/RreluWithNoiseKernels.h>
 
+#include <concepts>
+
 namespace at::native::xpu {
 
 template <typename scalar_t, int unroll_factor, typename transform_t>
@@ -125,7 +127,7 @@ inline void _rrelu_with_noise_xpu_train(
   double lower = lower_.to<double>();
   double upper = upper_.to<double>();
 
-  if (std::is_same_v<scalar_t, double>) {
+  if constexpr (std::same_as<scalar_t, double>) {
     templates::xpu::Uniform2DistributionFunctor tfn;
     auto fn = RreluWithNoiseKernelFunctor<scalar_t, 2, decltype(tfn)>(
         numel,

--- a/src/ATen/native/xpu/sycl/SortingCommon.h
+++ b/src/ATen/native/xpu/sycl/SortingCommon.h
@@ -44,7 +44,7 @@ struct KeyTraits<NullType> {
   static inline NullType deconvert(Type v) {
     return NullType();
   }
-  static inline unsigned int endbit() {
+  static constexpr unsigned int endbit() {
     return 0;
   }
 };
@@ -61,7 +61,7 @@ struct KeyTraits<float> {
     Type mask = (v & 0x80000000) ? 0x80000000 : 0xffffffff;
     return __int_as_float(v ^ mask);
   }
-  static inline int endbit() {
+  static constexpr int endbit() {
     return sizeof(Type) << 3;
   }
 };
@@ -75,7 +75,7 @@ struct KeyTraits<bool> {
   static inline bool deconvert(Type v) {
     return v;
   }
-  static inline int endbit() {
+  static constexpr int endbit() {
     return 1;
   }
 };
@@ -89,7 +89,7 @@ struct KeyTraits<uint8_t> {
   static inline uint8_t deconvert(Type v) {
     return v;
   }
-  static inline int endbit() {
+  static constexpr int endbit() {
     return sizeof(Type) << 3;
   }
 };
@@ -104,7 +104,7 @@ struct KeyTraits<uint16_t> {
   static inline SrcType deconvert(Type v) {
     return v;
   }
-  static inline int endbit() {
+  static constexpr int endbit() {
     return sizeof(Type) << 3;
   }
 };
@@ -119,7 +119,7 @@ struct KeyTraits<uint32_t> {
   static inline SrcType deconvert(Type v) {
     return v;
   }
-  static inline int endbit() {
+  static constexpr int endbit() {
     return sizeof(Type) << 3;
   }
 };
@@ -134,7 +134,7 @@ struct KeyTraits<uint64_t> {
   static inline SrcType deconvert(Type v) {
     return v;
   }
-  static inline int endbit() {
+  static constexpr int endbit() {
     return sizeof(Type) << 3;
   }
 };
@@ -147,7 +147,7 @@ struct KeyTraits<int8_t> {
   static inline int8_t deconvert(Type v) {
     return v - 128;
   }
-  static inline int endbit() {
+  static constexpr int endbit() {
     return sizeof(Type) << 3;
   }
 };
@@ -161,7 +161,7 @@ struct KeyTraits<int16_t> {
   static inline int16_t deconvert(Type v) {
     return v - 32768;
   }
-  static inline int endbit() {
+  static constexpr int endbit() {
     return sizeof(Type) << 3;
   }
 };
@@ -175,7 +175,7 @@ struct KeyTraits<int32_t> {
   static inline int32_t deconvert(Type v) {
     return v - 2147483648u;
   }
-  static inline int endbit() {
+  static constexpr int endbit() {
     return sizeof(Type) << 3;
   }
 };
@@ -189,7 +189,7 @@ struct KeyTraits<int64_t> {
   static inline int64_t deconvert(Type v) {
     return v - 9223372036854775808ull;
   }
-  static inline int endbit() {
+  static constexpr int endbit() {
     return sizeof(Type) << 3;
   }
 };
@@ -206,7 +206,7 @@ struct KeyTraits<double> {
     Type mask = ((v >> 63) - 1) | 0x8000000000000000;
     return __long_long_as_double(v ^ mask);
   }
-  static inline int endbit() {
+  static constexpr int endbit() {
     return sizeof(Type) << 3;
   }
 };
@@ -224,7 +224,7 @@ struct KeyTraits<at::Half> {
     Type v_de = v ^ mask;
     return reinterpret_cast<at::Half&>(v_de);
   }
-  static inline int endbit() {
+  static constexpr int endbit() {
     return sizeof(Type) << 3;
   }
 };
@@ -242,7 +242,7 @@ struct KeyTraits<at::BFloat16> {
     Type v_de = v ^ mask;
     return reinterpret_cast<at::BFloat16&>(v_de);
   }
-  static inline int endbit() {
+  static constexpr int endbit() {
     return sizeof(Type) << 3;
   }
 };
@@ -299,7 +299,7 @@ inline T group_cumsum(T* storage, sycl::nd_item<1>& item) {
   auto storage_lanes = storage + lid * COUNTER_LANES;
   T lane_all_sum = 0;
 
-  if (EXCLUSIVE) {
+  if constexpr (EXCLUSIVE) {
 #pragma unroll
     for (int lane = 0; lane < COUNTER_LANES; ++lane) {
       lane_temp_values[lane] = lane_all_sum;

--- a/src/ATen/native/xpu/sycl/SortingRadixSort.h
+++ b/src/ATen/native/xpu/sycl/SortingRadixSort.h
@@ -93,7 +93,7 @@ class GroupRadixSort {
   inline void load_bin_offsets(int* counts, int group_id, int num_groups) {
     int bin_idx = lid_;
     if (lid_ < RADIX_BUCKETS) {
-      if (IS_DESCENDING)
+      if constexpr (IS_DESCENDING)
         bin_idx = RADIX_BUCKETS - bin_idx - 1;
       bin_offset_ = counts[group_id + bin_idx * num_groups];
     }
@@ -123,7 +123,7 @@ class GroupRadixSort {
         if constexpr (std::is_same<KeyTraitsT, bool>::value) {
           padding_key = IS_DESCENDING ? false : true;
         } else {
-          if (IS_DESCENDING) {
+          if constexpr (IS_DESCENDING) {
             padding_key = 0;
           } else {
             constexpr uint64_t KEY_TRAITS_TYPE_MASK = uint64_t{1}
@@ -342,7 +342,7 @@ class GroupRadixSort {
       auto digit = extract_digit(ukeys_[ITEM]);
       auto sub_counter = digit >> LOG_COUNTER_LANES;
       auto counter_lane = digit & (COUNTER_LANES - 1);
-      if (IS_DESCENDING) {
+      if constexpr (IS_DESCENDING) {
         sub_counter = PACKING_RATIO - 1 - sub_counter;
         counter_lane = COUNTER_LANES - 1 - counter_lane;
       }
@@ -382,7 +382,7 @@ class GroupRadixSort {
     if (enable_bin_offsets_) {
       int digit = lid_;
       if (lid_ < RADIX_BUCKETS) {
-        if (IS_DESCENDING)
+        if constexpr (IS_DESCENDING)
           digit = RADIX_BUCKETS - digit - 1;
         auto sub_counter = digit >> LOG_COUNTER_LANES;
         auto counter_lane = digit & (COUNTER_LANES - 1);
@@ -442,7 +442,7 @@ class GroupRadixSort {
         auto digit = extract_digit(ukeys_[ITEM]);
         auto sub_counter = digit >> LOG_COUNTER_LANES;
         auto counter_lane = digit & (COUNTER_LANES - 1);
-        if (IS_DESCENDING) {
+        if constexpr (IS_DESCENDING) {
           sub_counter = PACKING_RATIO - 1 - sub_counter;
           counter_lane = COUNTER_LANES - 1 - counter_lane;
         }
@@ -517,14 +517,14 @@ class GroupRadixSort {
         offset_select = k - num_selected;
       if (offset_select > 0) {
         store_keys(out_keys, offset_select, num_selected);
-        if (!KEYS_ONLY)
+        if constexpr (!KEYS_ONLY)
           store_values(out_values, offset_select, num_selected);
       }
       num_selected += offset_select;
       if (num_selected == k)
         break;
       exchange_keys(offset_select, offset_active, &active_mask);
-      if (!KEYS_ONLY)
+      if constexpr (!KEYS_ONLY)
         exchange_values(offset_select, offset_active);
     }
   }
@@ -549,7 +549,7 @@ class GroupRadixSort {
           if constexpr (std::is_same<KeyTraitsT, bool>::value) {
             padding_key = IS_DESCENDING ? false : true;
           } else {
-            if (IS_DESCENDING) {
+            if constexpr (IS_DESCENDING) {
               padding_key = 0;
             } else {
               constexpr uint64_t KEY_TRAITS_TYPE_MASK = uint64_t{1}
@@ -774,7 +774,7 @@ class RadixSortUpsweep {
 #pragma unroll
       for (int i = 0; i < SUBGROUP_SIZE; ++i)
         bin_count += local_storage_.group_counters[i][bin_idx];
-      if (IS_DESCENDING)
+      if constexpr (IS_DESCENDING)
         bin_idx = RADIX_BUCKETS - bin_idx - 1;
       count_out_[(num_groups_ * bin_idx) + gid_] = bin_count;
     }

--- a/src/ATen/native/xpu/sycl/SummaryOpsKernels.cpp
+++ b/src/ATen/native/xpu/sycl/SummaryOpsKernels.cpp
@@ -180,7 +180,7 @@ void tensor_histogram(
     at::acc_type_device<input_t, kXPU> min_value,
     at::acc_type_device<input_t, kXPU> max_value) {
   checkBackend("tensor_histogram", {a, b}, Backend::XPU);
-  if (has_weights) {
+  if constexpr (has_weights) {
     checkBackend("tensor_histogram", {c}, Backend::XPU);
   }
   auto total_elements = b.numel();
@@ -191,7 +191,7 @@ void tensor_histogram(
   using IndexType = int64_t;
   auto a_info = getTensorInfo<output_t, IndexType>(a);
   auto b_info = getTensorInfo<const input_t, IndexType>(b);
-  if (has_weights) {
+  if constexpr (has_weights) {
     auto c_info = getTensorInfo<output_t, IndexType>(c);
     const IndexingFunctor<output_t, IndexType, decltype(c_info)> get_weights_op(
         c_info);

--- a/src/ATen/native/xpu/sycl/TensorShapeKernels.cpp
+++ b/src/ATen/native/xpu/sycl/TensorShapeKernels.cpp
@@ -214,7 +214,7 @@ inline void copy_chunk_with_pad(
     int64_t thread_idx,
     int64_t num_threads) {
   // Supports type cast
-  if (!std::is_same_v<dst_t, src_t>) {
+  if constexpr (!std::is_same_v<dst_t, src_t>) {
     const int64_t max_num_elems = max_chunk_size / sizeof(dst_t);
     const int64_t actual_num_elems = actual_chunk_size / sizeof(src_t);
     int64_t elem_index = thread_idx;


### PR DESCRIPTION
Convert runtime if/ternary on compile-time-constant template params and type traits to if constexpr, and static const/static inline to constexpr where the initializer is constant.  

