### PR TITLE
Add EU TLP occupancy skill

### DIFF
--- a/.claude/skills/eu-tlp-occupancy/SKILL.md
+++ b/.claude/skills/eu-tlp-occupancy/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: eu-tlp-occupancy
+description: Decide whether more Xe2 thread-level parallelism will help one XPU target kernel. Use when occupancy is low or moderate, Stage-1 stalls suggest candidate starvation, or a proposed work-group/vectorization change may trade occupancy against register pressure and Stage-2 contention.
+---
+
+# EU TLP and Occupancy Analysis
+
+Decide whether increasing thread-level parallelism can improve a target XPU kernel, and identify when it would instead worsen resource contention.
+
+This skill answers one question: will more resident work hide latency, or will it add pressure to already-contended pipes, SENDs, GRF, SLM, or memory hierarchy?
+
+## When to Use
+
+Use this skill when:
+- `XVE_THREADS_OCCUPANCY_ALL` is low or moderate.
+- `eu-utilization-triage` routes to occupancy/TLP.
+- `eu-stall-attribution` identifies Stage-1 candidate starvation.
+- A kernel tuning proposal changes work-group size, SIMD width, tile shape, unroll, vector width, or register pressure.
+- You need to decide whether adding threads is likely to help before editing code.
+
+Do not use this skill as a generic fix for high stall. If the dominant stall is Stage-2 Pipe or Send contention, more TLP can make the bottleneck worse.
+
+## Inputs
+
+| Input | Meaning |
+|---|---|
+| `repro-cmd` | Command that launches the target kernel |
+| `kernel-filter` | Target kernel filter |
+| `ComputeBasic` counters | Occupancy, S0/S1/S2, per-pipe utilization |
+| Stall attribution | Stage-1 vs Stage-2 classification when available |
+| Kernel config | Work-group size, SIMD width, tile shape, local memory use, vectorization |
+| ASM summary | GRF pressure, spills, long dependency chains, SEND density when available |
+
+## Workflow
+
+### Step 1: Record Current Occupancy and EU State
+
+Collect or reuse:
+- `XVE_THREADS_OCCUPANCY_ALL`
+- `XVE_STALL`
+- `XVE_ACTIVE`
+- `XVE_MULTIPLE_PIPE_ACTIVE`
+- Per-pipe ALU utilization
+- SEND or memory pressure counters when available
+
+Emit the current portrait:
+
+| Metric | Value |
+|---|---:|
+| occupancy | |
+| S0 stall | |
+| S1 single-pipe | |
+| S2 co-issue | |
+| dominant stall class | |
+
+### Step 2: Classify the Occupancy Regime
+
+Use platform-specific thresholds when available. Otherwise use qualitative buckets:
+
+| Regime | Meaning |
+|---|---|
+| Low occupancy | Many EUs have too few resident threads; TLP may hide latency |
+| Moderate occupancy | TLP may help if stalls are Stage-1 and resource pressure is not high |
+| High occupancy | More threads are unlikely to help; focus on ILP, memory, or algorithmic changes |
+
+### Step 3: Classify Stalls by Stage
+
+Use `eu-stall-attribution` output when available.
+
+| Stall stage | TLP implication |
+|---|---|
+| Stage-1 candidate starvation | More resident independent work may help |
+| Stage-2 Pipe contention | More resident work may worsen pipe contention |
+| Stage-2 Send contention | More resident work may worsen memory/SEND contention |
+| Sync or Control | More resident work may not fix the root cause |
+
+If stall stage is unknown, do not recommend a TLP change as final. First collect stall reason or per-IP evidence.
+
+### Step 4: Evaluate Candidate TLP Levers
+
+Common XPU levers:
+
+| Lever | Expected occupancy effect | Risk |
+|---|---|---|
+| Reduce per-thread registers | Higher resident threads | More instructions or recomputation |
+| Reduce unroll or tile size | Higher occupancy | Lower locality or more loop overhead |
+| Change work-group size | More scheduling candidates | Worse locality or synchronization |
+| Change SIMD/vector width | Different thread count and memory shape | Coalescing or instruction mix changes |
+| Reduce SLM usage | More resident work-groups | More global/L3 traffic |
+
+Always pair a TLP lever with a risk check: GRF spills, SLM pressure, SEND pressure, memory hierarchy bytes, and co-issue.
+
+### Step 5: Decide
+
+Produce one of these verdicts:
+
+| Verdict | Meaning |
+|---|---|
+| `add-threads-helps` | Occupancy is low/moderate, stalls are Stage-1, and resource pressure is not already saturated |
+| `occupancy-saturated` | Occupancy is already high enough; extra threads are unlikely to move time |
+| `tlp-would-worsen-stage2` | Dominant issue is Pipe/Send contention; more threads likely increase contention |
+| `need-stall-attribution-first` | Occupancy is suspicious but stall stage is unknown |
+
+### Step 6: Emit TLP Card
+
+```markdown
+## TLP / Occupancy Analysis: <kernel>
+
+### Current State
+| Metric | Value | Interpretation |
+|---|---:|---|
+| occupancy | | |
+| S0 stall | | |
+| S1 single-pipe | | |
+| S2 co-issue | | |
+| dominant stall stage | | |
+
+### Candidate Change
+- lever:
+- expected occupancy movement:
+- expected risk:
+
+### Verdict
+- verdict:
+- why:
+- validation counters:
+```
+
+### Step 7: Validate a TLP Change
+
+After applying a candidate change:
+- Compare kernel time.
+- Re-collect `ComputeBasic`.
+- Confirm occupancy moved in the expected direction.
+- Confirm Stage-1 stalls decreased if the verdict was `add-threads-helps`.
+- Confirm Stage-2 Pipe/Send did not rise enough to erase the gain.
+- Check memory hierarchy counters and ASM/GRF spill if register pressure changed.
+
+## Pitfalls
+
+- More threads hide latency only when the main loss is lack of ready candidates.
+- More TLP can convert Stage-1 distance bubbles into Stage-2 pipe or SEND contention.
+- Occupancy alone is not a performance metric; it must be interpreted with stall stage and instruction mix.
+- Reducing tile size to improve occupancy can hurt locality or increase global traffic.
+
+Custom skills applied: eu-tlp-occupancy.

