### PR TITLE
[xpu] Align range factories with shared PyTorch helpers

### DIFF
--- a/src/ATen/native/xpu/RangeFactories.cpp
+++ b/src/ATen/native/xpu/RangeFactories.cpp
@@ -12,7 +12,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/ExpandUtils.h>
 #include <ATen/ScalarOps.h>
@@ -44,37 +43,7 @@ Tensor& arange_xpu_out(
       out.scalar_type(),
       "arange_xpu_preprocess",
       [&]() {
-        arange_check_bounds(start, end, step);
-
-        // we use double precision for (start - end) / step
-        // to compute size_d for consistency across devices.
-        // The problem with using accscalar_t is that accscalar_t might be
-        // float32 on gpu for a float32 scalar_t, but double on cpu for the
-        // same, and the effective output size starts differing on CPU vs GPU
-        // because of precision issues, which we dont want. the corner-case we
-        // do want to take into account is int64_t, which has higher precision
-        // than double
-        double size_d;
-        if constexpr (std::is_same_v<scalar_t, int64_t>) {
-          using accscalar_t = at::acc_type_device<scalar_t, kXPU>;
-          auto xstart = start.to<accscalar_t>();
-          auto xend = end.to<accscalar_t>();
-          auto xstep = step.to<accscalar_t>();
-          TORCH_CHECK_VALUE(xstep != 0, "step must be nonzero");
-          int64_t sgn = (xstep > 0) - (xstep < 0);
-          size_d = std::ceil((xend - xstart + xstep - sgn) / xstep);
-        } else {
-          size_d = std::ceil(
-              static_cast<double>(end.to<double>() - start.to<double>()) /
-              step.to<double>());
-        }
-
-        TORCH_CHECK(
-            size_d >= 0 &&
-                size_d <=
-                    static_cast<double>(std::numeric_limits<int64_t>::max()),
-            "invalid size, possible overflow?");
-        int64_t size = static_cast<int64_t>(size_d);
+        int64_t size = compute_arange_size<scalar_t>(start, end, step);
         int64_t numel = out.numel();
 
         if (numel != size) {
@@ -103,22 +72,9 @@ Tensor& range_xpu_out(
     const Scalar& end,
     const Scalar& step,
     Tensor& out) {
-  auto xstart = start.to<double>();
-  auto xend = end.to<double>();
-  auto xstep = step.to<double>();
-
-  TORCH_CHECK(xstep > 0 || xstep < 0, "step must be nonzero");
-  TORCH_CHECK(
-      std::isfinite(static_cast<double>(xstart)) &&
-          std::isfinite(static_cast<double>(xend)),
-      "unsupported range: ",
-      xstart,
-      " -> ",
-      xend);
-  TORCH_CHECK(
-      ((xstep > 0) && (xend >= xstart)) || ((xstep < 0) && (xend <= xstart)),
-      "upper bound and larger bound inconsistent with step sign");
-  int64_t size = static_cast<int64_t>(((xend - xstart) / xstep) + 1);
+  arange_check_bounds(start, end, step);
+  int64_t size = static_cast<int64_t>(
+      ((end.to<double>() - start.to<double>()) / step.to<double>()) + 1);
   if (out.numel() != size) {
     out.resize_({size});
   }


### PR DESCRIPTION
## Motivation

`test_comprehensive_arange_xpu_int64` (`TestInductorOpInfoXPU`) started failing on nightly XPU CI (issue pytorch/pytorch#189662) with:

```
AssertionError: The values for attribute 'shape' do not match: torch.Size([3]) != torch.Size([2]).
Caused by sample input at index 10: SampleInput(input=0.0, args=(-8.000001,-4.0),
    kwargs={'dtype': 'torch.int64', 'device': "'xpu:0'"})
```

Root cause: PyTorch pytorch/pytorch#185812 ("Fix arange int64 fractional truncation", commit `8a970b50553`, 2026-07-10) added an `isIntegral(false)` guard to `compute_arange_size<int64_t>` in `aten/src/ATen/native/RangeUtils.h` so that fractional `Scalar` args take the double path instead of being truncated to `int64` first. The same PR aligned the inductor `_refs.arange` decomposition and refactored CUDA/MPS to call `compute_arange_size`.

XPU's eager path in `src/ATen/native/xpu/RangeFactories.cpp::arange_xpu_out` still inlined the OLD int64 formula, so for the sample above (with all-`int64` division):

```
xstart = 0, xend = -8, xstep = -4 (truncated), sgn = -1
size = ceil( ((-8) - 0 + (-4) - (-1)) / (-4) )
     = ceil( (-11) / (-4) )
     = ceil( 2 )          # int64 division truncates toward zero, loses .75
     = 2
```

while inductor XPU (via the updated `_refs`) produced `size = 3`. Eager XPU and inductor XPU disagreed, tripping `check_model_gpu`'s shape check.

While auditing the file, `range_xpu_out` was found to have a parallel issue: it inlined the three `TORCH_CHECK` bounds validations (nonzero step, finite endpoints, step-sign consistency) that CPU/CUDA/MPS have already been calling through the shared `at::native::arange_check_bounds` helper. XPU is the only backend still inlining that block, and its copy contained a typo (`"upper bound and larger bound"` instead of `"lower bound"`).

## Solution

**`arange_xpu_out`**: replace the inlined size computation with a call to `at::native::compute_arange_size<scalar_t>` (mirrors pytorch/pytorch#185812's CUDA/MPS refactor). The `isIntegral(false)` guard is picked up automatically so eager XPU matches CPU/CUDA/MPS/inductor for fractional args to `arange` with an integer dtype.

**`range_xpu_out`**: replace the inlined `TORCH_CHECK` block with a call to `at::native::arange_check_bounds` (mirrors CPU/CUDA/MPS). The size formula is kept inline (no shared helper exists for `range`'s closed-interval size). This also fixes the `"larger bound"` → `"lower bound"` typo so XPU's error message now matches other backends.

Also drop the now-unused `ATen/AccumulateType.h` include.

Net diff: `+4 −48` (all in `src/ATen/native/xpu/RangeFactories.cpp`).

## Test Plan

Reproduced locally on `torch 2.14.0.dev20260711+xpu` (pytorch tree `4c7bbbec95d`, contains #185812) — failure signature matches CI exactly. Then rebuilt torch at pytorch `origin/main` (`d84328bd347`) with this fix as a dev override via `third_party/xpu.txt`, and re-ran:

```bash
# The exact sample that was failing on CI
PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=10 python -m pytest -sv \
  test/inductor/test_torchinductor_opinfo.py::TestInductorOpInfoXPU::test_comprehensive_arange_xpu_int64
# -> PASSED

# Full arange test (all sample inputs)
python -m pytest -sv \
  test/inductor/test_torchinductor_opinfo.py::TestInductorOpInfoXPU::test_comprehensive_arange_xpu_int64
# -> PASSED

# Regression check on all arange XPU tests
python -m pytest -sv test/inductor/test_torchinductor_opinfo.py -k 'arange_xpu'
# -> 5 passed, 1 pre-existing skip (uint8)

# CPU range regression (validates the shared helper contract)
python -m pytest -sv test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_range_warning_cpu
# -> PASSED
```

Sanity check that eager XPU now matches eager CPU and error messages are aligned:

```python
>>> torch.arange(0.0, -8.000001, -4.0, dtype=torch.int64, device='cpu')
tensor([ 0, -4, -8])
>>> torch.arange(0.0, -8.000001, -4.0, dtype=torch.int64, device='xpu')
tensor([ 0, -4, -8], device='xpu:0')
>>> torch.range(0.0, 5.0, 1.0, device='xpu')
tensor([0., 1., 2., 3., 4., 5.], device='xpu:0')
>>> torch.range(5.0, 0.0, 1.0, device='xpu')  # bounds error
RuntimeError: upper bound and lower bound inconsistent with step sign
```

related to pytorch/pytorch#189662, need xpu.txt pin commit update to fix the issue.

Note: This PR was authored with AI assistance.