### PR TITLE
Use sub group scope clock instead of device scope

### DIFF
--- a/src/ATen/xpu/Sleep.cpp
+++ b/src/ATen/xpu/Sleep.cpp
@@ -31,20 +31,20 @@ void sleep(uint64_t cycles) {
     extern "C"
     SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclex::single_task_kernel))
     void spin_kernel(uint64_t cycles) {
-      uint64_t start = syclex::clock<syclex::clock_scope::device>();
-      while (syclex::clock<syclex::clock_scope::device>() - start < cycles) {}
+      uint64_t start = syclex::clock<syclex::clock_scope::sub_group>();
+      while (syclex::clock<syclex::clock_scope::sub_group>() - start < cycles) {}
     }
   )""";
 
   namespace syclex = sycl::ext::oneapi::experimental;
-  // TODO: PVC does not expose sycl_ext_oneapi_device_clock because its bundled
+  // TODO: PVC does not expose ext_oneapi_clock_sub_group because its bundled
   // IGC (Intel Graphics Compiler) is too old, and enabling the extension breaks
   // AOT builds on PVC. Online compilation is used here as a workaround. Once
   // the driver ships a newer IGC, migrate to a functor-based implementation.
   TORCH_CHECK_NOT_IMPLEMENTED(
       c10::xpu::get_raw_device(c10::xpu::current_device())
-          .has(sycl::aspect::ext_oneapi_clock_device),
-      "Requires the sycl_ext_oneapi_device_clock extension, "
+          .has(sycl::aspect::ext_oneapi_clock_sub_group),
+      "Requires the ext_oneapi_clock_sub_group extension, "
       "which is not supported on this device. ",
       "Please upgrade to a newer driver.");
   auto& queue = getCurrentSYCLQueue();


### PR DESCRIPTION
# Motivation
The compiler team said L0 backend only supports `sub_group` scope currently.

# Additional Context
See CMPLRLLVM-76989, verifed in local machine.