### PR TITLE
test/xpu: sync aotdispatch subclass-metadata-mutation tests with upstream

### DIFF
--- a/test/xpu/functorch/test_aotdispatch_xpu.py
+++ b/test/xpu/functorch/test_aotdispatch_xpu.py
@@ -2284,17 +2284,12 @@ def forward(self, primals_1):
             x = torch.ones(1, 2, 4, requires_grad=req_grad).clone()
             return [(x,), (x,)]
 
-        # See https://github.com/pytorch/pytorch/issues/114975
-        with self.assertRaisesRegex(
-            RuntimeError,
-            "Metadata mutations are currently not allowed on tensor subclasses",
-        ):
-            self.verify_aot_autograd(
-                f,
-                partial(inp_callable, req_grad=req_grad),
-                test_mutation=True,
-                make_inputs_subclasses=True,
-            )
+        self.verify_aot_autograd(
+            f,
+            partial(inp_callable, req_grad=req_grad),
+            test_mutation=True,
+            make_inputs_subclasses=True,
+        )
 
     def test_input_data_and_metadata_mutation(self):
         def f(a):
@@ -3275,7 +3270,7 @@ def forward(self, primals_1, primals_2):
 
         with self.assertRaisesRegex(
             RuntimeError,
-            "Metadata mutations are currently not allowed on tensor subclasses",
+            "Encountered aliased inputs that are mutated in the graph",
         ):
             self.verify_aot_autograd(
                 f,
@@ -7150,9 +7145,6 @@ metadata incorrectly.
         self.assertEqual(b_ref_base.grad.a, b_test_base.grad.a)
         self.assertEqual(b_ref_base.grad.b, b_test_base.grad.b)
 
-    # NB: Metadata mutation for subclasses is currently broken and disabled
-    # See https://github.com/pytorch/pytorch/issues/114975
-    @unittest.expectedFailure
     def test_aot_dispatch_input_metadata_mutation(self):
         def f(a, b):
             a.t_()
@@ -7193,6 +7185,9 @@ metadata incorrectly.
         self.assertEqual(a_test, a_ref)
         self.assertEqual(b_test.a, b_ref.a)
         self.assertEqual(b_test.b, b_ref.b)
+        self.assertTensorMetadataEqual(a_test, a_ref)
+        self.assertTensorMetadataEqual(b_test, b_ref)
+        self.assertTensorMetadataEqual(out_test, out_ref)
 
         # NOTE: we need to use b in our gradient compute. Otherwise we will need to recompile the backward.
         (b_ref * out_ref).sum().backward()


### PR DESCRIPTION
## Summary

Upstream [pytorch/pytorch#114975](https://github.com/pytorch/pytorch/issues/114975)
enabled metadata mutation on tensor subclasses. `test/functorch/test_aotdispatch.py`
in upstream was updated accordingly, but the XPU vendored copy in
`test/xpu/functorch/test_aotdispatch_xpu.py` still reflects the pre-fix
state, so these four tests fail on XPU:

* `test_subclass_metadata_mutation_req_grad_False`
* `test_subclass_metadata_mutation_req_grad_True`
* `test_input_mutation_aliases_bases_out_of_order`
* `test_aot_dispatch_input_metadata_mutation`

Sync each with upstream:

* `test_subclass_metadata_mutation`: drop the `assertRaisesRegex`
  wrapper and call `verify_aot_autograd` directly.
* `test_input_mutation_aliases_bases_out_of_order`: update the error
  message regex from "Metadata mutations are currently not allowed on
  tensor subclasses" to "Encountered aliased inputs that are mutated
  in the graph".
* `test_aot_dispatch_input_metadata_mutation`: drop
  `@unittest.expectedFailure` and add the three
  `assertTensorMetadataEqual` checks that upstream added.

## Test Plan

```
pytest -sv test/xpu/functorch/test_aotdispatch_xpu.py \
    -k "test_subclass_metadata_mutation or \
       test_input_mutation_aliases_bases_out_of_order or \
       test_aot_dispatch_input_metadata_mutation"
```

## Related

Sub-issue 32/2 in [CuiYifeng/torch-xpu-ops-sandbox#120](https://github.com/CuiYifeng/torch-xpu-ops-sandbox/issues/120)

This PR was authored with an AI assistant.