### PR TITLE
test/xpu: drop stale native_group_norm xfails now passing on nightly

### DIFF
--- a/test/xpu/functorch/test_ops_xpu.py
+++ b/test/xpu/functorch/test_ops_xpu.py
@@ -1262,7 +1262,6 @@ class TestOperators(TestCase):
                 xfail("as_strided"),
                 xfail("as_strided_copy"),
                 xfail("as_strided", "partial_views"),
-                xfail("native_group_norm"),
             }
         ),
     )
@@ -1378,7 +1377,6 @@ class TestOperators(TestCase):
         vmapjvpall_fail.union(
             {
                 xfail("as_strided_copy"),
-                xfail("native_group_norm"),
             }
         ),
     )
@@ -1442,7 +1440,6 @@ class TestOperators(TestCase):
                 xfail("nn.functional.dropout3d", ""),
                 xfail("as_strided_scatter", ""),
                 xfail("renorm"),  # hit vmap fallback, which is disabled
-                xfail("native_group_norm"),
             }
         ),
     )
@@ -1561,7 +1558,6 @@ class TestOperators(TestCase):
                 xfail(
                     "index_fill"
                 ),  # aten::_unique hit the vmap fallback which is currently disabled
-                xfail("native_group_norm"),
             }
         ),
     )
@@ -1670,7 +1666,6 @@ class TestOperators(TestCase):
                 # TODO: implement batching rule
                 xfail("_batch_norm_with_update"),
                 xfail("as_strided", "partial_views"),
-                xfail("native_group_norm"),
             }
         ),
     )

--- a/test/xpu/functorch/test_vmap_xpu.py
+++ b/test/xpu/functorch/test_vmap_xpu.py
@@ -4410,7 +4410,6 @@ class TestVmapOperatorsOpInfo(TestCase):
                         sample.kwargs["memory_format"] == torch.channels_last
                     ),
                 ),
-                xfail("native_group_norm"),
             }
         ),
     )
@@ -4574,7 +4573,6 @@ class TestVmapOperatorsOpInfo(TestCase):
                 skip("_softmax_backward_data"),
                 # One or more of the overload doesn't have a Batch rule.
                 xfail("bincount"),
-                xfail("native_group_norm"),
             }
         ),
     )


### PR DESCRIPTION
Fixes stale `xfail("native_group_norm")` entries left behind after
pytorch/pytorch#186414 landed (2026-07-24). That PR made `native_group_norm`
handle non-contiguous inputs — exactly what vmap tests exercise — so seven
of the entries added in #4297 are now firing as `Unexpected success` and
turning CI red. Example failing job: https://github.com/intel/torch-xpu-ops/actions/runs/30393697348/job/90451977949

## What this PR does

Deletes 7 stale `xfail("native_group_norm")` entries:

- `test/xpu/functorch/test_ops_xpu.py` (5): `test_vmapvjp`, `test_vmapjvpall`,
  `test_vmapjvpall_has_batch_rule`, `test_vmapvjp_has_batch_rule`,
  `test_vjpvmap`.
- `test/xpu/functorch/test_vmap_xpu.py` (2): `test_vmap_exhaustive`,
  `test_op_has_batch_rule`.

The two **double-backward** variants keep their xfail:

- `test_vmapvjpvjp_native_group_norm` (test_ops_xpu.py L1101)
- `test_vmapjvpvjp_native_group_norm` (test_ops_xpu.py L2073)

They are not just slow: on PVC each hangs long enough (~90 s and >300 s) to
crash pytest-xdist workers (`node down: Not properly terminated`). Removing
their xfail would re-introduce multi-minute worker hangs into CI. This is the
same failure class as dashboard sub-issue `1/4` ("2x group_norm vmap
double-backward TIMEOUT", NEEDS_HUMAN).

## Verified locally

PVC (Intel Data Center GPU Max 1100), `torch==2.14.0.dev20260728+xpu`:

```
pytest -v test/xpu/functorch/test_ops_xpu.py \
  -k 'native_group_norm and (test_vmapvjp or test_vmapjvpall or test_vjpvmap or test_vmapjvpall_has_batch_rule or test_vmapvjp_has_batch_rule)'
# -> 5 passed

pytest -v test/xpu/functorch/test_vmap_xpu.py \
  -k 'native_group_norm and (test_vmap_exhaustive or test_op_has_batch_rule)'
# -> 2 passed

pytest -v test/xpu/functorch/test_ops_xpu.py \
  -k 'native_group_norm and (test_vmapvjpvjp or test_vmapjvpvjp)'
# -> 2 xfailed (still hanging; xfail is kept)
```

Test: test/xpu/functorch/test_ops_xpu.py, test/xpu/functorch/test_vmap_xpu.py

Authored-with an AI assistant (OpenCode / Claude).
