### PR TITLE
[XPU] Fix D2H non_blocking copy synchronization on PVC

### DIFF
--- a/src/ATen/native/xpu/Copy.cpp
+++ b/src/ATen/native/xpu/Copy.cpp
@@ -296,7 +296,21 @@ void _copy_xpu(TensorIterator& iter, bool non_blocking) {
             at::xpu::getCurrentXPUStream());
       }
     } else {
-      q.memcpy(dst, src, nbytes);
+      // D2H (Device-to-Host) non_blocking copy.
+      //
+      // Capture the SYCL event from q.memcpy() and chain it with an explicit
+      // barrier so the queue's command graph properly tracks the copy.
+      // On SYCL in-order queues the implicit ordering should guarantee that
+      // a subsequent ext_oneapi_submit_barrier() waits for the memcpy, but
+      // on hardware with dedicated copy engines (e.g., PVC) the runtime may
+      // route the memcpy through a separate DMA engine whose completion is
+      // not captured by the next queue-only barrier.  By submitting an
+      // explicit barrier that depends on the copy event we force the runtime
+      // to account for the DMA operation, so that torch.Event().record() /
+      // synchronize() (which internally calls ext_oneapi_submit_barrier())
+      // correctly waits for the D2H transfer to complete.
+      auto copy_event = q.memcpy(dst, src, nbytes);
+      q.ext_oneapi_submit_barrier({copy_event});
       if (at::detail::getXPUHooks().isPinnedPtr(dst)) {
         at::getHostAllocator(at::kXPU)->record_event(
             const_cast<void*>(dst),


### PR DESCRIPTION
The D2H (Device-to-Host) non_blocking copy path in `_copy_xpu()` discards the `sycl::event` returned by `q.memcpy()`. On hardware with dedicated DMA copy engines (e.g., PVC / Intel Data Center GPU Max 1550), the SYCL runtime may route the memcpy through a separate engine whose completion is not captured by a subsequent `ext_oneapi_submit_barrier()` on the main queue. This means `torch.Event().record() + synchronize()` (which internally uses `ext_oneapi_submit_barrier()`) can return before the D2H transfer has actually finished, leading to stale/zero data on the CPU side.

## Fix

Capture the `sycl::event` from `q.memcpy()` and chain it with an explicit `ext_oneapi_submit_barrier({copy_event})` so the queue's command graph properly accounts for the DMA operation. Any subsequent queue barrier will now correctly wait for the D2H copy to complete.

```cpp
// BEFORE (BROKEN)
q.memcpy(dst, src, nbytes);

// AFTER (FIXED)
auto copy_event = q.memcpy(dst, src, nbytes);
q.ext_oneapi_submit_barrier({copy_event});
```

This is a no-op on Xe2 hardware where the SYCL runtime uses the queue itself for memcpy.

## Why the explicit barrier is needed despite in-order queue semantics

An in-order queue guarantees operation order **within the main command stream**, but on PVC the SYCL runtime routes D2H `q.memcpy()` through a **dedicated hardware DMA engine** that operates asynchronously from the main queue. `ext_oneapi_submit_barrier()` without event dependencies only tracks the main queue's command stream — it does not capture DMA engine operations. By passing the copy event as a dependency to `ext_oneapi_submit_barrier({copy_event})`, we force the runtime to account for the DMA operation in its command graph.

This was confirmed empirically: the bug only manifests on PVC after a driver update enabled DMA engine routing for memcpy, and only in the AOTI test wrapper which exercises a specific timing profile that triggers the race.

## Validation

- ✅ **PVC (Intel Data Center GPU Max 1550):** D2H non_blocking copy tests (single, multi, large) — **ALL PASS**
- ✅ **BMG (Intel Battlemage GPU):** D2H non_blocking copy tests (single, multi, large) — **ALL PASS**
- `test_copy_non_blocking_is_pinned_xpu` (AOTInductorTestDualWrapper) passes on Xe2 (Intel Arc Pro B60)

## Related Issues

Fixes pytorch/pytorch#189327
Fixes pytorch/pytorch#189326
