### PR TITLE
Turn Philox and Reduce #define constants into inline constexpr and reuse uniform helpers

### DIFF
--- a/src/ATen/native/xpu/sycl/Philox4x32.h
+++ b/src/ATen/native/xpu/sycl/Philox4x32.h
@@ -47,6 +47,7 @@
 
 #include <ATen/core/DistributionsHelper.h>
 #include <ATen/native/xpu/sycl/MemoryAccess.h>
+#include <numbers>
 
 namespace at {
 namespace native {
@@ -328,21 +329,19 @@ static inline uint4 rand4(randStatePhilox4_32_10_t* state) {
   return r;
 }
 
-#define RAND_2POW32_INV (2.3283064e-10f)
-#define RAND_2POW32_INV_2PI (2.3283064e-10f * 6.2831855f)
-#define RAND_2POW53_INV_DOUBLE (1.1102230246251565e-16)
-#define RAND_PI_DOUBLE (3.1415926535897932)
+inline constexpr float RAND_2POW32_INV = 0x1p-32f;
+inline constexpr float RAND_2POW32_INV_2PI =
+    RAND_2POW32_INV * 2 * std::numbers::pi_v<float>;
+inline constexpr double RAND_2POW53_INV_DOUBLE = 0x1p-53;
 
 // =================== uniform ===================
 
 static inline float _rand_uniform(unsigned int x) {
-  return x * RAND_2POW32_INV + (RAND_2POW32_INV / 2.0f);
+  return x * RAND_2POW32_INV + RAND_2POW32_INV / 2;
 }
 
 static inline float _rand_uniform(unsigned long long x) {
-  unsigned int t;
-  t = (unsigned int)(x >> 32);
-  return t * RAND_2POW32_INV + (RAND_2POW32_INV / 2.0f);
+  return _rand_uniform((unsigned int)(x >> 32));
 }
 
 static inline float rand_uniform(randStatePhilox4_32_10_t* state) {
@@ -352,10 +351,10 @@ static inline float rand_uniform(randStatePhilox4_32_10_t* state) {
 static inline float4 rand_uniform4(randStatePhilox4_32_10_t* state) {
   auto x = rand4(state);
   float4 y;
-  y.x = x.x * RAND_2POW32_INV + (RAND_2POW32_INV / 2.0f);
-  y.y = x.y * RAND_2POW32_INV + (RAND_2POW32_INV / 2.0f);
-  y.z = x.z * RAND_2POW32_INV + (RAND_2POW32_INV / 2.0f);
-  y.w = x.w * RAND_2POW32_INV + (RAND_2POW32_INV / 2.0f);
+  y.x = _rand_uniform(x.x);
+  y.y = _rand_uniform(x.y);
+  y.z = _rand_uniform(x.z);
+  y.w = _rand_uniform(x.w);
   return y;
 }
 
@@ -377,8 +376,8 @@ static inline double2 rand_uniform2_double(randStatePhilox4_32_10_t* state) {
 
 static inline float2 _rand_box_muller(unsigned int x, unsigned int y) {
   float2 result;
-  float u = x * RAND_2POW32_INV + (RAND_2POW32_INV / 2);
-  float v = y * RAND_2POW32_INV_2PI + (RAND_2POW32_INV_2PI / 2);
+  float u = _rand_uniform(x);
+  float v = y * RAND_2POW32_INV_2PI + RAND_2POW32_INV_2PI / 2;
   float s = sycl::sqrt(-2.0f * sycl::log(u));
   result.x = sycl::sin(v);
   result.y = sycl::cos(v);
@@ -407,16 +406,14 @@ static inline double2 _rand_box_muller_double(
     unsigned int y0,
     unsigned int y1) {
   double2 result;
-  unsigned long long zx =
-      (unsigned long long)x0 ^ ((unsigned long long)x1 << (53 - 32));
-  double u = zx * RAND_2POW53_INV_DOUBLE + (RAND_2POW53_INV_DOUBLE / 2.0);
+  double u = _rand_uniform_double_hq(x0, x1);
   unsigned long long zy =
       (unsigned long long)y0 ^ ((unsigned long long)y1 << (53 - 32));
   double v = zy * (RAND_2POW53_INV_DOUBLE * 2.0) + RAND_2POW53_INV_DOUBLE;
   double s = sycl::sqrt(-2.0 * sycl::log(u));
 
-  result.x = sycl::sin(v * RAND_PI_DOUBLE);
-  result.y = sycl::cos(v * RAND_PI_DOUBLE);
+  result.x = sycl::sin(v * std::numbers::pi);
+  result.y = sycl::cos(v * std::numbers::pi);
   result.x *= s;
   result.y *= s;
 
@@ -469,6 +466,7 @@ static inline double lgamma_integer(int a) {
       0.0, // a=0: undefined, but return 0
       0.0, // a=1: log(Gamma(1)) = log(0!) = 0
       0.0, // a=2: log(Gamma(2)) = log(1!) = 0
+      // NOLINTNEXTLINE(modernize-use-std-numbers)
       0.6931471805599453, // a=3: log(Gamma(3)) = log(2!) = log(2)
       1.7917594692280550, // a=4: log(Gamma(4)) = log(3!) = log(6)
       3.1780538303479458, // a=5: log(Gamma(5)) = log(4!) = log(24)

--- a/src/ATen/native/xpu/sycl/Reduce.h
+++ b/src/ATen/native/xpu/sycl/Reduce.h
@@ -1153,7 +1153,7 @@ class AccumulationBuffer {
   at::DataPtr buffer_;
 };
 
-#define DEFAULT_OUTPUT_VEC_SIZE 4
+inline constexpr int DEFAULT_OUTPUT_VEC_SIZE = 4;
 template <typename scalar_t, int vt1>
 int get_output_vec_size(at::TensorIterator& iter) {
   int vec_size = DEFAULT_OUTPUT_VEC_SIZE;


### PR DESCRIPTION
Replace the object-like macros in `Philox4x32.h` and `Reduce.h` (`RAND_2POW32_INV*`, `RAND_2POW53_INV_DOUBLE`, `DEFAULT_OUTPUT_VEC_SIZE`) with `inline constexpr`. Pi constants come from `std::numbers`, powers of two use hex-float literals, and the duplicated uniform-mapping expressions now reuse `_rand_uniform`/`_rand_uniform_double_hq`. All values are bit-exact with the old literals and -O2 codegen is unchanged; the lgamma table's log(2!) entry keeps its literal with a NOLINT.

Test: none (build-only refactor, covered by existing random/reduce tests)