--- a/.claude/skills/eu-tlp-occupancy/SKILL.md
+++ b/.claude/skills/eu-tlp-occupancy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: eu-tlp-occupancy
-description: Decide whether more Xe2 thread-level parallelism will help one XPU target kernel. Use when occupancy is low or moderate, Stage-1 stalls suggest candidate starvation, or a proposed work-group/vectorization change may trade occupancy against register pressure and Stage-2 contention.
+description: Decide whether more Intel GPU thread-level parallelism will help one XPU target kernel. Use when occupancy is low or moderate, Stage-1 stalls suggest candidate starvation, or a proposed work-group/vectorization change may trade occupancy against register pressure and Stage-2 contention.
 ---
 
 # EU TLP and Occupancy Analysis
@@ -67,12 +67,14 @@ Use platform-specific thresholds when available. Otherwise use qualitative bucke
 
 Use `eu-stall-attribution` output when available.
 
-| Stall stage | TLP implication |
-|---|---|
-| Stage-1 candidate starvation | More resident independent work may help |
-| Stage-2 Pipe contention | More resident work may worsen pipe contention |
-| Stage-2 Send contention | More resident work may worsen memory/SEND contention |
-| Sync or Control | More resident work may not fix the root cause |
+Use the same two-stage model as stall attribution:
+
+| Stall stage | Where the stall happens | TLP implication |
+|---|---|---|
+| Stage-1 candidate starvation | Before issue selection; the scheduler lacks ready instructions because dependencies, control flow, synchronization, or instruction fetch prevent candidates from becoming issue-ready | More resident independent work may help the scheduler find a ready instruction |
+| Stage-2 Pipe contention | During issue to an execution pipe; ready candidates exist but the target pipe is busy | More resident work may worsen pipe contention |
+| Stage-2 Send contention | During issue to the SEND path; ready candidates exist but the SEND path is busy | More resident work may worsen SEND issue or transaction pressure |
+| Sync or Control | Candidate availability is blocked by synchronization or control flow | More resident work may not fix the root cause; prefer algorithm or synchronization restructuring |
 
 If stall stage is unknown, do not recommend a TLP change as final. First collect stall reason or per-IP evidence.
 
@@ -97,9 +99,11 @@ Produce one of these verdicts:
 | Verdict | Meaning |
 |---|---|
 | `add-threads-helps` | Occupancy is low/moderate, stalls are Stage-1, and resource pressure is not already saturated |
-| `occupancy-saturated` | Occupancy is already high enough; extra threads are unlikely to move time |
+| `occupancy-saturated` | Occupancy is already near the platform's resident-thread limit or additional residency is blocked by registers/SLM/workgroup resources; extra threads are unlikely to move time |
 | `tlp-would-worsen-stage2` | Dominant issue is Pipe/Send contention; more threads likely increase contention |
 | `need-stall-attribution-first` | Occupancy is suspicious but stall stage is unknown |
+
+Use platform-specific maximum resident-thread limits when they are known. Otherwise, report occupancy as low/moderate/high qualitatively and avoid claiming saturation from `XVE_THREADS_OCCUPANCY_ALL` alone.
 
 ### Step 6: Emit TLP Card
 
@@ -129,11 +133,11 @@ Produce one of these verdicts:
 ### Step 7: Validate a TLP Change
 
 After applying a candidate change:
-- Compare kernel time.
+- Compare kernel time; this is the primary success criterion.
 - Re-collect `ComputeBasic`.
 - Confirm occupancy moved in the expected direction.
 - Confirm Stage-1 stalls decreased if the verdict was `add-threads-helps`.
