### PR TITLE
Pass macro definitions to sycl kernel code

### DIFF
--- a/cmake/BuildFlags.cmake
+++ b/cmake/BuildFlags.cmake
@@ -37,12 +37,22 @@ macro(set_build_flags)
     return()
   endif()
   set(SYCL_HOST_FLAGS)
+  set(SYCL_DEVICE_COMPILE_DEFINITIONS)
   set(SYCL_KERNEL_OPTIONS)
   set(SYCL_COMPILE_FLAGS ${SYCL_FLAGS})
   set(SYCL_DEVICE_LINK_FLAGS ${SYCL_LINK_FLAGS})
   set(SYCL_OFFLINE_COMPILER_AOT_OPTIONS)
   set(SYCL_OFFLINE_COMPILER_CG_OPTIONS)
   set(SYCL_OFFLINE_COMPILER_FLAGS)
+
+  # Definitions that must reach the SYCL device compiler only, not the
+  # host C++ compilation. Consumed by SYCL_WRAP_SRCS in FindSYCL.cmake.
+  if(NOT DEFINED SYCL_COMPILER_VERSION OR NOT DEFINED USE_XPU)
+    message(FATAL_ERROR "SYCL_COMPILER_VERSION and USE_XPU must be defined. "
+      "Ensure SYCLToolkit is found before building torch-xpu-ops.")
+  endif()
+  list(APPEND SYCL_DEVICE_COMPILE_DEFINITIONS SYCL_COMPILER_VERSION=${SYCL_COMPILER_VERSION})
+  list(APPEND SYCL_DEVICE_COMPILE_DEFINITIONS USE_XPU=${USE_XPU})
 
   set(CPP_STD c++20)
   # -- Host flags (SYCL_CXX_FLAGS)
@@ -94,7 +104,7 @@ macro(set_build_flags)
   #
   # PSEUDO of separate compilation with DPCPP compiler.
   # 1. Kernel source compilation:
-  # icpx -fsycl -fsycl-target=${SYCL_TARGETS_OPTION} ${SYCL_KERNEL_OPTIONS} -fsycl-host-compiler=gcc -fsycl-host-compiler-options='${CMAKE_HOST_FLAGS}' kernel.cpp -o kernel.o
+  # icpx -fsycl -fsycl-target=${SYCL_TARGETS_OPTION} ${SYCL_KERNEL_OPTIONS} ${SYCL_DEVICE_COMPILE_DEFINITIONS} -fsycl-host-compiler=gcc -fsycl-host-compiler-options='${CMAKE_HOST_FLAGS}' kernel.cpp -o kernel.o
   # 2. Device code linkage:
   # icpx -fsycl -fsycl-target=${SYCL_TARGETS_OPTION} -fsycl-link ${SYCL_DEVICE_LINK_FLAGS} -Xs '${SYCL_OFFLINE_COMPILER_FLAGS}' kernel.o -o device-code.o
   # 3. Host only source compilation:

--- a/cmake/Modules/FindSYCL.cmake
+++ b/cmake/Modules/FindSYCL.cmake
@@ -194,6 +194,9 @@ macro(SYCL_WRAP_SRCS sycl_target generated_files)
 
   set(SYCL_compile_definitions "$<TARGET_PROPERTY:${sycl_target},COMPILE_DEFINITIONS>")
 
+  # Extra definitions for the SYCL device compiler only, not host C++ code.
+  set(SYCL_compile_definitions "${SYCL_compile_definitions};${SYCL_DEVICE_COMPILE_DEFINITIONS}")
+
   SYCL_GET_SOURCES_AND_OPTIONS(
     _sycl_sources
     _cxx_sources

--- a/src/ATen/xpu/Sleep.cpp
+++ b/src/ATen/xpu/Sleep.cpp
@@ -12,6 +12,11 @@
 #include <c10/xpu/XPUStream.h>
 #include <comm/SYCLContext.h>
 
+#if !defined(SYCL_COMPILER_VERSION)
+#error \
+    "SYCL_COMPILER_VERSION is not defined. Ensure SYCLToolkit is found before building torch-xpu-ops."
+#endif
+
 namespace at::xpu {
 
 void sleep(uint64_t cycles) {
@@ -38,7 +43,7 @@ void sleep(uint64_t cycles) {
   // the driver ships a newer IGC, migrate to a functor-based implementation.
   TORCH_CHECK_NOT_IMPLEMENTED(
       c10::xpu::get_raw_device(c10::xpu::current_device())
-          .has(sycl::aspect::ext_oneapi_device_clock),
+          .has(sycl::aspect::ext_oneapi_clock_device),
       "Requires the sycl_ext_oneapi_device_clock extension, "
       "which is not supported on this device. ",
       "Please upgrade to a newer driver.");


### PR DESCRIPTION
# Motivation
https://github.com/intel/torch-xpu-ops/pull/3629 introduces `SYCL_COMPILER_VERSION` for use in device code, but @NeoZhangJianyu found that it doesn't work as expected.

The reason is that this macro is currently only added to the host compilation. For SYCL device code, compile definitions must be passed through `SYCL_compile_definitions`, so `SYCL_COMPILER_VERSION` is not visible during device compilation.

We fix it in this PR and guard it in `Sleep.cpp` via `#error` syntax.

# Additional Context
Why the CI can't catch the error in https://github.com/pytorch/pytorch/pull/189527?
I found that the test was skipped due to CI lacks of pyzes:
```bash
2026-07-16T05:57:24.5881011Z test_xpu_expandable_segments.py::TestXpu::test_sleep <- test/test_xpu.py SKIPPED [0.0002s] (pyzes is required for this test) [ 43%]
```
See https://github.com/pytorch/pytorch/actions/runs/29469731264/job/87584586906?pr=189527#step:13:3160