### PR TITLE
test/xpu: mark nn.ConvTranspose1d test_cpu_gpu_parity as XPU-pass

### DIFF
--- a/test/xpu/xpu_test_utils.py
+++ b/test/xpu/xpu_test_utils.py
@@ -376,6 +376,9 @@ _cuda_xfail_xpu_pass = [
     ("_refs.true_divide", "test_python_ref_torch_fallback"),
     ("argsort", "test_non_standard_bool_values"),
     ("sort", "test_non_standard_bool_values"),
+    # ConvTranspose1d chalf test_cpu_gpu_parity: upstream xfails CUDA
+    # ("Not implemented for chalf on CPU"), but XPU passes -> unexpected success.
+    ("nn.ConvTranspose1d", "test_cpu_gpu_parity"),
 ]
 
 # Additional unscoped (device_type=None) expectedFailure entries that should


### PR DESCRIPTION
## Summary

Upstream `torch/testing/_internal/common_modules.py` marks `test_cpu_gpu_parity` for `nn.ConvTranspose1d` with `chalf` as an `expectedFailure` on CUDA ("Not implemented for chalf on CPU"):

```python
ModuleInfo(torch.nn.ConvTranspose1d,
           ...
           skips=(
               DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_cpu_gpu_parity',
                            dtypes=(torch.chalf,), device_type='cuda'),
           ),
```

`XPUPatchForImport.align_db_decorators` in `test/xpu/xpu_test_utils.py` retags CUDA-scoped `expectedFailure` DecorateInfos as XPU unless the `(op_name, test_name)` pair is listed in `_cuda_xfail_xpu_pass`. XPU supports `chalf` `ConvTranspose1d` so the test passes and reports "unexpected success".

Add `("nn.ConvTranspose1d", "test_cpu_gpu_parity")` to `_cuda_xfail_xpu_pass` so the CUDA xfail is left alone on XPU.

## Test Plan

```
pytest -sv test/xpu/test_modules_xpu.py -k test_cpu_gpu_parity_nn_ConvTranspose1d_xpu_complex32
```

## Related

Sub-issue 18/1 in [CuiYifeng/torch-xpu-ops-sandbox#120](https://github.com/CuiYifeng/torch-xpu-ops-sandbox/issues/120)

This PR was authored with an AI assistant.