### PR TITLE
Fix bot command aliases and simplify PR checkout condition

### DIFF
--- a/.github/actions/linux-testenv/action.yml
+++ b/.github/actions/linux-testenv/action.yml
@@ -101,7 +101,7 @@ runs:
             TORCH_XPU_OPS_COMMIT="${{ inputs.torch_xpu_ops }}"
           fi
         fi
-        if [ "${{ github.event_name }}" == "pull_request" ] && [[ "${{ inputs.pytorch }}" != *"_wheel" ]];then
+        if [ "${{ github.event_name }}" == "pull_request" ];then
           cp -r ${{ github.workspace }}/torch-xpu-ops third_party/torch-xpu-ops
           cd third_party/torch-xpu-ops
         else

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -72,7 +72,7 @@ jobs:
 
             const command = match[1].toLowerCase();
             const args = (match[2] || '').trim();
-            const validCommands = ['merge', 'revert', 'rebase', 'lint', 'rerun', 'review', 'ut-check', 'help'];
+            const validCommands = ['merge', 'revert', 'rebase', 'lint', 'rerun', 'review', 'pr-review', 'ut-check', 'check-ut', 'ut', 'help'];
 
             if (!validCommands.includes(command)) {
               core.setOutput('command', 'invalid');
@@ -81,6 +81,11 @@ jobs:
               core.setOutput('authorized', 'false');
               return;
             }
+
+            // Normalize command aliases
+            const normalizedCommand = (command === 'pr-review') ? 'review'
+              : (command === 'check-ut' || command === 'ut') ? 'ut-check'
+              : command;
 
             // Permission check
             const privileged = ['OWNER', 'MEMBER', 'COLLABORATOR'];
@@ -126,7 +131,7 @@ jobs:
               }
             }
 
-            core.setOutput('command', command);
+            core.setOutput('command', normalizedCommand);
             core.setOutput('force', force);
             core.setOutput('rerun_mode', rerunMode);
             core.setOutput('pytorch_ref', pytorchRef);
@@ -202,8 +207,8 @@ jobs:
             | \`@torchxpubot rerun\` | Re-trigger full CI |
             | \`@torchxpubot rerun failed\` | Re-run only failed CI jobs |
             | \`@torchxpubot rerun -b <branch_or_commit>\` | Rerun CI against a pytorch ref |
-            | \`@torchxpubot review\` | AI-powered PR code review |
-            | \`@torchxpubot ut-check\` | Analyze UT results: new failures, relevance, coverage |
+            | \`@torchxpubot review\` (or \`pr-review\`) | AI-powered PR code review |
+            | \`@torchxpubot ut-check\` (or \`check-ut\`, \`ut\`) | Analyze UT results: new failures, relevance, coverage |
             | \`@torchxpubot help\` | Show this help message |`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -616,6 +621,18 @@ jobs:
 
             // Handle rerun -b (workflow_dispatch mode)
             if (pytorchRef) {
+              // Cancel any in-progress runs for this PR before triggering new one
+              const runs = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner, repo: context.repo.repo,
+                workflow_id: 'pull.yml', head_sha: headSha, per_page: 5
+              });
+              for (const run of runs.data.workflow_runs) {
+                if (run.status === 'in_progress' || run.status === 'queued') {
+                  await github.rest.actions.cancelWorkflowRun({
+                    owner: context.repo.owner, repo: context.repo.repo, run_id: run.id
+                  });
+                }
+              }
               try {
                 await github.rest.actions.createWorkflowDispatch({
                   owner: context.repo.owner,
@@ -676,6 +693,22 @@ jobs:
                   body: `Re-running failed jobs: ${failedNames}\nWorkflow run: ${latestRun.html_url}`
                 });
               } else {
+                // Cancel in-progress run before full re-run
+                if (latestRun.status === 'in_progress' || latestRun.status === 'queued') {
+                  await github.rest.actions.cancelWorkflowRun({
+                    owner: context.repo.owner, repo: context.repo.repo, run_id: runId
+                  });
+                  // Wait for cancellation to take effect
+                  let attempts = 0;
+                  while (attempts < 30) {
+                    const check = await github.rest.actions.getWorkflowRun({
+                      owner: context.repo.owner, repo: context.repo.repo, run_id: runId
+                    });
+                    if (check.data.status === 'completed') break;
+                    await new Promise(r => setTimeout(r, 2000));
+                    attempts++;
+                  }
+                }
                 await github.rest.actions.reRunWorkflow({
                   owner: context.repo.owner, repo: context.repo.repo, run_id: runId
                 });


### PR DESCRIPTION
## Summary
- Add bot command aliases: `pr-review` → `review`, `check-ut`/`ut` → `ut-check`
- Simplify PR checkout condition in linux-testenv action to only check `github.event_name == 'pull_request'` (remove pytorch wheel and torch_xpu_ops input checks)
