### PR TITLE
Validate index_select bounds for empty XPU tensors

### DIFF
--- a/src/ATen/native/xpu/sycl/Indexing.cpp
+++ b/src/ATen/native/xpu/sycl/Indexing.cpp
@@ -28,6 +28,7 @@ DISABLE_RETURN_TYPE_WARNING_BEGIN
 #include <ATen/native/xpu/sycl/SortingKernels.h>
 #include <ATen/native/xpu/sycl/pstl/PSTLFunctions.h>
 #include <ATen/ops/_sparse_coo_tensor_with_dims_and_tensors.h>
+#include <ATen/ops/aminmax.h>
 #include <ATen/ops/arange.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/gather.h>
@@ -2121,6 +2122,23 @@ void index_select_out_impl(
   }
 
   at::native::resize_output(out, newSize);
+
+  if (self.numel() == 0 && numIndices > 0) {
+    const auto indexing_axis_dim = self.size(dim);
+    TORCH_CHECK(
+        indexing_axis_dim > 0,
+        "index_select(): self indexing axis dim should be positive");
+
+    const auto [min_index, max_index] = at::aminmax(index);
+    const auto min_index_value = min_index.item<int64_t>();
+    const auto max_index_value = max_index.item<int64_t>();
+    TORCH_CHECK(
+        min_index_value >= 0 && max_index_value < indexing_axis_dim,
+        "INDICES element is out of DATA bounds, id=",
+        min_index_value < 0 ? min_index_value : max_index_value,
+        " axis_dim=",
+        indexing_axis_dim);
+  }
 
   uint64_t outTotalSize = out.numel();
   if (outTotalSize == 0) {

--- a/src/ATen/native/xpu/sycl/Indexing.cpp
+++ b/src/ATen/native/xpu/sycl/Indexing.cpp
@@ -28,6 +28,7 @@ DISABLE_RETURN_TYPE_WARNING_BEGIN
 #include <ATen/native/xpu/sycl/SortingKernels.h>
 #include <ATen/native/xpu/sycl/pstl/PSTLFunctions.h>
 #include <ATen/ops/_sparse_coo_tensor_with_dims_and_tensors.h>
+#include <ATen/ops/aminmax.h>
 #include <ATen/ops/arange.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/gather.h>
@@ -2142,6 +2143,23 @@ void index_select_out_impl(
   }
 
   at::native::resize_output(out, newSize);
+
+  if (self.numel() == 0 && numIndices > 0) {
+    const auto indexing_axis_dim = self.size(dim);
+    TORCH_CHECK(
+        indexing_axis_dim > 0,
+        "index_select(): self indexing axis dim should be positive");
+
+    const auto [min_index, max_index] = at::aminmax(index);
+    const auto min_index_value = min_index.item<int64_t>();
+    const auto max_index_value = max_index.item<int64_t>();
+    TORCH_CHECK(
+        min_index_value >= 0 && max_index_value < indexing_axis_dim,
+        "INDICES element is out of DATA bounds, id=",
+        min_index_value < 0 ? min_index_value : max_index_value,
+        " axis_dim=",
+        indexing_axis_dim);
+  }
 
   uint64_t outTotalSize = out.numel();
   if (outTotalSize == 0) {

--- a/test/xpu/test_indexing_xpu.py
+++ b/test/xpu/test_indexing_xpu.py
@@ -196,6 +196,29 @@ with XPUPatchForImport(False):
 
         self.assertEqual(out, dst)
 
+    def index_select_empty_source_bounds(self, device):
+        source = torch.empty((0, 3), device=device)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "self indexing axis dim should be positive"
+        ):
+            torch.index_select(
+                source, 0, torch.tensor([0, 1], device=device, dtype=torch.int64)
+            )
+
+        for indices in ([0, 5], [-1]):
+            with self.assertRaisesRegex(
+                RuntimeError, "INDICES element is out of DATA bounds"
+            ):
+                torch.index_select(
+                    source, 1, torch.tensor(indices, device=device, dtype=torch.int64)
+                )
+
+        result = torch.index_select(
+            source, 1, torch.tensor([0, 2], device=device, dtype=torch.int64)
+        )
+        self.assertEqual(result.shape, (0, 2))
+
     TestIndexing.test_index_put_deterministic_with_optional_tensors = (
         __test_index_put_deterministic_with_optional_tensors
     )
@@ -203,6 +226,9 @@ with XPUPatchForImport(False):
     TestIndexing.test_index_select = index_select
     TestIndexing.test_index_add_empty_index_1d = index_add_empty_index_1d
     TestIndexing.test_index_add_empty_index_2d = index_add_empty_index_2d
+    TestIndexing.test_index_select_empty_source_bounds = (
+        index_select_empty_source_bounds
+    )
 
 instantiate_device_type_tests(NumpyTests, globals(), only_for=("xpu"), allow_xpu=True)
 


### PR DESCRIPTION
## Background

XPU returns early when an empty source produces an empty `index_select` output. That bypasses index validation, so invalid indices either expose an internal null-source error or succeed silently instead of matching CPU.

## Upstream

- [pytorch/pytorch#70675](https://github.com/pytorch/pytorch/issues/70675) reports incorrect `index_select` behavior for empty input.
- [pytorch/pytorch#77881](https://github.com/pytorch/pytorch/pull/77881) and landed [commit f69c990](https://github.com/pytorch/pytorch/commit/f69c990ecce9dacb9f28f0dd530ba9ea7503a153) establish the CPU validation contract ported to XPU here.

## Fix

- validate a zero-sized indexed dimension before the empty-output return
- reduce non-empty indices to their minimum and maximum and reject out-of-range values
- preserve valid empty-output behavior

## Before and after

| Case | Before | After |
|---|---|---|
| Invalid index on empty source | Internal error or silent success | Clear bounds `RuntimeError` |
| Valid index on non-indexed empty dimension | Returns empty output | Still returns empty output |

## Testing

Intel Data Center GPU Max 1100: all four invalid and valid empty-source scenarios passed.

Fixes #3445
