### PR TITLE
test/xpu: guard bfloat16 x complex scalar in sparse_csr test_mul_scalar

### DIFF
--- a/test/xpu/test_sparse_csr_xpu.py
+++ b/test/xpu/test_sparse_csr_xpu.py
@@ -3216,8 +3216,8 @@ class TestSparseCSR(TestCase):
             for scalar_dtype in all_types_and_complex_and(
                 torch.bool, torch.bfloat16, torch.half
             ):
-                # ComplexHalf is experimental
-                if dtype is torch.half and scalar_dtype.is_complex:
+                # ComplexHalf/BComplex32 is experimental
+                if dtype in (torch.half, torch.bfloat16) and scalar_dtype.is_complex:
                     continue
 
                 scalar_t = torch.tensor(2, dtype=scalar_dtype)


### PR DESCRIPTION
## Summary

Upstream `test/test_sparse_csr.py` guards the experimental complex-half /
BComplex32 combinations in `test_mul_scalar` via:

```python
# ComplexHalf/BComplex32 is experimental
if dtype in (torch.half, torch.bfloat16) and scalar_dtype.is_complex:
    continue
```

The vendored copy in `test/xpu/test_sparse_csr_xpu.py` only skips
`torch.half`, so 8 `test_mul_scalar_*_bcomplex32` cases (bfloat16 tensor x
complex scalar) still run on XPU and fail because `bcomplex32` is an
unsupported experimental dtype.

Sync the guard with upstream.

## Test Plan

```
pytest -sv test/xpu/test_sparse_csr_xpu.py -k "test_mul_scalar and bcomplex32"
```

## Related

Sub-issue 29/1 in [CuiYifeng/torch-xpu-ops-sandbox#120](https://github.com/CuiYifeng/torch-xpu-ops-sandbox/issues/120)

This PR was authored with an AI assistant.