### PR TITLE
Declare-at-init and structured bindings in XPU kernels

### DIFF
--- a/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
@@ -576,8 +576,6 @@ void batch_norm_stats_template(
     double epsilon) {
   using accscalar_t = at::acc_type_device<scalar_t, kXPU>;
   int64_t n_input = input_.size(1);
-  Tensor dummy_mean_;
-  Tensor dummy_var_;
   auto input_reshaped = input_.reshape(
       {input_.size(0),
        input_.size(1),
@@ -5174,17 +5172,14 @@ std::tuple<Tensor, Tensor> batch_norm_gather_stats_kernel_template(
     double momentum,
     double epsilon,
     const Tensor& counts_) {
-  Tensor save_mean_;
-  Tensor save_invstd_;
-
   auto features = mean_.size(1);
   auto input_options = mean_.options();
   if (mean_.scalar_type() == at::ScalarType::Half ||
       mean_.scalar_type() == at::ScalarType::BFloat16) {
     input_options = input_options.dtype(ScalarType::Float);
   }
-  save_mean_ = at::empty({features}, input_options);
-  save_invstd_ = at::empty({features}, input_options);
+  Tensor save_mean_ = at::empty({features}, input_options);
+  Tensor save_invstd_ = at::empty({features}, input_options);
 
   auto mean =
       packed_accessor_or_dummy<accscalar_t, 2, RestrictPtrTraits, index_t>(

--- a/src/ATen/native/xpu/sycl/DilatedMaxPool2d.cpp
+++ b/src/ATen/native/xpu/sycl/DilatedMaxPool2d.cpp
@@ -1322,11 +1322,9 @@ void max_pool2d_with_indices_backward_kernel(
       __func__, {gradInput_arg, gradOutput_arg, input_arg, indices_arg});
 
   auto memory_format = input_.suggest_memory_format();
-  Tensor input, gradOutput, indices;
-
-  input = input_.contiguous(memory_format);
-  gradOutput = gradOutput_.contiguous(memory_format);
-  indices = indices_.contiguous(memory_format);
+  Tensor input = input_.contiguous(memory_format);
+  Tensor gradOutput = gradOutput_.contiguous(memory_format);
+  Tensor indices = indices_.contiguous(memory_format);
   gradInput.zero_();
 
   const int kH = safe_downcast<int, int64_t>(kernel_size[0]);

--- a/src/ATen/native/xpu/sycl/Dropout.cpp
+++ b/src/ATen/native/xpu/sycl/Dropout.cpp
@@ -389,10 +389,7 @@ std::tuple<Tensor, Tensor> dropout(
 
   Tensor ret = at::empty_like(self);
 
-  uint64_t counter_offset;
-  uint32_t num_groups, group_size;
-  std::tie(counter_offset, num_groups, group_size) =
-      calc_execution_policy(nelem);
+  auto [counter_offset, num_groups, group_size] = calc_execution_policy(nelem);
 
   PhiloxXpuState rng_engine_inputs;
   {

--- a/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
+++ b/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
@@ -779,8 +779,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> _embedding_bag_kernel(
   auto offsets_original = offsets_t.contiguous();
   auto per_sample_weights = per_sample_weights_t.contiguous();
 
-  Tensor indices, offsets;
-  std::tie(indices, offsets) =
+  auto [indices, offsets] =
       promoteIndicesAndOffsets(indices_original, offsets_original);
   auto indices_arg = TensorArg(indices, "indices", 1);
   checkScalarTypes("embedding_bag_kernel", indices_arg, {kLong, kInt});
@@ -925,8 +924,7 @@ Tensor _embedding_bag_per_sample_weights_backward_kernel(
   TORCH_INTERNAL_ASSERT(grad.dim() == 2);
   auto embedding_features = grad.size(1);
 
-  Tensor indices, offsets;
-  std::tie(indices, offsets) = promoteIndicesAndOffsets(indices_, offsets_);
+  auto [indices, offsets] = promoteIndicesAndOffsets(indices_, offsets_);
   TORCH_INTERNAL_ASSERT(indices.dim() == 1);
   auto num_samples = indices.size(0);
 

--- a/src/ATen/native/xpu/sycl/GroupNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/GroupNormKernels.cpp
@@ -89,9 +89,7 @@ struct GNRowwiseMomentsFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
         item, val, welford_op, shared_);
 
     if (item.get_local_id(0) == 0) {
-      T_ACC m1;
-      T_ACC m2;
-      std::tie(m2, m1) = welford_op.project(val);
+      auto [m2, m1] = welford_op.project(val);
       T_ACC rstd_val = c10::xpu::compat::rsqrt(m2 + static_cast<T_ACC>(eps_));
       mean_[i] = m1;
       rstd_[i] = rstd_val;
@@ -174,9 +172,7 @@ struct GNRowwiseMomentsVectorizedFunctor
       vec_t rstd_vec;
 #pragma unroll
       for (int v = 0; v < VEC_SIZE; ++v) {
-        T_ACC m1;
-        T_ACC m2;
-        std::tie(m2, m1) = welford_op.project(val[v]);
+        auto [m2, m1] = welford_op.project(val[v]);
         T_ACC rstd_val = c10::xpu::compat::rsqrt(m2 + static_cast<T_ACC>(eps_));
         mean_vec[v] = m1;
         rstd_vec[v] = rstd_val;

--- a/src/ATen/native/xpu/sycl/Indexing.cpp
+++ b/src/ATen/native/xpu/sycl/Indexing.cpp
@@ -2394,8 +2394,7 @@ Tensor index_select_sparse_kernel(
     const auto idx_nneg_index = at::arange(index_len, nneg_index.options());
     const auto idx_dim_indices = at::arange(nnz, dim_indices.options());
 
-    Tensor sorted_dim_indices, argsort_dim_indices;
-    std::tie(sorted_dim_indices, argsort_dim_indices) =
+    auto [sorted_dim_indices, argsort_dim_indices] =
         [&]() -> std::tuple<Tensor, Tensor> {
       if (dim == 0 && self.is_coalesced()) {
         return std::make_tuple(dim_indices, idx_dim_indices);
@@ -2404,9 +2403,7 @@ Tensor index_select_sparse_kernel(
       }
     }();
 
-    Tensor intrsc_counts_nneg_index;
-    Tensor intrsc_first_match_nneg_index;
-    std::tie(intrsc_counts_nneg_index, intrsc_first_match_nneg_index) =
+    auto [intrsc_counts_nneg_index, intrsc_first_match_nneg_index] =
         [&]() -> std::tuple<Tensor, Tensor> {
       auto intrsc_counts_nneg_index = at::zeros_like(nneg_index);
       auto intrsc_first_match_nneg_index = at::zeros_like(nneg_index);

--- a/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
@@ -222,9 +222,7 @@ struct RowwiseMomentsFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
         item_id, val, welford_op, shared_);
 
     if (item_id.get_local_id(0) == 0) {
-      T_ACC m1;
-      T_ACC m2;
-      std::tie(m2, m1) = welford_op.project(val);
+      auto [m2, m1] = welford_op.project(val);
       if constexpr (!rms_norm) {
         mean_[i] = m1;
         rstd_[i] = c10::xpu::compat::rsqrt(m2 + eps_);

--- a/src/ATen/native/xpu/sycl/TensorTopKKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorTopKKernel.cpp
@@ -31,9 +31,7 @@ void topk_out_with_sort(
     bool stable,
     const Tensor& values,
     const Tensor& indices) {
-  Tensor sorted_values, sorted_indices;
-  std::tie(sorted_values, sorted_indices) =
-      at::sort(self, stable, dim, largest);
+  auto [sorted_values, sorted_indices] = at::sort(self, stable, dim, largest);
   values.copy_(sorted_values.narrow(dim, 0, k));
   indices.copy_(sorted_indices.narrow(dim, 0, k));
 }
@@ -84,30 +82,18 @@ void topk_kernel(
     return;
   }
 
-  Tensor self_;
   bool need_infer_dim = dim != ndim - 1;
-  if (!need_infer_dim) {
-    self_ = self.contiguous();
-  } else {
-    self_ = self.transpose(ndim - 1, dim).contiguous();
+  if (need_infer_dim) {
     std::swap(out_sizes[ndim - 1], out_sizes[dim]);
   }
+  Tensor self_ = need_infer_dim ? self.transpose(ndim - 1, dim).contiguous()
+                                : self.contiguous();
 
-  Tensor values_, indices_;
-  bool newvalues = false;
-  bool newindices = false;
-  if (!need_infer_dim && values.is_contiguous()) {
-    values_ = values;
-  } else {
-    values_ = at::empty(out_sizes, values.options());
-    newvalues = true;
-  }
-  if (!need_infer_dim && indices.is_contiguous()) {
-    indices_ = indices;
-  } else {
-    indices_ = at::empty(out_sizes, indices.options());
-    newindices = true;
-  }
+  bool newvalues = need_infer_dim || !values.is_contiguous();
+  bool newindices = need_infer_dim || !indices.is_contiguous();
+  Tensor values_ = newvalues ? at::empty(out_sizes, values.options()) : values;
+  Tensor indices_ =
+      newindices ? at::empty(out_sizes, indices.options()) : indices;
 
   AT_DISPATCH_ALL_TYPES_AND2(
       at::ScalarType::Half,


### PR DESCRIPTION
Non-behavioral readability cleanup of the XPU SYCL kernels:

- Merge declarations with their initialization (declare-at-init) and convert
  `std::tie(...) = f()` to structured bindings.
- Rewrite topk's two-way if/else buffer selection as ternary initializers.
- Remove two unused local tensors in `batch_norm_stats`.

No runtime effect. The structured-binding captures rely on C++20 (the build sets
`CMAKE_CXX_STANDARD 20`).

Test: none (non-behavioral; covered by existing test/xpu op tests -- topk,
batch_norm, embedding_bag, index_select, layer_norm, group_norm, max_pool2d)

Authored with the assistance of Claude, an AI coding assistant.
