### PR TITLE
Fix test_warp_softmax_64bit_indexing OOM on ~24-26GB XPUs (BMG)

### DIFF
--- a/test/xpu/test_nn_xpu.py
+++ b/test/xpu/test_nn_xpu.py
@@ -14086,9 +14086,18 @@ class TestNNDeviceType(NNTestCase):
                         self.assertEqual(grad_input, ref_grad_input)
                         self.assertEqual(input.grad, ref_input.grad)
 
+    # The float32 output/grad buffers roughly double this test's peak memory
+    # relative to float16, so the XPU guard is dtype-dependent: float32 needs
+    # ~27GB and OOMs on ~24-26GB cards (e.g. Arc Pro B60), while float16 peaks
+    # ~18GB and must keep running. largeTensorTest accepts a callable size, so
+    # gate on the parametrized dtype instead of a single fixed threshold.
     @onlyOn(["cuda", "xpu"])
     @dtypes(torch.float, torch.half)
-    @largeTensorTest("20GB")
+    @largeTensorTest("20GB", "cuda")
+    @largeTensorTest(
+        lambda self, device, dtype: (27 if dtype == torch.float else 20) * 1024**3,
+        "xpu",
+    )
     @largeTensorTest("64GB", "cpu")
     def test_warp_softmax_64bit_indexing(self, device, dtype):
         def run_test(*shape):


### PR DESCRIPTION
## Summary
`test_warp_softmax_64bit_indexing` OOMs on ~24–26GB XPU cards (e.g. Arc Pro B60) because its XPU memory guard is a single fixed threshold, while the two parametrized dtypes have very different footprints. This gates the XPU guard on dtype so the OOM-prone float32 case is skipped on smaller cards while the float16 case keeps running.

## Root cause
The test runs `run_test(1.1e9, 2)` / `run_test(2.2e9, 1)` where the input `x` is always float16 but the `log_softmax` output and gradients follow the parametrized `dtype`. Measured peaks on an Arc Pro B60 (~25.5GB free):
- **float32**: ~26GB → **OOM** (`XPU out of memory. Tried to allocate 8.20 GiB`)
- **float16**: ~18GB → runs fine

The prior guard (a single `largeTensorTest("20GB")` covering XPU) was too low to skip float32 on a 25.5GB card, and any single value that skips float32 would also wrongly skip the passing float16 case — `largeTensorTest` skips iff `free_mem < size` and cannot discriminate by dtype with a fixed value.

## Fix
`largeTensorTest` accepts a callable `size(self, *args, **kwargs)`, so gate the XPU threshold on the parametrized dtype: ~27GB for float32 (skips on 24–26GB cards), 20GB for float16 (keeps running). CUDA (`20GB`) and CPU (`64GB`) guards are unchanged.

## Test plan
Verified via the real pytest harness on Arc Pro B60 (from-source XPU build):
```
test_warp_softmax_64bit_indexing_xpu_float16  PASSED
test_warp_softmax_64bit_indexing_xpu_float32  SKIPPED (Insufficient xpu memory)
```
float16 still exercises the 64-bit indexing kernel; float32 no longer OOMs CI. Larger XPUs (≥27GB) continue to run both.

## Risk
Test-only change; no runtime/kernel impact. Preserves float16 coverage on all XPUs and float32 coverage on ≥27GB XPUs. CUDA/CPU unaffected.

Fixes #4183.
