### PR TITLE
Port stateless Philox RNG ops to XPU

### DIFF
--- a/src/ATen/native/xpu/PhiloxDistribution.cpp
+++ b/src/ATen/native/xpu/PhiloxDistribution.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Dispatch layer for stateless Philox distribution operations.
+// Ported from CUDA: aten/src/ATen/native/cuda/PhiloxDistribution.cu
+// See PyTorch PR #177230.
+
+#include <ATen/core/Tensor.h>
+#include <ATen/native/xpu/sycl/PhiloxDistributionKernels.h>
+
+namespace at::native {
+
+Tensor& _philox_uniform_xpu_(
+    Tensor& self,
+    const Tensor& key,
+    double low,
+    double high) {
+  return xpu::_philox_uniform_xpu_(self, key, low, high);
+}
+
+Tensor& _philox_normal_xpu_(
+    Tensor& self,
+    const Tensor& key,
+    double mean,
+    double stddev) {
+  return xpu::_philox_normal_xpu_(self, key, mean, stddev);
+}
+
+} // namespace at::native

--- a/src/ATen/native/xpu/PhiloxKeySplit.cpp
+++ b/src/ATen/native/xpu/PhiloxKeySplit.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Dispatch layer for stateless Philox key operations.
+// Ported from CUDA: aten/src/ATen/native/cuda/PhiloxKeySplit.cu
+// See PyTorch PR #177229.
+
+#include <ATen/core/Tensor.h>
+#include <ATen/native/xpu/sycl/PhiloxKeySplitKernels.h>
+
+namespace at::native {
+
+Tensor _philox_key_split_xpu(const Tensor& key, int64_t num_splits) {
+  return xpu::_philox_key_split_xpu(key, num_splits);
+}
+
+Tensor _philox_key_fold_in_xpu(const Tensor& key, int64_t data) {
+  return xpu::_philox_key_fold_in_xpu(key, data);
+}
+
+} // namespace at::native

--- a/src/ATen/native/xpu/sycl/PhiloxDistributionKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PhiloxDistributionKernels.cpp
@@ -16,6 +16,7 @@
 #include <ATen/ExpandUtils.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/core/TransformationHelper.h>
+#include <ATen/native/xpu/sycl/MemoryAccess.h>
 #include <ATen/native/xpu/sycl/PhiloxDistributionKernels.h>
 #include <ATen/native/xpu/sycl/StatelessPhilox4x32.h>
 #include <comm/SYCLContext.h>
