### PR TITLE
Deduplicate and template the atomics in Atomics.h

### DIFF
--- a/src/ATen/native/xpu/sycl/Atomics.h
+++ b/src/ATen/native/xpu/sycl/Atomics.h
@@ -16,6 +16,7 @@
 #include <sycl/sycl.hpp>
 
 #include <concepts>
+#include <functional>
 #include <type_traits>
 
 namespace at::native::xpu {
@@ -36,51 +37,43 @@ template <typename T>
 using sycl_atomic_ref_rlx_wg_local_t =
     sycl::atomic_ref<T, sycl_mem_odr_rlx, sycl_mem_scp_wg, sycl_local_space>;
 
-// The integer atomics differ between the global and work-group-local address
-// spaces only in the atomic_ref they build, so they are parameterized on it.
-// Types narrower than a word are packed several-per-word and CAS the containing
-// 32-bit word; wider ones CAS their own word directly.
+// CAS-emulated atomics: types narrower than a word are packed several-per-word
+// and CAS the containing 32-bit word; wider ones CAS their own word directly.
 template <template <typename> class atomic_ref_t, std::integral T>
 struct AtomicIntegerImplBase {
+  // Pack an n-byte value (n in {1,2}) into its containing 32-bit word and CAS.
+  template <int n, typename func_t>
+  static inline void subWord(T* address, T val, const func_t& func) {
+    using sub_t = std::conditional_t<n == 1, uint8_t, uint16_t>;
+    constexpr uint32_t mask = (1u << (n * 8)) - 1;
+    size_t offset = (size_t)address & (4 - n);
+    uint32_t* address_as_ui = (uint32_t*)((char*)address - offset);
+    uint32_t shift = offset * 8;
+    uint32_t assumed = *address_as_ui;
+    uint32_t newval = 0;
+    atomic_ref_t<uint32_t> target(*address_as_ui);
+
+    do {
+      uint32_t old = (assumed >> shift) & mask;
+      // Cast through sub_t, not uint32_t, so negative signed values do not
+      // sign-extend (e.g. signed -1 stays 0xff, not ~0).
+      newval = static_cast<sub_t>(func(val, static_cast<T>(old)));
+      newval = (assumed & ~(mask << shift)) | (newval << shift);
+    } while (!target.compare_exchange_strong(assumed, newval));
+  }
+
   template <typename func_t>
   inline void operator()(T* address, T val, const func_t& func) {
     if constexpr (sizeof(T) == 1) {
-      size_t offset = (size_t)address & 3;
-      uint32_t* address_as_ui = (uint32_t*)((char*)address - offset);
-      uint32_t assumed = *address_as_ui;
-      uint32_t shift = offset * 8;
-      uint32_t newval;
-      atomic_ref_t<uint32_t> target(*address_as_ui);
-
-      do {
-        uint32_t old_byte = (assumed >> shift) & 0xff;
-        // preserve size in initial cast. Casting directly to uint32_t pads
-        // negative signed values with 1's (e.g. signed -1 = unsigned ~0).
-        newval = static_cast<uint8_t>(func(val, static_cast<T>(old_byte)));
-        newval = (assumed & ~(0x000000ff << shift)) | (newval << shift);
-      } while (!target.compare_exchange_strong(assumed, newval));
+      subWord<1>(address, val, func);
     } else if constexpr (sizeof(T) == 2) {
-      size_t offset = (size_t)address & 2;
-      uint32_t* address_as_ui = (uint32_t*)((char*)address - offset);
-      bool is_32_align = offset;
-      uint32_t assumed = *address_as_ui;
-      uint32_t newval;
-      atomic_ref_t<uint32_t> target(*address_as_ui);
-
-      do {
-        uint32_t old_half = is_32_align ? assumed >> 16 : assumed & 0xffff;
-        // preserve size in initial cast. Casting directly to uint32_t pads
-        // negative signed values with 1's (e.g. signed -1 = unsigned ~0).
-        newval = static_cast<uint16_t>(func(val, static_cast<T>(old_half)));
-        newval = is_32_align ? (assumed & 0xffff) | (newval << 16)
-                             : (assumed & 0xffff0000) | newval;
-      } while (!target.compare_exchange_strong(assumed, newval));
+      subWord<2>(address, val, func);
     } else {
       using proxy_t =
           std::conditional_t<sizeof(T) == 4, uint32_t, unsigned long long>;
       proxy_t* address_as_proxy = (proxy_t*)address;
       proxy_t assumed = *address_as_proxy;
-      proxy_t newval;
+      proxy_t newval = 0;
       atomic_ref_t<proxy_t> target(*address_as_proxy);
 
       do {
@@ -98,44 +91,12 @@ template <typename T>
 using AtomicIntegerImpl =
     AtomicIntegerImplBase<sycl_atomic_ref_rlx_dev_global_t, T>;
 
-#define SYCL_ATOMIC_INTEGER_LOCAL(NAME, OP, DTYPE)          \
-  static inline void atomic##NAME##Local(                   \
-      const sycl_local_ptr<DTYPE>& address, DTYPE val) {    \
-    AtomicIntegerImplLocal<DTYPE>()(                        \
-        address, val, [](DTYPE a, DTYPE b) { return OP; }); \
-  }
-
-#define SYCL_ATOMIC_INTEGER(NAME, OP, DTYPE)                \
-  static inline void atomic##NAME(                          \
-      const sycl_global_ptr<DTYPE>& address, DTYPE val) {   \
-    AtomicIntegerImpl<DTYPE>()(                             \
-        address, val, [](DTYPE a, DTYPE b) { return OP; }); \
-  }
-
-// For operations sycl::atomic_ref supports natively on 4/8-byte integers.
-#define SYCL_ATOMIC_INTEGER_NATIVE_IMPL(                                       \
-    NAME, METHOD, DTYPE, PTR_TYPE, ATOMIC_REF)                                 \
-  static inline void atomic##NAME(const PTR_TYPE<DTYPE>& address, DTYPE val) { \
-    ATOMIC_REF<DTYPE> target(*address);                                        \
-    target.METHOD(val);                                                        \
-  }
-
-#define SYCL_ATOMIC_INTEGER_NATIVE(NAME, METHOD, DTYPE) \
-  SYCL_ATOMIC_INTEGER_NATIVE_IMPL(                      \
-      NAME, METHOD, DTYPE, sycl_global_ptr, sycl_atomic_ref_rlx_dev_global_t)
-
-#define SYCL_ATOMIC_INTEGER_NATIVE_LOCAL(NAME, METHOD, DTYPE) \
-  SYCL_ATOMIC_INTEGER_NATIVE_IMPL(                            \
-      NAME, METHOD, DTYPE, sycl_local_ptr, sycl_atomic_ref_rlx_wg_local_t)
-
 template <typename T>
 concept atomic_fp_t =
     std::same_as<T, at::Half> || std::same_as<T, at::BFloat16> ||
     std::same_as<T, float> || std::same_as<T, double>;
 
 // CAS compares object representations, so NaN cannot livelock the loop.
-// Half/BFloat16 are packed two-per-word and CAS the containing 32-bit word;
-// float/double CAS their own word through a same-sized integer proxy.
 template <template <typename> class atomic_ref_t, atomic_fp_t T>
 struct AtomicFPImplBase {
   template <typename func_t>
@@ -145,7 +106,7 @@ struct AtomicFPImplBase {
       unsigned int* address_as_ui = (unsigned int*)((char*)address - offset);
       bool is_32_align = offset;
       unsigned int assumed = *address_as_ui;
-      unsigned int newval;
+      unsigned int newval = 0;
       atomic_ref_t<unsigned int> target(*address_as_ui);
 
       do {
@@ -162,7 +123,7 @@ struct AtomicFPImplBase {
           std::conditional_t<sizeof(T) == 4, unsigned int, unsigned long long>;
       proxy_t* address_as_proxy = (proxy_t*)address;
       proxy_t assumed = *address_as_proxy;
-      proxy_t newval;
+      proxy_t newval = 0;
       atomic_ref_t<proxy_t> target(*address_as_proxy);
 
       do {
@@ -178,197 +139,13 @@ using AtomicFPImpl = AtomicFPImplBase<sycl_atomic_ref_rlx_dev_global_t, T>;
 template <typename T>
 using AtomicFPImplLocal = AtomicFPImplBase<sycl_atomic_ref_rlx_wg_local_t, T>;
 
-#define SYCL_ATOMIC_FP(NAME, OP, DTYPE)                                       \
-  static inline void atomic##NAME(                                            \
-      const sycl_global_ptr<DTYPE>& address, DTYPE val) {                     \
-    AtomicFPImpl<DTYPE>()(address, val, [](DTYPE a, DTYPE b) { return OP; }); \
-  }
-
-#define SYCL_ATOMIC_FP_LOCAL(NAME, OP, DTYPE)               \
-  static inline void atomic##NAME##Local(                   \
-      const sycl_local_ptr<DTYPE>& address, DTYPE val) {    \
-    AtomicFPImplLocal<DTYPE>()(                             \
-        address, val, [](DTYPE a, DTYPE b) { return OP; }); \
-  }
-
-static inline void atomicAdd(const sycl_global_ptr<float>& address, float val) {
-  sycl_atomic_ref_rlx_dev_global_t<float> target(*address);
-  target.fetch_add(val);
-}
-
-static inline void atomicAdd(
-    const sycl_global_ptr<double>& address,
-    double val) {
-  sycl_atomic_ref_rlx_dev_global_t<double> target(*address);
-  target.fetch_add(val);
-}
-
-static inline void atomicAdd(const sycl_global_ptr<int>& address, int val) {
-  sycl_atomic_ref_rlx_dev_global_t<int> target(*address);
-  target.fetch_add(val);
-}
-
-static inline void atomicAdd(
-    const sycl_global_ptr<int64_t>& address,
-    int64_t val) {
-  sycl_atomic_ref_rlx_dev_global_t<int64_t> target(*address);
-  target.fetch_add(val);
-}
-
-static inline void atomicAdd(
-    const sycl_local_ptr<uint32_t>& address,
-    uint32_t val) {
-  sycl_atomic_ref_rlx_wg_local_t<uint32_t> target(*address);
-  target.fetch_add(val);
-}
-
-static inline void atomicAdd(
-    const sycl_local_ptr<uint64_t>& address,
-    uint64_t val) {
-  sycl_atomic_ref_rlx_wg_local_t<uint64_t> target(*address);
-  target.fetch_add(val);
-}
-
-static inline void atomicAdd(const sycl_local_ptr<int>& address, int val) {
-  sycl_atomic_ref_rlx_wg_local_t<int> target(*address);
-  target.fetch_add(val);
-}
-
-static inline void atomicAdd(
-    const sycl_local_ptr<int64_t>& address,
-    int64_t val) {
-  sycl_atomic_ref_rlx_wg_local_t<int64_t> target(*address);
-  target.fetch_add(val);
-}
-
-static inline void atomicAddLocal(
-    const sycl_local_ptr<float>& address,
-    float val) {
-  sycl_atomic_ref_rlx_wg_local_t<float> target(*address);
-  target.fetch_add(val);
-}
-
-static inline void atomicAddLocal(
-    const sycl_local_ptr<double>& address,
-    double val) {
-  sycl_atomic_ref_rlx_wg_local_t<double> target(*address);
-  target.fetch_add(val);
-}
-
-static inline void atomicAddLocal(const sycl_local_ptr<int>& address, int val) {
-  sycl_atomic_ref_rlx_wg_local_t<int> target(*address);
-  target.fetch_add(val);
-}
-
-static inline void atomicAddLocal(
-    const sycl_local_ptr<int64_t>& address,
-    int64_t val) {
-  sycl_atomic_ref_rlx_wg_local_t<int64_t> target(*address);
-  target.fetch_add(val);
-}
-
-static inline void atomicAddLocal(
-    const sycl_local_ptr<uint32_t>& address,
-    uint32_t val) {
-  sycl_atomic_ref_rlx_wg_local_t<uint32_t> target(*address);
-  target.fetch_add(val);
-}
-
-static inline void atomicAddLocal(
-    const sycl_local_ptr<uint64_t>& address,
-    uint64_t val) {
-  sycl_atomic_ref_rlx_wg_local_t<uint64_t> target(*address);
-  target.fetch_add(val);
-}
-
-// Atomic add local implementation.
-SYCL_ATOMIC_INTEGER_LOCAL(Add, a || b, bool)
-SYCL_ATOMIC_INTEGER_LOCAL(Add, std::plus<uint8_t>()(a, b), uint8_t)
-SYCL_ATOMIC_INTEGER_LOCAL(Add, std::plus<int8_t>()(a, b), int8_t)
-SYCL_ATOMIC_INTEGER_LOCAL(Add, std::plus<int16_t>()(a, b), int16_t)
-
-SYCL_ATOMIC_FP_LOCAL(Add, std::plus<at::Half>()(a, b), at::Half)
-SYCL_ATOMIC_FP_LOCAL(Add, std::plus<at::BFloat16>()(a, b), at::BFloat16)
-
-// Atomic add implementation.
-SYCL_ATOMIC_INTEGER(Add, a || b, bool)
-SYCL_ATOMIC_INTEGER(Add, std::plus<uint8_t>()(a, b), uint8_t)
-SYCL_ATOMIC_INTEGER(Add, std::plus<int8_t>()(a, b), int8_t)
-SYCL_ATOMIC_INTEGER(Add, std::plus<int16_t>()(a, b), int16_t)
-
-SYCL_ATOMIC_FP(Add, std::plus<at::Half>()(a, b), at::Half)
-SYCL_ATOMIC_FP(Add, std::plus<at::BFloat16>()(a, b), at::BFloat16)
-
+// 4/8-byte integers: native sycl::atomic_ref fetch_*.
 template <typename T>
-static inline void atomicAdd(
-    const sycl_global_ptr<c10::complex<T>>& address,
-    c10::complex<T> val) {
-  atomicAdd(&address->real_, val.real_);
-  atomicAdd(&address->imag_, val.imag_);
-}
+concept atomic_native_int_t =
+    std::integral<T> && (sizeof(T) == 4 || sizeof(T) == 8);
 
-template <typename T>
-static inline void atomicAddLocal(
-    const sycl_local_ptr<c10::complex<T>>& address,
-    c10::complex<T> val) {
-  atomicAddLocal(&address->real_, val.real_);
-  atomicAddLocal(&address->imag_, val.imag_);
-}
-
-// Atomic multiplication implementation.
-SYCL_ATOMIC_INTEGER(Mul, std::multiplies<uint8_t>()(a, b), uint8_t)
-SYCL_ATOMIC_INTEGER(Mul, std::multiplies<int8_t>()(a, b), int8_t)
-SYCL_ATOMIC_INTEGER(Mul, std::multiplies<int16_t>()(a, b), int16_t)
-SYCL_ATOMIC_INTEGER(Mul, std::multiplies<int32_t>()(a, b), int32_t)
-SYCL_ATOMIC_INTEGER(Mul, std::multiplies<int64_t>()(a, b), int64_t)
-SYCL_ATOMIC_INTEGER(Mul, std::multiplies<uint32_t>()(a, b), uint32_t)
-SYCL_ATOMIC_INTEGER(Mul, std::multiplies<uint64_t>()(a, b), uint64_t)
-
-SYCL_ATOMIC_FP(Mul, std::multiplies<float>()(a, b), float)
-SYCL_ATOMIC_FP(Mul, std::multiplies<double>()(a, b), double)
-SYCL_ATOMIC_FP(Mul, std::multiplies<at::Half>()(a, b), at::Half)
-SYCL_ATOMIC_FP(Mul, std::multiplies<at::BFloat16>()(a, b), at::BFloat16)
-
-// Atomic maximum implementation.
-
-SYCL_ATOMIC_INTEGER_NATIVE_LOCAL(Max, fetch_max, int32_t)
-SYCL_ATOMIC_INTEGER_NATIVE_LOCAL(Max, fetch_max, int64_t)
-
-SYCL_ATOMIC_INTEGER(Max, safe_max<uint8_t>(a, b), uint8_t)
-SYCL_ATOMIC_INTEGER(Max, safe_max<int8_t>(a, b), int8_t)
-SYCL_ATOMIC_INTEGER(Max, safe_max<int16_t>(a, b), int16_t)
-SYCL_ATOMIC_INTEGER_NATIVE(Max, fetch_max, int32_t)
-SYCL_ATOMIC_INTEGER_NATIVE(Max, fetch_max, int64_t)
-SYCL_ATOMIC_INTEGER_NATIVE(Max, fetch_max, uint32_t)
-SYCL_ATOMIC_INTEGER_NATIVE(Max, fetch_max, uint64_t)
-
-SYCL_ATOMIC_FP(Max, safe_max<float>(a, b), float)
-SYCL_ATOMIC_FP(Max, safe_max<double>(a, b), double)
-SYCL_ATOMIC_FP(Max, safe_max<at::Half>(a, b), at::Half)
-SYCL_ATOMIC_FP(Max, safe_max<at::BFloat16>(a, b), at::BFloat16)
-
-// Atomic minimum implementation.
-SYCL_ATOMIC_INTEGER(Min, safe_min<uint8_t>(a, b), uint8_t)
-SYCL_ATOMIC_INTEGER(Min, safe_min<int8_t>(a, b), int8_t)
-SYCL_ATOMIC_INTEGER(Min, safe_min<int16_t>(a, b), int16_t)
-SYCL_ATOMIC_INTEGER_NATIVE(Min, fetch_min, int32_t)
-SYCL_ATOMIC_INTEGER_NATIVE(Min, fetch_min, int64_t)
-SYCL_ATOMIC_INTEGER_NATIVE(Min, fetch_min, uint32_t)
-SYCL_ATOMIC_INTEGER_NATIVE(Min, fetch_min, uint64_t)
-
-SYCL_ATOMIC_FP(Min, safe_min<float>(a, b), float)
-SYCL_ATOMIC_FP(Min, safe_min<double>(a, b), double)
-SYCL_ATOMIC_FP(Min, safe_min<at::Half>(a, b), at::Half)
-SYCL_ATOMIC_FP(Min, safe_min<at::BFloat16>(a, b), at::BFloat16)
-
-// =========================================================================
-// ------------------------------AtomicCAS----------------------------------
-// =========================================================================
-
-// atomicCAS is only used on 4/8-byte integer index types. sycl::atomic_ref
-// supports them directly, and compare_exchange_strong compares object
-// representations, matching CUDA atomicCAS bit semantics; expected is updated
-// with the old value on failure, so it is the return value either way.
+// compare_exchange_strong compares object representations; expected is updated
+// with the old value on failure, so it is returned either way.
 template <typename T, template <typename> class R>
 struct AtomicCASImpl {
   inline T operator()(T* address, T expected, T desired) {
@@ -378,19 +155,144 @@ struct AtomicCASImpl {
   }
 };
 
-#define SYCL_ATOMIC_CAS_IMPL(DTYPE, PTR_TYPE, ATOMIC_REF)                  \
-  static inline DTYPE atomicCAS(                                           \
-      const PTR_TYPE<DTYPE>& address, DTYPE expected, DTYPE desired) {     \
-    return AtomicCASImpl<DTYPE, ATOMIC_REF>()(address, expected, desired); \
+// Free-function atomics, overloaded on address space (sycl_global_ptr vs
+// sycl_local_ptr). Native fetch_* where supported, else the CAS-emulated cores.
+
+// Atomic add.
+template <typename T>
+  requires(std::integral<T> || atomic_fp_t<T>)
+static inline void atomicAdd(const sycl_global_ptr<T>& address, T val) {
+  if constexpr (
+      atomic_native_int_t<T> || std::is_same_v<T, float> ||
+      std::is_same_v<T, double>) {
+    sycl_atomic_ref_rlx_dev_global_t<T> target(*address);
+    target.fetch_add(val);
+  } else if constexpr (std::integral<T>) {
+    AtomicIntegerImpl<T>()(address, val, std::plus<T>());
+  } else {
+    AtomicFPImpl<T>()(address, val, std::plus<T>());
   }
+}
 
-#define SYCL_ATOMIC_CAS_ALL(DTYPE) \
-  /* local CAS version */          \
-  SYCL_ATOMIC_CAS_IMPL(DTYPE, sycl_local_ptr, sycl_atomic_ref_rlx_wg_local_t)
+template <typename T>
+  requires(std::integral<T> || atomic_fp_t<T>)
+static inline void atomicAdd(const sycl_local_ptr<T>& address, T val) {
+  if constexpr (
+      atomic_native_int_t<T> || std::is_same_v<T, float> ||
+      std::is_same_v<T, double>) {
+    sycl_atomic_ref_rlx_wg_local_t<T> target(*address);
+    target.fetch_add(val);
+  } else if constexpr (std::integral<T>) {
+    AtomicIntegerImplLocal<T>()(address, val, std::plus<T>());
+  } else {
+    AtomicFPImplLocal<T>()(address, val, std::plus<T>());
+  }
+}
 
-SYCL_ATOMIC_CAS_ALL(int)
-SYCL_ATOMIC_CAS_ALL(int64_t)
-SYCL_ATOMIC_CAS_ALL(uint32_t)
-SYCL_ATOMIC_CAS_ALL(uint64_t)
+template <typename T>
+static inline void atomicAdd(
+    const sycl_global_ptr<c10::complex<T>>& address,
+    c10::complex<T> val) {
+  atomicAdd(sycl_global_ptr<T>(&address->real_), val.real_);
+  atomicAdd(sycl_global_ptr<T>(&address->imag_), val.imag_);
+}
+
+template <typename T>
+static inline void atomicAdd(
+    const sycl_local_ptr<c10::complex<T>>& address,
+    c10::complex<T> val) {
+  atomicAdd(sycl_local_ptr<T>(&address->real_), val.real_);
+  atomicAdd(sycl_local_ptr<T>(&address->imag_), val.imag_);
+}
+
+// Atomic multiply (no native fetch_mul; always CAS-emulated).
+template <typename T>
+  requires(std::integral<T> || atomic_fp_t<T>)
+static inline void atomicMul(const sycl_global_ptr<T>& address, T val) {
+  if constexpr (std::integral<T>) {
+    AtomicIntegerImpl<T>()(address, val, std::multiplies<T>());
+  } else {
+    AtomicFPImpl<T>()(address, val, std::multiplies<T>());
+  }
+}
+
+template <typename T>
+  requires(std::integral<T> || atomic_fp_t<T>)
+static inline void atomicMul(const sycl_local_ptr<T>& address, T val) {
+  if constexpr (std::integral<T>) {
+    AtomicIntegerImplLocal<T>()(address, val, std::multiplies<T>());
+  } else {
+    AtomicFPImplLocal<T>()(address, val, std::multiplies<T>());
+  }
+}
+
+// Atomic maximum.
+template <typename T>
+  requires(std::integral<T> || atomic_fp_t<T>)
+static inline void atomicMax(const sycl_global_ptr<T>& address, T val) {
+  if constexpr (atomic_native_int_t<T>) {
+    sycl_atomic_ref_rlx_dev_global_t<T> target(*address);
+    target.fetch_max(val);
+  } else if constexpr (std::integral<T>) {
+    AtomicIntegerImpl<T>()(
+        address, val, [](T a, T b) { return safe_max<T>(a, b); });
+  } else {
+    AtomicFPImpl<T>()(address, val, [](T a, T b) { return safe_max<T>(a, b); });
+  }
+}
+
+template <typename T>
+  requires(std::integral<T> || atomic_fp_t<T>)
+static inline void atomicMax(const sycl_local_ptr<T>& address, T val) {
+  if constexpr (atomic_native_int_t<T>) {
+    sycl_atomic_ref_rlx_wg_local_t<T> target(*address);
+    target.fetch_max(val);
+  } else if constexpr (std::integral<T>) {
+    AtomicIntegerImplLocal<T>()(
+        address, val, [](T a, T b) { return safe_max<T>(a, b); });
+  } else {
+    AtomicFPImplLocal<T>()(
+        address, val, [](T a, T b) { return safe_max<T>(a, b); });
+  }
+}
+
+// Atomic minimum.
+template <typename T>
+  requires(std::integral<T> || atomic_fp_t<T>)
+static inline void atomicMin(const sycl_global_ptr<T>& address, T val) {
+  if constexpr (atomic_native_int_t<T>) {
+    sycl_atomic_ref_rlx_dev_global_t<T> target(*address);
+    target.fetch_min(val);
+  } else if constexpr (std::integral<T>) {
+    AtomicIntegerImpl<T>()(
+        address, val, [](T a, T b) { return safe_min<T>(a, b); });
+  } else {
+    AtomicFPImpl<T>()(address, val, [](T a, T b) { return safe_min<T>(a, b); });
+  }
+}
+
+template <typename T>
+  requires(std::integral<T> || atomic_fp_t<T>)
+static inline void atomicMin(const sycl_local_ptr<T>& address, T val) {
+  if constexpr (atomic_native_int_t<T>) {
+    sycl_atomic_ref_rlx_wg_local_t<T> target(*address);
+    target.fetch_min(val);
+  } else if constexpr (std::integral<T>) {
+    AtomicIntegerImplLocal<T>()(
+        address, val, [](T a, T b) { return safe_min<T>(a, b); });
+  } else {
+    AtomicFPImplLocal<T>()(
+        address, val, [](T a, T b) { return safe_min<T>(a, b); });
+  }
+}
+
+// Atomic compare-and-swap, work-group-local only.
+template <typename T>
+  requires std::integral<T> && (sizeof(T) == 4 || sizeof(T) == 8)
+static inline T
+    atomicCAS(const sycl_local_ptr<T>& address, T expected, T desired) {
+  return AtomicCASImpl<T, sycl_atomic_ref_rlx_wg_local_t>()(
+      address, expected, desired);
+}
 
 } // namespace at::native::xpu

--- a/src/ATen/native/xpu/sycl/Atomics.h
+++ b/src/ATen/native/xpu/sycl/Atomics.h
@@ -15,6 +15,9 @@
 
 #include <sycl/sycl.hpp>
 
+#include <concepts>
+#include <type_traits>
+
 namespace at::native::xpu {
 
 template <typename T>
@@ -30,185 +33,82 @@ static inline T safe_min(T a, T b) {
 }
 
 template <typename T>
-using sycl_atomic_ref_rlx_dev_global_t =
-    sycl::atomic_ref<T, sycl_mem_odr_rlx, sycl_mem_scp_dev, sycl_global_space>;
-
-template <typename T>
 using sycl_atomic_ref_rlx_wg_local_t =
     sycl::atomic_ref<T, sycl_mem_odr_rlx, sycl_mem_scp_wg, sycl_local_space>;
 
-template <typename T, size_t n>
-struct AtomicIntegerImplLocal;
-
-template <typename T>
-struct AtomicIntegerImplLocal<T, 1> {
+// The integer atomics differ between the global and work-group-local address
+// spaces only in the atomic_ref they build, so they are parameterized on it.
+// Types narrower than a word are packed several-per-word and CAS the containing
+// 32-bit word; wider ones CAS their own word directly.
+template <template <typename> class atomic_ref_t, std::integral T>
+struct AtomicIntegerImplBase {
   template <typename func_t>
   inline void operator()(T* address, T val, const func_t& func) {
-    size_t offset = (size_t)address & 3;
-    uint32_t* address_as_ui = (uint32_t*)((char*)address - offset);
-    uint32_t assumed = *address_as_ui;
-    uint32_t shift = offset * 8;
-    uint32_t newval;
-    uint32_t newval_byte;
-    sycl_atomic_ref_rlx_wg_local_t<uint32_t> target(*address_as_ui);
+    if constexpr (sizeof(T) == 1) {
+      size_t offset = (size_t)address & 3;
+      uint32_t* address_as_ui = (uint32_t*)((char*)address - offset);
+      uint32_t assumed = *address_as_ui;
+      uint32_t shift = offset * 8;
+      uint32_t newval;
+      atomic_ref_t<uint32_t> target(*address_as_ui);
 
-    do {
-      newval = assumed;
-      newval_byte = (newval >> shift) & 0xff;
-      // preserve size in initial cast. Casting directly to uint32_t pads
-      // negative signed values with 1's (e.g. signed -1 = unsigned ~0).
-      newval = static_cast<uint8_t>(func(val, static_cast<T>(newval_byte)));
-      newval = (assumed & ~(0x000000ff << shift)) | (newval << shift);
-    } while (!target.compare_exchange_strong(assumed, newval));
+      do {
+        uint32_t old_byte = (assumed >> shift) & 0xff;
+        // preserve size in initial cast. Casting directly to uint32_t pads
+        // negative signed values with 1's (e.g. signed -1 = unsigned ~0).
+        newval = static_cast<uint8_t>(func(val, static_cast<T>(old_byte)));
+        newval = (assumed & ~(0x000000ff << shift)) | (newval << shift);
+      } while (!target.compare_exchange_strong(assumed, newval));
+    } else if constexpr (sizeof(T) == 2) {
+      size_t offset = (size_t)address & 2;
+      uint32_t* address_as_ui = (uint32_t*)((char*)address - offset);
+      bool is_32_align = offset;
+      uint32_t assumed = *address_as_ui;
+      uint32_t newval;
+      atomic_ref_t<uint32_t> target(*address_as_ui);
+
+      do {
+        uint32_t old_half = is_32_align ? assumed >> 16 : assumed & 0xffff;
+        // preserve size in initial cast. Casting directly to uint32_t pads
+        // negative signed values with 1's (e.g. signed -1 = unsigned ~0).
+        newval = static_cast<uint16_t>(func(val, static_cast<T>(old_half)));
+        newval = is_32_align ? (assumed & 0xffff) | (newval << 16)
+                             : (assumed & 0xffff0000) | newval;
+      } while (!target.compare_exchange_strong(assumed, newval));
+    } else {
+      using proxy_t =
+          std::conditional_t<sizeof(T) == 4, uint32_t, unsigned long long>;
+      proxy_t* address_as_proxy = (proxy_t*)address;
+      proxy_t assumed = *address_as_proxy;
+      proxy_t newval;
+      atomic_ref_t<proxy_t> target(*address_as_proxy);
+
+      do {
+        newval = static_cast<proxy_t>(func(val, static_cast<T>(assumed)));
+      } while (!target.compare_exchange_strong(assumed, newval));
+    }
   }
 };
 
 template <typename T>
-struct AtomicIntegerImplLocal<T, 2> {
-  template <typename func_t>
-  inline void operator()(T* address, T val, const func_t& func) {
-    size_t offset = (size_t)address & 2;
-    uint32_t* address_as_ui = (uint32_t*)((char*)address - offset);
-    bool is_32_align = offset;
-    uint32_t assumed = *address_as_ui;
-    uint32_t newval;
-    uint32_t newval_bytes;
-    sycl_atomic_ref_rlx_wg_local_t<uint32_t> target(*address_as_ui);
-
-    do {
-      newval = assumed;
-      newval_bytes = is_32_align ? newval >> 16 : newval & 0xffff;
-      // preserve size in initial cast. Casting directly to uint32_t pads
-      // negative signed values with 1's (e.g. signed -1 = unsigned ~0).
-      newval = static_cast<uint16_t>(func(val, static_cast<T>(newval_bytes)));
-      newval = is_32_align ? (assumed & 0xffff) | (newval << 16)
-                           : (assumed & 0xffff0000) | newval;
-    } while (!target.compare_exchange_strong(assumed, newval));
-  }
-};
+using AtomicIntegerImplLocal =
+    AtomicIntegerImplBase<sycl_atomic_ref_rlx_wg_local_t, T>;
 
 template <typename T>
-struct AtomicIntegerImplLocal<T, 4> {
-  template <typename func_t>
-  inline void operator()(T* address, T val, const func_t& func) {
-    uint32_t* address_as_ui = (uint32_t*)(address);
-    uint32_t assumed = *address_as_ui;
-    uint32_t newval;
-    sycl_atomic_ref_rlx_wg_local_t<uint32_t> target(*address_as_ui);
-
-    do {
-      newval = static_cast<uint32_t>(func(val, static_cast<T>(assumed)));
-    } while (!target.compare_exchange_strong(assumed, newval));
-  }
-};
-
-template <typename T>
-struct AtomicIntegerImplLocal<T, 8> {
-  template <typename func_t>
-  inline void operator()(T* address, T val, const func_t& func) {
-    unsigned long long* address_as_ull = (unsigned long long*)(address);
-    unsigned long long assumed = *address_as_ull;
-    unsigned long long newval;
-    sycl_atomic_ref_rlx_wg_local_t<unsigned long long> target(*address_as_ull);
-
-    do {
-      newval = static_cast<uint64_t>(func(val, static_cast<T>(assumed)));
-    } while (!target.compare_exchange_strong(assumed, newval));
-  }
-};
+using AtomicIntegerImpl =
+    AtomicIntegerImplBase<sycl_atomic_ref_rlx_dev_global_t, T>;
 
 #define SYCL_ATOMIC_INTEGER_LOCAL(NAME, OP, DTYPE)          \
   static inline void atomic##NAME##Local(                   \
       const sycl_local_ptr<DTYPE>& address, DTYPE val) {    \
-    AtomicIntegerImplLocal<DTYPE, sizeof(DTYPE)>()(         \
+    AtomicIntegerImplLocal<DTYPE>()(                        \
         address, val, [](DTYPE a, DTYPE b) { return OP; }); \
   }
-
-template <typename T, size_t n>
-struct AtomicIntegerImpl;
-
-template <typename T>
-struct AtomicIntegerImpl<T, 1> {
-  template <typename func_t>
-  inline void operator()(T* address, T val, const func_t& func) {
-    size_t offset = (size_t)address & 3;
-    uint32_t* address_as_ui = (uint32_t*)((char*)address - offset);
-    uint32_t assumed = *address_as_ui;
-    uint32_t shift = offset * 8;
-    uint32_t newval;
-    uint32_t newval_byte;
-    sycl_atomic_ref_rlx_dev_global_t<uint32_t> target(*address_as_ui);
-
-    do {
-      newval = assumed;
-      newval_byte = (newval >> shift) & 0xff;
-      // preserve size in initial cast. Casting directly to uint32_t pads
-      // negative signed values with 1's (e.g. signed -1 = unsigned ~0).
-      newval = static_cast<uint8_t>(func(val, static_cast<T>(newval_byte)));
-      newval = (assumed & ~(0x000000ff << shift)) | (newval << shift);
-    } while (!target.compare_exchange_strong(assumed, newval));
-  }
-};
-
-template <typename T>
-struct AtomicIntegerImpl<T, 2> {
-  template <typename func_t>
-  inline void operator()(T* address, T val, const func_t& func) {
-    size_t offset = (size_t)address & 2;
-    uint32_t* address_as_ui = (uint32_t*)((char*)address - offset);
-    bool is_32_align = offset;
-    uint32_t assumed = *address_as_ui;
-    uint32_t newval;
-    uint32_t newval_bytes;
-    sycl_atomic_ref_rlx_dev_global_t<uint32_t> target(*address_as_ui);
-
-    do {
-      newval = assumed;
-      newval_bytes = is_32_align ? newval >> 16 : newval & 0xffff;
-      // preserve size in initial cast. Casting directly to uint32_t pads
-      // negative signed values with 1's (e.g. signed -1 = unsigned ~0).
-      newval = static_cast<uint16_t>(func(val, static_cast<T>(newval_bytes)));
-      newval = is_32_align ? (assumed & 0xffff) | (newval << 16)
-                           : (assumed & 0xffff0000) | newval;
-    } while (!target.compare_exchange_strong(assumed, newval));
-  }
-};
-
-template <typename T>
-struct AtomicIntegerImpl<T, 4> {
-  template <typename func_t>
-  inline void operator()(T* address, T val, const func_t& func) {
-    uint32_t* address_as_ui = (uint32_t*)(address);
-    uint32_t assumed = *address_as_ui;
-    uint32_t newval;
-    sycl_atomic_ref_rlx_dev_global_t<uint32_t> target(*address_as_ui);
-
-    do {
-      newval = static_cast<uint32_t>(func(val, static_cast<T>(assumed)));
-    } while (!target.compare_exchange_strong(assumed, newval));
-  }
-};
-
-template <typename T>
-struct AtomicIntegerImpl<T, 8> {
-  template <typename func_t>
-  inline void operator()(T* address, T val, const func_t& func) {
-    unsigned long long* address_as_ull = (unsigned long long*)(address);
-    unsigned long long assumed = *address_as_ull;
-    unsigned long long newval;
-    sycl_atomic_ref_rlx_dev_global_t<unsigned long long> target(
-        *address_as_ull);
-
-    do {
-      newval = static_cast<uint64_t>(func(val, static_cast<T>(assumed)));
-    } while (!target.compare_exchange_strong(assumed, newval));
-  }
-};
 
 #define SYCL_ATOMIC_INTEGER(NAME, OP, DTYPE)                \
   static inline void atomic##NAME(                          \
       const sycl_global_ptr<DTYPE>& address, DTYPE val) {   \
-    AtomicIntegerImpl<DTYPE, sizeof(DTYPE)>()(              \
+    AtomicIntegerImpl<DTYPE>()(                             \
         address, val, [](DTYPE a, DTYPE b) { return OP; }); \
   }
 
@@ -228,118 +128,61 @@ struct AtomicIntegerImpl<T, 8> {
   SYCL_ATOMIC_INTEGER_NATIVE_IMPL(                            \
       NAME, METHOD, DTYPE, sycl_local_ptr, sycl_atomic_ref_rlx_wg_local_t)
 
-// float/double are supported by sycl::atomic_ref directly;
-// compare_exchange_strong compares object representations, so NaN cannot
-// livelock the loop. Half/BFloat16 use the containing-word emulation below.
 template <typename T>
-struct AtomicFPImpl {
+concept atomic_fp_t =
+    std::same_as<T, at::Half> || std::same_as<T, at::BFloat16> ||
+    std::same_as<T, float> || std::same_as<T, double>;
+
+// CAS compares object representations, so NaN cannot livelock the loop.
+// Half/BFloat16 are packed two-per-word and CAS the containing 32-bit word;
+// float/double CAS their own word through a same-sized integer proxy.
+template <template <typename> class atomic_ref_t, atomic_fp_t T>
+struct AtomicFPImplBase {
   template <typename func_t>
   inline void operator()(T* address, T val, const func_t& func) {
-    T assumed = *address;
-    sycl_atomic_ref_rlx_dev_global_t<T> target(*address);
-    while (!target.compare_exchange_strong(assumed, func(val, assumed))) {
+    if constexpr (sizeof(T) == 2) {
+      size_t offset = (size_t)address & 2;
+      unsigned int* address_as_ui = (unsigned int*)((char*)address - offset);
+      bool is_32_align = offset;
+      unsigned int assumed = *address_as_ui;
+      unsigned int newval;
+      atomic_ref_t<unsigned int> target(*address_as_ui);
+
+      do {
+        uint16_t prev = static_cast<uint16_t>(
+            is_32_align ? assumed >> 16 : assumed & 0xffff);
+        uint16_t res =
+            sycl::bit_cast<uint16_t>(func(sycl::bit_cast<T>(prev), val));
+        newval = is_32_align
+            ? (assumed & 0xffff) | (static_cast<unsigned int>(res) << 16)
+            : (assumed & 0xffff0000) | res;
+      } while (!target.compare_exchange_strong(assumed, newval));
+    } else {
+      using proxy_t =
+          std::conditional_t<sizeof(T) == 4, unsigned int, unsigned long long>;
+      proxy_t* address_as_proxy = (proxy_t*)address;
+      proxy_t assumed = *address_as_proxy;
+      proxy_t newval;
+      atomic_ref_t<proxy_t> target(*address_as_proxy);
+
+      do {
+        newval = sycl::bit_cast<proxy_t>(func(val, sycl::bit_cast<T>(assumed)));
+      } while (!target.compare_exchange_strong(assumed, newval));
     }
   }
 };
 
-template <>
-struct AtomicFPImpl<at::Half> {
-  template <typename func_t>
-  inline void operator()(at::Half* address, at::Half val, const func_t& func) {
-    unsigned int* address_as_ui =
-        (unsigned int*)((char*)address - ((size_t)address & 2));
-    unsigned int assumed = *address_as_ui;
-    unsigned int newval;
-    sycl_atomic_ref_rlx_dev_global_t<unsigned int> target(*address_as_ui);
+template <typename T>
+using AtomicFPImpl = AtomicFPImplBase<sycl_atomic_ref_rlx_dev_global_t, T>;
 
-    do {
-      newval = assumed;
-      at::Half hsum;
-      hsum.x = (size_t)address & 2 ? (newval >> 16) : (newval & 0xffff);
-      hsum = func(hsum, val);
-      newval = (size_t)address & 2 ? (newval & 0xffff) | (hsum.x << 16)
-                                   : (newval & 0xffff0000) | hsum.x;
-    } while (!target.compare_exchange_strong(assumed, newval));
-  }
-};
-
-template <>
-struct AtomicFPImpl<at::BFloat16> {
-  template <typename func_t>
-  inline void operator()(
-      at::BFloat16* address,
-      at::BFloat16 val,
-      const func_t& func) {
-    unsigned int* address_as_ui =
-        (unsigned int*)((char*)address - ((size_t)address & 2));
-    unsigned int assumed = *address_as_ui;
-    unsigned int newval;
-    sycl_atomic_ref_rlx_dev_global_t<unsigned int> target(*address_as_ui);
-
-    do {
-      newval = assumed;
-      at::BFloat16 bsum;
-      bsum.x = (size_t)address & 2 ? (newval >> 16) : (newval & 0xffff);
-      bsum = func(bsum, val);
-      newval = (size_t)address & 2 ? (newval & 0xffff) | (bsum.x << 16)
-                                   : (newval & 0xffff0000) | bsum.x;
-    } while (!target.compare_exchange_strong(assumed, newval));
-  }
-};
+template <typename T>
+using AtomicFPImplLocal = AtomicFPImplBase<sycl_atomic_ref_rlx_wg_local_t, T>;
 
 #define SYCL_ATOMIC_FP(NAME, OP, DTYPE)                                       \
   static inline void atomic##NAME(                                            \
       const sycl_global_ptr<DTYPE>& address, DTYPE val) {                     \
     AtomicFPImpl<DTYPE>()(address, val, [](DTYPE a, DTYPE b) { return OP; }); \
   }
-
-template <typename T>
-struct AtomicFPImplLocal;
-
-template <>
-struct AtomicFPImplLocal<at::Half> {
-  template <typename func_t>
-  inline void operator()(at::Half* address, at::Half val, const func_t& func) {
-    unsigned int* address_as_ui =
-        (unsigned int*)((char*)address - ((size_t)address & 2));
-    unsigned int assumed = *address_as_ui;
-    unsigned int newval;
-    sycl_atomic_ref_rlx_wg_local_t<unsigned int> target(*address_as_ui);
-
-    do {
-      newval = assumed;
-      at::Half hsum;
-      hsum.x = (size_t)address & 2 ? (newval >> 16) : (newval & 0xffff);
-      hsum = func(hsum, val);
-      newval = (size_t)address & 2 ? (newval & 0xffff) | (hsum.x << 16)
-                                   : (newval & 0xffff0000) | hsum.x;
-    } while (!target.compare_exchange_strong(assumed, newval));
-  }
-};
-
-template <>
-struct AtomicFPImplLocal<at::BFloat16> {
-  template <typename func_t>
-  inline void operator()(
-      at::BFloat16* address,
-      at::BFloat16 val,
-      const func_t& func) {
-    unsigned int* address_as_ui =
-        (unsigned int*)((char*)address - ((size_t)address & 2));
-    unsigned int assumed = *address_as_ui;
-    unsigned int newval;
-    sycl_atomic_ref_rlx_wg_local_t<unsigned int> target(*address_as_ui);
-
-    do {
-      newval = assumed;
-      at::BFloat16 bsum;
-      bsum.x = (size_t)address & 2 ? (newval >> 16) : (newval & 0xffff);
-      bsum = func(bsum, val);
-      newval = (size_t)address & 2 ? (newval & 0xffff) | (bsum.x << 16)
-                                   : (newval & 0xffff0000) | bsum.x;
-    } while (!target.compare_exchange_strong(assumed, newval));
-  }
-};
 
 #define SYCL_ATOMIC_FP_LOCAL(NAME, OP, DTYPE)               \
   static inline void atomic##NAME##Local(                   \

--- a/src/ATen/native/xpu/sycl/Indexing.cpp
+++ b/src/ATen/native/xpu/sycl/Indexing.cpp
@@ -1048,13 +1048,14 @@ struct IndexFuncLargeIndexFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
       IndexType current_offset = smem_offsets[smem_idx];
 
       if (current_offset == dstOffset) {
-        atomicAddLocal(
-            static_cast<sycl_local_ptr<T>>(&smem_values[smem_idx]), val);
+        atomicAdd(static_cast<sycl_local_ptr<T>>(&smem_values[smem_idx]), val);
       } else if (current_offset == (IndexType)-1) {
         IndexType expected = (IndexType)-1;
-        if (atomicCAS(&smem_offsets[smem_idx], expected, dstOffset) ==
-            expected) {
-          atomicAddLocal(
+        if (atomicCAS(
+                sycl_local_ptr<IndexType>(&smem_offsets[smem_idx]),
+                expected,
+                dstOffset) == expected) {
+          atomicAdd(
               static_cast<sycl_local_ptr<T>>(&smem_values[smem_idx]), val);
         } else {
           op_(dst_.data, dstOffset, dstNumel_, &val);

--- a/src/ATen/native/xpu/sycl/LossCTCKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LossCTCKernels.cpp
@@ -679,9 +679,10 @@ struct CTCLossBackwardCollectNonblankKernelFunctor {
                lb_target_stride_ * (s * 2 + 1)] +
           nll - lp));
       atomicAdd(
-          &gradient_data_
-              [gr_batch_offset + t * gr_input_stride_ +
-               gr_char_stride_ * target],
+          sycl_global_ptr<scalar_t>(
+              &gradient_data_
+                  [gr_batch_offset + t * gr_input_stride_ +
+                   gr_char_stride_ * target]),
           -exp_val * gr);
     }
   }


### PR DESCRIPTION
Two-step modernization of Atomics.h (review the two commits in order):

1. Collapse the per-address-space x per-size CAS specializations into two base
   templates (`AtomicIntegerImplBase`, `AtomicFPImplBase`) parameterized on the
   `sycl::atomic_ref` alias and constrained by C++20 concepts; drop a duplicate
   `atomic_ref` alias already provided by `comm/SYCLHelpers.h`.

2. Replace the `SYCL_ATOMIC_*` macros and the hand-written
   `atomicAdd`/`atomicAddLocal` overloads with one address-space-overloaded
   function template per op (`sycl_global_ptr` vs `sycl_local_ptr`). The body
   uses native `fetch_*` for 4/8-byte ints and float/double Add, and otherwise
   falls back to the CAS-emulated cores; `atomicCAS` becomes a local-only
   template. `Indexing` follows: `atomicAddLocal` -> `atomicAdd`, and its
   `atomicCAS` argument is wrapped for template deduction.

The macro set and the `atomicXLocal` naming are gone; overloads are visible in
source, and the pointer type selects global vs work-group-local.
