### PR TITLE
Add EU utilization triage skill

### DIFF
--- a/.claude/skills/eu-utilization-triage/SKILL.md
+++ b/.claude/skills/eu-utilization-triage/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: eu-utilization-triage
+description: Lightweight entry workflow for Xe2 EU efficiency triage. Use when asked whether an XPU kernel is EU-bound, where EU time is going, how to interpret stall/single-pipe/co-issue, or which focused EU analysis skill to run next.
+---
+
+# EU Utilization Triage
+
+Use one cheap counter pass to classify where loaded EU time goes and route to the right focused workflow.
+
+This skill is an entry point. It does not replace source-code roofline analysis. Use `kernel-perf-analysis` first when you still need to decide whether the kernel is memory-hierarchy, compute-pipe, or cache-traffic limited.
+
+## When to Use
+
+Use this skill when:
+- A target XPU kernel is already identified.
+- You have or can collect `ComputeBasic` counters.
+- The question is whether EU time is dominated by stall, single-pipe execution, low co-issue, or low occupancy.
+- You need to choose between stall attribution, ILP/co-issue analysis, and TLP/occupancy analysis.
+
+Do not use this as the first step for broad workload triage, multi-kernel analysis, or roofline memory-hierarchy closure.
+
+## Inputs
+
+| Input | Meaning |
+|---|---|
+| `repro-cmd` | Command that launches the target kernel |
+| `kernel-filter` | Optional substring/regex for the target kernel |
+| `ComputeBasic` counters | At minimum `XVE_STALL`, `XVE_ACTIVE`, `XVE_MULTIPLE_PIPE_ACTIVE`, `XVE_THREADS_OCCUPANCY_ALL` |
+
+## Workflow
+
+### Step 1: Collect the Three-State Portrait
+
+Collect `ComputeBasic` for the target kernel and compute:
+
+| State | Meaning | XPU counter basis |
+|---|---|---|
+| S0 stall | Loaded EU cycles that are stalled | `XVE_STALL` |
+| S1 single-pipe | Active cycles without co-issue | `XVE_ACTIVE - XVE_MULTIPLE_PIPE_ACTIVE` |
+| S2 co-issue | Multiple pipes active in the same cycle | `XVE_MULTIPLE_PIPE_ACTIVE` |
+
+Also record `XVE_THREADS_OCCUPANCY_ALL`.
+
+### Step 2: Check Occupancy First
+
+If `XVE_THREADS_OCCUPANCY_ALL` is critically low, route to `eu-tlp-occupancy` before interpreting S0/S1/S2 too aggressively. Low occupancy means many EUs have too few loaded threads, so optimizing ILP or stall on the few active threads may have poor whole-device impact.
+
+### Step 3: Compute Efficiency
+
+Use the two-factor view:
+
+```text
+efficiency = (1 - stall_fraction) * coissue / (single_pipe + coissue)
+```
+
+Keep both factors visible:
+- `(1 - stall_fraction)` says whether S0 is the main loss.
+- `coissue / (single_pipe + coissue)` says whether active cycles mostly co-issue or stay single-pipe.
+
+### Step 4: Route
+
+| Observation | Route |
+|---|---|
+| Stall high, typically about 30% or higher | `eu-stall-attribution` |
+| Stall low but co-issue share low | `eu-ilp-coissue` |
+| Occupancy low or moderate and stall appears candidate-starved | `eu-tlp-occupancy` |
+| Stall low, co-issue healthy, occupancy healthy | Stop; EU utilization is not the main issue |
+
+### Step 5: Emit Triage Card
+
+```markdown
+## EU Utilization Triage
+
+### Target
+- kernel:
+- repro:
+
+### Three-State Portrait
+| Metric | Value |
+|---|---:|
+| S0 stall | |
+| S1 single-pipe | |
+| S2 co-issue | |
+| occupancy | |
+| efficiency | |
+
+### Route
+- routed workflow:
+- reason:
+- evidence needed next:
+```
+
+## Pitfalls
+
+- Do not route to ILP just because co-issue is low if stall is dominant.
+- Do not route to TLP when stall is clearly Stage-2 resource contention; more threads may worsen resource pressure.
+- Do not add S0/S1/S2 to idle time. The portrait is for loaded EU cycles.
+- Do not use this skill to explain exact stall cause; use `eu-stall-attribution` with stall reason and ASM evidence.
+
+Custom skills applied: eu-utilization-triage.

--- a/.claude/skills/eu-utilization-triage/SKILL.md
+++ b/.claude/skills/eu-utilization-triage/SKILL.md
@@ -17,8 +17,6 @@ Use this skill when:
 - The question is whether EU time is dominated by stall, single-pipe execution, low co-issue, or low occupancy.
 - You need to choose between stall attribution, ILP/co-issue analysis, and TLP/occupancy analysis.
 
