### PR TITLE
Fix NLLLoss2d backward int32 offset overflow (#4723)

### DIFF
--- a/src/ATen/native/xpu/sycl/LossNLL2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LossNLL2dKernels.cpp
@@ -366,27 +366,24 @@ struct NllLoss2dBackwardNoReduceKernelFunctor {
   int64_t ignore_index_;
 };
 
-template <typename scalar_t>
+template <typename scalar_t, typename index_t>
 struct NllLoss2dBackwardKernelFunctor {
   void operator()(sycl::nd_item<1> item) const {
     const auto grad =
         -(size_average_ ? *grad_output_ / *total_weight_ : *grad_output_);
 
-    // Use 64-bit offsets: sample * map_nelem_ * n_classes_ overflows a 32-bit
-    // int once the flattened extent reaches 2147483648 (INT_MAX + 1), wrapping
-    // the per-sample base pointer and silently dropping gradients for the tail
-    // samples (#4723, pytorch/pytorch#190139). The CUDA path guards this by
-    // selecting a 64-bit index type when 32-bit indexing is unsafe.
-    const int64_t sample = item.get_group(0) / blocks_per_sample_;
-    const int step = item.get_local_range(0) * blocks_per_sample_;
+    const index_t sample = item.get_group(0) / blocks_per_sample_;
+    const index_t step =
+        static_cast<index_t>(item.get_local_range(0)) * blocks_per_sample_;
 
-    const int64_t toffset = sample * map_nelem_;
+    const index_t toffset = sample * map_nelem_;
     const auto* const target_thread = target_ + toffset;
 
-    const int64_t ioffset = sample * map_nelem_ * n_classes_;
+    const index_t ioffset = sample * map_nelem_ * n_classes_;
     auto* const grad_input_thread = grad_input_ + ioffset;
 
-    for (int i = (item.get_group(0) % blocks_per_sample_) *
+    for (index_t i =
+             static_cast<index_t>(item.get_group(0) % blocks_per_sample_) *
                  item.get_local_range(0) +
              item.get_local_id(0);
          i < map_nelem_;
@@ -408,8 +405,8 @@ struct NllLoss2dBackwardKernelFunctor {
       const scalar_t* weights,
       const scalar_t* total_weight,
       bool size_average,
-      int n_classes,
-      int map_nelem,
+      index_t n_classes,
+      index_t map_nelem,
       int blocks_per_sample,
       int64_t ignore_index)
       : grad_input_(grad_input),
@@ -430,8 +427,8 @@ struct NllLoss2dBackwardKernelFunctor {
   const scalar_t* weights_;
   const scalar_t* total_weight_;
   bool size_average_;
-  int n_classes_;
-  int map_nelem_;
+  index_t n_classes_;
+  index_t map_nelem_;
   int blocks_per_sample_;
   int64_t ignore_index_;
 };
@@ -520,28 +517,39 @@ void nll_loss2d_backward_kernel(
           auto target_ = target.contiguous();
           auto weight_ = optional_contiguous(weight);
           int64_t map_nelem = target_numel / batch_size;
-          using KernelClass = NllLoss2dBackwardKernelFunctor<scalar_t>;
-          int64_t max_work_group_size = syclMaxWorkGroupSize<KernelClass>();
-          int blocks_per_sample =
-              (map_nelem + max_work_group_size - 1) / max_work_group_size / 128;
-          blocks_per_sample = (blocks_per_sample == 0) ? 1 : blocks_per_sample;
-          int total_blocks = blocks_per_sample * batch_size;
-          KernelClass kfn(
-              grad_input.mutable_data_ptr<scalar_t>(),
-              grad_output.const_data_ptr<scalar_t>(),
-              target_.const_data_ptr<int64_t>(),
-              optional_data<scalar_t>(weight_),
-              total_weight.const_data_ptr<scalar_t>(),
-              reduction == at::Reduction::Mean,
-              input.size(1),
-              map_nelem,
-              blocks_per_sample,
-              ignore_index);
-          sycl_kernel_submit(
-              total_blocks * max_work_group_size,
-              max_work_group_size,
-              getCurrentSYCLQueue(),
-              kfn);
+          AT_DISPATCH_INDEX_TYPES(
+              at::native::canUse32BitIndexMath(input, INT_MAX)
+                  ? ScalarType::Int
+                  : ScalarType::Long,
+              "nll_loss2d_backward_launcher",
+              [&] {
+                using KernelClass =
+                    NllLoss2dBackwardKernelFunctor<scalar_t, index_t>;
+                int64_t max_work_group_size =
+                    syclMaxWorkGroupSize<KernelClass>();
+                int blocks_per_sample =
+                    (map_nelem + max_work_group_size - 1) /
+                    max_work_group_size / 128;
+                blocks_per_sample =
+                    (blocks_per_sample == 0) ? 1 : blocks_per_sample;
+                int total_blocks = blocks_per_sample * batch_size;
+                KernelClass kfn(
+                    grad_input.mutable_data_ptr<scalar_t>(),
+                    grad_output.const_data_ptr<scalar_t>(),
+                    target_.const_data_ptr<int64_t>(),
+                    optional_data<scalar_t>(weight_),
+                    total_weight.const_data_ptr<scalar_t>(),
+                    reduction == at::Reduction::Mean,
+                    input.size(1),
+                    map_nelem,
+                    blocks_per_sample,
+                    ignore_index);
+                sycl_kernel_submit(
+                    total_blocks * max_work_group_size,
+                    max_work_group_size,
+                    getCurrentSYCLQueue(),
+                    kfn);
+              });
         });
   }
 }

--- a/src/ATen/native/xpu/sycl/LossNLL2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LossNLL2dKernels.cpp
@@ -373,10 +373,10 @@ struct NllLoss2dBackwardKernelFunctor {
         -(size_average_ ? *grad_output_ / *total_weight_ : *grad_output_);
 
     // Use 64-bit offsets: sample * map_nelem_ * n_classes_ overflows a 32-bit
-    // int once the flattened extent reaches 2^31, wrapping the per-sample base
-    // pointer and silently dropping gradients for the tail samples (#4723,
-    // pytorch/pytorch#190139). The CUDA path guards this by selecting a 64-bit
-    // index type when 32-bit indexing is unsafe.
+    // int once the flattened extent reaches 2147483648 (INT_MAX + 1), wrapping
+    // the per-sample base pointer and silently dropping gradients for the tail
+    // samples (#4723, pytorch/pytorch#190139). The CUDA path guards this by
+    // selecting a 64-bit index type when 32-bit indexing is unsafe.
     const int64_t sample = item.get_group(0) / blocks_per_sample_;
     const int step = item.get_local_range(0) * blocks_per_sample_;
 

--- a/src/ATen/native/xpu/sycl/LossNLL2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LossNLL2dKernels.cpp
@@ -372,13 +372,18 @@ struct NllLoss2dBackwardKernelFunctor {
     const auto grad =
         -(size_average_ ? *grad_output_ / *total_weight_ : *grad_output_);
 
-    const int sample = item.get_group(0) / blocks_per_sample_;
+    // Use 64-bit offsets: sample * map_nelem_ * n_classes_ overflows a 32-bit
+    // int once the flattened extent reaches 2^31, wrapping the per-sample base
+    // pointer and silently dropping gradients for the tail samples (#4723,
+    // pytorch/pytorch#190139). The CUDA path guards this by selecting a 64-bit
+    // index type when 32-bit indexing is unsafe.
+    const int64_t sample = item.get_group(0) / blocks_per_sample_;
     const int step = item.get_local_range(0) * blocks_per_sample_;
 
-    const int toffset = sample * map_nelem_;
+    const int64_t toffset = sample * map_nelem_;
     const auto* const target_thread = target_ + toffset;
 
-    const int ioffset = sample * map_nelem_ * n_classes_;
+    const int64_t ioffset = sample * map_nelem_ * n_classes_;
     auto* const grad_input_thread = grad_input_ + ioffset;
 
     for (int i = (item.get_group(0) % blocks_per_sample_) *

--- a/src/ATen/native/xpu/sycl/LossNLL2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LossNLL2dKernels.cpp
@@ -527,8 +527,7 @@ void nll_loss2d_backward_kernel(
                     NllLoss2dBackwardKernelFunctor<scalar_t, index_t>;
                 int64_t max_work_group_size =
                     syclMaxWorkGroupSize<KernelClass>();
-                int blocks_per_sample =
-                    (map_nelem + max_work_group_size - 1) /
+                int blocks_per_sample = (map_nelem + max_work_group_size - 1) /
                     max_work_group_size / 128;
                 blocks_per_sample =
                     (blocks_per_sample == 0) ? 1 : blocks_per_sample;

--- a/test/repro/test_nll_loss2d_backward_offset_overflow.py
+++ b/test/repro/test_nll_loss2d_backward_offset_overflow.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2026 Intel Corporation
+# Copyright 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,11 +23,15 @@ import unittest
 
 import torch
 import torch.nn.functional as F
+from torch.testing._internal.common_device_type import largeTensorTest
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 @unittest.skipIf(not torch.xpu.is_available(), "XPU not available")
 class TestNllLoss2dBackwardOffsetOverflow(TestCase):
+    # The (2**16 + 1, 2**15, 1, 1) FP16 input plus its gradient is ~9GB; skip on
+    # devices without enough memory so the Reproducer CI stays reliable.
+    @largeTensorTest("10GB", device="xpu")
     def test_backward_offset_no_overflow(self):
         # (2**16 + 1) samples of 2**15 classes: the last sample's input offset
         # sample * map_nelem * n_classes exceeds 2**31, overflowing int32.

--- a/test/repro/test_nll_loss2d_backward_offset_overflow.py
+++ b/test/repro/test_nll_loss2d_backward_offset_overflow.py
@@ -1,0 +1,51 @@
+# Copyright 2020-2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Owner(s): ["module: intel"]
+"""
+Reproducer for issue #4723 (pytorch/pytorch#190139): NLLLoss2d backward
+silently zeroed the gradient of the tail samples for large inputs.
+
+The backward kernel computed the per-sample base offsets
+(sample, toffset = sample * map_nelem, ioffset = sample * map_nelem * n_classes)
+in 32-bit int. Once the flattened extent reaches 2**31 the multiplication
+overflows and wraps the base pointer, so the trailing samples receive no
+gradient (grad == 0) instead of the correct value. The fix widens those offsets
+to int64_t, matching the forward kernel's index type selection.
+"""
+
+import unittest
+
+import torch
+import torch.nn.functional as F
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+@unittest.skipIf(not torch.xpu.is_available(), "XPU not available")
+class TestNllLoss2dBackwardOffsetOverflow(TestCase):
+    def test_backward_offset_no_overflow(self):
+        # (2**16 + 1) samples of 2**15 classes: the last sample's input offset
+        # sample * map_nelem * n_classes exceeds 2**31, overflowing int32.
+        x = torch.zeros(
+            (2**16 + 1, 2**15, 1, 1),
+            device="xpu",
+            dtype=torch.float16,
+            requires_grad=True,
+        )
+        target = torch.zeros((2**16 + 1, 1, 1), device="xpu", dtype=torch.long)
+
+        F.nll_loss(x, target, reduction="sum").backward()
+
+        # With reduction="sum" and target class 0, every selected gradient is -1.
+        # Pre-fix, the wrapped offset leaves the tail sample's gradient at 0.
+        self.assertEqual(x.grad[0, 0, 0, 0].item(), -1.0)
+        self.assertEqual(x.grad[-1, 0, 0, 0].item(), -1.0)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/repro/test_nll_loss2d_backward_offset_overflow.py
+++ b/test/repro/test_nll_loss2d_backward_offset_overflow.py
@@ -11,12 +11,10 @@
 Reproducer for issue #4723 (pytorch/pytorch#190139): NLLLoss2d backward
 silently zeroed the gradient of the tail samples for large inputs.
 
-The backward kernel computed the per-sample base offsets
-(sample, toffset = sample * map_nelem, ioffset = sample * map_nelem * n_classes)
-in 32-bit int. Once the flattened extent reaches 2**31 the multiplication
-overflows and wraps the base pointer, so the trailing samples receive no
-gradient (grad == 0) instead of the correct value. The fix widens those offsets
-to int64_t, matching the forward kernel's index type selection.
+The backward kernel computed per-sample offsets in 32-bit arithmetic. Once the
+flattened extent reaches 2**31, the multiplication overflows and the trailing
+samples receive no gradient. The fix selects 32- or 64-bit indexing based on
+the input tensor, matching the forward kernel and pytorch/pytorch#190144.
 """
 
 import unittest
@@ -29,26 +27,40 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 @unittest.skipIf(not torch.xpu.is_available(), "XPU not available")
 class TestNllLoss2dBackwardOffsetOverflow(TestCase):
-    # The (2**16 + 1, 2**15, 1, 1) FP16 input plus its gradient is ~9GB; skip on
-    # devices without enough memory so the Reproducer CI stays reliable.
-    @largeTensorTest("10GB", device="xpu")
+    @largeTensorTest("5GB", device="xpu")
     def test_backward_offset_no_overflow(self):
-        # (2**16 + 1) samples of 2**15 classes: the last sample's input offset
-        # sample * map_nelem * n_classes exceeds 2**31, overflowing int32.
-        x = torch.zeros(
-            (2**16 + 1, 2**15, 1, 1),
+        batch_size = 2**16 + 1
+        num_classes = 2**15
+        ignore_index = -100
+
+        # Reduced backward only uses input metadata. Expanding a scalar avoids
+        # materializing another four-GiB tensor.
+        input = torch.empty(
+            (),
             device="xpu",
             dtype=torch.float16,
-            requires_grad=True,
+        ).expand(batch_size, num_classes, 1, 1)
+        target = torch.full(
+            (batch_size, 1, 1),
+            ignore_index,
+            dtype=torch.int64,
+            device="xpu",
         )
-        target = torch.zeros((2**16 + 1, 1, 1), device="xpu", dtype=torch.long)
+        target[-1] = 0
+        one = torch.ones((), dtype=torch.float16, device="xpu")
 
-        F.nll_loss(x, target, reduction="sum").backward()
+        grad_input = torch.ops.aten.nll_loss2d_backward.default(
+            one,
+            input,
+            target,
+            None,
+            F._Reduction.get_enum("sum"),
+            ignore_index,
+            one,
+        )
 
-        # With reduction="sum" and target class 0, every selected gradient is -1.
-        # Pre-fix, the wrapped offset leaves the tail sample's gradient at 0.
-        self.assertEqual(x.grad[0, 0, 0, 0].item(), -1.0)
-        self.assertEqual(x.grad[-1, 0, 0, 0].item(), -1.0)
+        torch.xpu.synchronize()
+        self.assertEqual(grad_input[-1, 0, 0, 0], -1)
 
 
 if __name__ == "__main__":

--- a/test/xpu/test_nn_xpu.py
+++ b/test/xpu/test_nn_xpu.py
@@ -15933,55 +15933,46 @@ class TestNNDeviceType(NNTestCase):
                 )
 
     # Ref: https://github.com/intel/torch-xpu-ops/issues/4723
-    # (pytorch/pytorch#190139). The 4D-input nll_loss2d backward kernel computed
-    # its per-sample base offsets in 32-bit int; once the flattened extent
-    # reaches 2**31 the offset wraps and the tail samples' gradients are silently
-    # dropped. This mirrors test_nll_loss_large_tensor above but exercises the
-    # nll_loss2d path (4D input) instead of the 1D nll_loss path.
+    # Ref: https://github.com/pytorch/pytorch/pull/190144
     @onlyOn(["cuda", "xpu"])
-    @largeTensorTest("120GB", "cpu")
-    @largeTensorTest("45GB", "cuda")
-    @largeTensorTest("45GB", "xpu")
-    @parametrize_test("reduction", ("none", "mean", "sum"))
-    def test_nll_loss2d_large_tensor(self, device, reduction):
-        # (2**16 + 1) samples of 2**15 classes, 1x1 spatial: numel > 2**31 so the
-        # last sample's input offset sample * map_nelem * n_classes overflows int32.
-        shape = [int(2**16) + 1, int(2**15), 1, 1]
+    @largeTensorTest("5GB", "cuda")
+    @largeTensorTest("5GB", "xpu")
+    def test_nll_loss2d_backward_large_sample_offset(self, device):
+        batch_size = 2**16 + 1
+        num_classes = 2**15
+        ignore_index = -100
 
-        input = torch.randn(
-            shape, device=device, dtype=torch.float32, requires_grad=True
+        # Reduced backward only uses input metadata. Expanding a scalar avoids
+        # materializing another four-GiB tensor.
+        input = torch.empty(
+            (),
+            device=device,
+            dtype=torch.float16,
+        ).expand(batch_size, num_classes, 1, 1)
+        target = torch.full(
+            (batch_size, 1, 1),
+            ignore_index,
+            dtype=torch.int64,
+            device=device,
         )
-        labels = torch.randint(
-            shape[1], (shape[0], shape[2], shape[3]), dtype=torch.long, device=device
+        target[-1] = 0
+        one = torch.ones((), dtype=torch.float16, device=device)
+
+        grad_input = torch.ops.aten.nll_loss2d_backward.default(
+            one,
+            input,
+            target,
+            None,
+            F._Reduction.get_enum("sum"),
+            ignore_index,
+            one,
         )
 
-        out = F.nll_loss(input, labels, reduction=reduction)
-
-        with torch.no_grad():
-            input_cpu = input.cpu().float().requires_grad_()
-            labels_cpu = labels.cpu()
-        out_cpu = F.nll_loss(input_cpu, labels_cpu, reduction=reduction)
-        # workaround to reduce memory usage vs. self.assertEqual, see #84944
-        rtol, atol = torch.testing._comparison.get_tolerances(
-            torch.float32, rtol=None, atol=None
-        )
-        if reduction == "sum":
-            orig_rtol, orig_atol = rtol, atol
-            rtol, atol = 7 * rtol, 3 * atol
-        with torch.no_grad():
-            self.assertTrue(torch.allclose(out.cpu(), out_cpu, rtol=rtol, atol=atol))
-        if reduction == "sum":
-            rtol, atol = orig_rtol, orig_atol
-
-        if reduction != "none":
-            out.backward()
-            out_cpu.backward()
-            with torch.no_grad():
-                self.assertTrue(
-                    torch.allclose(
-                        input.grad.cpu(), input_cpu.grad, rtol=rtol, atol=atol
-                    )
-                )
+        if device == "cuda":
+            torch.cuda.synchronize()
+        else:
+            torch.xpu.synchronize()
+        self.assertEqual(grad_input[-1, 0, 0, 0], -1)
 
     # Ref: https://github.com/pytorch/pytorch/issues/108345
     @onlyOn(["cuda", "xpu"])

--- a/test/xpu/test_nn_xpu.py
+++ b/test/xpu/test_nn_xpu.py
@@ -15931,6 +15931,57 @@ class TestNNDeviceType(NNTestCase):
                     )
                 )
 
+    # Ref: https://github.com/intel/torch-xpu-ops/issues/4723
+    # (pytorch/pytorch#190139). The 4D-input nll_loss2d backward kernel computed
+    # its per-sample base offsets in 32-bit int; once the flattened extent
+    # reaches 2**31 the offset wraps and the tail samples' gradients are silently
+    # dropped. This mirrors test_nll_loss_large_tensor above but exercises the
+    # nll_loss2d path (4D input) instead of the 1D nll_loss path.
+    @onlyOn(["cuda", "xpu"])
+    @largeTensorTest("120GB", "cpu")
+    @largeTensorTest("45GB", "cuda")
+    @largeTensorTest("45GB", "xpu")
+    @parametrize_test("reduction", ("none", "mean", "sum"))
+    def test_nll_loss2d_large_tensor(self, device, reduction):
+        # (2**16 + 1) samples of 2**15 classes, 1x1 spatial: numel > 2**31 so the
+        # last sample's input offset sample * map_nelem * n_classes overflows int32.
+        shape = [int(2**16) + 1, int(2**15), 1, 1]
+
+        input = torch.randn(
+            shape, device=device, dtype=torch.float32, requires_grad=True
+        )
+        labels = torch.randint(
+            shape[1], (shape[0], shape[2], shape[3]), dtype=torch.long, device=device
+        )
+
+        out = F.nll_loss(input, labels, reduction=reduction)
+
+        with torch.no_grad():
+            input_cpu = input.cpu().float().requires_grad_()
+            labels_cpu = labels.cpu()
+        out_cpu = F.nll_loss(input_cpu, labels_cpu, reduction=reduction)
+        # workaround to reduce memory usage vs. self.assertEqual, see #84944
+        rtol, atol = torch.testing._comparison.get_tolerances(
+            torch.float32, rtol=None, atol=None
+        )
+        if reduction == "sum":
+            orig_rtol, orig_atol = rtol, atol
+            rtol, atol = 7 * rtol, 3 * atol
+        with torch.no_grad():
+            self.assertTrue(torch.allclose(out.cpu(), out_cpu, rtol=rtol, atol=atol))
+        if reduction == "sum":
+            rtol, atol = orig_rtol, orig_atol
+
+        if reduction != "none":
+            out.backward()
+            out_cpu.backward()
+            with torch.no_grad():
+                self.assertTrue(
+                    torch.allclose(
+                        input.grad.cpu(), input_cpu.grad, rtol=rtol, atol=atol
+                    )
+                )
+
     # Ref: https://github.com/pytorch/pytorch/issues/108345
     @onlyOn(["cuda", "xpu"])
     @largeTensorTest("20GB", "cpu")

--- a/test/xpu/test_nn_xpu.py
+++ b/test/xpu/test_nn_xpu.py
@@ -15932,6 +15932,57 @@ class TestNNDeviceType(NNTestCase):
                     )
                 )
 
+    # Ref: https://github.com/intel/torch-xpu-ops/issues/4723
+    # (pytorch/pytorch#190139). The 4D-input nll_loss2d backward kernel computed
+    # its per-sample base offsets in 32-bit int; once the flattened extent
+    # reaches 2**31 the offset wraps and the tail samples' gradients are silently
+    # dropped. This mirrors test_nll_loss_large_tensor above but exercises the
+    # nll_loss2d path (4D input) instead of the 1D nll_loss path.
+    @onlyOn(["cuda", "xpu"])
+    @largeTensorTest("120GB", "cpu")
+    @largeTensorTest("45GB", "cuda")
+    @largeTensorTest("45GB", "xpu")
+    @parametrize_test("reduction", ("none", "mean", "sum"))
+    def test_nll_loss2d_large_tensor(self, device, reduction):
+        # (2**16 + 1) samples of 2**15 classes, 1x1 spatial: numel > 2**31 so the
+        # last sample's input offset sample * map_nelem * n_classes overflows int32.
+        shape = [int(2**16) + 1, int(2**15), 1, 1]
+
+        input = torch.randn(
+            shape, device=device, dtype=torch.float32, requires_grad=True
+        )
+        labels = torch.randint(
+            shape[1], (shape[0], shape[2], shape[3]), dtype=torch.long, device=device
+        )
+
+        out = F.nll_loss(input, labels, reduction=reduction)
+
+        with torch.no_grad():
+            input_cpu = input.cpu().float().requires_grad_()
+            labels_cpu = labels.cpu()
+        out_cpu = F.nll_loss(input_cpu, labels_cpu, reduction=reduction)
+        # workaround to reduce memory usage vs. self.assertEqual, see #84944
+        rtol, atol = torch.testing._comparison.get_tolerances(
+            torch.float32, rtol=None, atol=None
+        )
+        if reduction == "sum":
+            orig_rtol, orig_atol = rtol, atol
+            rtol, atol = 7 * rtol, 3 * atol
+        with torch.no_grad():
+            self.assertTrue(torch.allclose(out.cpu(), out_cpu, rtol=rtol, atol=atol))
+        if reduction == "sum":
+            rtol, atol = orig_rtol, orig_atol
+
+        if reduction != "none":
+            out.backward()
+            out_cpu.backward()
+            with torch.no_grad():
+                self.assertTrue(
+                    torch.allclose(
+                        input.grad.cpu(), input_cpu.grad, rtol=rtol, atol=atol
+                    )
+                )
+
     # Ref: https://github.com/pytorch/pytorch/issues/108345
     @onlyOn(["cuda", "xpu"])
     @largeTensorTest("20GB", "cpu")

--- a/test/xpu/test_nn_xpu.py
+++ b/test/xpu/test_nn_xpu.py
@@ -15932,55 +15932,46 @@ class TestNNDeviceType(NNTestCase):
                 )
 
     # Ref: https://github.com/intel/torch-xpu-ops/issues/4723
-    # (pytorch/pytorch#190139). The 4D-input nll_loss2d backward kernel computed
-    # its per-sample base offsets in 32-bit int; once the flattened extent
-    # reaches 2**31 the offset wraps and the tail samples' gradients are silently
-    # dropped. This mirrors test_nll_loss_large_tensor above but exercises the
-    # nll_loss2d path (4D input) instead of the 1D nll_loss path.
+    # Ref: https://github.com/pytorch/pytorch/pull/190144
     @onlyOn(["cuda", "xpu"])
-    @largeTensorTest("120GB", "cpu")
-    @largeTensorTest("45GB", "cuda")
-    @largeTensorTest("45GB", "xpu")
-    @parametrize_test("reduction", ("none", "mean", "sum"))
-    def test_nll_loss2d_large_tensor(self, device, reduction):
-        # (2**16 + 1) samples of 2**15 classes, 1x1 spatial: numel > 2**31 so the
-        # last sample's input offset sample * map_nelem * n_classes overflows int32.
-        shape = [int(2**16) + 1, int(2**15), 1, 1]
+    @largeTensorTest("5GB", "cuda")
+    @largeTensorTest("5GB", "xpu")
+    def test_nll_loss2d_backward_large_sample_offset(self, device):
+        batch_size = 2**16 + 1
+        num_classes = 2**15
+        ignore_index = -100
 
-        input = torch.randn(
-            shape, device=device, dtype=torch.float32, requires_grad=True
+        # Reduced backward only uses input metadata. Expanding a scalar avoids
+        # materializing another four-GiB tensor.
+        input = torch.empty(
+            (),
+            device=device,
+            dtype=torch.float16,
+        ).expand(batch_size, num_classes, 1, 1)
+        target = torch.full(
+            (batch_size, 1, 1),
+            ignore_index,
+            dtype=torch.int64,
+            device=device,
         )
-        labels = torch.randint(
-            shape[1], (shape[0], shape[2], shape[3]), dtype=torch.long, device=device
+        target[-1] = 0
+        one = torch.ones((), dtype=torch.float16, device=device)
+
+        grad_input = torch.ops.aten.nll_loss2d_backward.default(
+            one,
+            input,
+            target,
+            None,
+            F._Reduction.get_enum("sum"),
+            ignore_index,
+            one,
         )
 
-        out = F.nll_loss(input, labels, reduction=reduction)
-
-        with torch.no_grad():
-            input_cpu = input.cpu().float().requires_grad_()
-            labels_cpu = labels.cpu()
-        out_cpu = F.nll_loss(input_cpu, labels_cpu, reduction=reduction)
-        # workaround to reduce memory usage vs. self.assertEqual, see #84944
-        rtol, atol = torch.testing._comparison.get_tolerances(
-            torch.float32, rtol=None, atol=None
-        )
-        if reduction == "sum":
-            orig_rtol, orig_atol = rtol, atol
-            rtol, atol = 7 * rtol, 3 * atol
-        with torch.no_grad():
-            self.assertTrue(torch.allclose(out.cpu(), out_cpu, rtol=rtol, atol=atol))
-        if reduction == "sum":
-            rtol, atol = orig_rtol, orig_atol
-
-        if reduction != "none":
-            out.backward()
-            out_cpu.backward()
-            with torch.no_grad():
-                self.assertTrue(
-                    torch.allclose(
-                        input.grad.cpu(), input_cpu.grad, rtol=rtol, atol=atol
-                    )
-                )
+        if device == "cuda":
+            torch.cuda.synchronize()
+        else:
+            torch.xpu.synchronize()
+        self.assertEqual(grad_input[-1, 0, 0, 0], -1)
 
     # Ref: https://github.com/pytorch/pytorch/issues/108345
     @onlyOn(["cuda", "xpu"])


### PR DESCRIPTION
## Background

XPU NLLLoss2d backward computes per-sample offsets in signed 32-bit integers. Once the flattened offset reaches `2^31`, it wraps and silently leaves gradients for later samples at zero.

## Upstream

- [pytorch/pytorch#190139](https://github.com/pytorch/pytorch/issues/190139) tracks the CUDA overflow.
- [pytorch/pytorch#190144](https://github.com/pytorch/pytorch/pull/190144) and landed [commit 1f18820](https://github.com/pytorch/pytorch/commit/1f18820beba94d55fabe7889653746a5eb7952dd) select 64-bit offsets for the CUDA backward path. XPU has separate offset arithmetic that remained 32-bit.

## Fix

- widen `sample`, `toffset`, and `ioffset` to `int64_t`
- add a regression at the `2^31` offset boundary

## Before and after

| Value | Before | After |
|---|---:|---:|
| First sample gradient | `-1.0` | `-1.0` |
| Last sample gradient | `0.0` | `-1.0` |

## Testing

Intel Data Center GPU Max 1100: the large-offset regression test passed after reproducing the zero tail gradient before the fix.

Fixes #4723
