### PR TITLE
Migrate remaining device-side std:: math calls to sycl::

### DIFF
--- a/src/ATen/native/quantized/sycl/FusedObsFakeQuantKernels.cpp
+++ b/src/ATen/native/quantized/sycl/FusedObsFakeQuantKernels.cpp
@@ -167,8 +167,8 @@ void ChooseQuantizationParamsKernelImpl(
       int symmetric_qmax = (qmax - qmin) / 2;
 
       float max_scale = std::max(
-          std::fabs(min_val / symmetric_qmin),
-          std::fabs(max_val / symmetric_qmax));
+          sycl::fabs(min_val / symmetric_qmin),
+          sycl::fabs(max_val / symmetric_qmax));
       min_val = max_scale * symmetric_qmin;
       max_val = max_scale * symmetric_qmax;
     }
@@ -189,9 +189,9 @@ void ChooseQuantizationParamsKernelImpl(
     double zero_point_from_min = qmin - min_val / static_cast<double>(scale[i]);
     double zero_point_from_max = qmax - max_val / static_cast<double>(scale[i]);
     double zero_point_from_min_error =
-        std::abs(qmin) + std::abs(min_val / static_cast<double>(scale[i]));
+        sycl::abs(qmin) + sycl::fabs(min_val / static_cast<double>(scale[i]));
     double zero_point_from_max_error =
-        std::abs(qmax) + std::abs(max_val / static_cast<double>(scale[i]));
+        sycl::abs(qmax) + sycl::fabs(max_val / static_cast<double>(scale[i]));
     double initial_zero_point =
         zero_point_from_min_error < zero_point_from_max_error
         ? zero_point_from_min

--- a/src/ATen/native/sparse/xpu/sycl/SparseSoftmaxKernels.cpp
+++ b/src/ATen/native/sparse/xpu/sycl/SparseSoftmaxKernels.cpp
@@ -211,7 +211,7 @@ struct SparseCooSoftmaxFunctor {
           auto values_row = input_values_acc[i];
           auto out_values_row = output_values_acc[i];
 
-          auto v = std::exp(values_row[j] - mx_row[j]);
+          auto v = sycl::exp(values_row[j] - mx_row[j]);
           if (!LogSoftMax) {
             out_values_row[j] = v;
           }
@@ -314,14 +314,14 @@ struct SparseCooSoftmaxbBackwardFunctor {
             auto grad_values_row = grad_values_accessor[j];
             if constexpr (LogSoftMax) {
               values_row[k] =
-                  grad_values_row[k] + std::exp(out_values_row[k]) * tmp_row;
+                  grad_values_row[k] + sycl::exp(out_values_row[k]) * tmp_row;
             } else {
               values_row[k] =
                   out_values_row[k] * (grad_values_row[k] + tmp_row);
             }
           } else {
             if constexpr (LogSoftMax) {
-              values_row[k] = std::exp(out_values_row[k]) * tmp_row;
+              values_row[k] = sycl::exp(out_values_row[k]) * tmp_row;
             } else {
               values_row[k] = out_values_row[k] * tmp_row;
             }

--- a/src/ATen/native/xpu/sycl/ForeachUnaryKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ForeachUnaryKernels.cpp
@@ -375,9 +375,14 @@ FOREACH_UNARY_KERNEL(sqrt) {
 
 template <typename T>
 struct Sigmoid {
-  T one = T(1);
   T operator()(T t) const {
-    return (one / (one + std::exp(-t)));
+    using opmath_t = at::opmath_type<T>;
+    const opmath_t one = opmath_t{1};
+    if constexpr (c10::is_complex<opmath_t>::value) {
+      return one / (one + std::exp(-static_cast<opmath_t>(t)));
+    } else {
+      return one / (one + sycl::exp(-static_cast<opmath_t>(t)));
+    }
   }
 };
 

--- a/src/ATen/native/xpu/sycl/Philox4x32.h
+++ b/src/ATen/native/xpu/sycl/Philox4x32.h
@@ -380,8 +380,8 @@ static inline float2 _rand_box_muller(unsigned int x, unsigned int y) {
   float u = x * RAND_2POW32_INV + (RAND_2POW32_INV / 2);
   float v = y * RAND_2POW32_INV_2PI + (RAND_2POW32_INV_2PI / 2);
   float s = sycl::sqrt(-2.0f * sycl::log(u));
-  result.x = std::sin(v);
-  result.y = std::cos(v);
+  result.x = sycl::sin(v);
+  result.y = sycl::cos(v);
   result.x *= s;
   result.y *= s;
   return result;
@@ -415,8 +415,8 @@ static inline double2 _rand_box_muller_double(
   double v = zy * (RAND_2POW53_INV_DOUBLE * 2.0) + RAND_2POW53_INV_DOUBLE;
   double s = sycl::sqrt(-2.0 * sycl::log(u));
 
-  result.x = std::sin(v * RAND_PI_DOUBLE);
-  result.y = std::cos(v * RAND_PI_DOUBLE);
+  result.x = sycl::sin(v * RAND_PI_DOUBLE);
+  result.y = sycl::cos(v * RAND_PI_DOUBLE);
   result.x *= s;
   result.y *= s;
 


### PR DESCRIPTION
Complete the std::->sycl:: migration for device-only call sites missed by the per-function unary migration:

- Philox4x32.h: std::sin/std::cos -> sycl::sin/sycl::cos in box-muller
- SparseSoftmaxKernels.cpp: std::exp -> sycl::exp (float/double dispatch)
- FusedObsFakeQuantKernels.cpp: std::fabs -> sycl::fabs, std::abs(int) ->
  sycl::abs, std::abs(double) -> sycl::fabs
- ForeachUnaryKernels.cpp: Sigmoid functor now branches on complex and uses sycl::exp with opmath_type cast for the real path