### PR TITLE
Enable fused half_to_float fast-path in _safe_softmax_xpu

### DIFF
--- a/src/ATen/native/xpu/SoftMax.cpp
+++ b/src/ATen/native/xpu/SoftMax.cpp
@@ -103,9 +103,8 @@ Tensor _safe_softmax_xpu(
     const Tensor& self,
     int64_t dim,
     std::optional<ScalarType> dtype) {
-  // TODO: uncomment after XPU softmax support half_to_float=true
-  // if (self.scalar_type() == ScalarType::Half && dtype == ScalarType::Float)
-  //   return xpu::_safe_softmax_kernel(self, dim_, true);
+  if (self.scalar_type() == ScalarType::Half && dtype == ScalarType::Float)
+    return xpu::_safe_softmax_kernel(self, dim, true);
   Tensor converted = dtype.has_value() ? self.toType(dtype.value()) : self;
   return xpu::_safe_softmax_kernel(converted, dim, false);
 }


### PR DESCRIPTION
`_safe_softmax_kernel` already supports `half_to_float=true`, so route `Half` input requested as `Float` through the fused kernel path instead of first materializing a full float copy of the input. This mirrors the upstream `at::native::softmax` dispatch condition (`is_xpu() && Half && dtype==Float`).