@@ -110,12 +111,17 @@ inline double2 box_muller_double(philox_uint4 r) {
 template <typename scalar_t, bool is_uniform>
 struct PhiloxSingleKeyFunctor {
   void operator()(sycl::nd_item<1> item) const {
+    auto key_vec = memory::ld_vec<16>(key_);
+    auto* key_vals = reinterpret_cast<const uint64_t*>(&key_vec);
+    uint64_t seed = key_vals[0];
+    uint64_t offset = key_vals[1];
+
     int64_t chunk = static_cast<int64_t>(item.get_global_id(0));
     constexpr int epc = elems_per_call<scalar_t>;
     int64_t num_full_chunks = num_elems_ / epc;
 
     if (chunk < num_full_chunks) {
-      auto r = philox_4x32(seed_, offset_ + static_cast<uint64_t>(chunk));
+      auto r = philox_4x32(seed, offset + static_cast<uint64_t>(chunk));
       int64_t base = chunk * epc;
       write_values(r, base, epc);
     }
@@ -125,8 +131,8 @@ struct PhiloxSingleKeyFunctor {
       int64_t tail_start = num_full_chunks * epc;
       int remaining = static_cast<int>(num_elems_ - tail_start);
       if (remaining > 0) {
-        auto r = philox_4x32(
-            seed_, offset_ + static_cast<uint64_t>(num_full_chunks));
+        auto r =
+            philox_4x32(seed, offset + static_cast<uint64_t>(num_full_chunks));
         write_values(r, tail_start, remaining);
       }
     }
@@ -134,14 +140,12 @@ struct PhiloxSingleKeyFunctor {
 
   PhiloxSingleKeyFunctor(
       scalar_t* output,
-      uint64_t seed,
-      uint64_t offset,
+      const uint64_t* key,
       int64_t num_elems,
       scalar_t param0,
       scalar_t param1)
       : output_(output),
-        seed_(seed),
-        offset_(offset),
+        key_(key),
         num_elems_(num_elems),
         param0_(param0),
         param1_(param1) {}
@@ -209,8 +213,7 @@ struct PhiloxSingleKeyFunctor {
   }
 
   scalar_t* output_;
-  uint64_t seed_;
-  uint64_t offset_;
+  const uint64_t* key_;
   int64_t num_elems_;
   scalar_t param0_; // low or mean
   scalar_t param1_; // high or stddev
@@ -218,13 +221,10 @@ struct PhiloxSingleKeyFunctor {
 
 // ─── Distribution dispatch ───────────────────────────────────────
 
-template <bool is_uniform>
-void philox_distribution_kernel(
+void philox_distribution_validate(
     const char* op_name,
-    Tensor& self,
-    const Tensor& key,
-    double param0,
-    double param1) {
+    const Tensor& self,
+    const Tensor& key) {
   TORCH_CHECK(
       self.is_floating_point(),
       op_name,
@@ -289,11 +289,6 @@ void philox_distribution_launch(
   auto output = self.contiguous();
   auto key_contig = key.contiguous();
 
-  // Key is on device — copy to host to read seed/offset.
-  auto key_cpu = key_contig.cpu();
-  uint64_t seed = key_cpu.data_ptr<uint64_t>()[0];
-  uint64_t offset = key_cpu.data_ptr<uint64_t>()[1];
-
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf,
       kBFloat16,
@@ -308,8 +303,7 @@ void philox_distribution_launch(
 
         auto functor = PhiloxSingleKeyFunctor<scalar_t, is_uniform>(
             output.mutable_data_ptr<scalar_t>(),
-            seed,
-            offset,
+            key_contig.const_data_ptr<uint64_t>(),
             self.numel(),
             static_cast<scalar_t>(param0),
             static_cast<scalar_t>(param1));
@@ -331,8 +325,7 @@ Tensor& _philox_uniform_xpu_(
     const Tensor& key,
     double low,
     double high) {
-  philox_distribution_kernel</*is_uniform=*/true>(
-      "_philox_uniform_", self, key, low, high);
+  philox_distribution_validate("_philox_uniform_", self, key);
   if (self.numel() > 0) {
     philox_distribution_launch</*is_uniform=*/true>(self, key, low, high);
   }
@@ -344,8 +337,7 @@ Tensor& _philox_normal_xpu_(
     const Tensor& key,
     double mean,
     double stddev) {
-  philox_distribution_kernel</*is_uniform=*/false>(
-      "_philox_normal_", self, key, mean, stddev);
+  philox_distribution_validate("_philox_normal_", self, key);
   if (self.numel() > 0) {
     philox_distribution_launch</*is_uniform=*/false>(self, key, mean, stddev);
   }

--- a/src/ATen/native/xpu/sycl/PhiloxDistributionKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PhiloxDistributionKernels.cpp
@@ -297,9 +297,9 @@ void philox_distribution_launch(
       [&] {
         constexpr int epc = elems_per_call<scalar_t>;
         int64_t num_chunks = (self.numel() + epc - 1) / epc;
-        constexpr int block_size = 256;
-        int num_blocks =
-            static_cast<int>((num_chunks + block_size - 1) / block_size);
+        constexpr int work_group_size = 256;
+        int work_group_num = static_cast<int>(
+            (num_chunks + work_group_size - 1) / work_group_size);
 
         auto functor = PhiloxSingleKeyFunctor<scalar_t, is_uniform>(
             output.mutable_data_ptr<scalar_t>(),
@@ -309,8 +309,8 @@ void philox_distribution_launch(
             static_cast<scalar_t>(param1));
 
         sycl_kernel_submit(
-            sycl::range<1>(num_blocks * block_size),
-            sycl::range<1>(block_size),
+            sycl::range<1>(work_group_num * work_group_size),
+            sycl::range<1>(work_group_size),
             at::xpu::getCurrentSYCLQueue(),
             functor);
 

--- a/src/ATen/native/xpu/sycl/PhiloxDistributionKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PhiloxDistributionKernels.cpp
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// SYCL kernels for _philox_uniform_ and _philox_normal_.
+// Ported from CUDA: aten/src/ATen/native/cuda/PhiloxDistribution.cu
+// See PyTorch PR #177230.
+
+#include <ATen/Dispatch.h>
+#include <ATen/ExpandUtils.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/core/TransformationHelper.h>
+#include <ATen/native/xpu/sycl/PhiloxDistributionKernels.h>
+#include <ATen/native/xpu/sycl/StatelessPhilox4x32.h>
+#include <comm/SYCLContext.h>
+
+#include <type_traits>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/_philox_normal_native.h>
+#include <ATen/ops/_philox_uniform_native.h>
+#endif
+
+namespace at::native::xpu {
+
+// Elements produced per Philox 4x32 call:
+// 4 for float/half/bfloat16, 2 for double.
+template <typename scalar_t>
+constexpr int elems_per_call = std::is_same_v<scalar_t, double> ? 2 : 4;
+
+// ─── Uniform transforms ─────────────────────────────────────────
+
+// uint32 → float uniform in [0, 1)
+inline float uint32_to_uniform_float(uint32_t val) {
+  constexpr uint32_t MASK = static_cast<uint32_t>(
+      (static_cast<uint64_t>(1) << std::numeric_limits<float>::digits) - 1);
+  constexpr float DIVISOR = static_cast<float>(1.0) /
+      static_cast<float>(static_cast<uint32_t>(1)
+                         << std::numeric_limits<float>::digits);
+  return static_cast<float>(val & MASK) * DIVISOR;
+}
+
+// uint64 → double uniform in [0, 1)
+inline double uint64_to_uniform_double(uint64_t val) {
+  constexpr uint64_t MASK =
+      (static_cast<uint64_t>(1) << std::numeric_limits<double>::digits) - 1;
+  constexpr double DIVISOR = 1.0 /
+      static_cast<double>(static_cast<uint64_t>(1)
+                          << std::numeric_limits<double>::digits);
+  return static_cast<double>(val & MASK) * DIVISOR;
+}
+
+// ─── Box-Muller normal transforms ────────────────────────────────
+
+struct float4 {
+  float x, y, z, w;
+};
+struct double2 {
+  double x, y;
+};
+
+// Box-Muller: 4 uint32 → 4 standard normal floats
+inline float4 box_muller_float(philox_uint4 r) {
+  constexpr float M = 2.3283064365386963e-10f; // 1/2^32
+  constexpr float TWO_PI = 6.2831853071795864f;
+  float u1 = sycl::fma(static_cast<float>(r.x), M, M * 0.5f);
+  float u2 = sycl::fma(static_cast<float>(r.y), M, M * 0.5f);
+  float u3 = sycl::fma(static_cast<float>(r.z), M, M * 0.5f);
+  float u4 = sycl::fma(static_cast<float>(r.w), M, M * 0.5f);
+
+  float radius1 = sycl::sqrt(-2.0f * sycl::log(u1));
+  float radius2 = sycl::sqrt(-2.0f * sycl::log(u3));
+  float angle1 = TWO_PI * u2;
+  float angle2 = TWO_PI * u4;
+
+  return {
+      radius1 * sycl::cos(angle1),
+      radius1 * sycl::sin(angle1),
+      radius2 * sycl::cos(angle2),
+      radius2 * sycl::sin(angle2)};
+}
+
+// Box-Muller: 4 uint32 → 2 standard normal doubles
+inline double2 box_muller_double(philox_uint4 r) {
+  constexpr double M = 2.3283064365386963e-10; // 1/2^32
+  constexpr double TWO_PI = 6.2831853071795864;
+  double u1 = sycl::fma(
+      static_cast<double>(r.x),
+      M,
+      static_cast<double>(r.y) * M * M + M * M * 0.5);
+  double u2 = sycl::fma(
+      static_cast<double>(r.z),
+      M,
+      static_cast<double>(r.w) * M * M + M * M * 0.5);
+  double radius = sycl::sqrt(-2.0 * sycl::log(u1));
+  double angle = TWO_PI * u2;
+  return {radius * sycl::cos(angle), radius * sycl::sin(angle)};
+}
+
+// ─── Single-key kernel ───────────────────────────────────────────
+
+template <typename scalar_t, bool is_uniform>
+struct PhiloxSingleKeyFunctor {
+  void operator()(sycl::nd_item<1> item) const {
+    int64_t chunk = static_cast<int64_t>(item.get_global_id(0));
+    constexpr int epc = elems_per_call<scalar_t>;
+    int64_t num_full_chunks = num_elems_ / epc;
+
+    if (chunk < num_full_chunks) {
+      auto r = philox_4x32(seed_, offset_ + static_cast<uint64_t>(chunk));
+      int64_t base = chunk * epc;
+      write_values(r, base, epc);
+    }
+
+    // Tail
+    if (chunk == num_full_chunks) {
+      int64_t tail_start = num_full_chunks * epc;
+      int remaining = static_cast<int>(num_elems_ - tail_start);
+      if (remaining > 0) {
+        auto r = philox_4x32(
+            seed_, offset_ + static_cast<uint64_t>(num_full_chunks));
+        write_values(r, tail_start, remaining);
+      }
+    }
+  }
+
+  PhiloxSingleKeyFunctor(
+      scalar_t* output,
+      uint64_t seed,
+      uint64_t offset,
+      int64_t num_elems,
+      scalar_t param0,
+      scalar_t param1)
+      : output_(output),
+        seed_(seed),
+        offset_(offset),
+        num_elems_(num_elems),
+        param0_(param0),
+        param1_(param1) {}
+
+ private:
+  void write_values(philox_uint4 r, int64_t base, int count) const {
+    if constexpr (is_uniform) {
+      write_uniform(r, base, count);
+    } else {
+      write_normal(r, base, count);
+    }
+  }
+
+  void write_uniform(philox_uint4 r, int64_t base, int count) const {
+    if constexpr (std::is_same_v<scalar_t, double>) {
+      uint64_t packed[2] = {
+          (static_cast<uint64_t>(r.x) << 32) | r.y,
+          (static_cast<uint64_t>(r.z) << 32) | r.w};
+      for (int j = 0; j < count; j++) {
+        double x = uint64_to_uniform_double(packed[j]);
+        output_[base + j] = static_cast<scalar_t>(
+            x * (static_cast<double>(param1_) - static_cast<double>(param0_)) +
+            static_cast<double>(param0_));
+      }
+    } else {
+      uint32_t vals[4] = {r.x, r.y, r.z, r.w};
+      for (int j = 0; j < count; j++) {
+        float x = uint32_to_uniform_float(vals[j]);
+        float result_f =
+            x * (static_cast<float>(param1_) - static_cast<float>(param0_)) +
+            static_cast<float>(param0_);
+        scalar_t val = static_cast<scalar_t>(result_f);
+        // For half/bfloat16, rounding can push val to high; step back in
+        // the reduced-precision representation.
+        if constexpr (
+            std::is_same_v<scalar_t, c10::BFloat16> ||
+            std::is_same_v<scalar_t, c10::Half>) {
+          if (val >= param1_) {
+            val.x -= 1;
+          }
+        }
+        output_[base + j] = val;
+      }
+    }
+  }
+
+  void write_normal(philox_uint4 r, int64_t base, int count) const {
+    if constexpr (std::is_same_v<scalar_t, double>) {
+      auto normals = box_muller_double(r);
+      double vals[2] = {normals.x, normals.y};
+      for (int j = 0; j < count; j++) {
+        output_[base + j] = static_cast<scalar_t>(
+            vals[j] * static_cast<double>(param1_) +
+            static_cast<double>(param0_));
+      }
+    } else {
+      auto normals = box_muller_float(r);
+      float vals[4] = {normals.x, normals.y, normals.z, normals.w};
+      for (int j = 0; j < count; j++) {
+        output_[base + j] = static_cast<scalar_t>(
+            vals[j] * static_cast<float>(param1_) +
+            static_cast<float>(param0_));
+      }
+    }
+  }
+
+  scalar_t* output_;
+  uint64_t seed_;
+  uint64_t offset_;
+  int64_t num_elems_;
+  scalar_t param0_; // low or mean
+  scalar_t param1_; // high or stddev
+};
+
+// ─── Distribution dispatch ───────────────────────────────────────
+
+template <bool is_uniform>
+void philox_distribution_kernel(
+    const char* op_name,
+    Tensor& self,
+    const Tensor& key,
+    double param0,
+    double param1) {
+  TORCH_CHECK(
+      self.is_floating_point(),
+      op_name,
+      ": self must be a floating point tensor, got ",
+      self.scalar_type());
+  TORCH_CHECK(
+      key.scalar_type() == kUInt64,
+      op_name,
+      ": key must have dtype uint64, got ",
+      key.scalar_type());
+  TORCH_CHECK(
+      self.device() == key.device(),
+      op_name,
+      ": self and key must be on the same device, got ",
+      self.device(),
+      " and ",
+      key.device());
+  TORCH_CHECK(
+      key.dim() >= 1 && key.size(-1) == 2,
+      op_name,
+      ": key must have shape (2,) or (*batch, 2), got shape ",
+      key.sizes());
+
+  if (key.dim() > 1) {
+    TORCH_CHECK(
+        key.dim() == self.dim() + 1,
+        op_name,
+        ": batched key must have ndim == output ndim + 1, "
+        "got key shape ",
+        key.sizes(),
+        " with output shape ",
+        self.sizes());
+    auto key_batch = key.sizes().slice(0, self.dim());
+    TORCH_CHECK(
+        is_expandable_to(key_batch, self.sizes()),
+        op_name,
+        ": key batch shape ",
+        key_batch,
+        " is not broadcastable with output shape ",
+        self.sizes());
+  }
+
+  if (self.numel() == 0) {
+    return;
+  }
+
+  // For now, only single-key (non-batched) is implemented.
+  // Batched key support can be added following the CUDA multi-key pattern.
+  TORCH_CHECK(
+      key.dim() == 1,
+      op_name,
+      ": batched keys not yet supported on XPU, got key shape ",
+      key.sizes());
+}
+
+template <bool is_uniform>
+void philox_distribution_launch(
+    Tensor& self,
+    const Tensor& key,
+    double param0,
+    double param1) {
+  auto output = self.contiguous();
+  auto key_contig = key.contiguous();
+
+  // Key is on device — copy to host to read seed/offset.
+  auto key_cpu = key_contig.cpu();
+  uint64_t seed = key_cpu.data_ptr<uint64_t>()[0];
+  uint64_t offset = key_cpu.data_ptr<uint64_t>()[1];
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      kHalf,
+      kBFloat16,
+      self.scalar_type(),
+      is_uniform ? "_philox_uniform_" : "_philox_normal_",
+      [&] {
+        constexpr int epc = elems_per_call<scalar_t>;
+        int64_t num_chunks = (self.numel() + epc - 1) / epc;
+        constexpr int block_size = 256;
+        int num_blocks =
+            static_cast<int>((num_chunks + block_size - 1) / block_size);
+
+        auto functor = PhiloxSingleKeyFunctor<scalar_t, is_uniform>(
+            output.mutable_data_ptr<scalar_t>(),
+            seed,
+            offset,
+            self.numel(),
+            static_cast<scalar_t>(param0),
+            static_cast<scalar_t>(param1));
+
+        sycl_kernel_submit(
+            sycl::range<1>(num_blocks * block_size),
+            sycl::range<1>(block_size),
+            at::xpu::getCurrentSYCLQueue(),
+            functor);
+
+        if (output.data_ptr() != self.data_ptr()) {
+          self.copy_(output);
+        }
+      });
+}
+
+Tensor& _philox_uniform_xpu_(
+    Tensor& self,
+    const Tensor& key,
+    double low,
+    double high) {
+  philox_distribution_kernel</*is_uniform=*/true>(
+      "_philox_uniform_", self, key, low, high);
+  if (self.numel() > 0) {
+    philox_distribution_launch</*is_uniform=*/true>(self, key, low, high);
+  }
+  return self;
+}
+
+Tensor& _philox_normal_xpu_(
+    Tensor& self,
+    const Tensor& key,
+    double mean,
+    double stddev) {
+  philox_distribution_kernel</*is_uniform=*/false>(
+      "_philox_normal_", self, key, mean, stddev);
+  if (self.numel() > 0) {
+    philox_distribution_launch</*is_uniform=*/false>(self, key, mean, stddev);
+  }
+  return self;
+}
+
+} // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/PhiloxDistributionKernels.h
+++ b/src/ATen/native/xpu/sycl/PhiloxDistributionKernels.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#pragma once
+
+#include <ATen/core/Tensor.h>
+
+namespace at::native::xpu {
+
+TORCH_XPU_API Tensor& _philox_uniform_xpu_(
+    Tensor& self,
+    const Tensor& key,
+    double low,
+    double high);
+
+TORCH_XPU_API Tensor& _philox_normal_xpu_(
+    Tensor& self,
+    const Tensor& key,
+    double mean,
+    double stddev);
+
+} // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/PhiloxKeySplitKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PhiloxKeySplitKernels.cpp
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// SYCL kernels for _philox_key_split and _philox_key_fold_in.
+// Ported from CUDA: aten/src/ATen/native/cuda/PhiloxKeySplit.cu
+// See PyTorch PR #177229.
+
+#include <ATen/core/Tensor.h>
+#include <ATen/native/xpu/sycl/PhiloxKeySplitKernels.h>
+#include <ATen/native/xpu/sycl/StatelessPhilox4x32.h>
+#include <comm/SYCLContext.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/_philox_key_fold_in_native.h>
+#include <ATen/ops/_philox_key_split_native.h>
+#include <ATen/ops/empty.h>
+#include <ATen/ops/empty_like.h>
+#endif
+
+namespace at::native::xpu {
+
+struct PhiloxKeySplitFunctor {
+  void operator()(sycl::nd_item<1> item) const {
+    int64_t tid = static_cast<int64_t>(item.get_global_id(0));
+    if (tid >= total_)
+      return;
+    int64_t split_idx = tid / num_keys_;
+    int64_t key_idx = tid % num_keys_;
+
+    uint64_t seed = input_[key_idx * 2];
+    uint64_t offset = input_[key_idx * 2 + 1];
+
+    auto r = philox_4x32(seed, offset + static_cast<uint64_t>(split_idx));
+    int64_t out = (split_idx * num_keys_ + key_idx) * 2;
+    philox_derive_key(r, &output_[out], &output_[out + 1]);
+  }
+
+  PhiloxKeySplitFunctor(
+      const uint64_t* input,
+      uint64_t* output,
+      int64_t num_keys,
+      int64_t total)
+      : input_(input), output_(output), num_keys_(num_keys), total_(total) {}
+
+ private:
+  const uint64_t* input_;
+  uint64_t* output_;
+  int64_t num_keys_;
+  int64_t total_;
+};
+
+struct PhiloxKeyFoldInFunctor {
+  void operator()(sycl::nd_item<1> item) const {
+    int64_t idx = static_cast<int64_t>(item.get_global_id(0));
+    if (idx >= num_keys_)
+      return;
+
+    uint64_t seed = input_[idx * 2];
+    uint64_t offset = input_[idx * 2 + 1];
+
+    auto r = philox_4x32(seed, offset + static_cast<uint64_t>(data_));
+    philox_derive_key(r, &output_[idx * 2], &output_[idx * 2 + 1]);
+  }
+
+  PhiloxKeyFoldInFunctor(
+      const uint64_t* input,
+      uint64_t* output,
+      int64_t num_keys,
+      int64_t data)
+      : input_(input), output_(output), num_keys_(num_keys), data_(data) {}
+
+ private:
+  const uint64_t* input_;
+  uint64_t* output_;
+  int64_t num_keys_;
+  int64_t data_;
+};
+
+Tensor _philox_key_split_xpu(const Tensor& key, int64_t num_splits) {
+  TORCH_CHECK(
+      key.dim() >= 1 && key.size(-1) == 2,
+      "_philox_key_split: key must have shape (*batch, 2), got shape ",
+      key.sizes());
+  TORCH_CHECK(
+      key.scalar_type() == kUInt64,
+      "_philox_key_split: key must have dtype uint64, got ",
+      key.scalar_type());
+  TORCH_CHECK(
+      num_splits > 0,
+      "_philox_key_split: num_splits must be positive, got ",
+      num_splits);
+
+  // Output shape: (num_splits, *key.shape)
+  auto output_sizes = key.sizes().vec();
+  output_sizes.insert(output_sizes.begin(), num_splits);
+  Tensor output = at::empty(output_sizes, key.options());
+  int64_t num_keys = key.numel() / 2;
+  if (num_keys == 0) {
+    return output;
+  }
+
+  int64_t total_threads = num_keys * num_splits;
+  constexpr int block_size = 256;
+  int num_blocks =
+      static_cast<int>((total_threads + block_size - 1) / block_size);
+
+  auto key_contig = key.contiguous();
+  auto functor = PhiloxKeySplitFunctor(
+      key_contig.data_ptr<uint64_t>(),
+      output.data_ptr<uint64_t>(),
+      num_keys,
+      total_threads);
+
+  sycl_kernel_submit(
+      sycl::range<1>(num_blocks * block_size),
+      sycl::range<1>(block_size),
+      at::xpu::getCurrentSYCLQueue(),
+      functor);
+
+  return output;
+}
+
+Tensor _philox_key_fold_in_xpu(const Tensor& key, int64_t data) {
+  TORCH_CHECK(
+      key.dim() >= 1 && key.size(-1) == 2,
+      "_philox_key_fold_in: key must have shape (*batch, 2), got shape ",
+      key.sizes());
+  TORCH_CHECK(
+      key.scalar_type() == kUInt64,
+      "_philox_key_fold_in: key must have dtype uint64, got ",
+      key.scalar_type());
+
+  Tensor output = at::empty_like(key);
+  int64_t num_keys = key.numel() / 2;
+  if (num_keys == 0) {
+    return output;
+  }
+
+  constexpr int block_size = 256;
+  int num_blocks = static_cast<int>((num_keys + block_size - 1) / block_size);
+
+  auto key_contig = key.contiguous();
+  auto functor = PhiloxKeyFoldInFunctor(
+      key_contig.data_ptr<uint64_t>(),
+      output.data_ptr<uint64_t>(),
+      num_keys,
+      data);
+
+  sycl_kernel_submit(
+      sycl::range<1>(num_blocks * block_size),
+      sycl::range<1>(block_size),
+      at::xpu::getCurrentSYCLQueue(),
+      functor);
+
+  return output;
+}
+
+} // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/PhiloxKeySplitKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PhiloxKeySplitKernels.cpp
@@ -109,21 +109,21 @@ Tensor _philox_key_split_xpu(const Tensor& key, int64_t num_splits) {
     return output;
   }
 
-  int64_t total_threads = num_keys * num_splits;
-  constexpr int block_size = 256;
-  int num_blocks =
-      static_cast<int>((total_threads + block_size - 1) / block_size);
+  int64_t total_work_items = num_keys * num_splits;
+  constexpr int work_group_size = 256;
+  int work_group_num = static_cast<int>(
+      (total_work_items + work_group_size - 1) / work_group_size);
 
   auto key_contig = key.contiguous();
   auto functor = PhiloxKeySplitFunctor(
       key_contig.data_ptr<uint64_t>(),
       output.data_ptr<uint64_t>(),
       num_keys,
-      total_threads);
+      total_work_items);
 
   sycl_kernel_submit(
-      sycl::range<1>(num_blocks * block_size),
-      sycl::range<1>(block_size),
+      sycl::range<1>(work_group_num * work_group_size),
+      sycl::range<1>(work_group_size),
       at::xpu::getCurrentSYCLQueue(),
       functor);
 
@@ -146,8 +146,9 @@ Tensor _philox_key_fold_in_xpu(const Tensor& key, int64_t data) {
     return output;
   }
 
-  constexpr int block_size = 256;
-  int num_blocks = static_cast<int>((num_keys + block_size - 1) / block_size);
+  constexpr int work_group_size = 256;
+  int work_group_num =
+      static_cast<int>((num_keys + work_group_size - 1) / work_group_size);
 
   auto key_contig = key.contiguous();
   auto functor = PhiloxKeyFoldInFunctor(
@@ -157,8 +158,8 @@ Tensor _philox_key_fold_in_xpu(const Tensor& key, int64_t data) {
       data);
 
   sycl_kernel_submit(
-      sycl::range<1>(num_blocks * block_size),
-      sycl::range<1>(block_size),
+      sycl::range<1>(work_group_num * work_group_size),
+      sycl::range<1>(work_group_size),
       at::xpu::getCurrentSYCLQueue(),
       functor);
 

--- a/src/ATen/native/xpu/sycl/PhiloxKeySplitKernels.h
+++ b/src/ATen/native/xpu/sycl/PhiloxKeySplitKernels.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#pragma once
+
+#include <ATen/core/Tensor.h>
+
+namespace at::native::xpu {
+
+TORCH_XPU_API Tensor
+_philox_key_split_xpu(const Tensor& key, int64_t num_splits);
+
+TORCH_XPU_API Tensor _philox_key_fold_in_xpu(const Tensor& key, int64_t data);
+
+} // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/StatelessPhilox4x32.h
+++ b/src/ATen/native/xpu/sycl/StatelessPhilox4x32.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020-2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Stateless Philox-4x32 PRNG implementation for XPU.
+//
+// Unlike PhiloxRNGEngine (Philox4x32.h), this is a pure function: given
+// (seed, offset) it returns 4 pseudo-random uint32 values with no mutable
+// state. This makes it suitable for use in stateless random APIs.
+//
+// Ported from CUDA: aten/src/ATen/cuda/StatelessPhilox4x32.cuh
+// See PyTorch PRs #177229 and #177230.
+
+#pragma once
+
+#include <cstdint>
+
+namespace at::native::xpu {
+
+struct philox_uint2 {
+  uint32_t x, y;
+};
+
+struct philox_uint4 {
+  uint32_t x, y, z, w;
+};
+
+inline philox_uint4 philox_round(philox_uint4 ctr, philox_uint2 key) {
+  constexpr uint32_t kPhiloxSA = 0xD2511F53;
+  constexpr uint32_t kPhiloxSB = 0xCD9E8D57;
+
+  uint64_t prod0 =
+      static_cast<uint64_t>(kPhiloxSA) * static_cast<uint64_t>(ctr.x);
+  uint64_t prod1 =
+      static_cast<uint64_t>(kPhiloxSB) * static_cast<uint64_t>(ctr.z);
+
+  uint32_t r0_lo = static_cast<uint32_t>(prod0);
+  uint32_t r0_hi = static_cast<uint32_t>(prod0 >> 32);
+  uint32_t r1_lo = static_cast<uint32_t>(prod1);
+  uint32_t r1_hi = static_cast<uint32_t>(prod1 >> 32);
+
+  return {r1_hi ^ ctr.y ^ key.x, r1_lo, r0_hi ^ ctr.w ^ key.y, r0_lo};
+}
+
+// Stateless Philox-4x32-10. Returns 4 pseudo-random uint32 values (128 bits)
+// determined entirely by (seed, offset). Each unique offset produces a
+// distinct 128-bit output.
+template <int N_ROUNDS = 10>
+inline philox_uint4 philox_4x32(uint64_t seed, uint64_t offset) {
+  philox_uint2 key = {
+      static_cast<uint32_t>(seed), static_cast<uint32_t>(seed >> 32)};
+  philox_uint4 ctr = {
+      static_cast<uint32_t>(offset),
+      static_cast<uint32_t>(offset >> 32),
+      // restrict subsequence=0
+      0,
+      0};
+
+  constexpr uint32_t kPhilox10A = 0x9E3779B9;
+  constexpr uint32_t kPhilox10B = 0xBB67AE85;
+
+#pragma unroll
+  for (int i = 0; i < N_ROUNDS - 1; i++) {
+    ctr = philox_round(ctr, key);
+    key.x += kPhilox10A;
+    key.y += kPhilox10B;
+  }
+  return philox_round(ctr, key);
+}
+
+// Derive a new (seed, offset) key from 4 random uint32 values.
+inline void philox_derive_key(
+    philox_uint4 r,
+    uint64_t* out_seed,
+    uint64_t* out_offset) {
+  *out_seed = static_cast<uint64_t>(r.x) | (static_cast<uint64_t>(r.y) << 32);
+  *out_offset = static_cast<uint64_t>(r.z) | (static_cast<uint64_t>(r.w) << 32);
+}
+
+} // namespace at::native::xpu


### PR DESCRIPTION
Port the stateless PRNG operators introduced upstream in pytorch/pytorch#177229 and pytorch/pytorch#177230 to the XPU backend: _philox_key_split, _philox_key_fold_in, _philox_uniform_, and _philox_normal_.

The shared stateless Philox-4x32 core (StatelessPhilox4x32.h) is adapted from the CUDA header, replacing the CUDA-only uint2/uint4 builtins with plain philox_uint2/philox_uint4 structs and __device__ helpers with SYCL-callable inline functions. The key-split/fold-in and distribution kernels are submitted via sycl_kernel_submit with one work-item per output chunk. Device function names (philox_round, philox_4x32, philox_derive_key) are kept identical to upstream to ease future alignment.
