### PR TITLE
Raise catchable errors for invalid index_add and index_reduce indices

### DIFF
--- a/src/ATen/native/xpu/sycl/Indexing.cpp
+++ b/src/ATen/native/xpu/sycl/Indexing.cpp
@@ -28,6 +28,7 @@ DISABLE_RETURN_TYPE_WARNING_BEGIN
 #include <ATen/native/xpu/sycl/SortingKernels.h>
 #include <ATen/native/xpu/sycl/pstl/PSTLFunctions.h>
 #include <ATen/ops/_sparse_coo_tensor_with_dims_and_tensors.h>
+#include <ATen/ops/aminmax.h>
 #include <ATen/ops/arange.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/gather.h>
@@ -1205,6 +1206,17 @@ bool indexShouldBeMajor(
   return false;
 }
 
+static void check_index_bounds(const Tensor& index, int64_t dim_size) {
+  if (index.numel() == 0) {
+    return;
+  }
+
+  const auto [min_index, max_index] = at::aminmax(index);
+  TORCH_CHECK_INDEX(
+      min_index.item<int64_t>() >= 0 && max_index.item<int64_t>() < dim_size,
+      "index out of range in self");
+}
+
 template <typename func_t>
 void index_reduce_add_xpu_template(
     const Tensor& self,
@@ -1226,6 +1238,7 @@ void index_reduce_add_xpu_template(
   // Scalars are treated as 1-d tensor
   const Tensor self_ = (result.dim() == 0) ? result.view(1) : result;
   const Tensor source_ = (source.dim() == 0) ? source.view(1) : source;
+  check_index_bounds(index, self_.size(dim));
 
   TORCH_CHECK(
       result.dim() <= XPU_MAX_TENSORINFO_DIMS,
@@ -1498,6 +1511,7 @@ void index_reduce_func_xpu_template(
   // Scalars are treated as 1-d tensor
   Tensor self_ = (result.dim() == 0) ? result.view(1) : result;
   Tensor source_ = (source.dim() == 0) ? source.view(1) : source;
+  check_index_bounds(index, self_.size(dim));
 
   TORCH_CHECK(
       result.dim() <= XPU_MAX_TENSORINFO_DIMS,

--- a/test/xpu/test_indexing_xpu.py
+++ b/test/xpu/test_indexing_xpu.py
@@ -196,6 +196,26 @@ with XPUPatchForImport(False):
 
         self.assertEqual(out, dst)
 
+    def index_add_reduce_out_of_range_index(self, device):
+        dim_size = 4
+        source = torch.ones(1, device=device)
+
+        for bad_index in (-1, 4):
+            index = torch.tensor([bad_index], device=device, dtype=torch.int64)
+            with self.assertRaisesRegex(IndexError, "index out of range in self"):
+                torch.zeros(dim_size, device=device).index_add(0, index, source)
+            with self.assertRaisesRegex(IndexError, "index out of range in self"):
+                torch.zeros(dim_size, device=device).index_reduce(
+                    0, index, source, "prod", include_self=True
+                )
+
+        for valid_index in (0, dim_size - 1):
+            index = torch.tensor([valid_index], device=device, dtype=torch.int64)
+            torch.zeros(dim_size, device=device).index_add(0, index, source)
+            torch.zeros(dim_size, device=device).index_reduce(
+                0, index, source, "prod", include_self=True
+            )
+
     TestIndexing.test_index_put_deterministic_with_optional_tensors = (
         __test_index_put_deterministic_with_optional_tensors
     )
@@ -203,6 +223,9 @@ with XPUPatchForImport(False):
     TestIndexing.test_index_select = index_select
     TestIndexing.test_index_add_empty_index_1d = index_add_empty_index_1d
     TestIndexing.test_index_add_empty_index_2d = index_add_empty_index_2d
+    TestIndexing.test_index_add_reduce_out_of_range_index = (
+        index_add_reduce_out_of_range_index
+    )
 
 instantiate_device_type_tests(NumpyTests, globals(), only_for=("xpu"), allow_xpu=True)
 


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/4284

Invalid indices currently reach the XPU index_add/index_reduce kernels and trigger `SYCL_KERNEL_ASSERT`, aborting the Python process. Add a synchronous `aminmax` host bounds check before kernel launch so negative and upper-bound violations raise a catchable `IndexError`, matching CPU semantics. This intentionally differs from CUDA device-assert handling because the current XPU assertion path terminates the process; the host-device synchronization cost is accepted for correctness. this rejects `-1`, which CPU confirms is invalid for both operators.

Test: test/xpu/test_indexing_xpu.py

Test command: `python test/xpu/test_indexing_xpu.py TestIndexingXPU.test_index_add_reduce_out_of_range_index_xpu TestIndexingXPU.test_index_add_empty_index_1d_xpu TestIndexingXPU.test_index_add_empty_index_2d_xpu`

Authored with assistance from OpenAI Codex.