### PR TITLE
Fix FFT tests after changes to XPU float promotion

### DIFF
--- a/test/xpu/test_meta_xpu.py
+++ b/test/xpu/test_meta_xpu.py
@@ -171,6 +171,29 @@ meta_dispatch_device_expected_failures["xpu"] = meta_dispatch_device_expected_fa
     "cuda"
 ]
 
+meta_function_device_skips["xpu"].update(
+    {
+        torch.fft.fft: {f16},
+        torch.fft.ifft: {f16},
+        torch.fft.rfft: {f16},
+        torch.fft.ihfft: {f16},
+        torch.fft.fft2: {f16},
+        torch.fft.ifft2: {f16},
+        torch.fft.rfft2: {f16},
+        torch.fft.ihfft2: {f16},
+        torch.fft.fftn: {f16},
+        torch.fft.ifftn: {f16},
+        torch.fft.rfftn: {f16},
+        torch.fft.ihfftn: {f16},
+        torch.fft.hfft: {f16},
+        torch.fft.irfft: {f16},
+        torch.fft.irfft2: {f16},
+        torch.fft.hfft2: {f16},
+        torch.fft.irfftn: {f16},
+        torch.fft.hfftn: {f16},
+    }
+)
+
 # ======================================================================
 # Override @onlyCUDA test methods to also run on XPU
 # ======================================================================


### PR DESCRIPTION
Issues reported here: https://github.com/intel/torch-xpu-ops/issues/4268
After changes were made here: https://github.com/pytorch/pytorch/pull/180766

According to documentation ([meta.md](https://github.com/pytorch/pytorch/blob/main/docs/source/meta.md)):

In some cases, not all device types (e.g., CPU and CUDA) have exactly the same output metadata for an operation; we typically prefer representing the CUDA behavior faithfully in this situation.

Disabled test cases for FFT with float16 in test_meta_xpu.py
Reported test cases in test_ops_xpu.py and test_spectral_ops_xpu.py cannot be disabled because those files are not fully copied to XPU, running native pytorch tests.