### PR TITLE
Update CI runner inputs and image support

### DIFF
--- a/.ci/docker/common/install_xpu.sh
+++ b/.ci/docker/common/install_xpu.sh
@@ -218,7 +218,7 @@ function install_ubuntu_client() {
     . /etc/os-release
 
     local -r supported_lts_versions=("plucky")
-    local -r supported_rolling_versions=("noble" "plucky")
+    local -r supported_rolling_versions=("noble" "plucky" "resolute")
 
     if [ "${XPU_DRIVER_TYPE}" == "lts" ]; then
         log_error "Ubuntu version ${VERSION_CODENAME} with ${XPU_DRIVER_TYPE} not supported"
@@ -249,12 +249,12 @@ function install_ubuntu_client() {
     # Install runtime packages based on driver type
     local -r base_packages=(
         libze-intel-gpu1 libze1 intel-metrics-discovery intel-opencl-icd clinfo intel-gsc
-        intel-media-va-driver-non-free libmfx-gen1 libvpl2 libvpl-tools libva-glx2 va-driver-all vainfo
+        intel-media-va-driver-non-free libmfx-gen1.2 libvpl2 libvpl-tools libva-glx2 va-driver-all vainfo
     )
     install_packages "ubuntu" "${base_packages[@]}"
 
     # Development packages
-    install_packages "ubuntu" libze-dev intel-ocloc xpu-smi libgomp1 pciutils
+    install_packages "ubuntu" libze-dev intel-ocloc xpu-smi pciutils
 
     log_info "Ubuntu installation completed successfully"
 }

--- a/.github/workflows/_linux_test_image.yml
+++ b/.github/workflows/_linux_test_image.yml
@@ -24,11 +24,11 @@ on:
         type: choice
         required: true
         default: '24.04'
-        description: 'Ubuntu version, 22.04 or 24.04'
+        description: 'Ubuntu version, 22.04, 24.04 or 26.04'
         options:
           - '22.04'
           - '24.04'
-          - '25.04'
+          - '26.04'
       gcc:
         type: choice
         required: true

--- a/.github/workflows/nightly_ondemand.yml
+++ b/.github/workflows/nightly_ondemand.yml
@@ -10,6 +10,10 @@ on:
     - cron: '30 16 * * 5' # nightly wheel
   workflow_dispatch:
     inputs:
+      runner:
+        type: string
+        default: 'pvc'
+        description: What runner to use for tests
       pytorch:
         type: string
         default: 'main'
@@ -163,7 +167,7 @@ jobs:
         ut_name: ${{ fromJSON(needs.Conditions-Filter.outputs.ut) }}
     uses: ./.github/workflows/_linux_ut.yml
     with:
-      runner: pvc
+      runner: ${{ github.event_name == 'schedule' && 'pvc' || inputs.runner }}
       pytorch: ${{ needs.Conditions-Filter.outputs.pytorch }}
       torch_xpu_ops: ${{ needs.Conditions-Filter.outputs.torch_xpu_ops }}
       python: ${{ needs.Conditions-Filter.outputs.python }}
@@ -181,7 +185,7 @@ jobs:
         scenario: ${{ fromJSON(needs.Conditions-Filter.outputs.scenario) }}
     uses: ./.github/workflows/_linux_e2e.yml
     with:
-      runner: ${{ matrix.scenario == 'performance' && 'pvc-1550' || 'pvc' }}
+      runner: ${{ (inputs.runner == 'pvc' || github.event_name == 'schedule') && (matrix.scenario == 'performance' && 'pvc-1550' || 'pvc') || inputs.runner }}
       test_type: ${{ needs.Conditions-Filter.outputs.test_type }}
       pytorch: ${{ needs.Conditions-Filter.outputs.pytorch }}
       python: ${{ needs.Conditions-Filter.outputs.python }}
@@ -219,7 +223,7 @@ jobs:
         microbench: [microbench]
     uses: ./.github/workflows/_linux_op_benchmark.yml
     with:
-      runner: pvc
+      runner: ${{ github.event_name == 'schedule' && 'pvc' || inputs.runner }}
       pytorch: ${{ needs.Conditions-Filter.outputs.pytorch }}
       python: ${{ needs.Conditions-Filter.outputs.python }}
 


### PR DESCRIPTION
Split out from #3910.

## Summary
- Add an on-demand runner input to `nightly_ondemand.yml` and thread it through UT/E2E/microbench jobs.
- Add Ubuntu 26.04 as a test image option.
- Update Ubuntu client package support for the newer client image.

This intentionally excludes the E2E/PT2E runner refactor, summary/reporting changes, and benchmark model-list overlay changes.
