### PR TITLE
Fix local atomicMax doing fetch_add

### DIFF
--- a/src/ATen/native/xpu/sycl/Atomics.h
+++ b/src/ATen/native/xpu/sycl/Atomics.h
@@ -526,14 +526,14 @@ static inline void atomicMax(
     const sycl_local_ptr<int32_t>& address,
     int32_t val) {
   sycl_atomic_ref_rlx_wg_local_t<int32_t> target(*address);
-  target.fetch_add(val);
+  target.fetch_max(val);
 }
 
 static inline void atomicMax(
     const sycl_local_ptr<int64_t>& address,
     int64_t val) {
   sycl_atomic_ref_rlx_wg_local_t<int64_t> target(*address);
-  target.fetch_add(val);
+  target.fetch_max(val);
 }
 
 SYCL_ATOMIC_INTEGER(Max, safe_max<uint8_t>(a, b), uint8_t)


### PR DESCRIPTION
The `sycl_local_ptr<int32_t/int64_t>` `atomicMax` overloads called `fetch_add`, so racing threads accumulated instead of taking the max. Reached via MultinomialKernel's `foundPos` update (upstream CUDA uses `atomicMax(&foundPos, cat)` at the same spot).

Test: none (2-line fix; covered by existing multinomial tests, failure needs a same-bucket thread race)