### PR TITLE
Prevent numpy error for block diag on Windows when numpy>=2.0

### DIFF
--- a/test/xpu/test_tensor_creation_ops_xpu.py
+++ b/test/xpu/test_tensor_creation_ops_xpu.py
@@ -485,10 +485,16 @@ class TestTensorCreation(TestCase):
             torch.float32,
         ]
 
+        # numpy < 2.0 on Windows used int32 as the default integer type
+        # numpy >= 2.0 uses int64 everywhere
+        scipy_int_type = (
+            torch.int32
+            if IS_WINDOWS and np.lib.NumpyVersion(np.__version__) < "2.0.0"
+            else torch.int64
+        )
         expected_scipy_types = [
             torch.float64,
-            # windows scipy block_diag returns int32 types
-            torch.int32 if IS_WINDOWS else torch.int64,
+            scipy_int_type,
             torch.complex128,
             torch.float64,
         ]


### PR DESCRIPTION
 From version 2.0 NumPy on Windows uses int64 as default integer: https://numpy.org/devdocs/numpy_2_0_migration_guide.html#windows-default-integer. Checking NumPy version will prevent from the error `AssertionError: Object comparison failed: torch.int64 != torch.int32` when NumPy will be updated on CI. Issue: https://github.com/intel/torch-xpu-ops/issues/4326