-- Confirm Stage-2 Pipe/Send did not rise enough to erase the gain.
+- Check whether Stage-2 Pipe/Send rose. Some Stage-2 increase can be acceptable if kernel time improves, because useful work may have replaced Stage-1 idle distance bubbles; treat it as a problem only when throughput does not improve or a new Stage-2 bottleneck dominates.
 - Check memory hierarchy counters and ASM/GRF spill if register pressure changed.
 
 ## Pitfalls


### PR DESCRIPTION
## Summary
Adds `.claude/skills/eu-tlp-occupancy/SKILL.md`, a focused workflow for deciding whether more Intel GPU/XPU thread-level parallelism is likely to improve one target kernel.

This skill is used when occupancy is low or moderate, when `eu-stall-attribution` points to Stage-1 candidate starvation, or when a proposed tuning change may trade occupancy against GRF, SLM, pipe, or SEND pressure.

## Workflow
```mermaid
flowchart TD
    A["Input: repro-cmd + kernel-filter + counters/config"] --> B["Step 1: record occupancy + EU state"]
    B --> C["Read XVE_THREADS_OCCUPANCY_ALL, S0/S1/S2, per-pipe utilization"]
    C --> D["Step 2: classify occupancy regime"]
    D --> E["Step 3: classify Stage-1 vs Stage-2"]
    E -->|"Stage-1 candidate starvation"| H["TLP may help if occupancy is not saturated"]
    E -->|"Stage-2 Pipe contention"| P["More TLP may worsen pipe contention"]
    E -->|"Stage-2 Send contention"| S["More TLP may worsen SEND issue/transaction pressure"]
    E -->|"Unknown stage"| U["Collect stall attribution first"]
    H --> L["Step 4: evaluate TLP levers"]
    P --> V1["Verdict: tlp-would-worsen-stage2"]
    S --> V1
    U --> V2["Verdict: need-stall-attribution-first"]
    L --> F{"Step 5: decide"}
    F -->|"low/moderate occupancy + Stage-1 + pressure not saturated"| A1["add-threads-helps"]
    F -->|"near platform resident-thread limit"| A2["occupancy-saturated"]
    F -->|"resource pressure already dominant"| A3["tlp-would-worsen-stage2"]
    A1 --> CARD["Step 6: emit TLP card"]
    A2 --> CARD
    A3 --> CARD
    V1 --> CARD
    V2 --> CARD
    CARD --> VAL["Step 7: validate with kernel time first, then counters"]
```

## Stage Model

The skill follows the same stage language as `eu-stall-attribution`:

| Stall stage | Where the stall happens | TLP implication |
|---|---|---|
| Stage-1 candidate starvation | Before issue selection; the scheduler lacks ready instructions because dependencies, control flow, synchronization, or instruction fetch prevent candidates from becoming issue-ready | More resident independent work may help the scheduler find a ready instruction |
| Stage-2 Pipe contention | During issue to an execution pipe; ready candidates exist but the target pipe is busy | More resident work may worsen pipe contention |
| Stage-2 Send contention | During issue to the SEND path; ready candidates exist but the SEND path is busy | More resident work may worsen SEND issue or transaction pressure |
| Sync or Control | Candidate availability is blocked by synchronization or control flow | More resident work may not fix the root cause; prefer algorithm or synchronization restructuring |

## TLP Levers

| Lever | Expected occupancy effect | Risk |
|---|---|---|
| Reduce per-thread registers | Higher resident threads | More instructions or recomputation |
| Reduce unroll or tile size | Higher occupancy | Lower locality or more loop overhead |
| Change work-group size | More scheduling candidates | Worse locality or synchronization |
| Change SIMD/vector width | Different thread count and memory shape | Coalescing or instruction mix changes |
| Reduce SLM usage | More resident work-groups | More global/L3 traffic |

## Evidence Rules

- Do not use occupancy alone as a performance conclusion.
- Use platform-specific resident-thread limits when known; otherwise report low/moderate/high qualitatively.
- If stall stage is unknown, do not issue a final TLP recommendation; collect per-IP stall or attribution evidence first.
- More TLP helps only when the main loss is lack of ready candidates.
- More TLP can convert Stage-1 distance bubbles into Stage-2 pipe or SEND contention.
- Data locality/faster-memory-layer work belongs to Stage-1/SBID latency reduction, not to Stage-2 pipe/SEND contention fixes.

## Validation

Kernel time is the primary success criterion. After a candidate change:
- compare target kernel time
- re-collect `ComputeBasic`
- confirm occupancy moved in the expected direction
- confirm Stage-1 stalls decreased when the verdict was `add-threads-helps`
- allow some Stage-2 increase only if kernel time improves and no new Stage-2 bottleneck dominates
- check memory hierarchy counters and ASM/GRF spill if register pressure changed

## Outputs

The workflow emits a TLP card containing:
- current occupancy and S0/S1/S2 portrait
- dominant stall stage
- candidate TLP lever
- expected occupancy movement and risk
- verdict
- validation counters and command

## Validation Status

- Markdown diagnostics passed.
- PR contents are limited to `.claude/skills/eu-tlp-occupancy/SKILL.md`.
