### PR TITLE
Fix UpSampleBilinear2d backward width-index using height dimension

### DIFF
--- a/src/ATen/native/xpu/sycl/UpSampleBilinear2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleBilinear2dKernels.cpp
@@ -449,7 +449,7 @@ struct UpsampleBilinear2dBackwardNotAlignKernelFunctor {
                 static_cast<accscalar_t>(odata_[idx_cl(
                     n,
                     (point_h - input_height_) / (2 * input_height_),
-                    (point_w - input_height_) / (2 * input_width_),
+                    (point_w - input_width_) / (2 * input_width_),
                     c,
                     output_height_,
                     output_width_,
@@ -459,7 +459,7 @@ struct UpsampleBilinear2dBackwardNotAlignKernelFunctor {
                 ((n * channels_ + c) * output_height_ +
                  (point_h - input_height_) / (2 * input_height_)) *
                     output_width_ +
-                (point_w - input_height_) / (2 * input_width_);
+                (point_w - input_width_) / (2 * input_width_);
             tmp += scale * static_cast<accscalar_t>(odata_[output_index]);
           }
         }

--- a/test/xpu/test_nn_xpu.py
+++ b/test/xpu/test_nn_xpu.py
@@ -13353,6 +13353,38 @@ class TestNNDeviceType(NNTestCase):
 
                     self.assertEqual(a_cuda.grad, a_cpu.grad)
 
+    def test_upsamplingBilinear2d_backward_nonsquare(self, device):
+        # Regression test for intel/torch-xpu-ops#4322: the bilinear2d backward
+        # kernel computed the width index using the input *height* extent
+        # ((point_w - input_height_) instead of (point_w - input_width_)), so
+        # the gradient was wrong for NON-SQUARE inputs. The bug only shows on
+        # the optimized backward path (float32, align_corners=False, integer
+        # upscale), so the case below is chosen to exercise exactly that path.
+        nondet_tol = 1e-4 if torch.device(device).type in ("cuda", "xpu") else 0.0
+
+        def _check(in_h, in_w, scale):
+            out_h, out_w = in_h * scale, in_w * scale
+            a_dev = torch.randn(
+                1, 3, in_h, in_w, device=device, dtype=torch.float32
+            ).requires_grad_()
+            a_cpu = a_dev.detach().cpu().requires_grad_()
+            grad = torch.randn(1, 3, out_h, out_w)
+
+            F.interpolate(
+                a_dev, size=(out_h, out_w), mode="bilinear", align_corners=False
+            ).backward(grad.to(device))
+            F.interpolate(
+                a_cpu, size=(out_h, out_w), mode="bilinear", align_corners=False
+            ).backward(grad)
+
+            self.assertEqual(a_dev.grad, a_cpu.grad, atol=nondet_tol, rtol=0)
+
+        # Square control (H == W): unaffected by the height/width mixup.
+        _check(4, 4, 3)
+        # Non-square regression guards: wrong on the old kernel, correct now.
+        _check(9, 5, 2)
+        _check(28, 7, 4)
+
     @parametrize_test("antialias", [True, False])
     @parametrize_test("num_channels", [3, 5])
     @parametrize_test("mode", ["nearest", "nearest-exact", "bilinear", "bicubic"])

--- a/test/xpu/test_nn_xpu.py
+++ b/test/xpu/test_nn_xpu.py
@@ -13353,37 +13353,34 @@ class TestNNDeviceType(NNTestCase):
 
                     self.assertEqual(a_cuda.grad, a_cpu.grad)
 
-    def test_upsamplingBilinear2d_backward_nonsquare(self, device):
-        # Regression test for intel/torch-xpu-ops#4322: the bilinear2d backward
-        # kernel computed the width index using the input *height* extent
-        # ((point_w - input_height_) instead of (point_w - input_width_)), so
-        # the gradient was wrong for NON-SQUARE inputs. The bug only shows on
-        # the optimized backward path (float32, align_corners=False, integer
-        # upscale), so the case below is chosen to exercise exactly that path.
+    # Regression test for intel/torch-xpu-ops#4322: the bilinear2d backward
+    # kernel computed the width index using the input *height* extent
+    # ((point_w - input_height_) instead of (point_w - input_width_)), so the
+    # gradient was wrong for NON-SQUARE inputs. The bug only shows on the
+    # optimized backward path (float32, align_corners=False, integer upscale),
+    # so the cases below are chosen to exercise exactly that path. The (4, 4, 3)
+    # case is a square (H == W) control unaffected by the mixup; the non-square
+    # cases are wrong on the old kernel and correct now.
+    @parametrize_test("in_h, in_w, scale", [(4, 4, 3), (9, 5, 2), (28, 7, 4)])
+    def test_upsamplingBilinear2d_backward_nonsquare(
+        self, device, in_h, in_w, scale
+    ):
         nondet_tol = 1e-4 if torch.device(device).type in ("cuda", "xpu") else 0.0
+        out_h, out_w = in_h * scale, in_w * scale
+        a_dev = torch.randn(
+            1, 3, in_h, in_w, device=device, dtype=torch.float32
+        ).requires_grad_()
+        a_cpu = a_dev.detach().cpu().requires_grad_()
+        grad = torch.randn(1, 3, out_h, out_w)
 
-        def _check(in_h, in_w, scale):
-            out_h, out_w = in_h * scale, in_w * scale
-            a_dev = torch.randn(
-                1, 3, in_h, in_w, device=device, dtype=torch.float32
-            ).requires_grad_()
-            a_cpu = a_dev.detach().cpu().requires_grad_()
-            grad = torch.randn(1, 3, out_h, out_w)
+        F.interpolate(
+            a_dev, size=(out_h, out_w), mode="bilinear", align_corners=False
+        ).backward(grad.to(device))
+        F.interpolate(
+            a_cpu, size=(out_h, out_w), mode="bilinear", align_corners=False
+        ).backward(grad)
 
-            F.interpolate(
-                a_dev, size=(out_h, out_w), mode="bilinear", align_corners=False
-            ).backward(grad.to(device))
-            F.interpolate(
-                a_cpu, size=(out_h, out_w), mode="bilinear", align_corners=False
-            ).backward(grad)
-
-            self.assertEqual(a_dev.grad, a_cpu.grad, atol=nondet_tol, rtol=0)
-
-        # Square control (H == W): unaffected by the height/width mixup.
-        _check(4, 4, 3)
-        # Non-square regression guards: wrong on the old kernel, correct now.
-        _check(9, 5, 2)
-        _check(28, 7, 4)
+        self.assertEqual(a_dev.grad, a_cpu.grad, atol=nondet_tol, rtol=0)
 
     @parametrize_test("antialias", [True, False])
     @parametrize_test("num_channels", [3, 5])


### PR DESCRIPTION
## Summary
The XPU `UpSampleBilinear2d` backward kernel computes an incorrect width index for non-square inputs, because a width-coordinate expression subtracts the input *height* extent instead of the width. This produces wrong gradients whenever `H != W` on the optimized backward path. Square inputs are unaffected, which is why it went unnoticed.

## Root cause
In `UpSampleBilinear2dKernels.cpp`, `UpsampleBilinear2dBackwardNotAlignKernelFunctor` has two width-index expressions (channels-last and contiguous) written as `(point_w - input_height_) / (2 * input_width_)`. `point_w` is a width coordinate, so it must be offset by `input_width_`, not `input_height_`. The symmetric height expression correctly uses `input_height_`. For square tensors `input_height_ == input_width_`, so the error is masked.

## Fix
Change both expressions to `(point_w - input_width_) / (2 * input_width_)`, making the width index symmetric with the (already correct) height index.

## Test plan
Added `test_upsamplingBilinear2d_backward_nonsquare` in `test/xpu/test_nn_xpu.py`, comparing XPU gradients against the CPU reference for a square control plus non-square cases on the optimized path (float32, `align_corners=False`, integer upscale).

Verified on Arc Pro B60:
- Before fix (non-square, e.g. 9x5→18x10): max abs error vs CPU ≈ **3.2–7.6**
- After fix: max abs error ≈ **1e-6** (parity)
- Square control passes on both.

## Risk
Low blast radius. Only affects `UpSampleBilinear2d` backward (optimized not-aligned path) on XPU for non-square inputs — currently incorrect. Square-input results, the forward pass, and CPU/CUDA paths are unchanged.

Fixes #4322.
