### PR TITLE
[XPU] Fix exact-GELU erf-tail catastrophic cancellation

### DIFF
--- a/src/ATen/native/xpu/sycl/ActivationGeluKernel.cpp
+++ b/src/ATen/native/xpu/sycl/ActivationGeluKernel.cpp
@@ -68,8 +68,14 @@ struct GeluErfFunctor {
   scalar_t operator()(scalar_t x) const {
     using opmath_t = at::opmath_type<scalar_t>;
     constexpr opmath_t kAlpha = std::numbers::sqrt2_v<opmath_t> / 2;
+    // Compute the normal CDF as 0.5 * erfc(-x / sqrt(2)) rather than
+    // 0.5 * (1 + erf(x / sqrt(2))). The two are mathematically identical,
+    // but for large negative x, erf(x / sqrt(2)) -> -1 and the "1 + erf"
+    // form cancels catastrophically in fp32 (flushing gelu to exactly 0.0
+    // from x ~ -6 on). erfc(-x / sqrt(2)) is evaluated directly and stays
+    // accurate in the tail. Aligns XPU with pytorch/pytorch#189234.
     return static_cast<opmath_t>(x) * opmath_t(0.5) *
-        (opmath_t(1) + sycl::erf(static_cast<opmath_t>(x) * kAlpha));
+        sycl::erfc(-static_cast<opmath_t>(x) * kAlpha);
   }
 };
 
@@ -79,8 +85,11 @@ struct GeluErfBackwardFunctor {
     using opmath_t = at::opmath_type<scalar_t>;
     constexpr opmath_t kAlpha = std::numbers::sqrt2_v<opmath_t> / 2;
     constexpr opmath_t kBeta = std::numbers::inv_sqrtpi_v<opmath_t> * kAlpha;
-    const opmath_t cdf = opmath_t(0.5) *
-        (opmath_t(1) + sycl::erf(static_cast<opmath_t>(x) * kAlpha));
+    // cdf subterm rewritten from 0.5 * (1 + erf(x / sqrt(2))) to the
+    // cancellation-free 0.5 * erfc(-x / sqrt(2)); the pdf term is unchanged.
+    // Aligns XPU with pytorch/pytorch#189234.
+    const opmath_t cdf =
+        opmath_t(0.5) * sycl::erfc(-static_cast<opmath_t>(x) * kAlpha);
     const opmath_t pdf = c10::xpu::compat::exp(
                              opmath_t(-0.5) * static_cast<opmath_t>(x) *
                              static_cast<opmath_t>(x)) *

--- a/test/regressions/test_gelu_tail_accuracy.py
+++ b/test/regressions/test_gelu_tail_accuracy.py
@@ -42,8 +42,11 @@ class TestGeluTailAccuracy(TestCase):
 
         tail = xref.abs() >= 4.0
         rel_err = (
-            (actual - expected)[tail] / expected[tail].abs().clamp(min=1e-30)
-        ).abs().max().item()
+            ((actual - expected)[tail] / expected[tail].abs().clamp(min=1e-30))
+            .abs()
+            .max()
+            .item()
+        )
         # Pre-fix this was ~1.0 (100% off, flushed to zero); fp32 rounding of
         # x / sqrt(2) leaves a residual well under 1e-3 after the fix.
         self.assertLess(rel_err, 1e-3)
@@ -64,16 +67,17 @@ class TestGeluTailAccuracy(TestCase):
 
         tail = xref.abs() >= 4.0
         rel_err = (
-            (actual - expected)[tail] / expected[tail].abs().clamp(min=1e-30)
-        ).abs().max().item()
+            ((actual - expected)[tail] / expected[tail].abs().clamp(min=1e-30))
+            .abs()
+            .max()
+            .item()
+        )
         self.assertLess(rel_err, 1e-3)
 
     def test_gelu_matches_cpu_tail_xpu(self):
         # CPU exact gelu is already accurate in the tail; XPU should match it.
         dtype = torch.float32
-        x = torch.tensor(
-            [-10.0, -8.0, -6.0, -5.5, -5.0, -2.0, 3.0], dtype=dtype
-        )
+        x = torch.tensor([-10.0, -8.0, -6.0, -5.5, -5.0, -2.0, 3.0], dtype=dtype)
         y_cpu = F.gelu(x)
         y_xpu = F.gelu(x.to(xpu_device)).cpu()
         self.assertEqual(y_cpu, y_xpu, atol=1e-6, rtol=1e-5)

