### PR TITLE
Fix stale found-flag in radix select findPattern

### DIFF
--- a/src/ATen/native/xpu/sycl/SortingRadixSelect.h
+++ b/src/ATen/native/xpu/sycl/SortingRadixSelect.h
@@ -346,8 +346,9 @@ scalar_t findPattern(
   auto local_id = item_id.get_local_id(0);
   auto smem_ptr = static_cast<scalar_t*>(static_cast<void*>(
       smem.template get_multi_ptr<sycl::access::decorated::no>().get()));
-  if (local_id < RADIX_SIZE) {
-    smem_ptr[RADIX_SIZE] = static_cast<scalar_t>(0);
+  // Zero slots 0/1 (found-flag, value); else stale from countRadixUsingMask.
+  if (local_id < 2) {
+    smem_ptr[local_id] = static_cast<scalar_t>(0);
   }
 
   sycl::group_barrier(item_id.get_group());


### PR DESCRIPTION
findPattern zeroed slot RADIX_SIZE instead of slots 0/1 (found-flag, value), so
the loop read a stale flag left by countRadixUsingMask and could return early
with the wrong value. Zero slots 0/1 (matches upstream CUDA
SortingRadixSelect.cuh).

