### PR TITLE
test_utils_xpu: fix DataLoader test regression on windows

### DIFF
--- a/test/xpu/test_utils_xpu.py
+++ b/test/xpu/test_utils_xpu.py
@@ -13,16 +13,18 @@
 # Owner(s): ["module: intel"]
 # ruff: noqa: F401
 
+import os
+
 import torch
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import run_tests
 
 try:
-    from xpu_test_utils import XPUImportCtx
+    from xpu_test_utils import ensure_pytorch_test_path, XPUImportCtx
 except Exception:
-    from .xpu_test_utils import XPUImportCtx
+    from .xpu_test_utils import ensure_pytorch_test_path, XPUImportCtx
 
-with XPUImportCtx(False):
+with XPUImportCtx(False) as patcher:
     from test_utils import (
         TestAssert,
         TestCheckpoint,
@@ -41,6 +43,9 @@ with XPUImportCtx(False):
         TestTryImport,
     )
 
+# Keep upstream test directory importable for Windows spawn workers.
+test_dir = os.path.abspath(patcher.test_package[0])
+ensure_pytorch_test_path(test_dir)
 
 # --- TestTraceback overrides ---
 


### PR DESCRIPTION
This change fixes a Windows-specific regression in the XPU test wrapper where DataLoader workers failed because test_utils was no longer importable after leaving XPUImportCtx. Since Windows uses spawn for multiprocessing, each worker starts a fresh interpreter and must re-import modules.

The fix keeps the upstream test directory importable by calling ensure_pytorch_test_path in test/xpu/test_utils_xpu.py.

Fixes: https://github.com/intel/torch-xpu-ops/issues/4404