### PR TITLE
Align Windows disable_build behavior with Linux

### DIFF
--- a/.github/workflows/_windows_build.yml
+++ b/.github/workflows/_windows_build.yml
@@ -35,6 +35,7 @@ env:
 
 jobs:
   build:
+    if: ${{ ! endsWith(inputs.pytorch, '_wheel') }}
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 1000
     outputs:
@@ -137,3 +138,24 @@ jobs:
           name: Torch-XPU-Windows-Binary-${{ github.event.pull_request.number || github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: 'C:\actions-runner\_work\torch-xpu-ops\pytorch\dist'
           compression-level: 0
+
+  build-status-check:
+    needs: [build]
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check build result
+        run: |
+          result="${{ needs.build.result }}"
+          echo "build result: $result"
+          if [ "$result" = "skipped" ]; then
+            echo "build was skipped, marking as pass"
+            exit 0
+          elif [ "$result" = "success" ]; then
+            echo "build passed"
+            exit 0
+          else
+            echo "build failed with result: $result"
+            exit 1
+          fi

--- a/.github/workflows/_windows_ut.yml
+++ b/.github/workflows/_windows_ut.yml
@@ -43,10 +43,12 @@ jobs:
       - name: Checkout torch-xpu-ops
         uses: actions/checkout@v4
       - name: Clean old wheel artifacts
+        if: ${{ ! endsWith(inputs.pytorch, '_wheel') }}
         shell: cmd
         run: |
           if exist "%GITHUB_WORKSPACE%\wheel_artifact" rmdir /s /q "%GITHUB_WORKSPACE%\wheel_artifact"
       - name: Download Torch Wheel
+        if: ${{ ! endsWith(inputs.pytorch, '_wheel') }}
         uses: actions/download-artifact@v4
         with:
           pattern: Torch-XPU-Windows-Binary-${{ github.event.pull_request.number || github.sha }}-*
@@ -77,6 +79,14 @@ jobs:
           )
           set pytorch=${{ inputs.pytorch }}
           set torch_xpu_ops=${{ inputs.torch_xpu_ops }}
+
+          REM Skip pytorch clone for nightly wheel - will be handled after install
+          echo %pytorch% | findstr /C:"_wheel" >nul
+          if %errorlevel% equ 0 (
+            echo "Nightly wheel mode: skipping pytorch clone (will clone after install)"
+            goto :setup_done
+          )
+
           echo %pytorch% | findstr /C:"https://" >nul
           if %errorlevel% equ 0 (
               echo %pytorch% | findstr "@" >nul
@@ -131,13 +141,40 @@ jobs:
             )
             powershell -Command "(Get-Content caffe2/CMakeLists.txt) -replace 'checkout --quiet \${TORCH_XPU_OPS_COMMIT}', 'log -n 1' | Set-Content caffe2/CMakeLists.txt"
           )
+          :setup_done
       - name: Install PyTorch Wheel and Dependencies
         shell: cmd
         run: |
           call "C:\ProgramData\miniforge3\Scripts\activate.bat"
           call conda activate windows_ut
