### PR TITLE
Use float std::numbers variants in sycltla flash attention

### DIFF
--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_epilogue.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/collective/xe_fmha_fwd_epilogue.h
@@ -218,8 +218,8 @@ class FMHAFwdEpilogue {
             lane_id) { // only 1 lane contain the correct row maxima for that
                        // particular row
       // The softmax scale was multiplied by log2(e) in the mainloop
-      // Need to divide it to restore the value
-      tA_max[0] = tA_max[0] / std::numbers::log2e;
+      // Multiply by ln(2) == 1/log2(e) to restore the value
+      tA_max[0] = tA_max[0] * std::numbers::ln2_v<float>;
       float lse_val = tA_max[0] + logf(non_reciprocal_rAsum);
       *(pLSE + lse_offset + tile_row_idx) =
           lse_val == -std::numeric_limits<float>::infinity() ? 0 : lse_val;

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd.h
@@ -139,7 +139,7 @@ struct Param {
         dv_ptr(dv),
         pb_ptr(pb),
         scale_softmax(softmax_scale),
-        scale_softmax_log2(softmax_scale * std::numbers::log2e),
+        scale_softmax_log2(softmax_scale * std::numbers::log2e_v<float>),
         p_dropout(p_dropout),
         p_dropout_in_uint16_t(p_dropout_in_uint16_t),
         rp_dropout(rp_dropout) {}

--- a/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
+++ b/src/ATen/native/transformers/xpu/flash_attn/sycltla/mha_bwd_launch.h
@@ -457,7 +457,7 @@ CUTLASS_DEVICE void scale_apply_exp2(
     const float row_max = max(m);
     const float max_scaled = row_max == -std::numeric_limits<float>::infinity()
         ? 0.f
-        : row_max * std::numbers::log2e;
+        : row_max * std::numbers::log2e_v<float>;
     CUTLASS_PRAGMA_UNROLL
     for (int ni = 0; ni < size<1>(tensor); ++ni) {
       tensor(mi, ni) = exp2f(tensor(mi, ni) * scale_softmax_log2 - max_scaled);

--- a/src/ATen/native/xpu/sycl/LogAddExpKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LogAddExpKernels.cpp
@@ -151,15 +151,15 @@ template <typename scalar_t>
 struct LogAddExp2Functor {
   scalar_t operator()(scalar_t a_, scalar_t b_) const {
     using opmath_t = at::opmath_type<scalar_t>;
-    const auto inv_log_2 =
-        static_cast<opmath_t>(1.0 / std::numbers::ln2_v<double>);
     const auto a = static_cast<opmath_t>(a_);
     const auto b = static_cast<opmath_t>(b_);
     if (sycl::isinf(a) && a == b) {
       return a;
     } else {
       const auto m = std::max(a, b);
-      return m + sycl::log1p(sycl::exp2(-sycl::fabs(a - b))) * inv_log_2;
+      return m +
+          sycl::log1p(sycl::exp2(-sycl::fabs(a - b))) *
+          std::numbers::log2e_v<opmath_t>;
     }
   }
 };


### PR DESCRIPTION
Use `_v<float>` std::numbers constants in the sycltla flash attention kernels: the double `log2e`/`ln2` forced fp64 ops in float expressions; CUDA flash attention likewise uses `float(M_LOG2E)` in-kernel. The epilogue LSE restore multiplies by `ln2_v<float>` (bit-exact `float(1/log2e)`, faster than dividing). LogAddExp2's `1.0 / ln2_v<double>` becomes `log2e_v<opmath_t>`.

Numeric differences (20M random samples, all constants bit-exact, all diffs exactly 1 ulp):

| site | instructions | inputs that differ |
|---|---|---|
| epilogue LSE restore (device, per row) | fp32->fp64 convert + fp64 divide + fp64->fp32 convert -> one fp32 multiply | 3.4% |
| `max_scaled` (bwd device, per row/tile) and `scale_softmax_log2` (host, per launch) | fp32->fp64 convert + fp64 multiply + fp64->fp32 convert -> one fp32 multiply | 16.7% (now matches the fwd mainloop, which already used `log2e_v<ElementS>`) |
| LogAddExp2 `inv_log_2` | compile-time constant either way | 0% (bit-identical) |

Besides fewer instructions, this removes the kernels' only fp64 ops: on devices without `aspect::fp64` (e.g. Arc consumer GPUs) those required software emulation.

Test: none (covered by existing flash attention and logaddexp tests)