### PR TITLE
Fix angle_kernel dispatch for Half and BFloat16 on XPU

### DIFF
--- a/src/ATen/native/xpu/sycl/UnaryComplexKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UnaryComplexKernels.cpp
@@ -134,7 +134,8 @@ struct AngleWrapper {
     if (at::_isnan(v)) {
       return v;
     }
-    return v < 0 ? std::numbers::pi_v<scalar_t> : scalar_t(0);
+    return v < 0 ? static_cast<scalar_t>(std::numbers::pi_v<double>)
+                 : scalar_t(0);
   }
 };
 
@@ -156,9 +157,13 @@ void angle_kernel(TensorIteratorBase& iter) {
         kComplexHalf,
         kBComplex32);
   } else {
-    AT_DISPATCH_FLOATING_TYPES(dtype, "angle_xpu", [&]() {
-      gpu_kernel(iter, AngleWrapper<scalar_t>());
-    });
+    AT_DISPATCH_V2(
+        dtype,
+        "angle_xpu",
+        AT_WRAP([&]() { gpu_kernel(iter, AngleWrapper<scalar_t>()); }),
+        AT_EXPAND(AT_FLOATING_TYPES),
+        kHalf,
+        kBFloat16);
   }
 }
 


### PR DESCRIPTION
## Summary

The XPU `angle_kernel` for non-complex types only dispatched `float` and `double` via `AT_DISPATCH_FLOATING_TYPES`, causing `NotImplementedError` for `float16` and `bfloat16` inputs.

Additionally, `std::numbers::pi_v<scalar_t>` is undefined for `c10::Half` / `c10::BFloat16`.

Fix both issues to match the CUDA implementation in `UnaryComplexKernels.cu`:
- Change dispatch from `AT_DISPATCH_FLOATING_TYPES` to `AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, ...)`
- Use `static_cast<scalar_t>(std::numbers::pi_v<double>)` to work for all floating-point types including Half/BFloat16

Fixes: pytorch/pytorch#191434, pytorch/pytorch#191438

## Test Plan

Verified locally on Intel Arc Pro B60 (BMG):

**1. SYCL kernel symbols for `c10::Half` and `c10::BFloat16` exist in the compiled binary:**
```
nm -D libtorch-xpu-ops-sycl-UnaryComplexKernels.so | c++filt | grep AngleWrapper
# AngleWrapper<c10::Half>     -- present ✅
# AngleWrapper<c10::BFloat16> -- present ✅
```

**2. Official dtype coverage test passes:**
```
python test/test_ops.py TestCommonXPU.test_dtypes_angle_xpu
# Ran 1 test in 0.273s - OK ✅
```

**3. float16/bfloat16 produce correct values on xpu:0:**
```python
torch.angle(torch.tensor([-1., 1.], dtype=torch.float16,  device='xpu'))
# -> tensor([3.140625, 0.], device='xpu:0', dtype=torch.float16)  ✅
torch.angle(torch.tensor([-1., 1.], dtype=torch.bfloat16, device='xpu'))
# -> tensor([3.140625, 0.], device='xpu:0', dtype=torch.bfloat16) ✅
```
Before the fix, both raised `NotImplementedError: Could not run 'aten::angle' with arguments from the 'XPU' backend`.

---
*Authored with the assistance of an AI coding agent.*