-          for /r "%GITHUB_WORKSPACE%\wheel_artifact" %%f in (*.whl) do set "TORCH_WHL=%%f"
-          python -m pip install "%TORCH_WHL%"
+          set PYTORCH_INPUT=${{ inputs.pytorch }}
+          echo %PYTORCH_INPUT% | findstr /C:"_wheel" >nul
+          if %errorlevel% equ 0 (
+            echo "Installing PyTorch from nightly wheel..."
+            python -m pip install torch torchvision torchaudio --pre --index-url https://download.pytorch.org/whl/nightly/xpu
+            REM Clone pytorch source at the installed version's commit for test infra
+            for /f "delims=" %%v in ('python -c "import torch; print(torch.version.git_version)"') do set TORCH_COMMIT_ID=%%v
+            echo "Installed torch commit: %TORCH_COMMIT_ID%"
+            cd %GITHUB_WORKSPACE%\..
+            git clone https://github.com/pytorch/pytorch.git pytorch
+            cd pytorch && git checkout %TORCH_COMMIT_ID%
+            REM Prepare torch-xpu-ops for test scripts
+            set torch_xpu_ops=${{ inputs.torch_xpu_ops }}
+            if "%torch_xpu_ops%" == "pinned" (
+              echo "Using pinned torch-xpu-ops"
+            ) else (
+              cd third_party
+              if exist "torch-xpu-ops" rmdir /s /q torch-xpu-ops
+              cd ..
+              git clone "https://github.com/intel/torch-xpu-ops.git" "third_party\torch-xpu-ops"
+              cd "third_party\torch-xpu-ops"
+              git checkout "%torch_xpu_ops%"
+              cd ../..
+            )
+          ) else (
+            for /r "%GITHUB_WORKSPACE%\wheel_artifact" %%f in (*.whl) do set "TORCH_WHL=%%f"
+            python -m pip install "%TORCH_WHL%"
+          )
           cd %GITHUB_WORKSPACE%\..\pytorch
           python -m pip install -r .ci\docker\requirements-ci.txt
       - name: Torch Config Check

--- a/.github/workflows/_windows_ut.yml
+++ b/.github/workflows/_windows_ut.yml
@@ -161,7 +161,14 @@ jobs:
             REM Prepare torch-xpu-ops for test scripts
             set torch_xpu_ops=${{ inputs.torch_xpu_ops }}
             if "%torch_xpu_ops%" == "pinned" (
-              echo "Using pinned torch-xpu-ops"
+              for /f "delims=" %%c in ('type third_party\xpu.txt') do set XPU_OPS_COMMIT=%%c
+              cd third_party
+              if exist "torch-xpu-ops" rmdir /s /q torch-xpu-ops
+              cd ..
+              git clone "https://github.com/intel/torch-xpu-ops.git" "third_party\torch-xpu-ops"
+              cd "third_party\torch-xpu-ops"
+              git checkout "%XPU_OPS_COMMIT%"
+              cd ../..
             ) else (
               cd third_party
               if exist "torch-xpu-ops" rmdir /s /q torch-xpu-ops

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -331,6 +331,7 @@ jobs:
     with:
       runner: windows-build
       pytorch: ${{ contains(github.event.pull_request.labels.*.name, 'disable_build') && 'nightly_wheel' || github.base_ref }}
+      torch_xpu_ops: ${{ contains(github.event.pull_request.labels.*.name, 'disable_build') && 'pinned' || 'main' }}
 
   windows-ut:
     name: windows-ut
@@ -347,3 +348,4 @@ jobs:
       ut: op_extended,test_xpu
       runner: windows-test
       pytorch: ${{ contains(github.event.pull_request.labels.*.name, 'disable_build') && 'nightly_wheel' || github.base_ref }}
+      torch_xpu_ops: ${{ contains(github.event.pull_request.labels.*.name, 'disable_build') && 'pinned' || 'main' }}


### PR DESCRIPTION
## Summary

When the PR has the `disable_build` label, Linux skips the build job and installs PyTorch from the nightly XPU wheel instead. Windows was missing this logic — it would still attempt to build even with `disable_build`.

## Changes

- **`_windows_build.yml`**: Skip build job when `pytorch` ends with `_wheel` (same condition as Linux). Add `build-status-check` job that passes when build is skipped.
- **`_windows_ut.yml`**: When `pytorch` is `nightly_wheel`:
  - Skip downloading build artifact (no artifact exists)
  - Install torch/torchvision/torchaudio from nightly PyPI
  - Clone pytorch source at the installed torch's git commit (for test infrastructure)
  - Prepare torch-xpu-ops in `third_party/` for test scripts
- **`pull.yml`**: Pass `torch_xpu_ops: 'pinned'` for both `windows-build` and `windows-ut` when `disable_build` is set (was missing for Windows).

## Test Plan

Apply `disable_build` label to a PR and verify:
1. Windows build job is skipped
2. Windows UT installs from nightly wheel and runs tests successfully

Co-authored-by: AI Assistant