### PR TITLE
Modernize XPU math constants and macros

### DIFF
--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_epilogue.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_epilogue.h
@@ -22,6 +22,7 @@
 #include <flash_attention_v2/collective/copy_block_slm.hpp>
 #include <flash_attention_v2/collective/fmha_fusion.hpp>
 #include <sycl/sycl.hpp>
+#include <numbers>
 
 namespace cutlass::fmha::collective {
 
@@ -215,12 +216,12 @@ class FMHAFwdEpilogue {
         (tile_row_idx % rows_of_maxima) ==
             lane_id) { // only 1 lane contain the correct row maxima for that
                        // particular row
-      // The softmax scale was multiplied by the kLog2e in the mainloop
+      // The softmax scale was multiplied by log2(e) in the mainloop
       // Need to divide it to restore the value
-      double kLog2e = 1.4426950408889634074;
-      tA_max[0] = tA_max[0] / kLog2e;
+      tA_max[0] = tA_max[0] / std::numbers::log2e;
       float lse_val = tA_max[0] + logf(non_reciprocal_rAsum);
-      *(pLSE + lse_offset + tile_row_idx) = lse_val == -INFINITY ? 0 : lse_val;
+      *(pLSE + lse_offset + tile_row_idx) =
+          (sycl::isinf(lse_val) && lse_val < 0) ? 0 : lse_val;
     }
   }
 

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_epilogue.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_epilogue.h
@@ -22,6 +22,7 @@
 #include <flash_attention_v2/collective/copy_block_slm.hpp>
 #include <flash_attention_v2/collective/fmha_fusion.hpp>
 #include <sycl/sycl.hpp>
