### PR TITLE
index_add/index_reduce: raise catchable error on out-of-range index

### DIFF
--- a/src/ATen/native/xpu/sycl/Indexing.cpp
+++ b/src/ATen/native/xpu/sycl/Indexing.cpp
@@ -28,6 +28,7 @@ DISABLE_RETURN_TYPE_WARNING_BEGIN
 #include <ATen/native/xpu/sycl/SortingKernels.h>
 #include <ATen/native/xpu/sycl/pstl/PSTLFunctions.h>
 #include <ATen/ops/_sparse_coo_tensor_with_dims_and_tensors.h>
+#include <ATen/ops/aminmax.h>
 #include <ATen/ops/arange.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/gather.h>
@@ -1227,6 +1228,19 @@ void index_reduce_add_xpu_template(
   const Tensor self_ = (result.dim() == 0) ? result.view(1) : result;
   const Tensor source_ = (source.dim() == 0) ? source.view(1) : source;
 
+  // Host-side bounds check so an out-of-range index raises a catchable
+  // RuntimeError/IndexError instead of tripping the device-side
+  // SYCL_KERNEL_ASSERT (which aborts the process). Matches eager CPU/CUDA.
+  if (index.numel() > 0) {
+    auto [idx_min, idx_max] = at::aminmax(index);
+    int64_t dim_size = self_.size(dim);
+    TORCH_CHECK_INDEX(
+        idx_max.item<int64_t>() < dim_size &&
+            idx_min.item<int64_t>() >= -dim_size,
+        "index_add(): index out of range: expected indices in [",
+        -dim_size, ", ", dim_size - 1, "]");
+  }
+
   TORCH_CHECK(
       result.dim() <= XPU_MAX_TENSORINFO_DIMS,
       "tensor has too many (>",
@@ -1498,6 +1512,19 @@ void index_reduce_func_xpu_template(
   // Scalars are treated as 1-d tensor
   Tensor self_ = (result.dim() == 0) ? result.view(1) : result;
   Tensor source_ = (source.dim() == 0) ? source.view(1) : source;
+
+  // Host-side bounds check so an out-of-range index raises a catchable
+  // RuntimeError/IndexError instead of tripping the device-side
+  // SYCL_KERNEL_ASSERT (which aborts the process). Matches eager CPU/CUDA.
+  if (index.numel() > 0) {
+    auto [idx_min, idx_max] = at::aminmax(index);
+    int64_t dim_size = self_.size(dim);
+    TORCH_CHECK_INDEX(
+        idx_max.item<int64_t>() < dim_size &&
+            idx_min.item<int64_t>() >= -dim_size,
+        "index_reduce(): index out of range: expected indices in [",
+        -dim_size, ", ", dim_size - 1, "]");
+  }
 
   TORCH_CHECK(
       result.dim() <= XPU_MAX_TENSORINFO_DIMS,

--- a/src/ATen/native/xpu/sycl/Indexing.cpp
+++ b/src/ATen/native/xpu/sycl/Indexing.cpp
@@ -1230,15 +1230,16 @@ void index_reduce_add_xpu_template(
 
   // Host-side bounds check so an out-of-range index raises a catchable
   // RuntimeError/IndexError instead of tripping the device-side
-  // SYCL_KERNEL_ASSERT (which aborts the process). Matches eager CPU/CUDA.
+  // SYCL_KERNEL_ASSERT (which aborts the process). Negative indices are
+  // rejected rather than wrapped, matching eager CPU/CUDA.
   if (index.numel() > 0) {
     auto [idx_min, idx_max] = at::aminmax(index);
     int64_t dim_size = self_.size(dim);
     TORCH_CHECK_INDEX(
-        idx_max.item<int64_t>() < dim_size &&
-            idx_min.item<int64_t>() >= -dim_size,
-        "index_add(): index out of range: expected indices in [",
-        -dim_size, ", ", dim_size - 1, "]");
+        idx_min.item<int64_t>() >= 0 && idx_max.item<int64_t>() < dim_size,
+        "index_add(): index out of range in self: expected indices in [0, ",
+        dim_size - 1,
+        "]");
   }
 
   TORCH_CHECK(
@@ -1515,15 +1516,16 @@ void index_reduce_func_xpu_template(
 
   // Host-side bounds check so an out-of-range index raises a catchable
   // RuntimeError/IndexError instead of tripping the device-side
-  // SYCL_KERNEL_ASSERT (which aborts the process). Matches eager CPU/CUDA.
+  // SYCL_KERNEL_ASSERT (which aborts the process). Negative indices are
+  // rejected rather than wrapped, matching eager CPU/CUDA.
   if (index.numel() > 0) {
     auto [idx_min, idx_max] = at::aminmax(index);
     int64_t dim_size = self_.size(dim);
     TORCH_CHECK_INDEX(
-        idx_max.item<int64_t>() < dim_size &&
-            idx_min.item<int64_t>() >= -dim_size,
-        "index_reduce(): index out of range: expected indices in [",
-        -dim_size, ", ", dim_size - 1, "]");
+        idx_min.item<int64_t>() >= 0 && idx_max.item<int64_t>() < dim_size,
+        "index_reduce(): index out of range in self: expected indices in [0, ",
+        dim_size - 1,
+        "]");
   }
 
   TORCH_CHECK(

--- a/test/xpu/test_indexing_xpu.py
+++ b/test/xpu/test_indexing_xpu.py
@@ -196,6 +196,36 @@ with XPUPatchForImport(False):
 
         self.assertEqual(out, dst)
 
+    def index_add_reduce_out_of_range_index(self, device):
+        # Regression test for intel/torch-xpu-ops#4284. Pre-fix, an
+        # out-of-range index tripped a device-side assert that aborted the
+        # process (SIGABRT) instead of raising a catchable Python error.
+        # This asserts the fixed behavior: a catchable IndexError/RuntimeError,
+        # while valid (in-range) negative indices still work.
+        dim_size = 4
+        src = torch.ones(1, device=device)
+
+        # dim_size == 4 -> valid indices are [-4, 3]; 4 and -5 are out of range.
+        for bad_index in (4, -5):
+            index = torch.tensor([bad_index], device=device)
+            with self.assertRaises((IndexError, RuntimeError)):
+                out = torch.zeros(dim_size, device=device).index_add(0, index, src)
+                torch.xpu.synchronize()
+                _ = out.cpu()
+            with self.assertRaises((IndexError, RuntimeError)):
+                out = torch.zeros(dim_size, device=device).index_reduce(
+                    0, index, src, "prod", include_self=True
+                )
+                torch.xpu.synchronize()
+                _ = out.cpu()
+
+        # A valid negative index (-1 on dim size 4) must still work.
+        neg = torch.tensor([-1], device=device)
+        out = torch.zeros(dim_size, device=device).index_add(0, neg, src)
+        expected = torch.zeros(dim_size, device=device)
+        expected[-1] = 1.0
+        self.assertEqual(out, expected)
+
     TestIndexing.test_index_put_deterministic_with_optional_tensors = (
         __test_index_put_deterministic_with_optional_tensors
     )
@@ -203,6 +233,9 @@ with XPUPatchForImport(False):
     TestIndexing.test_index_select = index_select
     TestIndexing.test_index_add_empty_index_1d = index_add_empty_index_1d
     TestIndexing.test_index_add_empty_index_2d = index_add_empty_index_2d
+    TestIndexing.test_index_add_reduce_out_of_range_index = (
+        index_add_reduce_out_of_range_index
+    )
 
 instantiate_device_type_tests(NumpyTests, globals(), only_for=("xpu"), allow_xpu=True)
 

--- a/test/xpu/test_indexing_xpu.py
+++ b/test/xpu/test_indexing_xpu.py
@@ -200,13 +200,13 @@ with XPUPatchForImport(False):
         # Regression test for intel/torch-xpu-ops#4284. Pre-fix, an
         # out-of-range index tripped a device-side assert that aborted the
         # process (SIGABRT) instead of raising a catchable Python error.
-        # This asserts the fixed behavior: a catchable IndexError/RuntimeError,
-        # while valid (in-range) negative indices still work.
+        # This asserts the fixed behavior: a catchable IndexError/RuntimeError.
+        # Like eager CPU, negative indices are rejected rather than wrapped.
         dim_size = 4
         src = torch.ones(1, device=device)
 
-        # dim_size == 4 -> valid indices are [-4, 3]; 4 and -5 are out of range.
-        for bad_index in (4, -5):
+        # dim_size == 4 -> valid indices are [0, 3]; 4 and any negative are not.
+        for bad_index in (4, -1, -5):
             index = torch.tensor([bad_index], device=device)
             with self.assertRaises((IndexError, RuntimeError)):
                 out = torch.zeros(dim_size, device=device).index_add(0, index, src)
@@ -219,11 +219,16 @@ with XPUPatchForImport(False):
                 torch.xpu.synchronize()
                 _ = out.cpu()
 
-        # A valid negative index (-1 on dim size 4) must still work.
-        neg = torch.tensor([-1], device=device)
-        out = torch.zeros(dim_size, device=device).index_add(0, neg, src)
+            # CPU parity: the same index is rejected there too.
+            cpu_index = torch.tensor([bad_index])
+            with self.assertRaises((IndexError, RuntimeError)):
+                torch.zeros(dim_size).index_add(0, cpu_index, torch.ones(1))
+
+        # A valid index still works.
+        good = torch.tensor([3], device=device)
+        out = torch.zeros(dim_size, device=device).index_add(0, good, src)
         expected = torch.zeros(dim_size, device=device)
-        expected[-1] = 1.0
+        expected[3] = 1.0
         self.assertEqual(out, expected)
 
     TestIndexing.test_index_put_deterministic_with_optional_tensors = (


### PR DESCRIPTION
## Summary
On XPU, `index_add`/`index_reduce` with an out-of-range index aborts the process with an uncatchable `SIGABRT` (in assert-enabled builds) or silently produces a wrong result (in release/NDEBUG builds), instead of raising a Python-catchable error as CPU/CUDA do. This adds a host-side bounds check so out-of-range indices are reported catchably on all build types.

## Root cause
An out-of-bounds (or negative) index reaches the kernel, where `dstIndex` is `unsigned` in the 32-bit indexing path. A bad index wraps to a huge value and trips the device-side `SYCL_KERNEL_ASSERT`, which calls `abort()` → `SIGABRT`. Because it fires on-device it cannot be caught from Python, and in release builds where the assert is compiled out the bad index instead silently corrupts/no-ops.

## Fix
Add a host-side bounds check (`at::aminmax` + `TORCH_CHECK_INDEX`) in both `index_add_kernel` and `index_reduce_func_xpu_template`, placed after the `self_` view is built and before kernel launch. Out-of-range indices now raise a catchable `IndexError`/`RuntimeError` matching eager CPU/CUDA. Added `#include <ATen/ops/aminmax.h>`. Empty-index calls are gated by `index.numel() > 0`.

Valid indices are `[0, dim_size - 1]`. **Negative indices are rejected, not wrapped**, matching eager CPU: `aten/src/ATen/native/TensorAdvancedIndexing.cpp` checks `(self_i >= 0) && (self_i < self_dim_size)` on both the sliced and the 1-D fast path for `index_add` and `index_reduce`. The XPU kernels cannot wrap either — `IndexFuncSmallIndexFunctor` and the large-index functor compute an unsigned `dstIndex` and only assert `dstIndex < dstAddDimSize_`. The error message reuses CPU's `index out of range in self` wording so tests matching on that substring behave identically on XPU.

Perf note: the check uses `.item<int64_t>()`, introducing a host-device sync per call — accepted as the cost of correctness parity. Happy to move it device-side behind a flag if maintainers object to the sync.

## Test plan
`test_index_add_reduce_out_of_range_index` in `test/xpu/test_indexing_xpu.py`: indices `4`, `-1` and `-5` on dim size 4 raise a catchable error for both `index_add` and `index_reduce`, the same indices are cross-checked as rejected on CPU, and a valid index (`3`) still produces the correct result.

Verified on Arc Pro B60 (from-source build):
- Out-of-range → `IndexError` (catchable), process does not abort.
- Stock build: same out-of-range index silently returns a wrong result (release build), confirming the pre-fix hazard.

CPU reference behavior confirmed on stock PyTorch: `torch.zeros(4).index_add(0, torch.tensor([-1]), torch.ones(1))` → `IndexError: index out of range in self`.

## Risk
Low blast radius. Adds a validation-only guard on the XPU `index_add`/`index_reduce` path; correct in-range usage is unchanged aside from an added sync. No effect on CPU/CUDA.

Note: touches the same `index_add`/`index_reduce` code as open PR #3061 (small-index refactor); will need a rebase/coordination if that lands first.

Fixes #4284.