-Do not use this as the first step for broad workload triage, multi-kernel analysis, or roofline memory-hierarchy closure.
-
 ## Inputs
 
 | Input | Meaning |

--- a/.claude/skills/eu-utilization-triage/SKILL.md
+++ b/.claude/skills/eu-utilization-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: eu-utilization-triage
-description: Lightweight entry workflow for Xe2 EU efficiency triage. Use when asked whether an XPU kernel is EU-bound, where EU time is going, how to interpret stall/single-pipe/co-issue, or which focused EU analysis skill to run next.
+description: Lightweight entry workflow for EU efficiency triage. Use when asked whether an XPU kernel is EU-bound, where EU time is going, how to interpret stall/single-pipe/co-issue, or which focused EU analysis skill to run next.
 ---
 
 # EU Utilization Triage


### PR DESCRIPTION
## Summary
Adds `.claude/skills/eu-utilization-triage/SKILL.md`, a lightweight router workflow for Intel GPU/XPU EU efficiency triage.

The skill uses one `ComputeBasic` pass for a target kernel to build a loaded-EU three-state portrait, compute a compact efficiency score, and route to the focused follow-up workflow only when needed.

## Workflow
```mermaid
flowchart TD
    A["Input: repro-cmd + optional kernel-filter"] --> B["Step 1: Collect or read ComputeBasic counters"]
    B --> C["Build loaded-EU three-state portrait"]
    C --> C0["S0: stall = XVE_STALL"]
    C --> C1["S1: single-pipe active = XVE_ACTIVE - XVE_MULTIPLE_PIPE_ACTIVE"]
    C --> C2["S2: co-issue = XVE_MULTIPLE_PIPE_ACTIVE"]
    O["Record XVE_THREADS_OCCUPANCY_ALL"] --> P{"Step 2: Occupancy pre-check"}
    C --> O
    P -->|"XVE_THREADS_OCCUPANCY_ALL < 50%"| TLP["route -> eu-tlp-occupancy"]
    P -->|"enough loaded EU context"| E["Step 3: Compute efficiency"]
    E --> F["efficiency = (1 - stall_fraction) * coissue / (single_pipe + coissue)"]
    F --> R{"Step 4: Route by dominant deficit"}
    R -->|"stall high"| STALL["route -> eu-stall-attribution"]
    R -->|"stall low + co-issue share low"| ILP["route -> eu-ilp-coissue"]
    R -->|"candidate-starved + low/moderate occupancy"| TLP
    R -->|"stall low + co-issue healthy + occupancy healthy"| STOP["stop: EU utilization is not the main issue"]
    STALL --> CARD["Step 5: Emit triage card"]
    ILP --> CARD
    TLP --> CARD
    STOP --> CARD
```

## Three-State Model

| State | Meaning | Counter basis |
|---|---|---|
| S0 stall | Loaded EU cycles where no pipe is active | `XVE_STALL` |
| S1 single-pipe active | Active cycles without co-issue | `XVE_ACTIVE - XVE_MULTIPLE_PIPE_ACTIVE` |
| S2 co-issue | Cycles where multiple pipes are active | `XVE_MULTIPLE_PIPE_ACTIVE` |

The S0/S1/S2 portrait is for loaded EU cycles. Do not add it to idle time. Occupancy is checked separately with `XVE_THREADS_OCCUPANCY_ALL`. Low occupancy below 50% (occupancy < 50%) means S0/S1/S2 only describe the few loaded EUs, so route to `eu-tlp-occupancy` first.

## Routing Rules

| Observation | Route |
|---|---|
| XVE_THREADS_OCCUPANCY_ALL < 50% | `eu-tlp-occupancy` |
| Stall is high | `eu-stall-attribution` |
| Stall is low but co-issue share is low | `eu-ilp-coissue` |
| Occupancy is low/moderate and the stall appears candidate-starved | `eu-tlp-occupancy` |
| Stall is low, co-issue is healthy, and occupancy is healthy | Stop; EU utilization is not the main issue |

## Output

The workflow emits a triage card containing:

- target kernel and repro command
- S0/S1/S2 three-state portrait
- occupancy
- efficiency score
- routed workflow and reason
- evidence needed next

## Notes

- This is a router, not the full attribution workflow.
- It does not replace source-code based roofline analysis; use `kernel-perf-analysis` first when the bottleneck class is unknown.
- It should not explain exact stall cause. Route high-stall cases to `eu-stall-attribution`, which uses per-IP stall sampling and ASM/source mapping.
- It should not route to ILP just because co-issue is low if stall is dominant.
- It should not route Stage-2 resource contention to TLP; more resident threads can worsen resource pressure.

## Validation

- Markdown diagnostics passed.
- PR contents are limited to `.claude/skills/eu-utilization-triage/SKILL.md`.