+#include <limits>
 #include <numbers>
 
 namespace cutlass::fmha::collective {
@@ -217,11 +218,11 @@ class FMHAFwdEpilogue {
             lane_id) { // only 1 lane contain the correct row maxima for that
                        // particular row
       // The softmax scale was multiplied by log2(e) in the mainloop
-      // Need to divide it to restore the value
-      tA_max[0] = tA_max[0] / std::numbers::log2e;
+      // Multiply by ln(2) == 1/log2(e) to restore the value
+      tA_max[0] = tA_max[0] * std::numbers::ln2_v<float>;
       float lse_val = tA_max[0] + logf(non_reciprocal_rAsum);
       *(pLSE + lse_offset + tile_row_idx) =
-          (sycl::isinf(lse_val) && lse_val < 0) ? 0 : lse_val;
+          lse_val == -std::numeric_limits<float>::infinity() ? 0 : lse_val;
     }
   }
 

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_epilogue.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_epilogue.h
@@ -218,8 +218,8 @@ class FMHAFwdEpilogue {
             lane_id) { // only 1 lane contain the correct row maxima for that
                        // particular row
       // The softmax scale was multiplied by log2(e) in the mainloop
-      // Multiply by ln(2) == 1/log2(e) to restore the value
-      tA_max[0] = tA_max[0] * std::numbers::ln2_v<float>;
+      // Need to divide it to restore the value
+      tA_max[0] = tA_max[0] / std::numbers::log2e;
       float lse_val = tA_max[0] + logf(non_reciprocal_rAsum);
       *(pLSE + lse_offset + tile_row_idx) =
           lse_val == -std::numeric_limits<float>::infinity() ? 0 : lse_val;

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_mainloop.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_mainloop.h
@@ -176,7 +176,7 @@ struct FMHAFwdMainloop<
   static constexpr Params to_underlying_arguments(
       Arguments const& args,
       void* /* workspace */) {
-    ElementS val = args.scale * static_cast<ElementS>(std::numbers::log2e);
+    ElementS val = args.scale * std::numbers::log2e_v<ElementS>;
     return Params{
         val,
         args.philox_args,

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_mainloop.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_mainloop.h
@@ -19,6 +19,7 @@
 #include <cute/atom/mma_atom.hpp>
 
 #include <flash_attention_v2/collective/fmha_fusion.hpp>
+#include <numbers>
 
 #include <sycltla/dropout.h>
 
@@ -175,8 +176,7 @@ struct FMHAFwdMainloop<
   static constexpr Params to_underlying_arguments(
       Arguments const& args,
       void* /* workspace */) {
-    constexpr double kLog2e = 1.4426950408889634074; // log_2(e)
-    ElementS val = args.scale * static_cast<ElementS>(kLog2e);
+    ElementS val = args.scale * static_cast<ElementS>(std::numbers::log2e);
     return Params{
         val,
         args.philox_args,

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
@@ -139,7 +139,7 @@ struct Param {
         dv_ptr(dv),
         pb_ptr(pb),
         scale_softmax(softmax_scale),
-        scale_softmax_log2(softmax_scale * std::numbers::log2e),
+        scale_softmax_log2(softmax_scale * std::numbers::log2e_v<float>),
         p_dropout(p_dropout),
         p_dropout_in_uint16_t(p_dropout_in_uint16_t),
         rp_dropout(rp_dropout) {}

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
@@ -30,6 +30,7 @@
 #include <sycl/sycl.hpp>
 #include <sycltla/dropout.h>
 #include <sycltla/mha_common.h>
+#include <numbers>
 
 #pragma clang diagnostic pop
 #pragma GCC diagnostic pop
@@ -138,7 +139,7 @@ struct Param {
         dv_ptr(dv),
         pb_ptr(pb),
         scale_softmax(softmax_scale),
-        scale_softmax_log2(softmax_scale * M_LOG2E),
+        scale_softmax_log2(softmax_scale * std::numbers::log2e),
         p_dropout(p_dropout),
         p_dropout_in_uint16_t(p_dropout_in_uint16_t),
         rp_dropout(rp_dropout) {}

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
@@ -139,7 +139,7 @@ struct Param {
         dv_ptr(dv),
         pb_ptr(pb),
         scale_softmax(softmax_scale),
-        scale_softmax_log2(softmax_scale * std::numbers::log2e_v<float>),
+        scale_softmax_log2(softmax_scale * std::numbers::log2e),
         p_dropout(p_dropout),
         p_dropout_in_uint16_t(p_dropout_in_uint16_t),
         rp_dropout(rp_dropout) {}

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
@@ -457,7 +457,7 @@ CUTLASS_DEVICE void scale_apply_exp2(
     const float row_max = max(m);
     const float max_scaled = row_max == -std::numeric_limits<float>::infinity()
         ? 0.f
-        : row_max * std::numbers::log2e_v<float>;
+        : row_max * std::numbers::log2e;
     CUTLASS_PRAGMA_UNROLL
     for (int ni = 0; ni < size<1>(tensor); ++ni) {
       tensor(mi, ni) = exp2f(tensor(mi, ni) * scale_softmax_log2 - max_scaled);

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
@@ -16,6 +16,7 @@
 
 #include <ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h>
 #include <ATen/native/transformers/xpu/flash_attn/sycltla/mha_common.h>
+#include <limits>
 #include <numbers>
 
 namespace cute {
@@ -454,9 +455,9 @@ CUTLASS_DEVICE void scale_apply_exp2(
       }
     }
     const float row_max = max(m);
-    const float max_scaled = (sycl::isinf(row_max) && row_max < 0.f)
+    const float max_scaled = row_max == -std::numeric_limits<float>::infinity()
         ? 0.f
-        : row_max * std::numbers::log2e;
+        : row_max * std::numbers::log2e_v<float>;
     CUTLASS_PRAGMA_UNROLL
     for (int ni = 0; ni < size<1>(tensor); ++ni) {
       tensor(mi, ni) = exp2f(tensor(mi, ni) * scale_softmax_log2 - max_scaled);

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
@@ -16,6 +16,7 @@
 
 #include <ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h>
 #include <ATen/native/transformers/xpu/flash_attn/sycltla/mha_common.h>
+#include <numbers>
 
 namespace cute {
 
@@ -452,7 +453,10 @@ CUTLASS_DEVICE void scale_apply_exp2(
         continue;
       }
     }
-    const float max_scaled = max(m) == -INFINITY ? 0.f : max(m) * M_LOG2E;
+    const float row_max = max(m);
+    const float max_scaled = (sycl::isinf(row_max) && row_max < 0.f)
+        ? 0.f
+        : row_max * std::numbers::log2e;
     CUTLASS_PRAGMA_UNROLL
     for (int ni = 0; ni < size<1>(tensor); ++ni) {
       tensor(mi, ni) = exp2f(tensor(mi, ni) * scale_softmax_log2 - max_scaled);

--- a/src/ATen/native/xpu/sycl/ActivationGeluKernel.cpp
+++ b/src/ATen/native/xpu/sycl/ActivationGeluKernel.cpp
@@ -27,8 +27,8 @@ template <typename scalar_t>
 struct GeluTanhFunctor {
   scalar_t operator()(scalar_t x) const {
     using opmath_t = at::opmath_type<scalar_t>;
-    constexpr opmath_t kBeta = std::numbers::sqrt2_v<opmath_t> *
-        (2 * std::numbers::inv_sqrtpi_v<opmath_t>)*opmath_t(0.5);
+    constexpr opmath_t kBeta =
+        std::numbers::sqrt2_v<opmath_t> * std::numbers::inv_sqrtpi_v<opmath_t>;
     constexpr opmath_t kKappa = 0.044715;
     auto x_cube = static_cast<opmath_t>(x) * static_cast<opmath_t>(x) *
         static_cast<opmath_t>(x);
@@ -42,8 +42,8 @@ template <typename scalar_t>
 struct GeluTanhBackwardFunctor {
   scalar_t operator()(scalar_t dy, scalar_t x) const {
     using opmath_t = at::opmath_type<scalar_t>;
-    constexpr opmath_t kBeta = std::numbers::sqrt2_v<opmath_t> *
-        (2 * std::numbers::inv_sqrtpi_v<opmath_t>)*opmath_t(0.5);
+    constexpr opmath_t kBeta =
+        std::numbers::sqrt2_v<opmath_t> * std::numbers::inv_sqrtpi_v<opmath_t>;
     constexpr opmath_t kKappa = 0.044715;
     auto x_sq = static_cast<opmath_t>(x) * static_cast<opmath_t>(x);
     auto x_cube = x_sq * static_cast<opmath_t>(x);
@@ -67,10 +67,9 @@ template <typename scalar_t>
 struct GeluErfFunctor {
   scalar_t operator()(scalar_t x) const {
     using opmath_t = at::opmath_type<scalar_t>;
+    constexpr opmath_t kAlpha = std::numbers::sqrt2_v<opmath_t> / 2;
     return static_cast<opmath_t>(x) * opmath_t(0.5) *
-        (opmath_t(1) +
-         sycl::erf(
-             static_cast<opmath_t>(x) * std::numbers::inv_sqrt2_v<opmath_t>));
+        (opmath_t(1) + sycl::erf(static_cast<opmath_t>(x) * kAlpha));
   }
 };
 
@@ -78,14 +77,10 @@ template <typename scalar_t>
 struct GeluErfBackwardFunctor {
   scalar_t operator()(scalar_t dy, scalar_t x) const {
     using opmath_t = at::opmath_type<scalar_t>;
-    constexpr opmath_t kBeta =
-        (2 * std::numbers::inv_sqrtpi_v<opmath_t>)*std::numbers::inv_sqrt2_v<
-            opmath_t> *
-        opmath_t(0.5);
+    constexpr opmath_t kAlpha = std::numbers::sqrt2_v<opmath_t> / 2;
+    constexpr opmath_t kBeta = std::numbers::inv_sqrtpi_v<opmath_t> * kAlpha;
     const opmath_t cdf = opmath_t(0.5) *
-        (opmath_t(1) +
-         sycl::erf(
-             static_cast<opmath_t>(x) * std::numbers::inv_sqrt2_v<opmath_t>));
+        (opmath_t(1) + sycl::erf(static_cast<opmath_t>(x) * kAlpha));
     const opmath_t pdf = c10::xpu::compat::exp(
                              opmath_t(-0.5) * static_cast<opmath_t>(x) *
                              static_cast<opmath_t>(x)) *

--- a/src/ATen/native/xpu/sycl/ActivationGeluKernel.cpp
+++ b/src/ATen/native/xpu/sycl/ActivationGeluKernel.cpp
@@ -15,6 +15,7 @@
 #include <ATen/native/xpu/sycl/Loops.h>
 #include <comm/XPUMathCompat.h>
 #include <comm/xpu_aten.h>
+#include <numbers>
 
 #include <ATen/native/xpu/sycl/ActivationGeluKernel.h>
 
@@ -26,7 +27,8 @@ template <typename scalar_t>
 struct GeluTanhFunctor {
   scalar_t operator()(scalar_t x) const {
     using opmath_t = at::opmath_type<scalar_t>;
-    constexpr opmath_t kBeta = M_SQRT2 * M_2_SQRTPI * opmath_t(0.5);
+    constexpr opmath_t kBeta = std::numbers::sqrt2_v<opmath_t> *
+        (2 * std::numbers::inv_sqrtpi_v<opmath_t>)*opmath_t(0.5);
     constexpr opmath_t kKappa = 0.044715;
     auto x_cube = static_cast<opmath_t>(x) * static_cast<opmath_t>(x) *
         static_cast<opmath_t>(x);
@@ -40,7 +42,8 @@ template <typename scalar_t>
 struct GeluTanhBackwardFunctor {
   scalar_t operator()(scalar_t dy, scalar_t x) const {
     using opmath_t = at::opmath_type<scalar_t>;
-    constexpr opmath_t kBeta = M_SQRT2 * M_2_SQRTPI * opmath_t(0.5);
+    constexpr opmath_t kBeta = std::numbers::sqrt2_v<opmath_t> *
+        (2 * std::numbers::inv_sqrtpi_v<opmath_t>)*opmath_t(0.5);
     constexpr opmath_t kKappa = 0.044715;
     auto x_sq = static_cast<opmath_t>(x) * static_cast<opmath_t>(x);
     auto x_cube = x_sq * static_cast<opmath_t>(x);
@@ -64,9 +67,10 @@ template <typename scalar_t>
 struct GeluErfFunctor {
   scalar_t operator()(scalar_t x) const {
     using opmath_t = at::opmath_type<scalar_t>;
-    constexpr opmath_t kAlpha = M_SQRT1_2;
     return static_cast<opmath_t>(x) * opmath_t(0.5) *
-        (opmath_t(1) + sycl::erf(static_cast<opmath_t>(x) * kAlpha));
+        (opmath_t(1) +
+         sycl::erf(
+             static_cast<opmath_t>(x) * std::numbers::inv_sqrt2_v<opmath_t>));
   }
 };
 
@@ -74,10 +78,14 @@ template <typename scalar_t>
 struct GeluErfBackwardFunctor {
   scalar_t operator()(scalar_t dy, scalar_t x) const {
     using opmath_t = at::opmath_type<scalar_t>;
-    constexpr opmath_t kBeta = M_2_SQRTPI * M_SQRT1_2 * opmath_t(0.5);
-    constexpr opmath_t kAlpha = M_SQRT1_2;
+    constexpr opmath_t kBeta =
+        (2 * std::numbers::inv_sqrtpi_v<opmath_t>)*std::numbers::inv_sqrt2_v<
+            opmath_t> *
+        opmath_t(0.5);
     const opmath_t cdf = opmath_t(0.5) *
-        (opmath_t(1) + sycl::erf(static_cast<opmath_t>(x) * kAlpha));
+        (opmath_t(1) +
+         sycl::erf(
+             static_cast<opmath_t>(x) * std::numbers::inv_sqrt2_v<opmath_t>));
     const opmath_t pdf = c10::xpu::compat::exp(
                              opmath_t(-0.5) * static_cast<opmath_t>(x) *
                              static_cast<opmath_t>(x)) *

--- a/src/ATen/native/xpu/sycl/SharedReduceOps.h
+++ b/src/ATen/native/xpu/sycl/SharedReduceOps.h
@@ -24,12 +24,6 @@
 #include <complex>
 #include <type_traits>
 
-#define MAX(X, Y) max_impl(X, Y)
-#define MIN(X, Y) min_impl(X, Y)
-
-#define device_sqrt sycl::sqrt
-#define compat_pow sycl::pow
-
 namespace at {
 namespace native {
 namespace xpu {
@@ -95,7 +89,7 @@ struct WelfordOps {
     const auto mean = static_cast<scalar_t>(acc.mean);
     const auto divisor = acc.nf > correction ? acc.nf - correction : 0;
     const auto var = acc.m2 / divisor;
-    res_t results(take_sqrt ? device_sqrt(var) : var, mean);
+    res_t results(take_sqrt ? sycl::sqrt(var) : var, mean);
     return results;
   }
 
@@ -141,11 +135,11 @@ struct MeanOps {
 template <typename scalar_t, typename acc_t = scalar_t, typename out_t = acc_t>
 struct AbsMinOps {
   inline acc_t reduce(acc_t acc, scalar_t data, int64_t /*idx*/) const {
-    return MIN(acc, static_cast<acc_t>(std::abs(data)));
+    return min_impl(acc, static_cast<acc_t>(std::abs(data)));
   }
 
   inline acc_t combine(acc_t a, acc_t b) const {
-    return MIN(a, b);
+    return min_impl(a, b);
   }
 
   inline out_t project(acc_t a) const {
@@ -164,11 +158,11 @@ struct AbsMinOps {
 template <typename scalar_t, typename acc_t = scalar_t, typename out_t = acc_t>
 struct AbsMaxOps {
   inline acc_t reduce(acc_t acc, scalar_t data, int64_t /*idx*/) const {
-    return MAX(acc, static_cast<acc_t>(std::abs(data)));
+    return max_impl(acc, static_cast<acc_t>(std::abs(data)));
   }
 
   inline acc_t combine(acc_t a, acc_t b) const {
-    return MAX(a, b);
+    return max_impl(a, b);
   }
 
   inline out_t project(acc_t a) const {
@@ -189,7 +183,7 @@ struct NormOps {
   acc_t norm_;
 
   inline acc_t reduce(acc_t acc, scalar_t data, int64_t /*idx*/) const {
-    return acc + compat_pow(static_cast<acc_t>(std::abs(data)), norm_);
+    return acc + sycl::pow(static_cast<acc_t>(std::abs(data)), norm_);
   }
 
   inline acc_t combine(acc_t a, acc_t b) const {
@@ -197,7 +191,7 @@ struct NormOps {
   }
 
   inline out_t project(acc_t a) const {
-    return compat_pow(a, static_cast<acc_t>(1.0) / norm_);
+    return sycl::pow(a, static_cast<acc_t>(1.0) / norm_);
   }
 
   static acc_t translate_idx(acc_t acc, int64_t /*base_idx*/) {
@@ -289,7 +283,7 @@ struct NormTwoOps {
   }
 
   inline out_t project(acc_t a) const {
-    return device_sqrt(a);
+    return sycl::sqrt(a);
   }
 
   static acc_t translate_idx(acc_t acc, int64_t /*base_idx*/) {

--- a/src/ATen/native/xpu/sycl/UnaryComplexKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryComplexKernels.cpp
@@ -16,6 +16,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/native/TensorIterator.h>
 #include <c10/core/ScalarType.h>
+#include <numbers>
 
 #include <ATen/native/xpu/sycl/CopyKernel.h>
 #include <ATen/native/xpu/sycl/Loops.h>
@@ -133,7 +134,7 @@ struct AngleWrapper {
     if (at::_isnan(v)) {
       return v;
     }
-    return v < 0 ? M_PI : 0;
+    return v < 0 ? std::numbers::pi : 0;
   }
 };
 

--- a/src/ATen/native/xpu/sycl/UnaryComplexKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryComplexKernels.cpp
@@ -134,7 +134,7 @@ struct AngleWrapper {
     if (at::_isnan(v)) {
       return v;
     }
-    return v < 0 ? std::numbers::pi : 0;
+    return v < 0 ? std::numbers::pi_v<scalar_t> : scalar_t(0);
   }
 };
 

--- a/src/ATen/native/xpu/sycl/UnarySpecialOpsKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UnarySpecialOpsKernels.cpp
@@ -129,7 +129,7 @@ struct Exp2Functor<c10::complex<T>> {
   c10::complex<T> operator()(c10::complex<T> x) const {
     // There is no std::exp2 overload for complex, so instead
     // use the identity 2^x = e^(ln(2) * x)
-    return std::exp(static_cast<T>(std::numbers::ln2) * x);
+    return std::exp(std::numbers::ln2_v<T> * x);
   }
 };
 

--- a/src/ATen/native/xpu/sycl/UnarySpecialOpsKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UnarySpecialOpsKernels.cpp
@@ -22,6 +22,7 @@
 #include <c10/core/ScalarType.h>
 #include <c10/util/complex.h>
 #include <comm/xpu_aten.h>
+#include <numbers>
 
 #include <ATen/native/xpu/sycl/UnarySpecialOpsKernels.h>
 
@@ -128,8 +129,7 @@ struct Exp2Functor<c10::complex<T>> {
   c10::complex<T> operator()(c10::complex<T> x) const {
     // There is no std::exp2 overload for complex, so instead
     // use the identity 2^x = e^(ln(2) * x)
-    const auto ln_2 = static_cast<T>(0.693147180559945309417232121458176);
-    return std::exp(ln_2 * x);
+    return std::exp(static_cast<T>(std::numbers::ln2) * x);
   }
 };
 

--- a/src/comm/XPUMathCompat.h
+++ b/src/comm/XPUMathCompat.h
@@ -125,10 +125,10 @@ static inline double tanh(double x) {
 }
 
 static inline float normcdf(float x) {
-  return 0.5f * sycl::erfc(-x * static_cast<float>(std::numbers::inv_sqrt2));
+  return 0.5f * sycl::erfc(-x * (std::numbers::sqrt2_v<float> / 2));
 }
 static inline double normcdf(double x) {
-  return 0.5 * sycl::erfc(-x * std::numbers::inv_sqrt2);
+  return 0.5 * sycl::erfc(-x * (std::numbers::sqrt2_v<double> / 2));
 }
 
 // To walk around SYCL compiler optimization on data type promotion.

--- a/src/comm/XPUMathCompat.h
+++ b/src/comm/XPUMathCompat.h
@@ -13,126 +13,122 @@
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
 #include <sycl/sycl.hpp>
-
-#define __MATH_FUNCTIONS_DECL__ static inline
+#include <numbers>
 
 namespace c10::xpu::compat {
 
-__MATH_FUNCTIONS_DECL__ float abs(float x) {
+static inline float abs(float x) {
   return sycl::fabs(x);
 }
-__MATH_FUNCTIONS_DECL__ double abs(double x) {
+static inline double abs(double x) {
   return sycl::fabs(x);
 }
 
-__MATH_FUNCTIONS_DECL__ float exp(float x) {
+static inline float exp(float x) {
   return sycl::exp(x);
 }
-__MATH_FUNCTIONS_DECL__ double exp(double x) {
+static inline double exp(double x) {
   return sycl::exp(x);
 }
 
-__MATH_FUNCTIONS_DECL__ float ceil(float x) {
+static inline float ceil(float x) {
   return sycl::ceil(x);
 }
-__MATH_FUNCTIONS_DECL__ double ceil(double x) {
+static inline double ceil(double x) {
   return sycl::ceil(x);
 }
 
-__MATH_FUNCTIONS_DECL__ float copysign(float x, float y) {
+static inline float copysign(float x, float y) {
   return sycl::copysign(x, y);
 }
-__MATH_FUNCTIONS_DECL__ double copysign(double x, double y) {
+static inline double copysign(double x, double y) {
   return sycl::copysign(x, y);
 }
 
-__MATH_FUNCTIONS_DECL__ float floor(float x) {
+static inline float floor(float x) {
   return sycl::floor(x);
 }
-__MATH_FUNCTIONS_DECL__ double floor(double x) {
+static inline double floor(double x) {
   return sycl::floor(x);
 }
 
-__MATH_FUNCTIONS_DECL__ float log(float x) {
+static inline float log(float x) {
   return sycl::log(x);
 }
-__MATH_FUNCTIONS_DECL__ double log(double x) {
+static inline double log(double x) {
   return sycl::log(x);
 }
 
-__MATH_FUNCTIONS_DECL__ float log1p(float x) {
+static inline float log1p(float x) {
   return sycl::log1p(x);
 }
-__MATH_FUNCTIONS_DECL__ double log1p(double x) {
+static inline double log1p(double x) {
   return sycl::log1p(x);
 }
 
-__MATH_FUNCTIONS_DECL__ float max(float x, float y) {
+static inline float max(float x, float y) {
   return sycl::fmax(x, y);
 }
-__MATH_FUNCTIONS_DECL__ double max(double x, double y) {
+static inline double max(double x, double y) {
   return sycl::fmax(x, y);
 }
 
-__MATH_FUNCTIONS_DECL__ float min(float x, float y) {
+static inline float min(float x, float y) {
   return sycl::fmin(x, y);
 }
-__MATH_FUNCTIONS_DECL__ double min(double x, double y) {
+static inline double min(double x, double y) {
   return sycl::fmin(x, y);
 }
 
-__MATH_FUNCTIONS_DECL__ float pow(float x, float y) {
+static inline float pow(float x, float y) {
   return sycl::pow(x, y);
 }
-__MATH_FUNCTIONS_DECL__ double pow(double x, double y) {
+static inline double pow(double x, double y) {
   return sycl::pow(x, y);
 }
 
-__MATH_FUNCTIONS_DECL__ void sincos(float x, float* sptr, float* cptr) {
+static inline void sincos(float x, float* sptr, float* cptr) {
   *sptr = sycl::sin(x);
   *cptr = sycl::cos(x);
 }
-__MATH_FUNCTIONS_DECL__ void sincos(double x, double* sptr, double* cptr) {
+static inline void sincos(double x, double* sptr, double* cptr) {
   *sptr = sycl::sin(x);
   *cptr = sycl::cos(x);
 }
 
-__MATH_FUNCTIONS_DECL__ float sqrt(float x) {
+static inline float sqrt(float x) {
   return sycl::sqrt(x);
 }
-__MATH_FUNCTIONS_DECL__ double sqrt(double x) {
+static inline double sqrt(double x) {
   return sycl::sqrt(x);
 }
 
-__MATH_FUNCTIONS_DECL__ float rsqrt(float x) {
+static inline float rsqrt(float x) {
   return sycl::rsqrt(x);
 }
-__MATH_FUNCTIONS_DECL__ double rsqrt(double x) {
+static inline double rsqrt(double x) {
   return sycl::rsqrt(x);
 }
 
-__MATH_FUNCTIONS_DECL__ float tan(float x) {
+static inline float tan(float x) {
   return sycl::tan(x);
 }
-__MATH_FUNCTIONS_DECL__ double tan(double x) {
+static inline double tan(double x) {
   return sycl::tan(x);
 }
 
-__MATH_FUNCTIONS_DECL__ float tanh(float x) {
+static inline float tanh(float x) {
   return sycl::tanh(x);
 }
-__MATH_FUNCTIONS_DECL__ double tanh(double x) {
+static inline double tanh(double x) {
   return sycl::tanh(x);
 }
 
-// https://github.com/intel/llvm/blob/HEAD/libc/include/llvm-libc-macros/math-macros.h
-constexpr double kSqrt1_2 = 0x1.6a09e667f3bcdp-1; // 1/sqrt(2) M_SQRT1_2
-
-__MATH_FUNCTIONS_DECL__ float normcdf(float x) {
-  return 0.5f * sycl::erfc(-x * static_cast<float>(kSqrt1_2));
+static inline float normcdf(float x) {
+  return 0.5f * sycl::erfc(-x * static_cast<float>(std::numbers::inv_sqrt2));
 }
-__MATH_FUNCTIONS_DECL__ double normcdf(double x) {
-  return 0.5 * sycl::erfc(-x * kSqrt1_2);
+static inline double normcdf(double x) {
+  return 0.5 * sycl::erfc(-x * std::numbers::inv_sqrt2);
 }
 
 // To walk around SYCL compiler optimization on data type promotion.


### PR DESCRIPTION
Replace the `math.h` `M_*` macros and hand-rolled constants with typed `std::numbers::*_v<T>` (constexpr, defined on MSVC), and drop the vestigial `__MATH_FUNCTIONS_DECL__` / `MAX` / `MIN` / `device_sqrt` / `compat_pow` macros.

All constants are bit-identical to the old values; `std::numbers` has no `inv_sqrt2`, so 1/sqrt(2) is spelled `sqrt2_v<T> / 2` (exact). The flash-attention `log2e` sites keep double math per review, and `x == -INFINITY` becomes `x == -std::numeric_limits<float>::infinity()`.

---
Authored with the assistance of an AI coding agent (Claude).
