### PR TITLE
Fix int32 overflow in adaptive_avg_pool2d backward kernel

### DIFF
--- a/src/ATen/native/xpu/sycl/AdaptiveAveragePooling2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/AdaptiveAveragePooling2dKernels.cpp
@@ -89,7 +89,7 @@ struct AdaptiveAvgPool2dBwdKernelFunctor {
     oh_ = gyacc_.size(2);
     ow_ = gyacc_.size(3);
 
-    numel_ = ib_ * ic_ * ih_ * iw_;
+    numel_ = static_cast<int64_t>(ib_) * ic_ * ih_ * iw_;
     int total_item = std::min(numel_, syclMaxWorkItemsPerTile());
     local_range_ = syclMaxWorkItemsPerSubSlice();
     global_range_ = total_item < local_range_
@@ -205,7 +205,7 @@ struct AdaptiveAvgPool2dBwdSLMKernelFunctor
     oh_ = gyacc_.size(2);
     ow_ = gyacc_.size(3);
 
-    numel_ = ib_ * ic_ * ih_ * iw_;
+    numel_ = static_cast<int64_t>(ib_) * ic_ * ih_ * iw_;
     int total_item = std::min(numel_, syclMaxWorkItemsPerTile());
 
     local_range_ = syclMaxWorkGroupSize(*this);


### PR DESCRIPTION
The `numel_` computation in `AdaptiveAvgPool2dBwdKernelFunctor` and `AdaptiveAvgPool2dBwdSLMKernelFunctor` overflows int32 when the input tensor has more than `INT32_MAX` elements (e.g. shape `1 x 2 x 32769 x 65536`). All four size members (`ib_, ic_, ih_, iw_`) are int, so the multiplication is performed in 32-bit arithmetic before assignment to `int64_t numel_`. This causes the kernel to iterate over only a fraction of elements, producing incorrect gradients.

Cast the first operand to `int64_t` to promote the entire expression.

Fixes `test_adaptive_avg_pool2d_backward_large_index_offsets_xpu`