### PR TITLE
Fix SIMD macro hygiene and cover index_add's high-contention path

### DIFF
--- a/.github/scripts/microbench_summary.py
+++ b/.github/scripts/microbench_summary.py
@@ -44,7 +44,7 @@ def parse_logs(log_dir: str, get_backward: bool = False) -> pd.DataFrame:
         "case_name", "datatype", "op_name", "shape", "channels_last", "dim",
         "output_size", "P", "reduce", "kernel_size", "stride", "replacement",
         "num_samples", "scale_factor", "mode", "padding_mode", "align_corners",
-        "shifts", "affine", "backward", "time(us)"
+        "shifts", "affine", "distinct_indices", "backward", "time(us)"
     ]
 
     for log_file in glob.glob(os.path.join(log_dir, "*.log")):

--- a/src/ATen/native/xpu/sycl/DepthwiseConv2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/DepthwiseConv2dKernels.cpp
@@ -31,7 +31,6 @@
 #endif
 
 namespace at::native::xpu {
-#define NUM_THREADS 1024;
 
 template <
     typename scalar_t,

--- a/src/ATen/native/xpu/sycl/IndexKernelUtils.h
+++ b/src/ATen/native/xpu/sycl/IndexKernelUtils.h
@@ -48,7 +48,7 @@ inline bool fast_gather_kernel_eligible(
       get_alignment(static_cast<size_t>(iter.strides(0)[1])) == alignment;
 }
 
-#define SIMD 32
+inline constexpr int SIMD = 32;
 
 template <int Alignment, typename index_t>
 struct VectorizedGatherKernel {

--- a/test/microbench/indexing.index_add.py
+++ b/test/microbench/indexing.index_add.py
@@ -19,51 +19,62 @@ step = int(1024 / 2)
 cache_r = torch.randn((8192 * 8192), device=device)
 cache_w = torch.randn((8192 * 8192), device=device)
 
+# How many distinct positions along `dim` the indices land on. The first set
+# keeps every index unique; the second folds all `step` indices onto 8
+# positions, 64 accumulations each, which is the high-contention embedding
+# backward case that index_add's shared-local-memory path targets. Both are
+# deterministic, so the contention level cannot drift between runs.
+index_sets = [
+    (step, torch.linspace(0, 1022, steps=step, device=device).to(torch.long)),
+    (8, torch.arange(step, device=device) % 8),
+]
+
 for shape in shape_list:
     for dtype in [torch.bfloat16, torch.float16, torch.float32]:
         for dim in [0, 1]:
             input = torch.zeros(shape, dtype=dtype, device=device)
-            indices = torch.linspace(0, 1022, steps=step, device=device).to(torch.long)
             y_0 = torch.ones((512, 1024), dtype=dtype, device=device)
             y_1 = torch.randn((1024, 512), dtype=dtype, device=device)
+            for distinct_indices, indices in index_sets:
+                # warm up
+                for i in range(10):
+                    output = input.index_add(0, indices, y_0)
 
-            # warm up
-            for i in range(10):
-                output = input.index_add(0, indices, y_0)
+                # go
+                print(
+                    "shape:",
+                    (shape),
+                    "; datatype:",
+                    dtype,
+                    "; dim:",
+                    dim,
+                    "; distinct_indices:",
+                    distinct_indices,
+                    "; backward:",
+                    backward,
+                )
+                with profile(
+                    activities=[ProfilerActivity.CPU, ProfilerActivity.XPU],
+                    record_shapes=True,
+                ) as prof:
+                    for i in range(num_iter):
+                        cache_r = cache_w * i
+                        if dim == 0:
+                            output = input.index_add(dim, indices, y_0)
+                        else:
+                            output = input.index_add(dim, indices, y_1)
+                print(prof.key_averages().table(sort_by="xpu_time_total"))
 
-            # go
-            print(
-                "shape:",
-                (shape),
-                "; datatype:",
-                dtype,
-                "; dim:",
-                dim,
-                "; backward:",
-                backward,
-            )
-            with profile(
-                activities=[ProfilerActivity.CPU, ProfilerActivity.XPU],
-                record_shapes=True,
-            ) as prof:
+                # E2E time
+                torch.xpu.synchronize()
+                t1 = time.time()
                 for i in range(num_iter):
                     cache_r = cache_w * i
                     if dim == 0:
                         output = input.index_add(dim, indices, y_0)
                     else:
                         output = input.index_add(dim, indices, y_1)
-            print(prof.key_averages().table(sort_by="xpu_time_total"))
-
-            # E2E time
-            torch.xpu.synchronize()
-            t1 = time.time()
-            for i in range(num_iter):
-                cache_r = cache_w * i
-                if dim == 0:
-                    output = input.index_add(dim, indices, y_0)
-                else:
-                    output = input.index_add(dim, indices, y_1)
-            torch.xpu.synchronize()
-            t2 = time.time()
-            e2e_time = (t2 - t1) / num_iter
-            print("E2E total time:", f"{float(e2e_time):.20f}")
+                torch.xpu.synchronize()
+                t2 = time.time()
+                e2e_time = (t2 - t1) / num_iter
+                print("E2E total time:", f"{float(e2e_time):.20f}")


### PR DESCRIPTION
Three independent cleanups around the `SIMD` constant in the indexing kernels, plus benchmark coverage for the path they guard.

**`SIMD` macro to `inline constexpr`** (`IndexKernelUtils.h`). The macro had no `#undef`, so it leaked into every including TU and could rewrite `GroupReduceUtils.h`'s `template <typename T, int SIMD, int DIM>` parameter to `int 32` and break the build. The include chains don't cross today, so it's latent, not live. A constexpr can't clash: a template parameter shadows a constant, but nothing shadows a macro. All use sites are in `namespace at::native::xpu` and there is no `#ifdef SIMD`, so name lookup and the preprocessor both still resolve.

**Remove dead `#define NUM_THREADS 1024;`** (`DepthwiseConv2dKernels.cpp`). Zero uses -- the trailing semicolon means any use would expand to `foo(1024;)` and fail to compile. `KernelUtils.h` already carries the working `SYCL_NUM_THREADS`.

**Cover `index_add`'s high-contention path** (`indexing.index_add.py`, `microbench_summary.py`). #2294 added a shared-local-memory accumulation path for high-contention embedding backward, but the benchmark only ran distinct `linspace` indices -- zero contention -- so that path had no regression coverage. It now also folds all `step` indices onto 8 positions (64 accumulations each). Indices use deterministic `arange`, not `randint`, so contention cannot drift between runs and manufacture false regressions. `distinct_indices` is registered in `microbench_summary.py`'s column list, or the two contention levels collapse into duplicate rows.

Note: deliberately leaves the `SYCL_REQD_SUB_GROUP_SIZE(32)` attributes on `VectorizedGatherKernel`/`IndexFuncLargeIndexFunctor` untouched -- removing them is an unmeasured performance change and belongs in its own PR.

Test: test/microbench/indexing.index_add.py (requires an XPU device; the C++ changes are covered by existing indexing tests, e.g. `pytest test/xpu/test_ops_xpu.py -v -k "index_add or index_select or gather"`)

---
Authored with the assistance of an AI coding agent (Claude).