### PR TITLE
Fix inflated new-failure counts in UT check reporting and bump bot model

### DIFF
--- a/.claude/skills/ut-check/SKILL.md
+++ b/.claude/skills/ut-check/SKILL.md
@@ -33,6 +33,19 @@ by `.github/scripts/bot_ut_check.py`. The JSON contains:
 }
 ```
 
+### Ground Truth for New Failures
+
+The authoritative source for new failures is the `New-UT-Failures-*` artifact
+which contains `new_ut_failure_list.csv`. This CSV is produced by the CI
+summary job: `ut_result_check.sh` identifies new failures (not in the known
+issues list), and the workflow enriches them with error messages from the full
+failure CSV.
+
+**Always verify** the reported failure count is plausible. If the JSON
+`failures` list seems implausibly large (hundreds or thousands for a small PR),
+check whether the artifact generation step in `_linux_ut.yml` is matching
+correctly.
+
 ## Analysis Workflow
 
 ### Step 1: Read the Data

--- a/.github/scripts/bot_ut_check.py
+++ b/.github/scripts/bot_ut_check.py
@@ -83,17 +83,34 @@ def download_artifacts(repo, run_id, download_dir):
 
 
 def parse_new_failures(download_dir):
-    """Parse new_ut_failure_list.csv files from downloaded artifacts."""
+    """Parse new_ut_failure_list.csv from the New-UT-Failures-* artifact.
+
+    This artifact is the authoritative source for new failures. It is produced
+    by the CI summary job which filters all failures against the known issues
+    list. The file is a pipe-delimited markdown table:
+        | Category | Class name | Test name | Status | Message | Source |
+    """
     failures = []
     for csv_file in Path(download_dir).rglob("new_ut_failure_list.csv"):
         with open(csv_file) as f:
             for line in f:
                 line = line.strip()
-                if not line or line.startswith("Category"):
+                if not line:
                     continue
-                # CSV format: Category | Class name | Test name | Status | Message | Source
+                # Skip header and separator lines
+                if "---" in line and "|" in line:
+                    continue
+                if not line.startswith("|"):
+                    continue
+                # Pipe-delimited: | Cat | Class | Test | Status | Msg | Source |
+                # Split by | gives ['', ' Cat ', ' Class ', ..., '']
                 parts = [p.strip() for p in line.split("|")]
+                # Remove empty strings from leading/trailing pipes
+                parts = [p for p in parts if p]
                 if len(parts) >= 4:
+                    # Skip header row
+                    if parts[0] == "Category":
+                        continue
                     failures.append(
                         {
                             "category": parts[0],
@@ -277,7 +294,7 @@ def collect_data(repo, pr_number, run_id_arg):
     run(f"rm -rf {download_dir}", check=False)
     has_new_failures = download_artifacts(repo, run_id, download_dir)
 
-    # Parse results
+    # Parse results from the New-UT-Failures artifact (authoritative source)
     failures = parse_new_failures(download_dir) if has_new_failures else []
     passed_tests = parse_passed_tests(download_dir)
 

--- a/.github/workflows/_linux_ut.yml
+++ b/.github/workflows/_linux_ut.yml
@@ -231,8 +231,9 @@ jobs:
           ut_failure_csv=$(find "${{ github.workspace }}/ut_log" -name "ut_failure_list.csv" -type f | head -1)
           new_failure_csv="${{ github.workspace }}/ut_log/new_ut_failure_list.csv"
           if [ -s "$new_failure_list" ] && [ -n "$ut_failure_csv" ] && [ -f "$ut_failure_csv" ]; then
-            # Keep header lines
-            head -2 "$ut_failure_csv" > "$new_failure_csv"
+            # ut_failure_list.csv is headerless (see check-ut.py print_md_row);
+            # build the report from matched rows only.
+            : > "$new_failure_csv"
             # Match rows by class_name AND test_name to avoid substring false positives
             # filtered log format: category,class_name,test_name
             while IFS=',' read -r category class_name test_name; do
@@ -241,8 +242,8 @@ jobs:
               grep -F "| $class_name | $test_name |" "$ut_failure_csv" >> "$new_failure_csv" || true
             done < "$new_failure_list"
             # Verify count matches filtered log
-            expected_count=$(wc -l < "$new_failure_list")
-            actual_count=$(($(wc -l < "$new_failure_csv") - 2))  # subtract header lines
+            expected_count=$(grep -c . "$new_failure_list")
+            actual_count=$(grep -c . "$new_failure_csv")
             if [ "$actual_count" -ne "$expected_count" ]; then
               echo "::warning::New failure count mismatch: filtered=$expected_count, csv=$actual_count"
             fi

--- a/.github/workflows/_linux_ut.yml
+++ b/.github/workflows/_linux_ut.yml
@@ -233,11 +233,19 @@ jobs:
           if [ -s "$new_failure_list" ] && [ -n "$ut_failure_csv" ] && [ -f "$ut_failure_csv" ]; then
             # Keep header lines
             head -2 "$ut_failure_csv" > "$new_failure_csv"
-            # Match rows by test_name from filtered log (format: category,class_name,test_name)
+            # Match rows by class_name AND test_name to avoid substring false positives
+            # filtered log format: category,class_name,test_name
             while IFS=',' read -r category class_name test_name; do
               [ -z "$test_name" ] && continue
-              grep -F "$test_name" "$ut_failure_csv" >> "$new_failure_csv" || true
+              # Use both class_name and test_name for precise matching in pipe-delimited CSV
+              grep -F "| $class_name | $test_name |" "$ut_failure_csv" >> "$new_failure_csv" || true
             done < "$new_failure_list"
+            # Verify count matches filtered log
+            expected_count=$(wc -l < "$new_failure_list")
+            actual_count=$(($(wc -l < "$new_failure_csv") - 2))  # subtract header lines
+            if [ "$actual_count" -ne "$expected_count" ]; then
+              echo "::warning::New failure count mismatch: filtered=$expected_count, csv=$actual_count"
+            fi
             echo "has_new_failures=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_new_failures=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_linux_ut.yml
+++ b/.github/workflows/_linux_ut.yml
@@ -338,10 +338,12 @@ jobs:
             });
       - name: Fail if UT check failed
         if: ${{ steps.ut-check.outcome == 'failure' }}
+        shell: bash {0}
         run: |
           new_failure_list="${{ github.workspace }}/ut_log/new_failure_list.txt"
           if [ -s "$new_failure_list" ]; then
-            echo "::error::UT check failed with new failures:"
+            new_failure_count=$(grep -c . "$new_failure_list")
+            echo "::error::UT check failed with ${new_failure_count} new failures:"
             cat "$new_failure_list"
           else
             echo "::error::UT check failed"

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -9,7 +9,7 @@ on:
       - '.github/scripts/bot_*.py'
 
 env:
-  BEDROCK_MODEL: global.anthropic.claude-opus-4-6-v1
+  BEDROCK_MODEL: global.anthropic.claude-opus-5
   CLAUDE_ALLOWED_TOOLS: Bash,Read,Glob,Grep,WebFetch,Skill
   COST_TRACKING_ISSUE: 4251
 


### PR DESCRIPTION
## Summary

The UT-check summary reported wildly inflated new-failure counts. This PR makes the new-failure report exact and matches the filtered-log ground truth, cleans up the summary-job log output, and bumps the bot Bedrock model.

## Root causes fixed

1. **Substring matching** in the "Collect new failures" step used
   `grep -F "$test_name"` against the pipe-delimited `ut_failure_list.csv`, so a
   single test name matched many unrelated rows. Now matched precisely with
   `grep -F "| $class_name | $test_name |"`.

2. **Headerless CSV mishandling.** `ut_failure_list.csv` is headerless
   (`check-ut.py` writes the markdown header only to stdout, never to the file),
   but the step ran `head -2` on it, copying the first two real failure rows into
   `new_ut_failure_list.csv` as a fake header. Those two unrelated failures then
   surfaced in the report and were counted by `bot_ut_check.py`. The report is
   now built from matched rows only, and both sides are counted with
   `grep -c .`.

3. **Off-by-one CSV parse** in `bot_ut_check.py parse_new_failures` when
   splitting the pipe-delimited rows.

The filtered logs produced by `ut_result_check.sh` are treated as the ground
truth; the collection cross-checks against them and emits a `::warning::` on any
count mismatch.

## Log cleanup

The `summary` job runs under the default `shell: bash -xe {0}`, so the
"Fail if UT check failed" step (step:10) echoed every command with a `+`
prefix, cluttering the log around the error annotation. It now uses
`shell: bash {0}` and prints the total new-failure count in the error message.

## Bot model bump

Bumps `BEDROCK_MODEL` in the bot workflow from
`global.anthropic.claude-opus-4-6-v1` to `global.anthropic.claude-opus-5`.
