### PR TITLE
Skip frexp cpu compare on windows

### DIFF
--- a/test/xpu/extended/skip_list_win.py
+++ b/test/xpu/extended/skip_list_win.py
@@ -11,9 +11,6 @@ skip_dict = {
         "test_compare_cpu_pow_xpu_bfloat16",  # https://github.com/intel/torch-xpu-ops/pull/764
         "test_compare_cpu_argmin_xpu_int",
         # https://github.com/intel/torch-xpu-ops/issues/3805
-        "test_compare_cpu_frexp_xpu_bfloat16",
-        "test_compare_cpu_frexp_xpu_float16",
-        "test_compare_cpu_frexp_xpu_float32",
-        "test_compare_cpu_frexp_xpu_float64",
+        "test_compare_cpu_frexp_xpu",
     ),
 }

--- a/test/xpu/extended/skip_list_win.py
+++ b/test/xpu/extended/skip_list_win.py
@@ -10,5 +10,10 @@ skip_dict = {
     "test_ops_xpu.py": (
         "test_compare_cpu_pow_xpu_bfloat16",  # https://github.com/intel/torch-xpu-ops/pull/764
         "test_compare_cpu_argmin_xpu_int",
+        # https://github.com/intel/torch-xpu-ops/issues/3805
+        "test_compare_cpu_frexp_xpu_bfloat16",
+        "test_compare_cpu_frexp_xpu_float16",
+        "test_compare_cpu_frexp_xpu_float32",
+        "test_compare_cpu_frexp_xpu_float64",
     ),
 }


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/3805.

frexp(+-inf/nan) exponent is unspecified by the C standard: https://en.cppreference.com/cpp/numeric/math/frexp; MSVC (torch_cpu on windows) returns -1, Clang/DPC++ (torch_xpu device & torch_cpu on linux) returns 0. Due to this those tests should be skipped on windows as they touch undefined behavior.