--- a/test/regressions/test_gelu_tail_accuracy.py
+++ b/test/regressions/test_gelu_tail_accuracy.py
@@ -1,0 +1,79 @@
+# Copyright 2020-2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Owner(s): ["module: intel"]
+#
+# Regression test for the XPU exact-gelu tail accuracy bug.
+#
+# Exact gelu previously computed 0.5 * x * (1 + erf(x / sqrt(2))).  For large
+# negative x, erf(x / sqrt(2)) -> -1, so "1 + erf" cancels catastrophically in
+# fp32 and gelu flushes to exactly 0.0 from x ~ -6 on.  The fix rewrites the
+# normal CDF subterm as the cancellation-free 0.5 * erfc(-x / sqrt(2)) in both
+# the forward and backward XPU kernels, aligning XPU with the upstream
+# CPU/CUDA/MPS fix in pytorch/pytorch#189234.  See intel/torch-xpu-ops#4753.
+#
+# Baseline (pre-fix) XPU gelu forward had ~100% relative error in the tail;
+# with the fix it matches the float64 reference to fp32 rounding.
+import math
+
+import torch
+import torch.nn.functional as F
+from torch.testing._internal.common_utils import TestCase
+
+xpu_device = torch.device("xpu")
+
+
+class TestGeluTailAccuracy(TestCase):
+    def test_gelu_forward_tail_accuracy_xpu(self):
+        dtype = torch.float32
+        x = torch.arange(-12.0, 12.0, 2**-6, dtype=dtype, device=xpu_device)
+        xref = x.cpu().double()
+
+        kAlpha = math.sqrt(0.5)
+        # Cancellation-free float64 reference for exact gelu.
+        expected = 0.5 * xref * torch.erfc(-xref * kAlpha)
+
+        actual = F.gelu(x).cpu().double()
+
+        tail = xref.abs() >= 4.0
+        rel_err = (
+            (actual - expected)[tail] / expected[tail].abs().clamp(min=1e-30)
+        ).abs().max().item()
+        # Pre-fix this was ~1.0 (100% off, flushed to zero); fp32 rounding of
+        # x / sqrt(2) leaves a residual well under 1e-3 after the fix.
+        self.assertLess(rel_err, 1e-3)
+
+    def test_gelu_backward_tail_accuracy_xpu(self):
+        dtype = torch.float32
+        x = torch.arange(-12.0, 12.0, 2**-6, dtype=dtype, device=xpu_device)
+        xref = x.cpu().double()
+
+        kAlpha = math.sqrt(0.5)
+        kBeta = math.sqrt(2.0 / math.pi) * 0.5
+        expected = 0.5 * torch.erfc(-xref * kAlpha) + xref * kBeta * torch.exp(
+            -0.5 * xref * xref
+        )
+
+        grad = torch.ones_like(x)
+        actual = torch.ops.aten.gelu_backward(grad, x).cpu().double()
+
+        tail = xref.abs() >= 4.0
+        rel_err = (
+            (actual - expected)[tail] / expected[tail].abs().clamp(min=1e-30)
+        ).abs().max().item()
+        self.assertLess(rel_err, 1e-3)
+
+    def test_gelu_matches_cpu_tail_xpu(self):
+        # CPU exact gelu is already accurate in the tail; XPU should match it.
+        dtype = torch.float32
+        x = torch.tensor(
+            [-10.0, -8.0, -6.0, -5.5, -5.0, -2.0, 3.0], dtype=dtype
+        )
+        y_cpu = F.gelu(x)
+        y_xpu = F.gelu(x.to(xpu_device)).cpu()
+        self.assertEqual(y_cpu, y_xpu, atol=1e-6, rtol=1e-5)


### PR DESCRIPTION
## Background

Exact GELU computes its normal-CDF term as `0.5 * (1 + erf(x / sqrt(2)))`. In the negative tail, `erf` approaches `-1`, the addition cancels in fp32, and XPU can return exactly zero instead of the small reference value.

## Upstream

- [pytorch/pytorch#189234](https://github.com/pytorch/pytorch/pull/189234) applies the cancellation-free `erfc` form to upstream CPU/CUDA/MPS code. XPU uses a separate SYCL functor and needs the same numerical change here.

## Fix

- compute the CDF term as `0.5 * erfc(-x / sqrt(2))` in exact-GELU forward and backward
- leave the PDF term and tanh approximation unchanged
- add negative-tail accuracy and CPU-parity coverage

## Before and after

| Case | Before | After |
|---|---|---|
| Forward tail relative error | About `1.0` | Below `1e-3` |
| Backward tail relative error | About `3.3e-2` | Below `1e-3` |

## Testing

Linux XPU `op_regression` in [CI run 34858336918](https://github.com/intel/torch-xpu-ops/actions/runs/34858336918): 3 passed, 0 failed.

Fixes #4753
