### PR TITLE
Migrate kernels to use `AT_DISPATCH_V2`

### DIFF
--- a/src/ATen/native/nested/xpu/sycl/NestedTensorTransformerFunctionKernels.cpp
+++ b/src/ATen/native/nested/xpu/sycl/NestedTensorTransformerFunctionKernels.cpp
@@ -9,7 +9,7 @@
  */
 
 #include <ATen/ATen.h>
-#include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/core/TensorAccessor.h>
 #include <ATen/native/StridedRandomAccessor.h>
 #include <ATen/native/nested/NestedTensorUtils.h>
@@ -617,8 +617,10 @@ void add_padding_kernel(
     const std::vector<int64_t>& new_size,
     const int batch_size,
     const int output_batch_size) {
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      input.scalar_type(), "NestedTensor_to_padded_tensor_xpu", [&]() {
+  AT_DISPATCH_V2(
+      input.scalar_type(),
+      "NestedTensor_to_padded_tensor_xpu",
+      AT_WRAP([&]() {
         add_padding_kernel_impl<scalar_t>(
             input.data_ptr<scalar_t>(),
             output.data_ptr<scalar_t>(),
@@ -629,7 +631,9 @@ void add_padding_kernel(
             new_size,
             batch_size,
             output_batch_size);
-      });
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      kHalf);
 }
 
 #define JAGGED_TENSOR_DISPATCH_DIMS()                                         \
@@ -1143,20 +1147,21 @@ at::Tensor dense_to_jagged_forward_kernel(
   auto values = at::empty_symint({total_L_computed, D}, dense.options());
   auto output = at::empty_like(values);
 
-  AT_DISPATCH_ALL_TYPES_AND3(
-      at::ScalarType::Half,
-      at::ScalarType::BFloat16,
-      at::ScalarType::Bool,
+  AT_DISPATCH_V2(
       values.scalar_type(),
       "dense_to_jagged_xpu",
-      [&] {
+      AT_WRAP([&] {
         jagged_dense_elementwise_jagged_output_template<scalar_t>(
             values,
             offsets.vec(),
             dense,
             output,
             DenseToJaggedFunctor<scalar_t>());
-      });
+      }),
+      AT_EXPAND(AT_ALL_TYPES),
+      kHalf,
+      kBFloat16,
+      kBool);
 
   return output;
 }
@@ -1188,13 +1193,10 @@ at::Tensor jagged_to_padded_dense_forward_xpu_kernel(
   Tensor padded_values_view =
       D_folded ? padded_values.unsqueeze(-1) : padded_values;
 
-  AT_DISPATCH_ALL_TYPES_AND3(
-      at::ScalarType::Half,
-      at::ScalarType::BFloat16,
-      at::ScalarType::Bool,
+  AT_DISPATCH_V2(
       values.scalar_type(),
       "jagged_to_padded_dense_xpu",
-      [&] {
+      AT_WRAP([&] {
         scalar_t fill_value = at::native::_get_padding_value<scalar_t>(
             padding_value, values.is_floating_point());
         jagged_dense_elementwise_dense_template<scalar_t>(
@@ -1204,7 +1206,11 @@ at::Tensor jagged_to_padded_dense_forward_xpu_kernel(
             padded_values_view,
             PaddingValueFuncutor<scalar_t>(),
             fill_value);
-      });
+      }),
+      AT_EXPAND(AT_ALL_TYPES),
+      kHalf,
+      kBFloat16,
+      kBool);
 
   return padded_values;
 }

--- a/src/ATen/native/xpu/sycl/Embedding.cpp
+++ b/src/ATen/native/xpu/sycl/Embedding.cpp
@@ -8,7 +8,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/xpu/sycl/EmbeddingBackwardKernel.h>
 #include <ATen/native/xpu/sycl/SYCLGroupAlgorithm.h>
@@ -48,12 +48,10 @@ Tensor embedding_dense_backward_kernel(
 
   Tensor grad_weight;
 
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      at::ScalarType::Half,
-      at::ScalarType::BFloat16,
+  AT_DISPATCH_V2(
       grad.scalar_type(),
       "embedding_backward",
-      [&]() {
+      AT_WRAP([&]() {
         AT_DISPATCH_INDEX_TYPES(
             indices.scalar_type(), "embedding_backward", [&] {
               // TODO: port pstl functions
@@ -90,7 +88,10 @@ Tensor embedding_dense_backward_kernel(
                       num_weights,
                       padding_idx);
             });
-      });
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      kHalf,
+      kBFloat16);
   return grad_weight;
 }
 
@@ -235,12 +236,10 @@ Tensor& embedding_renorm_kernel(
 
         int dim = self.stride(0);
 
-        AT_DISPATCH_FLOATING_TYPES_AND2(
-            at::ScalarType::Half,
-            at::ScalarType::BFloat16,
+        AT_DISPATCH_V2(
             self.scalar_type(),
             "embedding_renorm_xpu_",
-            [&] {
+            AT_WRAP([&] {
               using accscalar_t = acc_type_device<scalar_t, kXPU>;
               embedding_renorm_template(
                   self.data_ptr<scalar_t>(),
@@ -251,7 +250,10 @@ Tensor& embedding_renorm_kernel(
                   self.stride(0),
                   self.stride(1),
                   num_unique_indices);
-            });
+            }),
+            AT_EXPAND(AT_FLOATING_TYPES),
+            kHalf,
+            kBFloat16);
       });
   return self;
 }

--- a/src/ATen/native/xpu/sycl/FusedAdamAmsgradKernels.cpp
+++ b/src/ATen/native/xpu/sycl/FusedAdamAmsgradKernels.cpp
@@ -9,7 +9,7 @@
  */
 
 #include <ATen/ATen.h>
-#include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/native/ForeachUtils.h>
 
 #include <ATen/native/xpu/sycl/FusedAdamKernels.h>
@@ -46,12 +46,10 @@ void fused_adam_amsgrad_kernel(
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
   const float* lr_ptr = nullptr;
 
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      kHalf,
-      kBFloat16,
+  AT_DISPATCH_V2(
       params[0].scalar_type(),
       "fused_adam_amsgrad_kernel_xpu",
-      [&]() {
+      AT_WRAP([&]() {
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
@@ -65,7 +63,10 @@ void fused_adam_amsgrad_kernel(
             maximize,
             grad_scale_ptr,
             found_inf_ptr);
-      });
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      kHalf,
+      kBFloat16);
 }
 
 void fused_adam_amsgrad_kernel(
@@ -96,12 +97,10 @@ void fused_adam_amsgrad_kernel(
       found_inf.has_value() ? found_inf->const_data_ptr<float>() : nullptr;
   const float* lr_ptr = lr.const_data_ptr<float>();
 
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      kHalf,
-      kBFloat16,
+  AT_DISPATCH_V2(
       params[0].scalar_type(),
       "fused_adam_amsgrad_kernel_xpu",
-      [&]() {
+      AT_WRAP([&]() {
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
@@ -115,7 +114,10 @@ void fused_adam_amsgrad_kernel(
             maximize,
             grad_scale_ptr,
             found_inf_ptr);
-      });
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      kHalf,
+      kBFloat16);
 }
 
 } // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/FusedAdamKernels.cpp
+++ b/src/ATen/native/xpu/sycl/FusedAdamKernels.cpp
@@ -9,7 +9,7 @@
  */
 
 #include <ATen/ATen.h>
-#include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/native/ForeachUtils.h>
 
 #include <ATen/native/xpu/sycl/FusedAdamKernels.h>
@@ -41,12 +41,10 @@ void fused_adam_kernel(
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
   const float* lr_ptr = nullptr;
 
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      kHalf,
-      kBFloat16,
+  AT_DISPATCH_V2(
       params[0].scalar_type(),
       "fused_adam_kernel_xpu",
-      [&]() {
+      AT_WRAP([&]() {
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
@@ -60,7 +58,10 @@ void fused_adam_kernel(
             maximize,
             grad_scale_ptr,
             found_inf_ptr);
-      });
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      kHalf,
+      kBFloat16);
 }
 
 void fused_adam_kernel(
@@ -86,12 +87,10 @@ void fused_adam_kernel(
       found_inf.has_value() ? found_inf->const_data_ptr<float>() : nullptr;
   const float* lr_ptr = lr.const_data_ptr<float>();
 
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      kHalf,
-      kBFloat16,
+  AT_DISPATCH_V2(
       params[0].scalar_type(),
       "fused_adam_kernel_xpu",
-      [&]() {
+      AT_WRAP([&]() {
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
@@ -105,7 +104,10 @@ void fused_adam_kernel(
             maximize,
             grad_scale_ptr,
             found_inf_ptr);
-      });
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      kHalf,
+      kBFloat16);
 }
 
 } // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/FusedAdamWAmsgradKernels.cpp
+++ b/src/ATen/native/xpu/sycl/FusedAdamWAmsgradKernels.cpp
@@ -9,7 +9,7 @@
  */
 
 #include <ATen/ATen.h>
-#include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/native/ForeachUtils.h>
 
 #include <ATen/native/xpu/sycl/FusedAdamUtils.h>
@@ -46,12 +46,10 @@ void fused_adamw_amsgrad_kernel(
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
   const float* lr_ptr = nullptr;
 
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      kHalf,
-      kBFloat16,
+  AT_DISPATCH_V2(
       params[0].scalar_type(),
       "fused_adamw_amsgrad_kernel_xpu",
-      [&]() {
+      AT_WRAP([&]() {
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
@@ -65,7 +63,10 @@ void fused_adamw_amsgrad_kernel(
             maximize,
             grad_scale_ptr,
             found_inf_ptr);
-      });
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      kHalf,
+      kBFloat16);
 }
 
 void fused_adamw_amsgrad_kernel(
@@ -96,12 +97,10 @@ void fused_adamw_amsgrad_kernel(
       found_inf.has_value() ? found_inf->const_data_ptr<float>() : nullptr;
   const float* lr_ptr = lr.const_data_ptr<float>();
 
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      kHalf,
-      kBFloat16,
+  AT_DISPATCH_V2(
       params[0].scalar_type(),
       "fused_adamw_amsgrad_kernel_xpu",
-      [&]() {
+      AT_WRAP([&]() {
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
@@ -115,7 +114,10 @@ void fused_adamw_amsgrad_kernel(
             maximize,
             grad_scale_ptr,
             found_inf_ptr);
-      });
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      kHalf,
+      kBFloat16);
 }
 
 } // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/FusedAdamWKernels.cpp
+++ b/src/ATen/native/xpu/sycl/FusedAdamWKernels.cpp
@@ -9,7 +9,7 @@
  */
 
 #include <ATen/ATen.h>
-#include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/native/ForeachUtils.h>
 
 #include <ATen/native/xpu/sycl/FusedAdamUtils.h>
@@ -41,12 +41,10 @@ void fused_adamw_kernel(
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
   const float* lr_ptr = nullptr;
 
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      kHalf,
-      kBFloat16,
+  AT_DISPATCH_V2(
       params[0].scalar_type(),
       "fused_adamw_kernel_xpu",
-      [&]() {
+      AT_WRAP([&]() {
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
@@ -60,7 +58,10 @@ void fused_adamw_kernel(
             maximize,
             grad_scale_ptr,
             found_inf_ptr);
-      });
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      kHalf,
+      kBFloat16);
 }
 
 void fused_adamw_kernel(
@@ -86,12 +87,10 @@ void fused_adamw_kernel(
       found_inf.has_value() ? found_inf->const_data_ptr<float>() : nullptr;
   const float* lr_ptr = lr.const_data_ptr<float>();
 
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      kHalf,
-      kBFloat16,
+  AT_DISPATCH_V2(
       params[0].scalar_type(),
       "fused_adamw_kernel_xpu",
-      [&]() {
+      AT_WRAP([&]() {
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
@@ -105,7 +104,10 @@ void fused_adamw_kernel(
             maximize,
             grad_scale_ptr,
             found_inf_ptr);
-      });
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      kHalf,
+      kBFloat16);
 }
 
 } // namespace at::native::xpu


### PR DESCRIPTION
Convert legacy `AT_DISPATCH_FLOATING_TYPES_AND2` and `AT_DISPATCH_ALL_TYPES_AND3` usages to `AT_DISPATCH_V2` in:
- src/ATen/native/xpu/sycl/FusedAdamKernels.cpp
- src/ATen/native/xpu/sycl/FusedAdamAmsgradKernels.cpp
- src/ATen/native/xpu/sycl/FusedAdamWKernels.cpp
- src/ATen/native/xpu/sycl/FusedAdamWAmsgradKernels.cpp
- src/ATen/native/xpu/sycl/Embedding.cpp
- src/ATen/native/nested/xpu/sycl/NestedTensorTransformerFunctionKernels.cpp

These kernels / files are already using the new dispatch in upstream.