### PR TITLE
Fix read/write races in topk single-workgroup kernel

### DIFF
--- a/src/ATen/native/xpu/sycl/TensorTopKSingleWgKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorTopKSingleWgKernel.cpp
@@ -164,6 +164,8 @@ struct SbtopkGatherFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
     for (int j = 0; j < SBTOPK_RADIX_SIZE; ++j) {
       counts[j] = smem[j];
     }
+    // WAR barrier: next radix pass re-zeros smem.
+    sycl::group_barrier(item.get_group());
   }
 
   // ================================================================
@@ -270,6 +272,8 @@ struct SbtopkGatherFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
     int cross_sg_prefix = (sg_id >= 1) ? static_cast<int>(smem[sg_id - 1]) : 0;
     out = sg_exclusive + cross_sg_prefix;
     carry = static_cast<int>(smem[num_sgs - 1]);
+    // WAR barrier: caller reuses smem next iteration.
+    sycl::group_barrier(item.get_group());
   }
 
   // ================================================================


### PR DESCRIPTION
TensorTopKSingleWgKernel.cpp reads `smem` then the next radix pass re-zeros it
(or callers reuse it) without a `group_barrier` — a read/write data race that can
give torn reads and wrong topk results. Add WAR barriers (matches upstream CUDA
`TensorTopK.cu`, which has `__syncthreads` at these points).

Test: none (not yet built/run on hardware; matched to upstream CUDA)
