### PR TITLE
Fix for XPU/export/tests: Operator Serialization AssertionError

### DIFF
--- a/test/xpu/export/test_cpp_serdes_xpu.py
+++ b/test/xpu/export/test_cpp_serdes_xpu.py
@@ -10,10 +10,15 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import inspect
+
 # Owner(s): ["module: intel"]
 import torch
-import inspect
-from torch._export.serde.serialize import deserialize, serialize, _reconstruct_fake_tensor
+from torch._export.serde.serialize import (
+    _reconstruct_fake_tensor,
+    deserialize,
+    serialize,
+)
 
 try:
     from . import test_export_xpu, testing_xpu

--- a/test/xpu/export/test_cpp_serdes_xpu.py
+++ b/test/xpu/export/test_cpp_serdes_xpu.py
@@ -11,11 +11,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Owner(s): ["module: intel"]
-import inspect
-
 import torch
-from torch._export.serde import serialize as serde_serialize
-from torch._export.serde.serialize import deserialize, serialize
+import inspect
+from torch._export.serde.serialize import deserialize, serialize, _reconstruct_fake_tensor
 
 try:
     from . import test_export_xpu, testing_xpu
@@ -24,10 +22,7 @@ except ImportError:
     import testing_xpu  # @manual=fbcode//caffe2/test:test_export-library
 
 from torch.export import export
-from torch.testing._internal import (
-    custom_tensor as custom_tensor_mod,
-    two_tensor as two_tensor_mod,
-)
+from torch.testing._internal import custom_tensor, two_tensor
 
 test_classes = {}
 
@@ -40,12 +35,12 @@ def _module_safe_globals():
     ]
     nn_classes = [obj for _, obj in inspect.getmembers(torch.nn, inspect.isclass)]
     two_tensor_classes = [
-        obj for _, obj in inspect.getmembers(two_tensor_mod, inspect.isclass)
+        obj for _, obj in inspect.getmembers(two_tensor, inspect.isclass)
     ]
     custom_tensor_classes = [
-        obj for _, obj in inspect.getmembers(custom_tensor_mod, inspect.isclass)
+        obj for _, obj in inspect.getmembers(custom_tensor, inspect.isclass)
     ]
-    serde_helpers = [serde_serialize._reconstruct_fake_tensor, torch.ScriptObject]
+    serde_helpers = [_reconstruct_fake_tensor, torch.ScriptObject]
     return (
         test_classes
         + nn_classes

--- a/test/xpu/export/test_cpp_serdes_xpu.py
+++ b/test/xpu/export/test_cpp_serdes_xpu.py
@@ -12,6 +12,7 @@
 
 # Owner(s): ["module: intel"]
 import inspect
+
 import torch
 from torch._export.serde import serialize as serde_serialize
 from torch._export.serde.serialize import deserialize, serialize
@@ -23,8 +24,10 @@ except ImportError:
     import testing_xpu  # @manual=fbcode//caffe2/test:test_export-library
 
 from torch.export import export
-from torch.testing._internal import custom_tensor as custom_tensor_mod
-from torch.testing._internal import two_tensor as two_tensor_mod
+from torch.testing._internal import (
+    custom_tensor as custom_tensor_mod,
+    two_tensor as two_tensor_mod,
+)
 
 test_classes = {}
 
@@ -36,10 +39,20 @@ def _module_safe_globals():
         if obj.__module__ == test_export_xpu.__name__
     ]
     nn_classes = [obj for _, obj in inspect.getmembers(torch.nn, inspect.isclass)]
-    two_tensor_classes = [obj for _, obj in inspect.getmembers(two_tensor_mod, inspect.isclass)]
-    custom_tensor_classes = [obj for _, obj in inspect.getmembers(custom_tensor_mod, inspect.isclass)]
+    two_tensor_classes = [
+        obj for _, obj in inspect.getmembers(two_tensor_mod, inspect.isclass)
+    ]
+    custom_tensor_classes = [
+        obj for _, obj in inspect.getmembers(custom_tensor_mod, inspect.isclass)
+    ]
     serde_helpers = [serde_serialize._reconstruct_fake_tensor, torch.ScriptObject]
-    return test_classes + nn_classes + two_tensor_classes + custom_tensor_classes + serde_helpers
+    return (
+        test_classes
+        + nn_classes
+        + two_tensor_classes
+        + custom_tensor_classes
+        + serde_helpers
+    )
 
 
 def _deserialize_with_safe_globals(payload):

--- a/test/xpu/export/test_cpp_serdes_xpu.py
+++ b/test/xpu/export/test_cpp_serdes_xpu.py
@@ -11,7 +11,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Owner(s): ["module: intel"]
+import inspect
 import torch
+from torch._export.serde import serialize as serde_serialize
 from torch._export.serde.serialize import deserialize, serialize
 
 try:
@@ -21,8 +23,28 @@ except ImportError:
     import testing_xpu  # @manual=fbcode//caffe2/test:test_export-library
 
 from torch.export import export
+from torch.testing._internal import custom_tensor as custom_tensor_mod
+from torch.testing._internal import two_tensor as two_tensor_mod
 
 test_classes = {}
+
+
+def _module_safe_globals():
+    test_classes = [
+        obj
+        for _, obj in inspect.getmembers(test_export_xpu, inspect.isclass)
+        if obj.__module__ == test_export_xpu.__name__
+    ]
+    nn_classes = [obj for _, obj in inspect.getmembers(torch.nn, inspect.isclass)]
+    two_tensor_classes = [obj for _, obj in inspect.getmembers(two_tensor_mod, inspect.isclass)]
+    custom_tensor_classes = [obj for _, obj in inspect.getmembers(custom_tensor_mod, inspect.isclass)]
+    serde_helpers = [serde_serialize._reconstruct_fake_tensor, torch.ScriptObject]
+    return test_classes + nn_classes + two_tensor_classes + custom_tensor_classes + serde_helpers
+
+
+def _deserialize_with_safe_globals(payload):
+    with torch.serialization.safe_globals(_module_safe_globals()):
+        return deserialize(payload)
 
 
 def mocked_cpp_serdes_export(*args, **kwargs):
@@ -34,7 +56,7 @@ def mocked_cpp_serdes_export(*args, **kwargs):
     cpp_ep = torch._C._export.deserialize_exported_program(payload.exported_program)
     loaded_json = torch._C._export.serialize_exported_program(cpp_ep)
     payload.exported_program = loaded_json.encode()
-    loaded_ep = deserialize(payload)
+    loaded_ep = _deserialize_with_safe_globals(payload)
     return loaded_ep
 
 

--- a/test/xpu/export/test_export_xpu.py
+++ b/test/xpu/export/test_export_xpu.py
@@ -396,12 +396,12 @@ class TestDynamismExpression(TestCase):
 graph():
     %p_parameter : [num_users=1] = placeholder[target=p_parameter]
     %x : [num_users=1] = placeholder[target=x]
-    %div : [num_users=2] = call_function[target=torch.ops.aten.div.Tensor](args = (%p_parameter, 2), kwargs = {})
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %div), kwargs = {})
-    return (div, add)""",
+    %div_tensor : [num_users=2] = call_function[target=torch.ops.aten.div.Tensor](args = (%p_parameter, 2), kwargs = {})
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %div_tensor), kwargs = {})
+    return (div_tensor, add_tensor)""",
         )
 
-        self.assertTrue("div" in val.keys())
+        self.assertTrue("div_tensor" in val.keys())
         self.assertTrue("parameter" in val.values())
 
         test_inp = torch.rand(4, 4)
@@ -812,14 +812,14 @@ class TestExport(TestCase):
         self.assertExpectedInline(
             str(custom_metadata),
             """\
-('call_function', 'cat', {'moo': 0})
-('call_function', 'item', {'moo': 0})
-('call_function', 'ge_1', {'moo': 0})
+('call_function', 'cat_default', {'moo': 0})
+('call_function', 'item_default', {'moo': 0})
+('call_function', 'ge', {'moo': 0})
 ('call_function', '_assert_scalar_default', {'moo': 0})
-('call_function', 'mul_1', {'moo': 0})
+('call_function', 'mul', {'moo': 0})
 ('call_function', 'le', {'moo': 0})
 ('call_function', '_assert_scalar_default_1', {'moo': 0})
-('call_function', 'mul', {'moo': 0})""",
+('call_function', 'mul_tensor', {'moo': 0})""",
         )
 
     def test_uplift_common_custom_meta(self) -> None:
@@ -984,144 +984,144 @@ def forward(self, x):
     v_proj_weight = self.v_proj.weight
     v_proj_bias = self.v_proj.bias
     _guards_fn = self._guards_fn(x);  _guards_fn = None
-    linear = torch.ops.aten.linear.default(x, q_proj_weight, q_proj_bias);  x = None
-    sum_1 = torch.ops.aten.sum.dim_IntList(linear, [-1])
-    detach = torch.ops.aten.detach.default(sum_1);  sum_1 = None
-    arange = torch.ops.aten.arange.start(0, 2, device = device(type='cpu'), pin_memory = False)
-    arange_1 = torch.ops.aten.arange.start(0, 1, device = device(type='cpu'), pin_memory = False)
-    arange_2 = torch.ops.aten.arange.start(0, 128, device = device(type='cpu'), pin_memory = False)
-    arange_3 = torch.ops.aten.arange.start(0, 128, device = device(type='cpu'), pin_memory = False)
+    linear_default = torch.ops.aten.linear.default(x, q_proj_weight, q_proj_bias);  x = None
+    sum_dim_int_list = torch.ops.aten.sum.dim_IntList(linear_default, [-1])
+    arange_start = torch.ops.aten.arange.start(0, 2, device = device(type='cpu'), pin_memory = False)
+    arange_start_1 = torch.ops.aten.arange.start(0, 1, device = device(type='cpu'), pin_memory = False)
+    arange_start_2 = torch.ops.aten.arange.start(0, 128, device = device(type='cpu'), pin_memory = False)
+    arange_start_3 = torch.ops.aten.arange.start(0, 128, device = device(type='cpu'), pin_memory = False)
+    detach_default = torch.ops.aten.detach.default(sum_dim_int_list);  sum_dim_int_list = None
     lazy_load_decompositions = torch._functorch.predispatch.lazy_load_decompositions();  lazy_load_decompositions = None
     _vmap_increment_nesting = torch._functorch.predispatch._vmap_increment_nesting(2, 'error');  _vmap_increment_nesting = None
-    _add_batch_dim = torch._functorch.predispatch._add_batch_dim(arange, 0, 1);  arange = None
+    _add_batch_dim = torch._functorch.predispatch._add_batch_dim(arange_start, 0, 1);  arange_start = None
     lazy_load_decompositions_1 = torch._functorch.predispatch.lazy_load_decompositions();  lazy_load_decompositions_1 = None
     _vmap_increment_nesting_1 = torch._functorch.predispatch._vmap_increment_nesting(1, 'error');  _vmap_increment_nesting_1 = None
-    _add_batch_dim_1 = torch._functorch.predispatch._add_batch_dim(arange_1, 0, 2);  arange_1 = _add_batch_dim_1 = None
+    _add_batch_dim_1 = torch._functorch.predispatch._add_batch_dim(arange_start_1, 0, 2);  arange_start_1 = _add_batch_dim_1 = None
     lazy_load_decompositions_2 = torch._functorch.predispatch.lazy_load_decompositions();  lazy_load_decompositions_2 = None
     _vmap_increment_nesting_2 = torch._functorch.predispatch._vmap_increment_nesting(128, 'error');  _vmap_increment_nesting_2 = None
-    _add_batch_dim_2 = torch._functorch.predispatch._add_batch_dim(arange_2, 0, 3);  arange_2 = None
+    _add_batch_dim_2 = torch._functorch.predispatch._add_batch_dim(arange_start_2, 0, 3);  arange_start_2 = None
     lazy_load_decompositions_3 = torch._functorch.predispatch.lazy_load_decompositions();  lazy_load_decompositions_3 = None
     _vmap_increment_nesting_3 = torch._functorch.predispatch._vmap_increment_nesting(128, 'error');  _vmap_increment_nesting_3 = None
-    _add_batch_dim_3 = torch._functorch.predispatch._add_batch_dim(arange_3, 0, 4);  arange_3 = None
-    remainder = torch.ops.aten.remainder.Scalar(_add_batch_dim_2, 128)
-    torch__dynamo__trace_wrapped_higher_order_op_mod_index0 = self.torch__dynamo__trace_wrapped_higher_order_op_ModIndex0
+    _add_batch_dim_3 = torch._functorch.predispatch._add_batch_dim(arange_start_3, 0, 4);  arange_start_3 = None
+    le_tensor = torch.ops.aten.le.Tensor(_add_batch_dim_3, _add_batch_dim_2);  _add_batch_dim_3 = None
+    remainder_scalar = torch.ops.aten.remainder.Scalar(_add_batch_dim_2, 128);  _add_batch_dim_2 = None
     function_const_func_spec0 = self.function_const_func_spec0
-    flat_apply = torch.ops.higher_order.flat_apply(function_const_func_spec0, torch__dynamo__trace_wrapped_higher_order_op_mod_index0, 'torch._dynamo._trace_wrapped_higher_order_op.ModIndex', detach, _add_batch_dim, remainder);  function_const_func_spec0 = torch__dynamo__trace_wrapped_higher_order_op_mod_index0 = _add_batch_dim = remainder = None
-    le = torch.ops.aten.le.Tensor(_add_batch_dim_3, _add_batch_dim_2);  _add_batch_dim_3 = _add_batch_dim_2 = None
-    gt = torch.ops.aten.gt.Scalar(flat_apply, 0);  flat_apply = None
-    and_1 = torch.ops.aten.__and__.Tensor(le, gt);  le = gt = None
-    _remove_batch_dim = torch._functorch.predispatch._remove_batch_dim(and_1, 4, 128, 0);  and_1 = None
+    torch__dynamo__trace_wrapped_higher_order_op_mod_index0 = self.torch__dynamo__trace_wrapped_higher_order_op_ModIndex0
+    flat_apply = torch.ops.higher_order.flat_apply(function_const_func_spec0, torch__dynamo__trace_wrapped_higher_order_op_mod_index0, 'torch._dynamo._trace_wrapped_higher_order_op.ModIndex', detach_default, _add_batch_dim, remainder_scalar);  function_const_func_spec0 = torch__dynamo__trace_wrapped_higher_order_op_mod_index0 = _add_batch_dim = remainder_scalar = None
+    gt_scalar = torch.ops.aten.gt.Scalar(flat_apply, 0);  flat_apply = None
+    __and___tensor = torch.ops.aten.__and__.Tensor(le_tensor, gt_scalar);  le_tensor = gt_scalar = None
+    _remove_batch_dim = torch._functorch.predispatch._remove_batch_dim(__and___tensor, 4, 128, 0);  __and___tensor = None
     _vmap_decrement_nesting = torch._functorch.predispatch._vmap_decrement_nesting();  _vmap_decrement_nesting = None
     _remove_batch_dim_1 = torch._functorch.predispatch._remove_batch_dim(_remove_batch_dim, 3, 128, 0);  _remove_batch_dim = None
     _vmap_decrement_nesting_1 = torch._functorch.predispatch._vmap_decrement_nesting();  _vmap_decrement_nesting_1 = None
     _remove_batch_dim_2 = torch._functorch.predispatch._remove_batch_dim(_remove_batch_dim_1, 2, 1, 0)
-    unsqueeze = torch.ops.aten.unsqueeze.default(_remove_batch_dim_1, 0);  _remove_batch_dim_1 = None
-    expand = torch.ops.aten.expand.default(unsqueeze, [1, 128, 128]);  unsqueeze = expand = None
+    unsqueeze_default = torch.ops.aten.unsqueeze.default(_remove_batch_dim_1, 0);  _remove_batch_dim_1 = None
+    expand_default = torch.ops.aten.expand.default(unsqueeze_default, [1, 128, 128]);  unsqueeze_default = expand_default = None
     _vmap_decrement_nesting_2 = torch._functorch.predispatch._vmap_decrement_nesting();  _vmap_decrement_nesting_2 = None
     _remove_batch_dim_3 = torch._functorch.predispatch._remove_batch_dim(_remove_batch_dim_2, 1, 2, 0);  _remove_batch_dim_2 = None
     _vmap_decrement_nesting_3 = torch._functorch.predispatch._vmap_decrement_nesting();  _vmap_decrement_nesting_3 = None
-    pad = torch.ops.aten.pad.default(_remove_batch_dim_3, [0, 0, 0, 0]);  _remove_batch_dim_3 = None
-    view = torch.ops.aten.view.default(pad, [2, 1, 1, 128, 1, 128]);  pad = None
-    permute = torch.ops.aten.permute.default(view, [0, 1, 2, 4, 3, 5]);  view = None
-    sum_2 = torch.ops.aten.sum.dim_IntList(permute, [-2, -1]);  permute = None
-    eq = torch.ops.aten.eq.Scalar(sum_2, 16384)
-    gt_1 = torch.ops.aten.gt.Scalar(sum_2, 0)
-    lt = torch.ops.aten.lt.Scalar(sum_2, 16384);  sum_2 = None
-    and_2 = torch.ops.aten.__and__.Tensor(gt_1, lt);  gt_1 = lt = None
-    _assert_tensor_metadata_default = torch.ops.aten._assert_tensor_metadata.default(and_2, dtype = torch.bool, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default = None
-    to = torch.ops.aten.to.dtype(and_2, torch.int8);  and_2 = None
-    _assert_tensor_metadata_default_1 = torch.ops.aten._assert_tensor_metadata.default(eq, dtype = torch.bool, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_1 = None
-    to_1 = torch.ops.aten.to.dtype(eq, torch.int8);  eq = None
-    _assert_tensor_metadata_default_2 = torch.ops.aten._assert_tensor_metadata.default(to, dtype = torch.int8, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_2 = None
-    to_2 = torch.ops.aten.to.dtype(to, torch.int32);  to = None
-    sum_3 = torch.ops.aten.sum.dim_IntList(to_2, [-1])
-    argsort = torch.ops.aten.argsort.stable(to_2, stable = True, descending = True);  to_2 = None
-    _assert_tensor_metadata_default_3 = torch.ops.aten._assert_tensor_metadata.default(sum_3, dtype = torch.int64, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_3 = None
-    to_3 = torch.ops.aten.to.dtype(sum_3, torch.int32, False, False, torch.contiguous_format);  sum_3 = None
-    _assert_tensor_metadata_default_4 = torch.ops.aten._assert_tensor_metadata.default(argsort, dtype = torch.int64, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_4 = None
-    to_4 = torch.ops.aten.to.dtype(argsort, torch.int32, False, False, torch.contiguous_format);  argsort = None
-    _assert_tensor_metadata_default_5 = torch.ops.aten._assert_tensor_metadata.default(to_1, dtype = torch.int8, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_5 = None
-    to_5 = torch.ops.aten.to.dtype(to_1, torch.int32);  to_1 = None
-    sum_4 = torch.ops.aten.sum.dim_IntList(to_5, [-1])
-    argsort_1 = torch.ops.aten.argsort.stable(to_5, stable = True, descending = True);  to_5 = None
-    _assert_tensor_metadata_default_6 = torch.ops.aten._assert_tensor_metadata.default(sum_4, dtype = torch.int64, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_6 = None
-    to_6 = torch.ops.aten.to.dtype(sum_4, torch.int32, False, False, torch.contiguous_format);  sum_4 = None
-    _assert_tensor_metadata_default_7 = torch.ops.aten._assert_tensor_metadata.default(argsort_1, dtype = torch.int64, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_7 = None
-    to_7 = torch.ops.aten.to.dtype(argsort_1, torch.int32, False, False, torch.contiguous_format);  argsort_1 = None
+    pad_default = torch.ops.aten.pad.default(_remove_batch_dim_3, [0, 0, 0, 0]);  _remove_batch_dim_3 = None
+    view_default = torch.ops.aten.view.default(pad_default, [2, 1, 1, 128, 1, 128]);  pad_default = None
+    permute_default = torch.ops.aten.permute.default(view_default, [0, 1, 2, 4, 3, 5]);  view_default = None
+    sum_dim_int_list_1 = torch.ops.aten.sum.dim_IntList(permute_default, [-2, -1]);  permute_default = None
+    eq_scalar = torch.ops.aten.eq.Scalar(sum_dim_int_list_1, 16384)
+    gt_scalar_1 = torch.ops.aten.gt.Scalar(sum_dim_int_list_1, 0)
+    lt_scalar = torch.ops.aten.lt.Scalar(sum_dim_int_list_1, 16384);  sum_dim_int_list_1 = None
+    __and___tensor_1 = torch.ops.aten.__and__.Tensor(gt_scalar_1, lt_scalar);  gt_scalar_1 = lt_scalar = None
+    _assert_tensor_metadata_default = torch.ops.aten._assert_tensor_metadata.default(__and___tensor_1, dtype = torch.bool, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default = None
+    to_dtype = torch.ops.aten.to.dtype(__and___tensor_1, torch.int8);  __and___tensor_1 = None
+    _assert_tensor_metadata_default_1 = torch.ops.aten._assert_tensor_metadata.default(eq_scalar, dtype = torch.bool, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_1 = None
+    to_dtype_1 = torch.ops.aten.to.dtype(eq_scalar, torch.int8);  eq_scalar = None
+    _assert_tensor_metadata_default_2 = torch.ops.aten._assert_tensor_metadata.default(to_dtype, dtype = torch.int8, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_2 = None
+    to_dtype_2 = torch.ops.aten.to.dtype(to_dtype, torch.int32);  to_dtype = None
+    argsort_stable = torch.ops.aten.argsort.stable(to_dtype_2, stable = True, descending = True)
+    sum_dim_int_list_2 = torch.ops.aten.sum.dim_IntList(to_dtype_2, [-1]);  to_dtype_2 = None
+    _assert_tensor_metadata_default_3 = torch.ops.aten._assert_tensor_metadata.default(sum_dim_int_list_2, dtype = torch.int64, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_3 = None
+    to_dtype_3 = torch.ops.aten.to.dtype(sum_dim_int_list_2, torch.int32, False, False, torch.contiguous_format);  sum_dim_int_list_2 = None
+    _assert_tensor_metadata_default_4 = torch.ops.aten._assert_tensor_metadata.default(argsort_stable, dtype = torch.int64, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_4 = None
+    to_dtype_4 = torch.ops.aten.to.dtype(argsort_stable, torch.int32, False, False, torch.contiguous_format);  argsort_stable = None
+    _assert_tensor_metadata_default_5 = torch.ops.aten._assert_tensor_metadata.default(to_dtype_1, dtype = torch.int8, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_5 = None
+    to_dtype_5 = torch.ops.aten.to.dtype(to_dtype_1, torch.int32);  to_dtype_1 = None
+    argsort_stable_1 = torch.ops.aten.argsort.stable(to_dtype_5, stable = True, descending = True)
+    sum_dim_int_list_3 = torch.ops.aten.sum.dim_IntList(to_dtype_5, [-1]);  to_dtype_5 = None
+    _assert_tensor_metadata_default_6 = torch.ops.aten._assert_tensor_metadata.default(sum_dim_int_list_3, dtype = torch.int64, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_6 = None
+    to_dtype_6 = torch.ops.aten.to.dtype(sum_dim_int_list_3, torch.int32, False, False, torch.contiguous_format);  sum_dim_int_list_3 = None
+    _assert_tensor_metadata_default_7 = torch.ops.aten._assert_tensor_metadata.default(argsort_stable_1, dtype = torch.int64, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_7 = None
+    to_dtype_7 = torch.ops.aten.to.dtype(argsort_stable_1, torch.int32, False, False, torch.contiguous_format);  argsort_stable_1 = None
     lazy_load_decompositions_4 = torch._functorch.predispatch.lazy_load_decompositions();  lazy_load_decompositions_4 = None
     _vmap_increment_nesting_4 = torch._functorch.predispatch._vmap_increment_nesting(2, 'error');  _vmap_increment_nesting_4 = None
-    _add_batch_dim_4 = torch._functorch.predispatch._add_batch_dim(to_3, 0, 1)
-    _add_batch_dim_5 = torch._functorch.predispatch._add_batch_dim(to_4, 0, 1)
+    _add_batch_dim_4 = torch._functorch.predispatch._add_batch_dim(to_dtype_3, 0, 1)
+    _add_batch_dim_5 = torch._functorch.predispatch._add_batch_dim(to_dtype_4, 0, 1)
     lazy_load_decompositions_5 = torch._functorch.predispatch.lazy_load_decompositions();  lazy_load_decompositions_5 = None
     _vmap_increment_nesting_5 = torch._functorch.predispatch._vmap_increment_nesting(1, 'error');  _vmap_increment_nesting_5 = None
     _add_batch_dim_6 = torch._functorch.predispatch._add_batch_dim(_add_batch_dim_4, 0, 2);  _add_batch_dim_4 = None
     _add_batch_dim_7 = torch._functorch.predispatch._add_batch_dim(_add_batch_dim_5, 0, 2);  _add_batch_dim_5 = None
-    new_zeros = torch.ops.aten.new_zeros.default(_add_batch_dim_7, [1, 2], dtype = torch.int32, pin_memory = False)
-    arange_4 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cpu'), pin_memory = False)
-    unsqueeze_1 = torch.ops.aten.unsqueeze.default(arange_4, -1);  arange_4 = None
-    arange_5 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cpu'), pin_memory = False)
-    unsqueeze_2 = torch.ops.aten.unsqueeze.default(_add_batch_dim_6, -1);  _add_batch_dim_6 = None
-    lt_1 = torch.ops.aten.lt.Tensor(arange_5, unsqueeze_2);  arange_5 = unsqueeze_2 = None
-    where = torch.ops.aten.where.ScalarOther(lt_1, _add_batch_dim_7, 1);  lt_1 = _add_batch_dim_7 = None
-    new_ones = torch.ops.aten.new_ones.default(new_zeros, [], pin_memory = False)
-    index_put_ = torch.ops.aten.index_put_.default(new_zeros, [unsqueeze_1, where], new_ones);  new_zeros = unsqueeze_1 = where = new_ones = None
-    slice_1 = torch.ops.aten.slice.Tensor(index_put_, 1, 0, 1);  index_put_ = None
-    _remove_batch_dim_4 = torch._functorch.predispatch._remove_batch_dim(slice_1, 2, 1, 0);  slice_1 = None
+    arange_default = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cpu'), pin_memory = False)
+    arange_default_1 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cpu'), pin_memory = False)
+    new_zeros_default = torch.ops.aten.new_zeros.default(_add_batch_dim_7, [1, 2], dtype = torch.int32, pin_memory = False)
+    new_ones_default = torch.ops.aten.new_ones.default(new_zeros_default, [], pin_memory = False)
+    unsqueeze_default_1 = torch.ops.aten.unsqueeze.default(_add_batch_dim_6, -1);  _add_batch_dim_6 = None
+    lt_tensor = torch.ops.aten.lt.Tensor(arange_default_1, unsqueeze_default_1);  arange_default_1 = unsqueeze_default_1 = None
+    unsqueeze_default_2 = torch.ops.aten.unsqueeze.default(arange_default, -1);  arange_default = None
+    where_scalar_other = torch.ops.aten.where.ScalarOther(lt_tensor, _add_batch_dim_7, 1);  lt_tensor = _add_batch_dim_7 = None
+    index_put__default = torch.ops.aten.index_put_.default(new_zeros_default, [unsqueeze_default_2, where_scalar_other], new_ones_default);  new_zeros_default = unsqueeze_default_2 = where_scalar_other = new_ones_default = None
+    slice_tensor = torch.ops.aten.slice.Tensor(index_put__default, 1, 0, 1);  index_put__default = None
+    _remove_batch_dim_4 = torch._functorch.predispatch._remove_batch_dim(slice_tensor, 2, 1, 0);  slice_tensor = None
     _vmap_decrement_nesting_4 = torch._functorch.predispatch._vmap_decrement_nesting();  _vmap_decrement_nesting_4 = None
     _remove_batch_dim_5 = torch._functorch.predispatch._remove_batch_dim(_remove_batch_dim_4, 1, 2, 0);  _remove_batch_dim_4 = None
     _vmap_decrement_nesting_5 = torch._functorch.predispatch._vmap_decrement_nesting();  _vmap_decrement_nesting_5 = None
-    transpose = torch.ops.aten.transpose.int(_remove_batch_dim_5, -2, -1);  _remove_batch_dim_5 = None
-    _assert_tensor_metadata_default_8 = torch.ops.aten._assert_tensor_metadata.default(transpose, dtype = torch.int32, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_8 = None
-    to_8 = torch.ops.aten.to.dtype(transpose, torch.int32);  transpose = None
-    sum_5 = torch.ops.aten.sum.dim_IntList(to_8, [-1])
-    argsort_2 = torch.ops.aten.argsort.stable(to_8, stable = True, descending = True);  to_8 = None
-    _assert_tensor_metadata_default_9 = torch.ops.aten._assert_tensor_metadata.default(sum_5, dtype = torch.int64, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_9 = None
-    to_9 = torch.ops.aten.to.dtype(sum_5, torch.int32, False, False, torch.contiguous_format);  sum_5 = None
-    _assert_tensor_metadata_default_10 = torch.ops.aten._assert_tensor_metadata.default(argsort_2, dtype = torch.int64, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_10 = None
-    to_10 = torch.ops.aten.to.dtype(argsort_2, torch.int32, False, False, torch.contiguous_format);  argsort_2 = None
+    transpose_int = torch.ops.aten.transpose.int(_remove_batch_dim_5, -2, -1);  _remove_batch_dim_5 = None
+    _assert_tensor_metadata_default_8 = torch.ops.aten._assert_tensor_metadata.default(transpose_int, dtype = torch.int32, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_8 = None
+    to_dtype_8 = torch.ops.aten.to.dtype(transpose_int, torch.int32);  transpose_int = None
+    argsort_stable_2 = torch.ops.aten.argsort.stable(to_dtype_8, stable = True, descending = True)
+    sum_dim_int_list_4 = torch.ops.aten.sum.dim_IntList(to_dtype_8, [-1]);  to_dtype_8 = None
+    _assert_tensor_metadata_default_9 = torch.ops.aten._assert_tensor_metadata.default(sum_dim_int_list_4, dtype = torch.int64, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_9 = None
+    to_dtype_9 = torch.ops.aten.to.dtype(sum_dim_int_list_4, torch.int32, False, False, torch.contiguous_format);  sum_dim_int_list_4 = None
+    _assert_tensor_metadata_default_10 = torch.ops.aten._assert_tensor_metadata.default(argsort_stable_2, dtype = torch.int64, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_10 = None
+    to_dtype_10 = torch.ops.aten.to.dtype(argsort_stable_2, torch.int32, False, False, torch.contiguous_format);  argsort_stable_2 = None
     lazy_load_decompositions_6 = torch._functorch.predispatch.lazy_load_decompositions();  lazy_load_decompositions_6 = None
     _vmap_increment_nesting_6 = torch._functorch.predispatch._vmap_increment_nesting(2, 'error');  _vmap_increment_nesting_6 = None
-    _add_batch_dim_8 = torch._functorch.predispatch._add_batch_dim(to_6, 0, 1)
-    _add_batch_dim_9 = torch._functorch.predispatch._add_batch_dim(to_7, 0, 1)
+    _add_batch_dim_8 = torch._functorch.predispatch._add_batch_dim(to_dtype_6, 0, 1)
+    _add_batch_dim_9 = torch._functorch.predispatch._add_batch_dim(to_dtype_7, 0, 1)
     lazy_load_decompositions_7 = torch._functorch.predispatch.lazy_load_decompositions();  lazy_load_decompositions_7 = None
     _vmap_increment_nesting_7 = torch._functorch.predispatch._vmap_increment_nesting(1, 'error');  _vmap_increment_nesting_7 = None
     _add_batch_dim_10 = torch._functorch.predispatch._add_batch_dim(_add_batch_dim_8, 0, 2);  _add_batch_dim_8 = None
     _add_batch_dim_11 = torch._functorch.predispatch._add_batch_dim(_add_batch_dim_9, 0, 2);  _add_batch_dim_9 = None
-    new_zeros_1 = torch.ops.aten.new_zeros.default(_add_batch_dim_11, [1, 2], dtype = torch.int32, pin_memory = False)
-    arange_6 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cpu'), pin_memory = False)
-    unsqueeze_3 = torch.ops.aten.unsqueeze.default(arange_6, -1);  arange_6 = None
-    arange_7 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cpu'), pin_memory = False)
-    unsqueeze_4 = torch.ops.aten.unsqueeze.default(_add_batch_dim_10, -1);  _add_batch_dim_10 = None
-    lt_2 = torch.ops.aten.lt.Tensor(arange_7, unsqueeze_4);  arange_7 = unsqueeze_4 = None
-    where_1 = torch.ops.aten.where.ScalarOther(lt_2, _add_batch_dim_11, 1);  lt_2 = _add_batch_dim_11 = None
-    new_ones_1 = torch.ops.aten.new_ones.default(new_zeros_1, [], pin_memory = False)
-    index_put__1 = torch.ops.aten.index_put_.default(new_zeros_1, [unsqueeze_3, where_1], new_ones_1);  new_zeros_1 = unsqueeze_3 = where_1 = new_ones_1 = None
-    slice_2 = torch.ops.aten.slice.Tensor(index_put__1, 1, 0, 1);  index_put__1 = None
-    _remove_batch_dim_6 = torch._functorch.predispatch._remove_batch_dim(slice_2, 2, 1, 0);  slice_2 = None
+    arange_default_2 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cpu'), pin_memory = False)
+    arange_default_3 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cpu'), pin_memory = False)
+    new_zeros_default_1 = torch.ops.aten.new_zeros.default(_add_batch_dim_11, [1, 2], dtype = torch.int32, pin_memory = False)
+    new_ones_default_1 = torch.ops.aten.new_ones.default(new_zeros_default_1, [], pin_memory = False)
+    unsqueeze_default_3 = torch.ops.aten.unsqueeze.default(_add_batch_dim_10, -1);  _add_batch_dim_10 = None
+    lt_tensor_1 = torch.ops.aten.lt.Tensor(arange_default_3, unsqueeze_default_3);  arange_default_3 = unsqueeze_default_3 = None
+    unsqueeze_default_4 = torch.ops.aten.unsqueeze.default(arange_default_2, -1);  arange_default_2 = None
+    where_scalar_other_1 = torch.ops.aten.where.ScalarOther(lt_tensor_1, _add_batch_dim_11, 1);  lt_tensor_1 = _add_batch_dim_11 = None
+    index_put__default_1 = torch.ops.aten.index_put_.default(new_zeros_default_1, [unsqueeze_default_4, where_scalar_other_1], new_ones_default_1);  new_zeros_default_1 = unsqueeze_default_4 = where_scalar_other_1 = new_ones_default_1 = None
+    slice_tensor_1 = torch.ops.aten.slice.Tensor(index_put__default_1, 1, 0, 1);  index_put__default_1 = None
+    _remove_batch_dim_6 = torch._functorch.predispatch._remove_batch_dim(slice_tensor_1, 2, 1, 0);  slice_tensor_1 = None
     _vmap_decrement_nesting_6 = torch._functorch.predispatch._vmap_decrement_nesting();  _vmap_decrement_nesting_6 = None
     _remove_batch_dim_7 = torch._functorch.predispatch._remove_batch_dim(_remove_batch_dim_6, 1, 2, 0);  _remove_batch_dim_6 = None
     _vmap_decrement_nesting_7 = torch._functorch.predispatch._vmap_decrement_nesting();  _vmap_decrement_nesting_7 = None
-    transpose_1 = torch.ops.aten.transpose.int(_remove_batch_dim_7, -2, -1);  _remove_batch_dim_7 = None
-    _assert_tensor_metadata_default_11 = torch.ops.aten._assert_tensor_metadata.default(transpose_1, dtype = torch.int32, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_11 = None
-    to_11 = torch.ops.aten.to.dtype(transpose_1, torch.int32);  transpose_1 = None
-    sum_6 = torch.ops.aten.sum.dim_IntList(to_11, [-1])
-    argsort_3 = torch.ops.aten.argsort.stable(to_11, stable = True, descending = True);  to_11 = None
-    _assert_tensor_metadata_default_12 = torch.ops.aten._assert_tensor_metadata.default(sum_6, dtype = torch.int64, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_12 = None
-    to_12 = torch.ops.aten.to.dtype(sum_6, torch.int32, False, False, torch.contiguous_format);  sum_6 = None
-    _assert_tensor_metadata_default_13 = torch.ops.aten._assert_tensor_metadata.default(argsort_3, dtype = torch.int64, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_13 = None
-    to_13 = torch.ops.aten.to.dtype(argsort_3, torch.int32, False, False, torch.contiguous_format);  argsort_3 = None
-    linear_1 = torch.ops.aten.linear.default(linear, q_proj_weight, q_proj_bias);  q_proj_weight = q_proj_bias = None
-    view_1 = torch.ops.aten.view.default(linear_1, [2, 1, 128, 64]);  linear_1 = None
-    detach_19 = torch.ops.aten.detach.default(view_1);  view_1 = None
-    linear_2 = torch.ops.aten.linear.default(linear, k_proj_weight, k_proj_bias);  k_proj_weight = k_proj_bias = None
-    view_2 = torch.ops.aten.view.default(linear_2, [2, 1, 128, 64]);  linear_2 = None
-    detach_20 = torch.ops.aten.detach.default(view_2);  view_2 = None
-    linear_3 = torch.ops.aten.linear.default(linear, v_proj_weight, v_proj_bias);  linear = v_proj_weight = v_proj_bias = None
-    view_3 = torch.ops.aten.view.default(linear_3, [2, 1, 128, 64]);  linear_3 = None
-    detach_21 = torch.ops.aten.detach.default(view_3);  view_3 = None
-    sdpa_score0 = self.sdpa_score0
+    transpose_int_1 = torch.ops.aten.transpose.int(_remove_batch_dim_7, -2, -1);  _remove_batch_dim_7 = None
+    _assert_tensor_metadata_default_11 = torch.ops.aten._assert_tensor_metadata.default(transpose_int_1, dtype = torch.int32, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_11 = None
+    to_dtype_11 = torch.ops.aten.to.dtype(transpose_int_1, torch.int32);  transpose_int_1 = None
+    argsort_stable_3 = torch.ops.aten.argsort.stable(to_dtype_11, stable = True, descending = True)
+    sum_dim_int_list_5 = torch.ops.aten.sum.dim_IntList(to_dtype_11, [-1]);  to_dtype_11 = None
+    _assert_tensor_metadata_default_12 = torch.ops.aten._assert_tensor_metadata.default(sum_dim_int_list_5, dtype = torch.int64, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_12 = None
+    to_dtype_12 = torch.ops.aten.to.dtype(sum_dim_int_list_5, torch.int32, False, False, torch.contiguous_format);  sum_dim_int_list_5 = None
+    _assert_tensor_metadata_default_13 = torch.ops.aten._assert_tensor_metadata.default(argsort_stable_3, dtype = torch.int64, device = device(type='cpu'), layout = torch.strided);  _assert_tensor_metadata_default_13 = None
+    to_dtype_13 = torch.ops.aten.to.dtype(argsort_stable_3, torch.int32, False, False, torch.contiguous_format);  argsort_stable_3 = None
+    linear_default_1 = torch.ops.aten.linear.default(linear_default, q_proj_weight, q_proj_bias);  q_proj_weight = q_proj_bias = None
+    view_default_1 = torch.ops.aten.view.default(linear_default_1, [2, 1, 128, 64]);  linear_default_1 = None
+    detach_default_1 = torch.ops.aten.detach.default(view_default_1);  view_default_1 = None
+    linear_default_2 = torch.ops.aten.linear.default(linear_default, k_proj_weight, k_proj_bias);  k_proj_weight = k_proj_bias = None
+    view_default_2 = torch.ops.aten.view.default(linear_default_2, [2, 1, 128, 64]);  linear_default_2 = None
+    detach_default_2 = torch.ops.aten.detach.default(view_default_2);  view_default_2 = None
+    linear_default_3 = torch.ops.aten.linear.default(linear_default, v_proj_weight, v_proj_bias);  linear_default = v_proj_weight = v_proj_bias = None
+    view_default_3 = torch.ops.aten.view.default(linear_default_3, [2, 1, 128, 64]);  linear_default_3 = None
+    detach_default_3 = torch.ops.aten.detach.default(view_default_3);  view_default_3 = None
     sdpa_mask0 = self.sdpa_mask0
-    flex_attention = torch.ops.higher_order.flex_attention(detach_19, detach_20, detach_21, sdpa_score0, (128, 128, to_3, to_4, to_6, to_7, to_9, to_10, to_12, to_13, None, None, None, None, 128, 128, sdpa_mask0), 0.125, {'BACKEND': 'AUTO', 'PRESCALE_QK': False, 'ROWS_GUARANTEED_SAFE': False, 'BLOCKS_ARE_CONTIGUOUS': False, 'WRITE_DQ': True, 'OUTPUT_LOGSUMEXP': False, 'OUTPUT_MAX': False}, (), (detach,));  detach_19 = detach_20 = detach_21 = sdpa_score0 = to_3 = to_4 = to_6 = to_7 = to_9 = to_10 = to_12 = to_13 = sdpa_mask0 = detach = None
+    sdpa_score0 = self.sdpa_score0
+    flex_attention = torch.ops.higher_order.flex_attention(detach_default_1, detach_default_2, detach_default_3, sdpa_score0, (128, 128, to_dtype_3, to_dtype_4, to_dtype_6, to_dtype_7, to_dtype_9, to_dtype_10, to_dtype_12, to_dtype_13, None, None, None, None, 128, 128, sdpa_mask0), 0.125, {'BACKEND': 'AUTO', 'PRESCALE_QK': False, 'ROWS_GUARANTEED_SAFE': False, 'BLOCKS_ARE_CONTIGUOUS': False, 'WRITE_DQ': True, 'OUTPUT_LOGSUMEXP': False, 'OUTPUT_MAX': False}, (), (detach_default,));  detach_default_1 = detach_default_2 = detach_default_3 = sdpa_score0 = to_dtype_3 = to_dtype_4 = to_dtype_6 = to_dtype_7 = to_dtype_9 = to_dtype_10 = to_dtype_12 = to_dtype_13 = sdpa_mask0 = detach_default = None
     getitem = flex_attention[0]
     getitem_1 = flex_attention[1];  getitem_1 = None
     getitem_2 = flex_attention[2];  flex_attention = getitem_2 = None
@@ -1152,10 +1152,10 @@ def forward(self, x):
 graph():
     %x : [num_users=4] = placeholder[target=x]
     %_guards_fn : [num_users=0] = call_module[target=_guards_fn](args = (%x,), kwargs = {})
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %x), kwargs = {})
-    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %x), kwargs = {})
-    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %add_1), kwargs = {})
-    return (add_2,)""",
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %x), kwargs = {})
+    %add_tensor_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_tensor, %x), kwargs = {})
+    %add_tensor_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %add_tensor_1), kwargs = {})
+    return (add_tensor_2,)""",
         )
 
     def test_bincount(self):
@@ -1596,10 +1596,10 @@ graph():
     %arg2_1 : [num_users=1] = placeholder[target=arg2_1]
     %arg3_1 : [num_users=1] = placeholder[target=arg3_1]
     %arg4_1 : [num_users=1] = placeholder[target=arg4_1]
-    %linear : [num_users=1] = call_function[target=torch.ops.aten.linear.default](args = (%arg0_1, %arg1_1, %arg2_1), kwargs = {})
-    %relu : [num_users=1] = call_function[target=torch.ops.aten.relu.default](args = (%linear,), kwargs = {})
-    %linear_1 : [num_users=1] = call_function[target=torch.ops.aten.linear.default](args = (%relu, %arg3_1, %arg4_1), kwargs = {})
-    return (linear_1,)""",
+    %linear_default : [num_users=1] = call_function[target=torch.ops.aten.linear.default](args = (%arg0_1, %arg1_1, %arg2_1), kwargs = {})
+    %relu_default : [num_users=1] = call_function[target=torch.ops.aten.relu.default](args = (%linear_default,), kwargs = {})
+    %linear_default_1 : [num_users=1] = call_function[target=torch.ops.aten.linear.default](args = (%relu_default, %arg3_1, %arg4_1), kwargs = {})
+    return (linear_default_1,)""",
         )
 
         stack = contextlib.ExitStack()
@@ -1793,8 +1793,8 @@ graph():
     %lifted_tensor_0 : [num_users=1] = get_attr[target=lifted_tensor_0]
     %x : [num_users=2] = placeholder[target=x]
     %_guards_fn : [num_users=0] = call_module[target=_guards_fn](args = (%x,), kwargs = {})
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %lifted_tensor_0), kwargs = {})
-    return (add,)""",
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %lifted_tensor_0), kwargs = {})
+    return (add_tensor,)""",
         )
 
     def test_int_shape_specialization(self):
@@ -2416,8 +2416,8 @@ graph():
                 """\
 graph():
     %x : [num_users=1] = placeholder[target=x]
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, 1), kwargs = {})
-    return (add,)""",
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, 1), kwargs = {})
+    return (add_tensor,)""",
             )
 
             with self.assertRaisesRegex(
@@ -3111,21 +3111,21 @@ class GraphModule(torch.nn.Module):
             str(ufm.graph_module.code).strip(),
             """\
 def forward(self, x):
-    add = torch.ops.aten.add.Tensor(x, 1);  x = None
-    dummy = self.dummy(add);  add = None
-    add_6 = torch.ops.aten.add.Tensor(dummy, 5);  dummy = None
-    return (add_6,)""",
+    add_tensor = torch.ops.aten.add.Tensor(x, 1);  x = None
+    dummy = self.dummy(add_tensor);  add_tensor = None
+    add_tensor_6 = torch.ops.aten.add.Tensor(dummy, 5);  dummy = None
+    return (add_tensor_6,)""",
         )
         self.assertExpectedInline(
             str(ufm.dummy.graph_module.code).strip(),
             """\
-def forward(self, add):
-    add_1 = torch.ops.aten.add.Tensor(add, 2)
-    add_2 = torch.ops.aten.add.Tensor(add, add_1);  add_1 = None
-    add_3 = torch.ops.aten.add.Tensor(add_2, 3);  add_2 = None
-    add_4 = torch.ops.aten.add.Tensor(add_3, add);  add_3 = add = None
-    add_5 = torch.ops.aten.add.Tensor(add_4, 4);  add_4 = None
-    return add_5""",
+def forward(self, add_tensor):
+    add_tensor_1 = torch.ops.aten.add.Tensor(add_tensor, 2)
+    add_tensor_2 = torch.ops.aten.add.Tensor(add_tensor, add_tensor_1);  add_tensor_1 = None
+    add_tensor_3 = torch.ops.aten.add.Tensor(add_tensor_2, 3);  add_tensor_2 = None
+    add_tensor_4 = torch.ops.aten.add.Tensor(add_tensor_3, add_tensor);  add_tensor_3 = add_tensor = None
+    add_tensor_5 = torch.ops.aten.add.Tensor(add_tensor_4, 4);  add_tensor_4 = None
+    return add_tensor_5""",
         )
 
     def test_state_primitives(self):
@@ -3526,11 +3526,11 @@ graph():
     %p_p1 : [num_users=1] = placeholder[target=p_p1]
     %p_p2 : [num_users=1] = placeholder[target=p_p2]
     %x : [num_users=1] = placeholder[target=x]
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul, %p_p2), kwargs = {})
-    %sum_1 : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%add,), kwargs = {})
-    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %sum_1), kwargs = {})
-    return (add_1,)""",
+    %mul_tensor : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul_tensor, %p_p2), kwargs = {})
+    %sum_default : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%add_tensor,), kwargs = {})
+    %add_tensor_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %sum_default), kwargs = {})
+    return (add_tensor_1,)""",
         )
 
         ep = export(m, (ref_x,)).run_decompositions({})
@@ -3542,13 +3542,13 @@ graph():
     %p_parametrizations_p2_original0 : [num_users=1] = placeholder[target=p_parametrizations_p2_original0]
     %p_parametrizations_p2_original1 : [num_users=1] = placeholder[target=p_parametrizations_p2_original1]
     %x : [num_users=1] = placeholder[target=x]
-    %mul : [num_users=2] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul, %p_parametrizations_p2_original0), kwargs = {})
-    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul, %p_parametrizations_p2_original1), kwargs = {})
-    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %add_1), kwargs = {})
-    %sum_1 : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%add_2,), kwargs = {})
-    %add_3 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %sum_1), kwargs = {})
-    return (add_3,)""",
+    %mul_tensor : [num_users=2] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul_tensor, %p_parametrizations_p2_original0), kwargs = {})
+    %add_tensor_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul_tensor, %p_parametrizations_p2_original1), kwargs = {})
+    %add_tensor_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_tensor, %add_tensor_1), kwargs = {})
+    %sum_default : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%add_tensor_2,), kwargs = {})
+    %add_tensor_3 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %sum_default), kwargs = {})
+    return (add_tensor_3,)""",
         )
         res = ep.module()(ref_x)
 
@@ -3589,13 +3589,13 @@ graph():
     %p_p1 : [num_users=1] = placeholder[target=p_p1]
     %p_p2 : [num_users=1] = placeholder[target=p_p2]
     %x : [num_users=2] = placeholder[target=x]
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %mul), kwargs = {})
-    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %p_p2), kwargs = {})
-    %sum_1 : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%add_1,), kwargs = {})
-    %sum_2 : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%sum_1,), kwargs = {})
-    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %sum_2), kwargs = {})
-    return (add_2,)""",
+    %mul_tensor : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %mul_tensor), kwargs = {})
+    %add_tensor_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_tensor, %p_p2), kwargs = {})
+    %sum_default : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%add_tensor_1,), kwargs = {})
+    %sum_default_1 : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%sum_default,), kwargs = {})
+    %add_tensor_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %sum_default_1), kwargs = {})
+    return (add_tensor_2,)""",
         )
 
         ep = export(m, (ref_x,))
@@ -3610,19 +3610,19 @@ graph():
     %p_parametrizations_p2_original2 : [num_users=1] = placeholder[target=p_parametrizations_p2_original2]
     %p_parametrizations_p2_original3 : [num_users=1] = placeholder[target=p_parametrizations_p2_original3]
     %x : [num_users=2] = placeholder[target=x]
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
-    %add : [num_users=4] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %mul), kwargs = {})
-    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %p_parametrizations_p2_original0), kwargs = {})
-    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %p_parametrizations_p2_original1), kwargs = {})
-    %add_3 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_1, %add_2), kwargs = {})
-    %add_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %p_parametrizations_p2_original2), kwargs = {})
-    %add_5 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %p_parametrizations_p2_original3), kwargs = {})
-    %add_6 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_4, %add_5), kwargs = {})
-    %add_7 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_3, %add_6), kwargs = {})
-    %sum_1 : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%add_7,), kwargs = {})
-    %sum_2 : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%sum_1,), kwargs = {})
-    %add_8 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %sum_2), kwargs = {})
-    return (add_8,)""",
+    %mul_tensor : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
+    %add_tensor : [num_users=4] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %mul_tensor), kwargs = {})
+    %add_tensor_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_tensor, %p_parametrizations_p2_original0), kwargs = {})
+    %add_tensor_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_tensor, %p_parametrizations_p2_original1), kwargs = {})
+    %add_tensor_3 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_tensor, %p_parametrizations_p2_original2), kwargs = {})
+    %add_tensor_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_tensor, %p_parametrizations_p2_original3), kwargs = {})
+    %add_tensor_5 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_tensor_1, %add_tensor_2), kwargs = {})
+    %add_tensor_6 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_tensor_3, %add_tensor_4), kwargs = {})
+    %add_tensor_7 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_tensor_5, %add_tensor_6), kwargs = {})
+    %sum_default : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%add_tensor_7,), kwargs = {})
+    %sum_default_1 : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%sum_default,), kwargs = {})
+    %add_tensor_8 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %sum_default_1), kwargs = {})
+    return (add_tensor_8,)""",
         )
         res = ep.module()(ref_x)
         self.assertEqual(res, ref_out)
@@ -3645,18 +3645,18 @@ graph():
 graph():
     %x : [num_users=1] = placeholder[target=x]
     %y : [num_users=2] = placeholder[target=y]
-    %sym_size_int_3 : [num_users=2] = call_function[target=torch.ops.aten.sym_size.int](args = (%y, 0), kwargs = {})
+    %sym_size_int : [num_users=2] = call_function[target=torch.ops.aten.sym_size.int](args = (%y, 0), kwargs = {})
     %lazy_load_decompositions : [num_users=0] = call_function[target=torch._functorch.predispatch.lazy_load_decompositions](args = (), kwargs = {})
-    %_vmap_increment_nesting : [num_users=0] = call_function[target=torch._functorch.predispatch._vmap_increment_nesting](args = (%sym_size_int_3, error), kwargs = {})
+    %_vmap_increment_nesting : [num_users=0] = call_function[target=torch._functorch.predispatch._vmap_increment_nesting](args = (%sym_size_int, error), kwargs = {})
     %_add_batch_dim : [num_users=1] = call_function[target=torch._functorch.predispatch._add_batch_dim](args = (%x, 0, 1), kwargs = {})
     %_add_batch_dim_1 : [num_users=1] = call_function[target=torch._functorch.predispatch._add_batch_dim](args = (%y, 0, 1), kwargs = {})
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%_add_batch_dim, %_add_batch_dim_1), kwargs = {})
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul, 1), kwargs = {})
-    %sum_1 : [num_users=1] = call_function[target=torch.ops.aten.sum.dim_IntList](args = (%add, [0]), kwargs = {})
-    %_remove_batch_dim : [num_users=1] = call_function[target=torch._functorch.predispatch._remove_batch_dim](args = (%sum_1, 1, %sym_size_int_3, 0), kwargs = {})
+    %mul_tensor : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%_add_batch_dim, %_add_batch_dim_1), kwargs = {})
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul_tensor, 1), kwargs = {})
+    %sum_dim_int_list : [num_users=1] = call_function[target=torch.ops.aten.sum.dim_IntList](args = (%add_tensor, [0]), kwargs = {})
+    %_remove_batch_dim : [num_users=1] = call_function[target=torch._functorch.predispatch._remove_batch_dim](args = (%sum_dim_int_list, 1, %sym_size_int, 0), kwargs = {})
     %_vmap_decrement_nesting : [num_users=0] = call_function[target=torch._functorch.predispatch._vmap_decrement_nesting](args = (), kwargs = {})
-    %sum_2 : [num_users=1] = call_function[target=torch.ops.aten.sum.dim_IntList](args = (%_remove_batch_dim, [0]), kwargs = {})
-    return (sum_2,)""",
+    %sum_dim_int_list_1 : [num_users=1] = call_function[target=torch.ops.aten.sum.dim_IntList](args = (%_remove_batch_dim, [0]), kwargs = {})
+    return (sum_dim_int_list_1,)""",
         )
         ep = torch.export.export(
             Vmap(), inputs, {}, dynamic_shapes=dynamic, strict=True
@@ -3667,18 +3667,18 @@ graph():
 graph():
     %x : [num_users=1] = placeholder[target=x]
     %y : [num_users=2] = placeholder[target=y]
-    %sym_size_int_2 : [num_users=2] = call_function[target=torch.ops.aten.sym_size.int](args = (%y, 0), kwargs = {})
+    %sym_size_int : [num_users=2] = call_function[target=torch.ops.aten.sym_size.int](args = (%y, 0), kwargs = {})
     %lazy_load_decompositions : [num_users=0] = call_function[target=torch._functorch.predispatch.lazy_load_decompositions](args = (), kwargs = {})
-    %_vmap_increment_nesting : [num_users=0] = call_function[target=torch._functorch.predispatch._vmap_increment_nesting](args = (%sym_size_int_2, error), kwargs = {})
+    %_vmap_increment_nesting : [num_users=0] = call_function[target=torch._functorch.predispatch._vmap_increment_nesting](args = (%sym_size_int, error), kwargs = {})
     %_add_batch_dim : [num_users=1] = call_function[target=torch._functorch.predispatch._add_batch_dim](args = (%x, 0, 1), kwargs = {})
     %_add_batch_dim_1 : [num_users=1] = call_function[target=torch._functorch.predispatch._add_batch_dim](args = (%y, 0, 1), kwargs = {})
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%_add_batch_dim, %_add_batch_dim_1), kwargs = {})
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul, 1), kwargs = {})
-    %sum_1 : [num_users=1] = call_function[target=torch.ops.aten.sum.dim_IntList](args = (%add, [0]), kwargs = {})
-    %_remove_batch_dim : [num_users=1] = call_function[target=torch._functorch.predispatch._remove_batch_dim](args = (%sum_1, 1, %sym_size_int_2, 0), kwargs = {})
+    %mul_tensor : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%_add_batch_dim, %_add_batch_dim_1), kwargs = {})
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul_tensor, 1), kwargs = {})
+    %sum_dim_int_list : [num_users=1] = call_function[target=torch.ops.aten.sum.dim_IntList](args = (%add_tensor, [0]), kwargs = {})
+    %_remove_batch_dim : [num_users=1] = call_function[target=torch._functorch.predispatch._remove_batch_dim](args = (%sum_dim_int_list, 1, %sym_size_int, 0), kwargs = {})
     %_vmap_decrement_nesting : [num_users=0] = call_function[target=torch._functorch.predispatch._vmap_decrement_nesting](args = (), kwargs = {})
-    %sum_2 : [num_users=1] = call_function[target=torch.ops.aten.sum.dim_IntList](args = (%_remove_batch_dim, [0]), kwargs = {})
-    return (sum_2,)""",
+    %sum_dim_int_list_1 : [num_users=1] = call_function[target=torch.ops.aten.sum.dim_IntList](args = (%_remove_batch_dim, [0]), kwargs = {})
+    return (sum_dim_int_list_1,)""",
         )
         self.assertTrue(torch.allclose(ep.module()(*inputs), Vmap()(*inputs)))
         ep = export(Vmap(), inputs, {}, dynamic_shapes=dynamic).run_decompositions({})
@@ -3721,14 +3721,14 @@ graph():
     %p_p2 : [num_users=1] = placeholder[target=p_p2]
     %b_b1 : [num_users=1] = placeholder[target=b_b1]
     %x : [num_users=1] = placeholder[target=x]
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul, %p_p2), kwargs = {})
-    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %b_b1), kwargs = {})
-    %sum_1 : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%add_1,), kwargs = {})
-    %access_subclass_inner_tensor_default_56 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%sum_1, a), kwargs = {})
-    %access_subclass_inner_tensor_default_61 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%access_subclass_inner_tensor_default_56, b), kwargs = {})
-    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %access_subclass_inner_tensor_default_61), kwargs = {})
-    return (add_2,)""",
+    %mul_tensor : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul_tensor, %p_p2), kwargs = {})
+    %add_tensor_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_tensor, %b_b1), kwargs = {})
+    %sum_default : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%add_tensor_1,), kwargs = {})
+    %access_subclass_inner_tensor_default : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%sum_default, a), kwargs = {})
+    %access_subclass_inner_tensor_default_1 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%access_subclass_inner_tensor_default, b), kwargs = {})
+    %add_tensor_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %access_subclass_inner_tensor_default_1), kwargs = {})
+    return (add_tensor_2,)""",
         )
         ep = export(m, (ref_x,))
         self.assertTrue(torch.allclose(ep.module()(ref_x), ref_out))
@@ -3775,14 +3775,14 @@ graph():
     %p_bar_p2 : [num_users=1] = placeholder[target=p_bar_p2]
     %b_bar_b1 : [num_users=1] = placeholder[target=b_bar_b1]
     %x : [num_users=1] = placeholder[target=x]
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_bar_p1, 2), kwargs = {})
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul, %p_bar_p2), kwargs = {})
-    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %b_bar_b1), kwargs = {})
-    %sum_1 : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%add_1,), kwargs = {})
-    %access_subclass_inner_tensor_default_56 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%sum_1, a), kwargs = {})
-    %access_subclass_inner_tensor_default_61 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%access_subclass_inner_tensor_default_56, b), kwargs = {})
-    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %access_subclass_inner_tensor_default_61), kwargs = {})
-    return (add_2,)""",
+    %mul_tensor : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_bar_p1, 2), kwargs = {})
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul_tensor, %p_bar_p2), kwargs = {})
+    %add_tensor_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_tensor, %b_bar_b1), kwargs = {})
+    %sum_default : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%add_tensor_1,), kwargs = {})
+    %access_subclass_inner_tensor_default : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%sum_default, a), kwargs = {})
+    %access_subclass_inner_tensor_default_1 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%access_subclass_inner_tensor_default, b), kwargs = {})
+    %add_tensor_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %access_subclass_inner_tensor_default_1), kwargs = {})
+    return (add_tensor_2,)""",
         )
         ep = export(m, (ref_x,))
         self.assertTrue(torch.allclose(ep.module()(ref_x), ref_out))
@@ -3814,13 +3814,13 @@ graph():
     %p_p1 : [num_users=1] = placeholder[target=p_p1]
     %p_p2 : [num_users=1] = placeholder[target=p_p2]
     %x : [num_users=1] = placeholder[target=x]
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul, %p_p2), kwargs = {})
-    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, 4), kwargs = {})
-    %access_subclass_inner_tensor_default_8 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%add_1, elem), kwargs = {})
-    %access_subclass_inner_tensor_default_11 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%access_subclass_inner_tensor_default_8, elem), kwargs = {})
-    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %access_subclass_inner_tensor_default_11), kwargs = {})
-    return (add_2,)""",
+    %mul_tensor : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul_tensor, %p_p2), kwargs = {})
+    %add_tensor_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_tensor, 4), kwargs = {})
+    %access_subclass_inner_tensor_default : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%add_tensor_1, elem), kwargs = {})
+    %access_subclass_inner_tensor_default_1 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%access_subclass_inner_tensor_default, elem), kwargs = {})
+    %add_tensor_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %access_subclass_inner_tensor_default_1), kwargs = {})
+    return (add_tensor_2,)""",
         )
         ep = export(m, (ref_x,))
         self.assertTrue(torch.allclose(ep.module()(ref_x), ref_out))
@@ -3891,16 +3891,16 @@ graph():
     %p_p1 : [num_users=1] = placeholder[target=p_p1]
     %p_p2 : [num_users=1] = placeholder[target=p_p2]
     %x : [num_users=1] = placeholder[target=x]
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
-    %add : [num_users=2] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul, %p_p2), kwargs = {})
-    %access_subclass_inner_tensor_default_16 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%add, a), kwargs = {})
-    %access_subclass_inner_tensor_default_19 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%access_subclass_inner_tensor_default_16, elem), kwargs = {})
-    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %access_subclass_inner_tensor_default_19), kwargs = {})
-    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_1, 4), kwargs = {})
-    %access_subclass_inner_tensor_default_23 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%add_2, a), kwargs = {})
-    %access_subclass_inner_tensor_default_26 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%access_subclass_inner_tensor_default_23, elem), kwargs = {})
-    %add_3 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %access_subclass_inner_tensor_default_26), kwargs = {})
-    return (add_3,)""",
+    %mul_tensor : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
+    %add_tensor : [num_users=2] = call_function[target=torch.ops.aten.add.Tensor](args = (%mul_tensor, %p_p2), kwargs = {})
+    %access_subclass_inner_tensor_default : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%add_tensor, a), kwargs = {})
+    %access_subclass_inner_tensor_default_1 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%access_subclass_inner_tensor_default, elem), kwargs = {})
+    %add_tensor_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_tensor, %access_subclass_inner_tensor_default_1), kwargs = {})
+    %add_tensor_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_tensor_1, 4), kwargs = {})
+    %access_subclass_inner_tensor_default_2 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%add_tensor_2, a), kwargs = {})
+    %access_subclass_inner_tensor_default_3 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%access_subclass_inner_tensor_default_2, elem), kwargs = {})
+    %add_tensor_3 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %access_subclass_inner_tensor_default_3), kwargs = {})
+    return (add_tensor_3,)""",
         )
         ep = export(m, (ref_x,))
         self.assertTrue(torch.allclose(ep.module()(ref_x), ref_out))
@@ -3931,13 +3931,13 @@ graph():
     %p_p1 : [num_users=1] = placeholder[target=p_p1]
     %p_p2 : [num_users=1] = placeholder[target=p_p2]
     %x : [num_users=1] = placeholder[target=x]
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %mul), kwargs = {})
-    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %p_p2), kwargs = {})
-    %access_subclass_inner_tensor_default_8 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%add_1, elem), kwargs = {})
-    %access_subclass_inner_tensor_default_11 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%access_subclass_inner_tensor_default_8, elem), kwargs = {})
-    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%access_subclass_inner_tensor_default_11, 4), kwargs = {})
-    return (add_2,)""",
+    %mul_tensor : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%p_p1, 2), kwargs = {})
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %mul_tensor), kwargs = {})
+    %add_tensor_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_tensor, %p_p2), kwargs = {})
+    %access_subclass_inner_tensor_default : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%add_tensor_1, elem), kwargs = {})
+    %access_subclass_inner_tensor_default_1 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%access_subclass_inner_tensor_default, elem), kwargs = {})
+    %add_tensor_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%access_subclass_inner_tensor_default_1, 4), kwargs = {})
+    return (add_tensor_2,)""",
         )
         ep = export(m, (ref_x,))
         self.assertTrue(torch.allclose(ep.module()(ref_x), ref_out))
@@ -4104,23 +4104,23 @@ graph():
                 str(ep.graph_module.code).strip(),
                 """\
 def forward(self, causal_mask, fill_value):
-    sym_size_int_4 = torch.ops.aten.sym_size.int(fill_value, 3)
-    clone = torch.ops.aten.clone.default(causal_mask);  causal_mask = None
-    slice_1 = torch.ops.aten.slice.Tensor(clone, 3, 0, sym_size_int_4);  sym_size_int_4 = None
-    copy_ = torch.ops.aten.copy_.default(slice_1, fill_value);  slice_1 = fill_value = copy_ = None
-    return (clone,)""",
+    sym_size_int = torch.ops.aten.sym_size.int(fill_value, 3)
+    clone_default = torch.ops.aten.clone.default(causal_mask);  causal_mask = None
+    slice_tensor = torch.ops.aten.slice.Tensor(clone_default, 3, 0, sym_size_int);  sym_size_int = None
+    copy__default = torch.ops.aten.copy_.default(slice_tensor, fill_value);  slice_tensor = fill_value = copy__default = None
+    return (clone_default,)""",
             )
             decomposed_ep = ep.run_decompositions()
             self.assertExpectedInline(
                 str(decomposed_ep.graph_module.code).strip(),
                 """\
 def forward(self, causal_mask, fill_value):
-    sym_size_int_5 = torch.ops.aten.sym_size.int(fill_value, 3)
-    clone = torch.ops.aten.clone.default(causal_mask);  causal_mask = None
-    slice_1 = torch.ops.aten.slice.Tensor(clone, 3, 0, sym_size_int_5)
-    copy = torch.ops.aten.copy.default(slice_1, fill_value);  slice_1 = fill_value = None
-    slice_scatter = torch.ops.aten.slice_scatter.default(clone, copy, 3, 0, sym_size_int_5);  clone = copy = sym_size_int_5 = None
-    return (slice_scatter,)""",
+    sym_size_int = torch.ops.aten.sym_size.int(fill_value, 3)
+    clone_default = torch.ops.aten.clone.default(causal_mask);  causal_mask = None
+    slice_tensor = torch.ops.aten.slice.Tensor(clone_default, 3, 0, sym_size_int)
+    copy_default = torch.ops.aten.copy.default(slice_tensor, fill_value);  slice_tensor = fill_value = None
+    slice_scatter_default = torch.ops.aten.slice_scatter.default(clone_default, copy_default, 3, 0, sym_size_int);  clone_default = copy_default = sym_size_int = None
+    return (slice_scatter_default,)""",
             )
 
     def test_dim_dynamic_specialization(self):
@@ -4423,9 +4423,9 @@ def forward(self, causal_mask, fill_value):
                 str(ep.graph_module.code).strip(),
                 """\
 def forward(self, p_linear_weight, p_linear_bias, x):
-    linear = torch.ops.aten.linear.default(x, p_linear_weight, p_linear_bias);  x = p_linear_weight = p_linear_bias = None
-    sin = torch.ops.aten.sin.default(linear);  linear = None
-    return (sin,)""",
+    linear_default = torch.ops.aten.linear.default(x, p_linear_weight, p_linear_bias);  x = p_linear_weight = p_linear_bias = None
+    sin_default = torch.ops.aten.sin.default(linear_default);  linear_default = None
+    return (sin_default,)""",
             )
 
     def test_export_preserve_linear_at_aot_level(self):
@@ -4450,11 +4450,11 @@ def forward(self, p_linear_weight, p_linear_bias, x):
             str(gm.code).strip(),
             """\
 def forward(self, p_linear_weight, p_linear_bias, x):
-    linear = torch.ops.aten.linear.default(x, p_linear_weight, p_linear_bias);  x = p_linear_weight = p_linear_bias = None
-    split_with_sizes = torch.ops.aten.split_with_sizes.default(linear, [1, 1, 1]);  linear = None
-    getitem = split_with_sizes[0]
-    getitem_1 = split_with_sizes[1]
-    getitem_2 = split_with_sizes[2];  split_with_sizes = None
+    linear_default = torch.ops.aten.linear.default(x, p_linear_weight, p_linear_bias);  x = p_linear_weight = p_linear_bias = None
+    split_with_sizes_default = torch.ops.aten.split_with_sizes.default(linear_default, [1, 1, 1]);  linear_default = None
+    getitem = split_with_sizes_default[0]
+    getitem_1 = split_with_sizes_default[1]
+    getitem_2 = split_with_sizes_default[2];  split_with_sizes_default = None
     return (getitem, getitem_1, getitem_2)""",
         )
 
@@ -4486,15 +4486,17 @@ def forward(self, p_linear_weight, p_linear_bias, x):
         for mod in gm.modules():
             if hasattr(mod, "graph"):
                 for node in mod.graph.nodes:
-                    if node.name in {"sin", "cos"}:
+                    if node.target in (
+                        torch.ops.aten.sin.default,
+                        torch.ops.aten.cos.default,
+                    ):
                         torch_fn = node.meta.get("torch_fn")
-                        print(torch_fn)
                         actual_torch_fns.append(torch_fn)
-        exp_torch_fns = [
-            ("cos_1", "method_descriptor.cos"),
+        exp_torch_fns = {
             ("sin_1", "method_descriptor.sin"),
-        ]
-        self.assertEqual(actual_torch_fns, exp_torch_fns)
+            ("cos_1", "method_descriptor.cos"),
+        }
+        self.assertEqual(set(actual_torch_fns), exp_torch_fns)
 
     def test_is_exporting(self):
         class Mod(torch.nn.Module):
@@ -5003,13 +5005,13 @@ def forward(self, p_linear_weight, p_linear_bias, x):
             str(ep_has_linear_convd.graph_module.code).strip(),
             """\
 def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, c_linear_weight, c_linear_bias, x, y):
-    conv2d = torch.ops.aten.conv2d.default(x, p_conv_weight, p_conv_bias);  x = p_conv_weight = p_conv_bias = None
-    conv1d = torch.ops.aten.conv1d.default(y, p_conv1d_weight, p_conv1d_bias);  y = p_conv1d_weight = p_conv1d_bias = None
-    linear = torch.ops.aten.linear.default(conv2d, c_linear_weight, c_linear_bias);  conv2d = c_linear_weight = c_linear_bias = None
-    cos = torch.ops.aten.cos.default(linear);  linear = None
-    sum_1 = torch.ops.aten.sum.default(conv1d);  conv1d = None
-    add = torch.ops.aten.add.Tensor(cos, sum_1);  cos = sum_1 = None
-    return (add,)""",
+    conv2d_default = torch.ops.aten.conv2d.default(x, p_conv_weight, p_conv_bias);  x = p_conv_weight = p_conv_bias = None
+    conv1d_default = torch.ops.aten.conv1d.default(y, p_conv1d_weight, p_conv1d_bias);  y = p_conv1d_weight = p_conv1d_bias = None
+    linear_default = torch.ops.aten.linear.default(conv2d_default, c_linear_weight, c_linear_bias);  conv2d_default = c_linear_weight = c_linear_bias = None
+    cos_default = torch.ops.aten.cos.default(linear_default);  linear_default = None
+    sum_default = torch.ops.aten.sum.default(conv1d_default);  conv1d_default = None
+    add_tensor = torch.ops.aten.add.Tensor(cos_default, sum_default);  cos_default = sum_default = None
+    return (add_tensor,)""",
         )
 
         decomp_table = default_decompositions()
@@ -5021,16 +5023,16 @@ def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, c_
             str(ep_has_convd.graph_module.code).strip(),
             """\
 def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, c_linear_weight, c_linear_bias, x, y):
-    conv2d = torch.ops.aten.conv2d.default(x, p_conv_weight, p_conv_bias);  x = p_conv_weight = p_conv_bias = None
-    conv1d = torch.ops.aten.conv1d.default(y, p_conv1d_weight, p_conv1d_bias);  y = p_conv1d_weight = p_conv1d_bias = None
-    view = torch.ops.aten.view.default(conv2d, [31680, 98]);  conv2d = None
-    permute = torch.ops.aten.permute.default(c_linear_weight, [1, 0]);  c_linear_weight = None
-    addmm = torch.ops.aten.addmm.default(c_linear_bias, view, permute);  c_linear_bias = view = permute = None
-    view_1 = torch.ops.aten.view.default(addmm, [20, 33, 48, 20]);  addmm = None
-    cos = torch.ops.aten.cos.default(view_1);  view_1 = None
-    sum_1 = torch.ops.aten.sum.dim_IntList(conv1d, []);  conv1d = None
-    add = torch.ops.aten.add.Tensor(cos, sum_1);  cos = sum_1 = None
-    return (add,)""",
+    conv2d_default = torch.ops.aten.conv2d.default(x, p_conv_weight, p_conv_bias);  x = p_conv_weight = p_conv_bias = None
+    conv1d_default = torch.ops.aten.conv1d.default(y, p_conv1d_weight, p_conv1d_bias);  y = p_conv1d_weight = p_conv1d_bias = None
+    view_default = torch.ops.aten.view.default(conv2d_default, [31680, 98]);  conv2d_default = None
+    permute_default = torch.ops.aten.permute.default(c_linear_weight, [1, 0]);  c_linear_weight = None
+    addmm_default = torch.ops.aten.addmm.default(c_linear_bias, view_default, permute_default);  c_linear_bias = view_default = permute_default = None
+    view_default_1 = torch.ops.aten.view.default(addmm_default, [20, 33, 48, 20]);  addmm_default = None
+    cos_default = torch.ops.aten.cos.default(view_default_1);  view_default_1 = None
+    sum_dim_int_list = torch.ops.aten.sum.dim_IntList(conv1d_default, []);  conv1d_default = None
+    add_tensor = torch.ops.aten.add.Tensor(cos_default, sum_dim_int_list);  cos_default = sum_dim_int_list = None
+    return (add_tensor,)""",
         )
         decomp_table = default_decompositions()
         del decomp_table[torch.ops.aten.conv2d.default]
@@ -5040,16 +5042,16 @@ def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, c_
             str(ep_has_convd.graph_module.code).strip(),
             """\
 def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, c_linear_weight, c_linear_bias, x, y):
-    conv2d = torch.ops.aten.conv2d.default(x, p_conv_weight, p_conv_bias);  x = p_conv_weight = p_conv_bias = None
-    convolution = torch.ops.aten.convolution.default(y, p_conv1d_weight, p_conv1d_bias, [1], [0], [1], False, [0], 1);  y = p_conv1d_weight = p_conv1d_bias = None
-    view = torch.ops.aten.view.default(conv2d, [31680, 98]);  conv2d = None
-    permute = torch.ops.aten.permute.default(c_linear_weight, [1, 0]);  c_linear_weight = None
-    addmm = torch.ops.aten.addmm.default(c_linear_bias, view, permute);  c_linear_bias = view = permute = None
-    view_1 = torch.ops.aten.view.default(addmm, [20, 33, 48, 20]);  addmm = None
-    cos = torch.ops.aten.cos.default(view_1);  view_1 = None
-    sum_1 = torch.ops.aten.sum.dim_IntList(convolution, []);  convolution = None
-    add = torch.ops.aten.add.Tensor(cos, sum_1);  cos = sum_1 = None
-    return (add,)""",
+    conv2d_default = torch.ops.aten.conv2d.default(x, p_conv_weight, p_conv_bias);  x = p_conv_weight = p_conv_bias = None
+    convolution_default = torch.ops.aten.convolution.default(y, p_conv1d_weight, p_conv1d_bias, [1], [0], [1], False, [0], 1);  y = p_conv1d_weight = p_conv1d_bias = None
+    view_default = torch.ops.aten.view.default(conv2d_default, [31680, 98]);  conv2d_default = None
+    permute_default = torch.ops.aten.permute.default(c_linear_weight, [1, 0]);  c_linear_weight = None
+    addmm_default = torch.ops.aten.addmm.default(c_linear_bias, view_default, permute_default);  c_linear_bias = view_default = permute_default = None
+    view_default_1 = torch.ops.aten.view.default(addmm_default, [20, 33, 48, 20]);  addmm_default = None
+    cos_default = torch.ops.aten.cos.default(view_default_1);  view_default_1 = None
+    sum_dim_int_list = torch.ops.aten.sum.dim_IntList(convolution_default, []);  convolution_default = None
+    add_tensor = torch.ops.aten.add.Tensor(cos_default, sum_dim_int_list);  cos_default = sum_dim_int_list = None
+    return (add_tensor,)""",
         )
 
     def test_keep_composite_ops_linear_convd_for_training_ir(self):
@@ -5087,13 +5089,13 @@ def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, c_
             str(ep_has_linear_convd.graph_module.code).strip(),
             """\
 def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, b_linear_weight, b_linear_bias, x, y):
-    conv2d = torch.ops.aten.conv2d.default(x, p_conv_weight, p_conv_bias);  x = p_conv_weight = p_conv_bias = None
-    conv1d = torch.ops.aten.conv1d.default(y, p_conv1d_weight, p_conv1d_bias);  y = p_conv1d_weight = p_conv1d_bias = None
-    linear = torch.ops.aten.linear.default(conv2d, b_linear_weight, b_linear_bias);  conv2d = b_linear_weight = b_linear_bias = None
-    cos = torch.ops.aten.cos.default(linear);  linear = None
-    sum_1 = torch.ops.aten.sum.default(conv1d);  conv1d = None
-    add = torch.ops.aten.add.Tensor(cos, sum_1);  cos = sum_1 = None
-    return (add,)""",
+    conv2d_default = torch.ops.aten.conv2d.default(x, p_conv_weight, p_conv_bias);  x = p_conv_weight = p_conv_bias = None
+    conv1d_default = torch.ops.aten.conv1d.default(y, p_conv1d_weight, p_conv1d_bias);  y = p_conv1d_weight = p_conv1d_bias = None
+    linear_default = torch.ops.aten.linear.default(conv2d_default, b_linear_weight, b_linear_bias);  conv2d_default = b_linear_weight = b_linear_bias = None
+    cos_default = torch.ops.aten.cos.default(linear_default);  linear_default = None
+    sum_default = torch.ops.aten.sum.default(conv1d_default);  conv1d_default = None
+    add_tensor = torch.ops.aten.add.Tensor(cos_default, sum_default);  cos_default = sum_default = None
+    return (add_tensor,)""",
         )
 
         decomp_table = default_decompositions()
@@ -5106,16 +5108,16 @@ def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, b_
             str(ep_has_convd.graph_module.code).strip(),
             """\
 def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, b_linear_weight, b_linear_bias, x, y):
-    conv2d = torch.ops.aten.conv2d.default(x, p_conv_weight, p_conv_bias);  x = p_conv_weight = p_conv_bias = None
-    conv1d = torch.ops.aten.conv1d.default(y, p_conv1d_weight, p_conv1d_bias);  y = p_conv1d_weight = p_conv1d_bias = None
-    view = torch.ops.aten.view.default(conv2d, [31680, 98]);  conv2d = None
-    permute = torch.ops.aten.permute.default(b_linear_weight, [1, 0]);  b_linear_weight = None
-    addmm = torch.ops.aten.addmm.default(b_linear_bias, view, permute);  b_linear_bias = view = permute = None
-    view_1 = torch.ops.aten.view.default(addmm, [20, 33, 48, 20]);  addmm = None
-    cos = torch.ops.aten.cos.default(view_1);  view_1 = None
-    sum_1 = torch.ops.aten.sum.dim_IntList(conv1d, []);  conv1d = None
-    add = torch.ops.aten.add.Tensor(cos, sum_1);  cos = sum_1 = None
-    return (add,)""",
+    conv2d_default = torch.ops.aten.conv2d.default(x, p_conv_weight, p_conv_bias);  x = p_conv_weight = p_conv_bias = None
+    conv1d_default = torch.ops.aten.conv1d.default(y, p_conv1d_weight, p_conv1d_bias);  y = p_conv1d_weight = p_conv1d_bias = None
+    view_default = torch.ops.aten.view.default(conv2d_default, [31680, 98]);  conv2d_default = None
+    permute_default = torch.ops.aten.permute.default(b_linear_weight, [1, 0]);  b_linear_weight = None
+    addmm_default = torch.ops.aten.addmm.default(b_linear_bias, view_default, permute_default);  b_linear_bias = view_default = permute_default = None
+    view_default_1 = torch.ops.aten.view.default(addmm_default, [20, 33, 48, 20]);  addmm_default = None
+    cos_default = torch.ops.aten.cos.default(view_default_1);  view_default_1 = None
+    sum_dim_int_list = torch.ops.aten.sum.dim_IntList(conv1d_default, []);  conv1d_default = None
+    add_tensor = torch.ops.aten.add.Tensor(cos_default, sum_dim_int_list);  cos_default = sum_dim_int_list = None
+    return (add_tensor,)""",
         )
 
         decomp_table = default_decompositions()
@@ -5126,16 +5128,16 @@ def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, b_
             str(ep_has_convd.graph_module.code).strip(),
             """\
 def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, b_linear_weight, b_linear_bias, x, y):
-    conv2d = torch.ops.aten.conv2d.default(x, p_conv_weight, p_conv_bias);  x = p_conv_weight = p_conv_bias = None
-    convolution = torch.ops.aten.convolution.default(y, p_conv1d_weight, p_conv1d_bias, [1], [0], [1], False, [0], 1);  y = p_conv1d_weight = p_conv1d_bias = None
-    view = torch.ops.aten.view.default(conv2d, [31680, 98]);  conv2d = None
-    permute = torch.ops.aten.permute.default(b_linear_weight, [1, 0]);  b_linear_weight = None
-    addmm = torch.ops.aten.addmm.default(b_linear_bias, view, permute);  b_linear_bias = view = permute = None
-    view_1 = torch.ops.aten.view.default(addmm, [20, 33, 48, 20]);  addmm = None
-    cos = torch.ops.aten.cos.default(view_1);  view_1 = None
-    sum_1 = torch.ops.aten.sum.dim_IntList(convolution, []);  convolution = None
-    add = torch.ops.aten.add.Tensor(cos, sum_1);  cos = sum_1 = None
-    return (add,)""",
+    conv2d_default = torch.ops.aten.conv2d.default(x, p_conv_weight, p_conv_bias);  x = p_conv_weight = p_conv_bias = None
+    convolution_default = torch.ops.aten.convolution.default(y, p_conv1d_weight, p_conv1d_bias, [1], [0], [1], False, [0], 1);  y = p_conv1d_weight = p_conv1d_bias = None
+    view_default = torch.ops.aten.view.default(conv2d_default, [31680, 98]);  conv2d_default = None
+    permute_default = torch.ops.aten.permute.default(b_linear_weight, [1, 0]);  b_linear_weight = None
+    addmm_default = torch.ops.aten.addmm.default(b_linear_bias, view_default, permute_default);  b_linear_bias = view_default = permute_default = None
+    view_default_1 = torch.ops.aten.view.default(addmm_default, [20, 33, 48, 20]);  addmm_default = None
+    cos_default = torch.ops.aten.cos.default(view_default_1);  view_default_1 = None
+    sum_dim_int_list = torch.ops.aten.sum.dim_IntList(convolution_default, []);  convolution_default = None
+    add_tensor = torch.ops.aten.add.Tensor(cos_default, sum_dim_int_list);  cos_default = sum_dim_int_list = None
+    return (add_tensor,)""",
         )
 
     @unittest.skip("See https://github.com/pytorch/pytorch/issues/135759")
@@ -5247,10 +5249,10 @@ def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, b_
             str(ep_preserve_sum.graph_module.code).strip(),
             """\
 def forward(self, x):
-    sin = torch.ops.aten.sin.default(x)
-    sum_1 = torch.ops.aten.sum.default(x);  x = None
-    add = torch.ops.aten.add.Tensor(sin, sum_1);  sin = sum_1 = None
-    return (add,)""",
+    sin_default = torch.ops.aten.sin.default(x)
+    sum_default = torch.ops.aten.sum.default(x);  x = None
+    add_tensor = torch.ops.aten.add.Tensor(sin_default, sum_default);  sin_default = sum_default = None
+    return (add_tensor,)""",
         )
 
         ep_no_preserve_sum = ep.run_decompositions()
@@ -5258,10 +5260,10 @@ def forward(self, x):
             str(ep_no_preserve_sum.graph_module.code).strip(),
             """\
 def forward(self, x):
-    sin = torch.ops.aten.sin.default(x)
-    sum_1 = torch.ops.aten.sum.dim_IntList(x, []);  x = None
-    add = torch.ops.aten.add.Tensor(sin, sum_1);  sin = sum_1 = None
-    return (add,)""",
+    sin_default = torch.ops.aten.sin.default(x)
+    sum_dim_int_list = torch.ops.aten.sum.dim_IntList(x, []);  x = None
+    add_tensor = torch.ops.aten.add.Tensor(sin_default, sum_dim_int_list);  sin_default = sum_dim_int_list = None
+    return (add_tensor,)""",
         )
 
     def test_set_grad_empty(self):
@@ -5349,8 +5351,8 @@ def forward(self, x):
             str(ep_for_training.graph_module.code).strip(),
             """\
 def forward(self, p_linear_weight, p_linear_bias, x):
-    linear = torch.ops.aten.linear.default(x, p_linear_weight, p_linear_bias);  x = p_linear_weight = p_linear_bias = None
-    return (linear,)""",
+    linear_default = torch.ops.aten.linear.default(x, p_linear_weight, p_linear_bias);  x = p_linear_weight = p_linear_bias = None
+    return (linear_default,)""",
         )
         gm = ep_for_training.module()
         self.assertExpectedInline(
@@ -5361,8 +5363,8 @@ def forward(self, x):
     linear_weight = self.linear.weight
     linear_bias = self.linear.bias
     _guards_fn = self._guards_fn(x);  _guards_fn = None
-    linear = torch.ops.aten.linear.default(x, linear_weight, linear_bias);  x = linear_weight = linear_bias = None
-    return pytree.tree_unflatten((linear,), self._out_spec)""",
+    linear_default = torch.ops.aten.linear.default(x, linear_weight, linear_bias);  x = linear_weight = linear_bias = None
+    return pytree.tree_unflatten((linear_default,), self._out_spec)""",
         )
 
         self.assertTrue(
@@ -5389,10 +5391,10 @@ def forward(self, x):
             str(ep_for_training.graph_module.code).strip(),
             """\
 def forward(self, b_buffer, x):
-    add_ = torch.ops.aten.add_.Tensor(x, 5);  x = None
-    add__1 = torch.ops.aten.add_.Tensor(b_buffer, 5);  b_buffer = None
-    add = torch.ops.aten.add.Tensor(add_, add__1);  add_ = add__1 = None
-    return (add,)""",
+    add__tensor = torch.ops.aten.add_.Tensor(x, 5);  x = None
+    add__tensor_1 = torch.ops.aten.add_.Tensor(b_buffer, 5);  b_buffer = None
+    add_tensor = torch.ops.aten.add.Tensor(add__tensor, add__tensor_1);  add__tensor = add__tensor_1 = None
+    return (add_tensor,)""",
         )
         gm = ep_for_training.module()
         self.assertExpectedInline(
@@ -5402,10 +5404,10 @@ def forward(self, x):
     x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
     buffer = self.buffer
     _guards_fn = self._guards_fn(x);  _guards_fn = None
-    add_ = torch.ops.aten.add_.Tensor(x, 5);  x = None
-    add__1 = torch.ops.aten.add_.Tensor(buffer, 5);  buffer = None
-    add = torch.ops.aten.add.Tensor(add_, add__1);  add_ = add__1 = None
-    return pytree.tree_unflatten((add,), self._out_spec)""",
+    add__tensor = torch.ops.aten.add_.Tensor(x, 5);  x = None
+    add__tensor_1 = torch.ops.aten.add_.Tensor(buffer, 5);  buffer = None
+    add_tensor = torch.ops.aten.add.Tensor(add__tensor, add__tensor_1);  add__tensor = add__tensor_1 = None
+    return pytree.tree_unflatten((add_tensor,), self._out_spec)""",
         )
 
         self.assertTrue(
@@ -5704,12 +5706,12 @@ def forward(self, x):
             str(ep_for_inference.graph_module.code).strip(),
             """\
 def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
-    add = torch.ops.aten.add.Tensor(b_buffer, 5);  b_buffer = None
-    permute = torch.ops.aten.permute.default(p_linear_weight, [1, 0]);  p_linear_weight = None
-    addmm = torch.ops.aten.addmm.default(p_linear_bias, x, permute);  p_linear_bias = x = permute = None
-    sum_1 = torch.ops.aten.sum.dim_IntList(add, [])
-    add_1 = torch.ops.aten.add.Tensor(addmm, sum_1);  addmm = sum_1 = None
-    return (add, add_1)""",
+    add_tensor = torch.ops.aten.add.Tensor(b_buffer, 5);  b_buffer = None
+    permute_default = torch.ops.aten.permute.default(p_linear_weight, [1, 0]);  p_linear_weight = None
+    addmm_default = torch.ops.aten.addmm.default(p_linear_bias, x, permute_default);  p_linear_bias = x = permute_default = None
+    sum_dim_int_list = torch.ops.aten.sum.dim_IntList(add_tensor, [])
+    add_tensor_1 = torch.ops.aten.add.Tensor(addmm_default, sum_dim_int_list);  addmm_default = sum_dim_int_list = None
+    return (add_tensor, add_tensor_1)""",
         )
 
     def test_derived_dim_out_of_order_simplified_repeat_non_derived(self):
@@ -6360,7 +6362,11 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
             M(),
             (torch.randn(100, 4), torch.tensor(10)),
         )
-        foo = [node for node in ep.graph.nodes if node.name == "foo_unbacked"][0]
+        foo = [
+            node
+            for node in ep.graph.nodes
+            if node.target == torch.ops.mylib.foo_unbacked.default
+        ][0]
         unbacked_bindings = foo.meta["unbacked_bindings"]
         self.assertEqual(len(unbacked_bindings), 1)  # check binding is {u: path}
         u = next(iter(unbacked_bindings.keys()))
@@ -8818,10 +8824,10 @@ graph():
     %_positional_arg_0 : [num_users=1] = placeholder[target=_positional_arg_0]
     %_spec_0 : [num_users=1] = get_attr[target=_spec_0]
     %tree_flatten_spec : [num_users=1] = call_function[target=torch.fx._pytree.tree_flatten_spec](args = (((%_positional_arg_0,), {}), %_spec_0), kwargs = {})
-    %to : [num_users=1] = call_function[target=operator.getitem](args = (%tree_flatten_spec, 0), kwargs = {})
-    %sum_1 : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%to,), kwargs = {})
+    %to_dtype : [num_users=1] = call_function[target=operator.getitem](args = (%tree_flatten_spec, 0), kwargs = {})
+    %sum_default : [num_users=1] = call_function[target=torch.ops.aten.sum.default](args = (%to_dtype,), kwargs = {})
     %_spec_1 : [num_users=1] = get_attr[target=_spec_1]
-    %tree_unflatten : [num_users=1] = call_function[target=torch.utils._pytree.tree_unflatten](args = ((%sum_1,), %_spec_1), kwargs = {})
+    %tree_unflatten : [num_users=1] = call_function[target=torch.utils._pytree.tree_unflatten](args = ((%sum_default,), %_spec_1), kwargs = {})
     return tree_unflatten""",
         )
 
@@ -9121,8 +9127,8 @@ graph():
             str(ep.graph_module.code).strip(),
             """\
 def forward(self, c_lifted_tensor_0, x):
-    clone = torch.ops.prims.clone.default(c_lifted_tensor_0, memory_format = torch.preserve_format);  c_lifted_tensor_0 = None
-    _assert_async = torch.ops.aten._assert_async.msg(clone, 'Fail');  clone = _assert_async = None
+    clone_default = torch.ops.prims.clone.default(c_lifted_tensor_0, memory_format = torch.preserve_format);  c_lifted_tensor_0 = None
+    _assert_async_msg = torch.ops.aten._assert_async.msg(clone_default, 'Fail');  clone_default = _assert_async_msg = None
     return (x,)""",
         )
 
@@ -9156,9 +9162,9 @@ def forward(self, x):
     bn_running_var = self.bn.running_var
     bn_num_batches_tracked = self.bn.num_batches_tracked;  bn_num_batches_tracked = None
     _guards_fn = self._guards_fn(x);  _guards_fn = None
-    conv2d = torch.ops.aten.conv2d.default(x, conv_weight, conv_bias);  x = conv_weight = conv_bias = None
-    batch_norm = torch.ops.aten.batch_norm.default(conv2d, bn_weight, bn_bias, bn_running_mean, bn_running_var, False, 0.1, 1e-05, False);  conv2d = bn_weight = bn_bias = bn_running_mean = bn_running_var = None
-    return pytree.tree_unflatten((batch_norm,), self._out_spec)""",
+    conv2d_default = torch.ops.aten.conv2d.default(x, conv_weight, conv_bias);  x = conv_weight = conv_bias = None
+    batch_norm_default = torch.ops.aten.batch_norm.default(conv2d_default, bn_weight, bn_bias, bn_running_mean, bn_running_var, False, 0.1, 1e-05, False);  conv2d_default = bn_weight = bn_bias = bn_running_mean = bn_running_var = None
+    return pytree.tree_unflatten((batch_norm_default,), self._out_spec)""",
         )
 
         mod.train()
@@ -9176,10 +9182,10 @@ def forward(self, x):
     bn_running_var = self.bn.running_var
     bn_num_batches_tracked = self.bn.num_batches_tracked
     _guards_fn = self._guards_fn(x);  _guards_fn = None
-    conv2d = torch.ops.aten.conv2d.default(x, conv_weight, conv_bias);  x = conv_weight = conv_bias = None
-    add_ = torch.ops.aten.add_.Tensor(bn_num_batches_tracked, 1);  bn_num_batches_tracked = add_ = None
-    batch_norm = torch.ops.aten.batch_norm.default(conv2d, bn_weight, bn_bias, bn_running_mean, bn_running_var, True, 0.1, 1e-05, False);  conv2d = bn_weight = bn_bias = bn_running_mean = bn_running_var = None
-    return pytree.tree_unflatten((batch_norm,), self._out_spec)""",
+    conv2d_default = torch.ops.aten.conv2d.default(x, conv_weight, conv_bias);  x = conv_weight = conv_bias = None
+    add__tensor = torch.ops.aten.add_.Tensor(bn_num_batches_tracked, 1);  bn_num_batches_tracked = add__tensor = None
+    batch_norm_default = torch.ops.aten.batch_norm.default(conv2d_default, bn_weight, bn_bias, bn_running_mean, bn_running_var, True, 0.1, 1e-05, False);  conv2d_default = bn_weight = bn_bias = bn_running_mean = bn_running_var = None
+    return pytree.tree_unflatten((batch_norm_default,), self._out_spec)""",
         )
 
     def test_constrain_size_in_eager(self):
@@ -9980,10 +9986,10 @@ def forward(self, b_a_buffer, x):
                 ep.graph_module.code.strip(),
                 """\
 def forward(self, b_a_buffer, x):
-    sym_size_int_1 = torch.ops.aten.sym_size.int(x, 0)
-    gt = sym_size_int_1 > 4;  sym_size_int_1 = None
-    true_graph_0 = self.true_graph_0
+    sym_size_int = torch.ops.aten.sym_size.int(x, 0)
+    gt = sym_size_int > 4;  sym_size_int = None
     false_graph_0 = self.false_graph_0
+    true_graph_0 = self.true_graph_0
     cond = torch.ops.higher_order.cond(gt, true_graph_0, false_graph_0, (x, b_a_buffer));  gt = true_graph_0 = false_graph_0 = x = b_a_buffer = None
     getitem = cond[0];  cond = None
     return (getitem,)""",
@@ -10523,8 +10529,8 @@ def forward(self, b_a_buffer, x):
             str(core_aten_ep.graph_module.code).strip(),
             """\
 def forward(self, p_lin_weight, p_lin_bias, x):
-    add = torch.ops.aten.add.Tensor(x, p_lin_bias);  x = p_lin_bias = None
-    return (add,)""",
+    add_tensor = torch.ops.aten.add.Tensor(x, p_lin_bias);  x = p_lin_bias = None
+    return (add_tensor,)""",
         )
 
     @unittest.skipIf(IS_FBCODE, "We can't customize decomp in fbcode")
@@ -10566,16 +10572,16 @@ def forward(self, p_lin_weight, p_lin_bias, x):
             str(ep_decompose_linear.graph_module.code).strip(),
             """\
 def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, c_linear_weight, c_linear_bias, x, y):
-    conv2d = torch.ops.aten.conv2d.default(x, p_conv_weight, p_conv_bias);  x = p_conv_weight = p_conv_bias = None
-    conv1d = torch.ops.aten.conv1d.default(y, p_conv1d_weight, p_conv1d_bias);  y = p_conv1d_weight = p_conv1d_bias = None
-    permute = torch.ops.aten.permute.default(c_linear_weight, [1, 0]);  c_linear_weight = None
-    matmul = torch.ops.aten.matmul.default(conv2d, permute);  conv2d = permute = None
-    mul = torch.ops.aten.mul.Tensor(c_linear_bias, 2);  c_linear_bias = None
-    add = torch.ops.aten.add.Tensor(matmul, mul);  matmul = mul = None
-    cos = torch.ops.aten.cos.default(add);  add = None
-    sum_1 = torch.ops.aten.sum.default(conv1d);  conv1d = None
-    add_1 = torch.ops.aten.add.Tensor(cos, sum_1);  cos = sum_1 = None
-    return (add_1,)""",
+    conv2d_default = torch.ops.aten.conv2d.default(x, p_conv_weight, p_conv_bias);  x = p_conv_weight = p_conv_bias = None
+    conv1d_default = torch.ops.aten.conv1d.default(y, p_conv1d_weight, p_conv1d_bias);  y = p_conv1d_weight = p_conv1d_bias = None
+    permute_default = torch.ops.aten.permute.default(c_linear_weight, [1, 0]);  c_linear_weight = None
+    matmul_default = torch.ops.aten.matmul.default(conv2d_default, permute_default);  conv2d_default = permute_default = None
+    mul_tensor = torch.ops.aten.mul.Tensor(c_linear_bias, 2);  c_linear_bias = None
+    add_tensor = torch.ops.aten.add.Tensor(matmul_default, mul_tensor);  matmul_default = mul_tensor = None
+    cos_default = torch.ops.aten.cos.default(add_tensor);  add_tensor = None
+    sum_default = torch.ops.aten.sum.default(conv1d_default);  conv1d_default = None
+    add_tensor_1 = torch.ops.aten.add.Tensor(cos_default, sum_default);  cos_default = sum_default = None
+    return (add_tensor_1,)""",
         )
 
     def test_export_decomps_dynamic(self):
@@ -10831,9 +10837,9 @@ def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, c_
             """\
 graph():
     %x : [num_users=2] = placeholder[target=x]
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %x), kwargs = {})
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%add, %x), kwargs = {})
-    return (mul,)""",
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %x), kwargs = {})
+    %mul_tensor : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%add_tensor, %x), kwargs = {})
+    return (mul_tensor,)""",
         )
 
         unflattened = unflatten(ep)
@@ -10866,10 +10872,10 @@ graph():
             """\
 graph():
     %x : [num_users=2] = placeholder[target=x]
-    %ones : [num_users=1] = call_function[target=torch.ops.aten.ones.default](args = ([3, 3],), kwargs = {device: cpu, pin_memory: False})
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %ones), kwargs = {})
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%add, %x), kwargs = {})
-    return (mul,)""",
+    %ones_default : [num_users=1] = call_function[target=torch.ops.aten.ones.default](args = ([3, 3],), kwargs = {device: cpu, pin_memory: False})
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %ones_default), kwargs = {})
+    %mul_tensor : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%add_tensor, %x), kwargs = {})
+    return (mul_tensor,)""",
         )
 
         unflattened = unflatten(ep)
@@ -10901,10 +10907,10 @@ graph():
 graph():
     %c_lifted_tensor_0 : [num_users=1] = placeholder[target=c_lifted_tensor_0]
     %x : [num_users=2] = placeholder[target=x]
-    %clone : [num_users=1] = call_function[target=torch.ops.aten.clone.default](args = (%c_lifted_tensor_0,), kwargs = {})
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %clone), kwargs = {})
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%add, %x), kwargs = {})
-    return (mul,)""",
+    %clone_default : [num_users=1] = call_function[target=torch.ops.aten.clone.default](args = (%c_lifted_tensor_0,), kwargs = {})
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %clone_default), kwargs = {})
+    %mul_tensor : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%add_tensor, %x), kwargs = {})
+    return (mul_tensor,)""",
         )
 
         unflattened = unflatten(ep)
@@ -10939,14 +10945,14 @@ graph():
 graph():
     %c_lifted_tensor_0 : [num_users=1] = placeholder[target=c_lifted_tensor_0]
     %x : [num_users=2] = placeholder[target=x]
-    %ones : [num_users=1] = call_function[target=torch.ops.aten.ones.default](args = ([3, 3],), kwargs = {device: cpu, pin_memory: False})
-    %detach : [num_users=1] = call_function[target=torch.ops.aten.detach.default](args = (%ones,), kwargs = {})
-    %clone : [num_users=1] = call_function[target=torch.ops.aten.clone.default](args = (%c_lifted_tensor_0,), kwargs = {})
-    %detach_1 : [num_users=1] = call_function[target=torch.ops.aten.detach.default](args = (%clone,), kwargs = {})
-    %mul : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%detach, %detach_1), kwargs = {})
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %mul), kwargs = {})
-    %mul_1 : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%add, %x), kwargs = {})
-    return (mul_1,)""",
+    %ones_default : [num_users=1] = call_function[target=torch.ops.aten.ones.default](args = ([3, 3],), kwargs = {device: cpu, pin_memory: False})
+    %clone_default : [num_users=1] = call_function[target=torch.ops.aten.clone.default](args = (%c_lifted_tensor_0,), kwargs = {})
+    %detach_default : [num_users=1] = call_function[target=torch.ops.aten.detach.default](args = (%ones_default,), kwargs = {})
+    %detach_default_1 : [num_users=1] = call_function[target=torch.ops.aten.detach.default](args = (%clone_default,), kwargs = {})
+    %mul_tensor : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%detach_default, %detach_default_1), kwargs = {})
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %mul_tensor), kwargs = {})
+    %mul_tensor_1 : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%add_tensor, %x), kwargs = {})
+    return (mul_tensor_1,)""",
         )
 
         unflattened = unflatten(ep)
@@ -11578,9 +11584,9 @@ graph():
     %x : [num_users=1] = placeholder[target=x]
     %weight : [num_users=1] = get_attr[target=weight]
     %bias : [num_users=1] = get_attr[target=bias]
-    %permute : [num_users=1] = call_function[target=torch.ops.aten.permute.default](args = (%weight, [1, 0]), kwargs = {})
-    %addmm : [num_users=1] = call_function[target=torch.ops.aten.addmm.default](args = (%bias, %x, %permute), kwargs = {})
-    return addmm""",
+    %permute_default : [num_users=1] = call_function[target=torch.ops.aten.permute.default](args = (%weight, [1, 0]), kwargs = {})
+    %addmm_default : [num_users=1] = call_function[target=torch.ops.aten.addmm.default](args = (%bias, %x, %permute_default), kwargs = {})
+    return addmm_default""",
         )
 
         gm_flat_non_strict = ep_non_strict.module()
@@ -11650,18 +11656,18 @@ graph():
     %x : [num_users=1] = placeholder[target=x]
     %weight : [num_users=1] = get_attr[target=weight]
     %bias : [num_users=1] = get_attr[target=bias]
-    %linear : [num_users=1] = call_function[target=torch.ops.aten.linear.default](args = (%x, %weight, %bias), kwargs = {})
-    return linear""",
+    %linear_default : [num_users=1] = call_function[target=torch.ops.aten.linear.default](args = (%x, %weight, %bias), kwargs = {})
+    return linear_default""",
         )
         self.assertExpectedInline(
             str(gm_unflat_non_strict.bar_different.leaf.linear.graph).strip(),
             """\
 graph():
-    %add_2 : [num_users=1] = placeholder[target=add_2]
+    %add_tensor_2 : [num_users=1] = placeholder[target=add_tensor_2]
     %weight : [num_users=1] = get_attr[target=weight]
     %bias : [num_users=1] = get_attr[target=bias]
-    %linear_1 : [num_users=1] = call_function[target=torch.ops.aten.linear.default](args = (%add_2, %weight, %bias), kwargs = {})
-    return linear_1""",
+    %linear_default_1 : [num_users=1] = call_function[target=torch.ops.aten.linear.default](args = (%add_tensor_2, %weight, %bias), kwargs = {})
+    return linear_default_1""",
         )
 
         gm_flat_non_strict = ep_non_strict.module()
@@ -13514,13 +13520,13 @@ graph():
             str(ep.graph_module.code).strip(),
             """\
 def forward(self, c_params, x):
-    add = torch.ops.aten.add.Tensor(c_params, 2)
-    add_1 = torch.ops.aten.add.Tensor(c_params, 1);  c_params = None
-    sub = torch.ops.aten.sub.Tensor(add, add_1);  add = add_1 = None
-    sum_1 = torch.ops.aten.sum.dim_IntList(sub, []);  sub = None
-    sum_2 = torch.ops.aten.sum.dim_IntList(x, []);  x = None
-    add_2 = torch.ops.aten.add.Tensor(sum_1, sum_2);  sum_1 = sum_2 = None
-    return (add_2,)""",
+    add_tensor = torch.ops.aten.add.Tensor(c_params, 2)
+    add_tensor_1 = torch.ops.aten.add.Tensor(c_params, 1);  c_params = None
+    sub_tensor = torch.ops.aten.sub.Tensor(add_tensor, add_tensor_1);  add_tensor = add_tensor_1 = None
+    sum_dim_int_list = torch.ops.aten.sum.dim_IntList(x, []);  x = None
+    sum_dim_int_list_1 = torch.ops.aten.sum.dim_IntList(sub_tensor, []);  sub_tensor = None
+    add_tensor_2 = torch.ops.aten.add.Tensor(sum_dim_int_list_1, sum_dim_int_list);  sum_dim_int_list_1 = sum_dim_int_list = None
+    return (add_tensor_2,)""",
         )
 
     def test_constant_tensor_with_non_functional_nested(self):
@@ -13558,13 +13564,13 @@ def forward(self, c_params, x):
             str(ep.graph_module.code).strip(),
             """\
 def forward(self, c_submod_params, x):
-    add = torch.ops.aten.add.Tensor(c_submod_params, 2)
-    add_1 = torch.ops.aten.add.Tensor(c_submod_params, 1);  c_submod_params = None
-    sub = torch.ops.aten.sub.Tensor(add, add_1);  add = add_1 = None
-    sum_1 = torch.ops.aten.sum.dim_IntList(sub, []);  sub = None
-    sum_2 = torch.ops.aten.sum.dim_IntList(x, []);  x = None
-    add_2 = torch.ops.aten.add.Tensor(sum_1, sum_2);  sum_1 = sum_2 = None
-    return (add_2,)""",
+    add_tensor = torch.ops.aten.add.Tensor(c_submod_params, 2)
+    add_tensor_1 = torch.ops.aten.add.Tensor(c_submod_params, 1);  c_submod_params = None
+    sub_tensor = torch.ops.aten.sub.Tensor(add_tensor, add_tensor_1);  add_tensor = add_tensor_1 = None
+    sum_dim_int_list = torch.ops.aten.sum.dim_IntList(x, []);  x = None
+    sum_dim_int_list_1 = torch.ops.aten.sum.dim_IntList(sub_tensor, []);  sub_tensor = None
+    add_tensor_2 = torch.ops.aten.add.Tensor(sum_dim_int_list_1, sum_dim_int_list);  sum_dim_int_list_1 = sum_dim_int_list = None
+    return (add_tensor_2,)""",
         )
 
     def test_cond_unflatten(self):
@@ -13688,16 +13694,16 @@ def forward(self, c_submod_params, x):
             """\
 graph():
     %x : [num_users=1] = placeholder[target=x]
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, 3), kwargs = {})
-    %n : [num_users=1] = call_module[target=n](args = (%add,), kwargs = {})
-    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n, 4), kwargs = {})
-    %n_1 : [num_users=1] = call_module[target=n@1](args = (%add_2,), kwargs = {})
-    %add_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n_1, 5), kwargs = {})
-    %p : [num_users=1] = call_module[target=p](args = (%add_4,), kwargs = {})
-    %add_6 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p, 6), kwargs = {})
-    %p_1 : [num_users=1] = call_module[target=p](args = (%add_6,), kwargs = {})
-    %add_8 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p_1, 7), kwargs = {})
-    return (add_8,)""",
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, 3), kwargs = {})
+    %n : [num_users=1] = call_module[target=n](args = (%add_tensor,), kwargs = {})
+    %add_tensor_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n, 4), kwargs = {})
+    %n_1 : [num_users=1] = call_module[target=n@1](args = (%add_tensor_2,), kwargs = {})
+    %add_tensor_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n_1, 5), kwargs = {})
+    %p : [num_users=1] = call_module[target=p](args = (%add_tensor_4,), kwargs = {})
+    %add_tensor_6 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p, 6), kwargs = {})
+    %p_1 : [num_users=1] = call_module[target=p](args = (%add_tensor_6,), kwargs = {})
+    %add_tensor_8 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p_1, 7), kwargs = {})
+    return (add_tensor_8,)""",
             ["", "n", "n@1", "p"],
             [("n@1", "p")],
         )
@@ -13708,16 +13714,16 @@ graph():
             """\
 graph():
     %x : [num_users=1] = placeholder[target=x]
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, 3), kwargs = {})
-    %n : [num_users=1] = call_module[target=n](args = (%add,), kwargs = {})
-    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n, 4), kwargs = {})
-    %n_1 : [num_users=1] = call_module[target=n@1](args = (%add_2,), kwargs = {})
-    %add_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n_1, 5), kwargs = {})
-    %p : [num_users=1] = call_module[target=p](args = (%add_4,), kwargs = {})
-    %add_6 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p, 6), kwargs = {})
-    %p_1 : [num_users=1] = call_module[target=p@1](args = (%add_6,), kwargs = {})
-    %add_8 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p_1, 7), kwargs = {})
-    return (add_8,)""",
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, 3), kwargs = {})
+    %n : [num_users=1] = call_module[target=n](args = (%add_tensor,), kwargs = {})
+    %add_tensor_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n, 4), kwargs = {})
+    %n_1 : [num_users=1] = call_module[target=n@1](args = (%add_tensor_2,), kwargs = {})
+    %add_tensor_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n_1, 5), kwargs = {})
+    %p : [num_users=1] = call_module[target=p](args = (%add_tensor_4,), kwargs = {})
+    %add_tensor_6 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p, 6), kwargs = {})
+    %p_1 : [num_users=1] = call_module[target=p@1](args = (%add_tensor_6,), kwargs = {})
+    %add_tensor_8 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p_1, 7), kwargs = {})
+    return (add_tensor_8,)""",
             ["", "n", "n@1", "p", "p@1"],
             [("n", "p"), ("n@1", "p@1")],
         )
@@ -13728,16 +13734,16 @@ graph():
             """\
 graph():
     %x : [num_users=1] = placeholder[target=x]
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, 3), kwargs = {})
-    %n : [num_users=1] = call_module[target=n](args = (%add,), kwargs = {})
-    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n, 4), kwargs = {})
-    %n_1 : [num_users=1] = call_module[target=n](args = (%add_2,), kwargs = {})
-    %add_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n_1, 5), kwargs = {})
-    %p : [num_users=1] = call_module[target=p](args = (%add_4,), kwargs = {})
-    %add_6 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p, 6), kwargs = {})
-    %p_1 : [num_users=1] = call_module[target=p@1](args = (%add_6,), kwargs = {})
-    %add_8 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p_1, 7), kwargs = {})
-    return (add_8,)""",
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, 3), kwargs = {})
+    %n : [num_users=1] = call_module[target=n](args = (%add_tensor,), kwargs = {})
+    %add_tensor_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n, 4), kwargs = {})
+    %n_1 : [num_users=1] = call_module[target=n](args = (%add_tensor_2,), kwargs = {})
+    %add_tensor_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n_1, 5), kwargs = {})
+    %p : [num_users=1] = call_module[target=p](args = (%add_tensor_4,), kwargs = {})
+    %add_tensor_6 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p, 6), kwargs = {})
+    %p_1 : [num_users=1] = call_module[target=p@1](args = (%add_tensor_6,), kwargs = {})
+    %add_tensor_8 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p_1, 7), kwargs = {})
+    return (add_tensor_8,)""",
             ["", "n", "p", "p@1"],
             [("n", "p")],
         )
@@ -13748,16 +13754,16 @@ graph():
             """\
 graph():
     %x : [num_users=1] = placeholder[target=x]
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, 3), kwargs = {})
-    %n : [num_users=1] = call_module[target=n](args = (%add,), kwargs = {})
-    %add_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n, 4), kwargs = {})
-    %n_1 : [num_users=1] = call_module[target=n@1](args = (%add_2,), kwargs = {})
-    %add_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n_1, 5), kwargs = {})
-    %p : [num_users=1] = call_module[target=p](args = (%add_4,), kwargs = {})
-    %add_6 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p, 6), kwargs = {})
-    %p_1 : [num_users=1] = call_module[target=p@1](args = (%add_6,), kwargs = {})
-    %add_8 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p_1, 7), kwargs = {})
-    return (add_8,)""",
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, 3), kwargs = {})
+    %n : [num_users=1] = call_module[target=n](args = (%add_tensor,), kwargs = {})
+    %add_tensor_2 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n, 4), kwargs = {})
+    %n_1 : [num_users=1] = call_module[target=n@1](args = (%add_tensor_2,), kwargs = {})
+    %add_tensor_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%n_1, 5), kwargs = {})
+    %p : [num_users=1] = call_module[target=p](args = (%add_tensor_4,), kwargs = {})
+    %add_tensor_6 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p, 6), kwargs = {})
+    %p_1 : [num_users=1] = call_module[target=p@1](args = (%add_tensor_6,), kwargs = {})
+    %add_tensor_8 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%p_1, 7), kwargs = {})
+    return (add_tensor_8,)""",
             ["", "n", "n@1", "p", "p@1"],
             [("n", "p@1"), ("p", "n@1")],
         )
@@ -13778,14 +13784,17 @@ graph():
             (torch.randn(4, 4),),
         ).run_decompositions({})
         # check correct lines are in stack trace
-        trace_mul = [node for node in ep.graph.nodes if node.name == "mul"][0].meta.get(
-            "stack_trace", ""
-        )
+        trace_mul = [
+            node for node in ep.graph.nodes if node.target == torch.ops.aten.mul.Tensor
+        ][0].meta.get("stack_trace", "")
         self.assertTrue(
             re.search(r"test_export(?:_xpu)?.py.*in forward\n.*x \*= 2.0", trace_mul)
         )
         trace_addmm = [
-            node for node in ep.graph.nodes if node.name in ["addmm", "linear"]
+            node
+            for node in ep.graph.nodes
+            if node.target
+            in (torch.ops.aten.addmm.default, torch.ops.aten.linear.default)
         ][0].meta.get("stack_trace", "")
         self.assertTrue(
             re.search(
@@ -13835,14 +13844,17 @@ graph():
             (torch.randn(4, 4),),
         ).run_decompositions({})
         # check correct lines are in stack trace
-        trace_mul = [node for node in ep.graph.nodes if node.name == "mul"][0].meta.get(
-            "stack_trace", ""
-        )
+        trace_mul = [
+            node for node in ep.graph.nodes if node.target == torch.ops.aten.mul.Tensor
+        ][0].meta.get("stack_trace", "")
         self.assertTrue(
             re.search(r"test_export(?:_xpu)?.py.*in forward\n.*x \*= 2.0", trace_mul)
         )
         trace_addmm = [
-            node for node in ep.graph.nodes if node.name in ["addmm", "linear"]
+            node
+            for node in ep.graph.nodes
+            if node.target
+            in (torch.ops.aten.addmm.default, torch.ops.aten.linear.default)
         ][0].meta.get("stack_trace", "")
         self.assertTrue(
             re.search(
@@ -13937,15 +13949,15 @@ graph():
             ep.graph_module.code.strip(),
             """\
 def forward(self, p_bar_linear_weight, p_bar_linear_bias, x):
-    cos = torch.ops.aten.cos.default(x)
-    sum_1 = torch.ops.aten.sum.default(x)
-    gt = torch.ops.aten.gt.Scalar(sum_1, 4);  sum_1 = None
-    true_graph_0 = self.true_graph_0
+    cos_default = torch.ops.aten.cos.default(x)
+    sum_default = torch.ops.aten.sum.default(x)
+    gt_scalar = torch.ops.aten.gt.Scalar(sum_default, 4);  sum_default = None
     false_graph_0 = self.false_graph_0
-    cond = torch.ops.higher_order.cond(gt, true_graph_0, false_graph_0, (p_bar_linear_bias, p_bar_linear_weight, x));  gt = true_graph_0 = false_graph_0 = p_bar_linear_bias = p_bar_linear_weight = x = None
+    true_graph_0 = self.true_graph_0
+    cond = torch.ops.higher_order.cond(gt_scalar, true_graph_0, false_graph_0, (p_bar_linear_bias, p_bar_linear_weight, x));  gt_scalar = true_graph_0 = false_graph_0 = p_bar_linear_bias = p_bar_linear_weight = x = None
     getitem = cond[0];  cond = None
-    add = torch.ops.aten.add.Tensor(cos, getitem);  cos = getitem = None
-    return (add,)""",
+    add_tensor = torch.ops.aten.add.Tensor(cos_default, getitem);  cos_default = getitem = None
+    return (add_tensor,)""",
         )
         schema = get_hop_schema(ep)
         self.assertExpectedInline(
@@ -14100,8 +14112,8 @@ def forward(self, p_bar_linear_weight, p_bar_linear_bias, x):
             str(exported_program.graph_module.code.strip()),
             """\
 def forward(self, b_pred, b_t, x, y):
-    true_graph_0 = self.true_graph_0
     false_graph_0 = self.false_graph_0
+    true_graph_0 = self.true_graph_0
     cond = torch.ops.higher_order.cond(b_pred, true_graph_0, false_graph_0, (b_t, x, y));  b_pred = true_graph_0 = false_graph_0 = b_t = x = y = None
     getitem = cond[0];  cond = None
     return (getitem,)""",
@@ -14111,9 +14123,9 @@ def forward(self, b_pred, b_t, x, y):
             str(exported_program.graph_module.true_graph_0.code.strip()),
             """\
 def forward(self, b_t, x, y):
-    submod_3 = self.submod_1
-    add_1 = torch.ops.higher_order.wrap_with_set_grad_enabled(True, submod_3, x, b_t, y);  submod_3 = x = b_t = y = None
-    getitem = add_1[0];  add_1 = None
+    submod_1 = self.submod_1
+    wrap_with_set_grad_enabled = torch.ops.higher_order.wrap_with_set_grad_enabled(True, submod_1, x, b_t, y);  submod_1 = x = b_t = y = None
+    getitem = wrap_with_set_grad_enabled[0];  wrap_with_set_grad_enabled = None
     return (getitem,)""",
         )
 
@@ -14121,10 +14133,10 @@ def forward(self, b_t, x, y):
             str(exported_program.graph_module.true_graph_0.submod_1.code.strip()),
             """\
 def forward(self, x, b_t, y):
-    sub = torch.ops.aten.sub.Tensor(x, 1);  x = None
-    add = torch.ops.aten.add.Tensor(sub, b_t);  sub = b_t = None
-    add_1 = torch.ops.aten.add.Tensor(add, y);  add = y = None
-    return (add_1,)""",
+    sub_tensor = torch.ops.aten.sub.Tensor(x, 1);  x = None
+    add_tensor = torch.ops.aten.add.Tensor(sub_tensor, b_t);  sub_tensor = b_t = None
+    add_tensor_1 = torch.ops.aten.add.Tensor(add_tensor, y);  add_tensor = y = None
+    return (add_tensor_1,)""",
         )
 
     def test_python_asserts_with_sym_int(self):
@@ -14605,11 +14617,11 @@ def forward(self, x):
                 str(ep.graph_module.code.strip()),
                 """\
 def forward(self, x):
-    cos = torch.ops.aten.cos.default(x)
-    auto_functionalized_v2 = torch.ops.higher_order.auto_functionalized_v2(torch.ops.testlib.foo.default, _x_base_index = 0, _z_base_index = 1, _all_bases = [x, cos]);  x = cos = None
-    getitem_3 = auto_functionalized_v2[3];  auto_functionalized_v2 = None
-    cos_1 = torch.ops.aten.cos.default(getitem_3)
-    return (getitem_3, getitem_3, cos_1)""",
+    cos_default = torch.ops.aten.cos.default(x)
+    auto_functionalized_v2 = torch.ops.higher_order.auto_functionalized_v2(torch.ops.testlib.foo.default, _x_base_index = 0, _z_base_index = 1, _all_bases = [x, cos_default]);  x = cos_default = None
+    getitem = auto_functionalized_v2[3];  auto_functionalized_v2 = None
+    cos_default_1 = torch.ops.aten.cos.default(getitem)
+    return (getitem, getitem, cos_default_1)""",
             )
 
     def test_custom_op_auto_warn_pre_dispatch(self):
@@ -14640,12 +14652,12 @@ def forward(self, x):
                 str(ep.graph_module.code.strip()),
                 """\
 def forward(self, x):
-    cos = torch.ops.aten.cos.default(x)
-    cos_1 = torch.ops.aten.cos.default(x);  x = None
-    auto_functionalized_v2 = torch.ops.higher_order.auto_functionalized_v2(torch.ops.testlib.foo.default, _x_base_index = 0, _z_base_index = 1, _all_bases = [cos, cos_1]);  cos = cos_1 = None
-    getitem_3 = auto_functionalized_v2[3];  auto_functionalized_v2 = None
-    cos_2 = torch.ops.aten.cos.default(getitem_3);  getitem_3 = None
-    return (cos_2,)""",
+    cos_default = torch.ops.aten.cos.default(x)
+    cos_default_1 = torch.ops.aten.cos.default(x);  x = None
+    auto_functionalized_v2 = torch.ops.higher_order.auto_functionalized_v2(torch.ops.testlib.foo.default, _x_base_index = 0, _z_base_index = 1, _all_bases = [cos_default, cos_default_1]);  cos_default = cos_default_1 = None
+    getitem = auto_functionalized_v2[3];  auto_functionalized_v2 = None
+    cos_default_2 = torch.ops.aten.cos.default(getitem);  getitem = None
+    return (cos_default_2,)""",
             )
 
         ep = torch.export._trace._export(M(), inps, pre_dispatch=True)
@@ -14653,8 +14665,8 @@ def forward(self, x):
             str(ep.graph_module.code.strip()),
             """\
 def forward(self, x):
-    foo_functional = torch.ops.testlib.foo_functional.default(x);  x = None
-    return (foo_functional,)""",
+    foo_functional_default = torch.ops.testlib.foo_functional.default(x);  x = None
+    return (foo_functional_default,)""",
         )
 
     @testing.expectedFailureStrictV2
@@ -14798,9 +14810,9 @@ def forward(self, x):
             ("mul", "placeholder"),
             ("add", "placeholder"),
             ("add_1", "placeholder"),
-            ("mul_1", "call_function"),
-            ("mul_2", "call_function"),
-            ("add_2", "call_function"),
+            ("mul_tensor", "call_function"),
+            ("mul_tensor_1", "call_function"),
+            ("add_tensor", "call_function"),
             ("output", "output"),
         ]
         real_names_and_ops = [(node.name, node.op) for node in ep.graph.nodes]
@@ -14840,8 +14852,8 @@ def forward(self, x):
             ("mul_2", "placeholder"),
             ("mul", "placeholder"),
             ("mul_1", "placeholder"),
-            ("mul_3", "call_function"),
-            ("mul_4", "call_function"),
+            ("mul_tensor", "call_function"),
+            ("mul_tensor_1", "call_function"),
             ("output", "output"),
         ]
         real_names_and_ops = [
@@ -14851,7 +14863,7 @@ def forward(self, x):
         # test set_grad_enabled subgraph
         expected_names_and_ops = [
             ("getitem", "placeholder"),
-            ("mul_1", "call_function"),
+            ("mul_tensor", "call_function"),
             ("output", "output"),
         ]
         real_names_and_ops = [
@@ -14874,15 +14886,15 @@ def forward(self, x):
             (torch.randn(4),),
         )
         ep = export(Foo(), inputs)
-        expected_getattr_names = [
-            "true_graph_2",
+        expected_getattr_names = {
             "false_graph_0",
-            "true_graph_3",
+            "true_graph_2",
             "false_graph_1",
-        ]
-        real_getattr_names = [
+            "true_graph_3",
+        }
+        real_getattr_names = {
             node.name for node in ep.graph.nodes if node.op == "get_attr"
-        ]
+        }
         self.assertEqual(expected_getattr_names, real_getattr_names)
 
     @testing.expectedFailureStrictV2
@@ -14938,8 +14950,8 @@ graph():
     %lazy_load_decompositions : [num_users=0] = call_function[target=torch._functorch.predispatch.lazy_load_decompositions](args = (), kwargs = {})
     %_vmap_increment_nesting : [num_users=0] = call_function[target=torch._functorch.predispatch._vmap_increment_nesting](args = (4, error), kwargs = {})
     %_add_batch_dim : [num_users=1] = call_function[target=torch._functorch.predispatch._add_batch_dim](args = (%indices, 0, 1), kwargs = {})
-    %torch__dynamo__trace_wrapped_higher_order_op_mod_index0 : [num_users=1] = get_attr[target=torch__dynamo__trace_wrapped_higher_order_op_ModIndex0]
     %function_const_func_spec0 : [num_users=1] = get_attr[target=function_const_func_spec0]
+    %torch__dynamo__trace_wrapped_higher_order_op_mod_index0 : [num_users=1] = get_attr[target=torch__dynamo__trace_wrapped_higher_order_op_ModIndex0]
     %flat_apply : [num_users=1] = call_function[target=torch.ops.higher_order.flat_apply](args = (%function_const_func_spec0, %torch__dynamo__trace_wrapped_higher_order_op_mod_index0, torch._dynamo._trace_wrapped_higher_order_op.ModIndex, %b_base, %_add_batch_dim), kwargs = {})
     %_remove_batch_dim : [num_users=1] = call_function[target=torch._functorch.predispatch._remove_batch_dim](args = (%flat_apply, 1, 4, 0), kwargs = {})
     %_vmap_decrement_nesting : [num_users=0] = call_function[target=torch._functorch.predispatch._vmap_decrement_nesting](args = (), kwargs = {})
@@ -14954,8 +14966,8 @@ graph():
 graph():
     %b_base : [num_users=1] = placeholder[target=b_base]
     %indices : [num_users=1] = placeholder[target=indices]
-    %index : [num_users=1] = call_function[target=torch.ops.aten.index.Tensor](args = (%b_base, [%indices]), kwargs = {})
-    return (index,)""",
+    %index_tensor : [num_users=1] = call_function[target=torch.ops.aten.index.Tensor](args = (%b_base, [%indices]), kwargs = {})
+    return (index_tensor,)""",
         )
         self.assertEqual(m(idxs), ep.module()(idxs))
 
@@ -14976,39 +14988,39 @@ graph():
             str(ep_pre.graph_module.submod_1.code).strip(),
             """\
 def forward(self, x):
-    item = torch.ops.aten.item.default(x);  x = None
-    ge = item >= 3
+    item_default = torch.ops.aten.item.default(x);  x = None
+    ge = item_default >= 3
     _assert_scalar_default = torch.ops.aten._assert_scalar.default(ge, "Runtime assertion failed for expression u0 >= 3 on node 'ge'");  ge = _assert_scalar_default = None
-    le = item <= 5
+    le = item_default <= 5
     _assert_scalar_default_1 = torch.ops.aten._assert_scalar.default(le, "Runtime assertion failed for expression u0 <= 5 on node 'le'");  le = _assert_scalar_default_1 = None
-    gt_1 = item > 2
-    _assert_scalar_default_2 = torch.ops.aten._assert_scalar.default(gt_1, "Runtime assertion failed for expression 2 < u0 on node 'gt_1'");  gt_1 = _assert_scalar_default_2 = None
-    lt_1 = item < 6
-    _assert_scalar_default_3 = torch.ops.aten._assert_scalar.default(lt_1, "Runtime assertion failed for expression u0 < 6 on node 'lt_1'");  lt_1 = _assert_scalar_default_3 = None
-    foo_unbacked = torch.ops.testlib.foo_unbacked.default(item);  item = None
-    return (foo_unbacked,)""",
+    gt = item_default > 2
+    _assert_scalar_default_2 = torch.ops.aten._assert_scalar.default(gt, "Runtime assertion failed for expression 2 < u0 on node 'gt_1'");  gt = _assert_scalar_default_2 = None
+    lt = item_default < 6
+    _assert_scalar_default_3 = torch.ops.aten._assert_scalar.default(lt, "Runtime assertion failed for expression u0 < 6 on node 'lt_1'");  lt = _assert_scalar_default_3 = None
+    foo_unbacked_default = torch.ops.testlib.foo_unbacked.default(item_default);  item_default = None
+    return (foo_unbacked_default,)""",
         )
         ep_aot = ep_pre.run_decompositions()
         self.assertExpectedInline(
             str(ep_aot.graph_module.code).strip(),
             """\
 def forward(self, x, y):
-    sin = torch.ops.aten.sin.default(y)
-    sum_1 = torch.ops.aten.sum.dim_IntList(sin, []);  sin = None
-    _local_scalar_dense = torch.ops.aten._local_scalar_dense.default(x);  x = None
-    ge_1 = _local_scalar_dense >= 3
-    _assert_scalar_default = torch.ops.aten._assert_scalar.default(ge_1, "Runtime assertion failed for expression u2 >= 3 on node 'ge_1'");  ge_1 = _assert_scalar_default = None
-    le_1 = _local_scalar_dense <= 5
-    _assert_scalar_default_1 = torch.ops.aten._assert_scalar.default(le_1, "Runtime assertion failed for expression u2 <= 5 on node 'le_1'");  le_1 = _assert_scalar_default_1 = None
-    gt = _local_scalar_dense > 2
-    _assert_scalar_2 = torch.ops.aten._assert_scalar.default(gt, "Runtime assertion failed for expression 2 < u0 on node 'gt_1'");  gt = _assert_scalar_2 = None
-    lt = _local_scalar_dense < 6;  _local_scalar_dense = None
-    _assert_scalar_3 = torch.ops.aten._assert_scalar.default(lt, "Runtime assertion failed for expression u0 < 6 on node 'lt_1'");  lt = _assert_scalar_3 = None
-    full = torch.ops.aten.full.default([4, 4], 1, dtype = torch.float32, layout = torch.strided, device = device(type='cpu'), pin_memory = False)
-    add = torch.ops.aten.add.Tensor(y, sum_1);  y = sum_1 = None
-    sum_2 = torch.ops.aten.sum.dim_IntList(full, []);  full = None
-    add_1 = torch.ops.aten.add.Tensor(add, sum_2);  add = sum_2 = None
-    return (add_1,)""",
+    sin_default = torch.ops.aten.sin.default(y)
+    _local_scalar_dense_default = torch.ops.aten._local_scalar_dense.default(x);  x = None
+    ge = _local_scalar_dense_default >= 3
+    sum_dim_int_list = torch.ops.aten.sum.dim_IntList(sin_default, []);  sin_default = None
+    add_tensor = torch.ops.aten.add.Tensor(y, sum_dim_int_list);  y = sum_dim_int_list = None
+    _assert_scalar_default = torch.ops.aten._assert_scalar.default(ge, "Runtime assertion failed for expression u2 >= 3 on node 'ge_1'");  ge = _assert_scalar_default = None
+    le = _local_scalar_dense_default <= 5
+    _assert_scalar_default_1 = torch.ops.aten._assert_scalar.default(le, "Runtime assertion failed for expression u2 <= 5 on node 'le_1'");  le = _assert_scalar_default_1 = None
+    gt = _local_scalar_dense_default > 2
+    _assert_scalar_default_2 = torch.ops.aten._assert_scalar.default(gt, "Runtime assertion failed for expression 2 < u0 on node 'gt_1'");  gt = _assert_scalar_default_2 = None
+    lt = _local_scalar_dense_default < 6;  _local_scalar_dense_default = None
+    _assert_scalar_default_3 = torch.ops.aten._assert_scalar.default(lt, "Runtime assertion failed for expression u0 < 6 on node 'lt_1'");  lt = _assert_scalar_default_3 = None
+    full_default = torch.ops.aten.full.default([4, 4], 1, dtype = torch.float32, layout = torch.strided, device = device(type='cpu'), pin_memory = False)
+    sum_dim_int_list_1 = torch.ops.aten.sum.dim_IntList(full_default, []);  full_default = None
+    add_tensor_1 = torch.ops.aten.add.Tensor(add_tensor, sum_dim_int_list_1);  add_tensor = sum_dim_int_list_1 = None
+    return (add_tensor_1,)""",
         )
 
     def test_nested_dynamic_shapes_spec(self):
@@ -15463,8 +15475,8 @@ def forward(self, x, y):
 graph():
     %c_foo : [num_users=2] = placeholder[target=c_foo]
     %x : [num_users=1] = placeholder[target=x]
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%c_foo, %x), kwargs = {})
-    return (c_foo, add)""",
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%c_foo, %x), kwargs = {})
+    return (c_foo, add_tensor)""",
         )
 
     def test_constant_requires_grad_const(self):
@@ -15660,17 +15672,17 @@ graph():
     %twotensor___init__0 : [num_users=1] = get_attr[target=twotensor___init__0]
     %twotensor_const_func_spec0 : [num_users=1] = get_attr[target=twotensor_const_func_spec0]
     %flat_apply : [num_users=2] = call_function[target=torch.ops.higher_order.flat_apply](args = (%twotensor_const_func_spec0, %twotensor___init__0, %x, %x), kwargs = {})
-    %access_subclass_inner_tensor_default_7 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%flat_apply, b), kwargs = {})
+    %access_subclass_inner_tensor_default : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%flat_apply, b), kwargs = {})
     %twotensor___init__1 : [num_users=1] = get_attr[target=twotensor___init__1]
     %twotensor_const_func_spec0_1 : [num_users=1] = get_attr[target=twotensor_const_func_spec0]
-    %flat_apply_1 : [num_users=2] = call_function[target=torch.ops.higher_order.flat_apply](args = (%twotensor_const_func_spec0_1, %twotensor___init__1, %access_subclass_inner_tensor_default_7, %flat_apply), kwargs = {})
-    %access_subclass_inner_tensor_default_17 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%flat_apply_1, b), kwargs = {})
-    %access_subclass_inner_tensor_default_23 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%access_subclass_inner_tensor_default_17, b), kwargs = {})
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%flat_apply_1, %b_buffer), kwargs = {})
-    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%access_subclass_inner_tensor_default_23, %add), kwargs = {})
-    %access_subclass_inner_tensor_default_24 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%add_1, b), kwargs = {})
-    %access_subclass_inner_tensor_default_29 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%access_subclass_inner_tensor_default_24, a), kwargs = {})
-    return (access_subclass_inner_tensor_default_29,)""",
+    %flat_apply_1 : [num_users=2] = call_function[target=torch.ops.higher_order.flat_apply](args = (%twotensor_const_func_spec0_1, %twotensor___init__1, %access_subclass_inner_tensor_default, %flat_apply), kwargs = {})
+    %access_subclass_inner_tensor_default_1 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%flat_apply_1, b), kwargs = {})
+    %access_subclass_inner_tensor_default_2 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%access_subclass_inner_tensor_default_1, b), kwargs = {})
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%flat_apply_1, %b_buffer), kwargs = {})
+    %add_tensor_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%access_subclass_inner_tensor_default_2, %add_tensor), kwargs = {})
+    %access_subclass_inner_tensor_default_3 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%add_tensor_1, b), kwargs = {})
+    %access_subclass_inner_tensor_default_4 : [num_users=1] = call_function[target=torch.ops.export.access_subclass_inner_tensor.default](args = (%access_subclass_inner_tensor_default_3, a), kwargs = {})
+    return (access_subclass_inner_tensor_default_4,)""",
         )
 
         inp = torch.randn(4, 4)
@@ -15687,9 +15699,9 @@ graph():
     %b_parametrizations_buffer_original0 : [num_users=0] = placeholder[target=b_parametrizations_buffer_original0]
     %b_parametrizations_buffer_original1 : [num_users=1] = placeholder[target=b_parametrizations_buffer_original1]
     %x : [num_users=2] = placeholder[target=x]
-    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %b_parametrizations_buffer_original1), kwargs = {})
-    %add_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %add_1), kwargs = {})
-    return (add_4,)""",
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %b_parametrizations_buffer_original1), kwargs = {})
+    %add_tensor_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %add_tensor), kwargs = {})
+    return (add_tensor_1,)""",
         )
 
         self.assertEqual(ep.module()(inp), mod(inp))
@@ -15718,9 +15730,9 @@ graph():
     %b_parametrizations_buffer_original0 : [num_users=0] = placeholder[target=b_parametrizations_buffer_original0]
     %b_parametrizations_buffer_original1 : [num_users=1] = placeholder[target=b_parametrizations_buffer_original1]
     %x : [num_users=2] = placeholder[target=x]
-    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %b_parametrizations_buffer_original1), kwargs = {})
-    %add_4 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %add_1), kwargs = {})
-    return (add_4,)""",
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %b_parametrizations_buffer_original1), kwargs = {})
+    %add_tensor_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%x, %add_tensor), kwargs = {})
+    return (add_tensor_1,)""",
             )
 
     def test_capture_subclass_wrong(self):
@@ -15952,12 +15964,12 @@ graph():
 graph():
     %x : [num_users=4] = placeholder[target=x]
     %_guards_fn : [num_users=0] = call_module[target=_guards_fn](args = (%x,), kwargs = {})
-    %sin : [num_users=1] = call_function[target=torch.ops.aten.sin.default](args = (%x,), kwargs = {})
-    %cos : [num_users=1] = call_function[target=torch.ops.aten.cos.default](args = (%x,), kwargs = {})
-    %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%sin, %cos), kwargs = {})
-    %cos_1 : [num_users=1] = call_function[target=torch.ops.aten.cos.default](args = (%x,), kwargs = {})
-    %add_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add, %cos_1), kwargs = {})
-    return (add_1,)""",
+    %sin_default : [num_users=1] = call_function[target=torch.ops.aten.sin.default](args = (%x,), kwargs = {})
+    %cos_default : [num_users=1] = call_function[target=torch.ops.aten.cos.default](args = (%x,), kwargs = {})
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%sin_default, %cos_default), kwargs = {})
+    %cos_default_1 : [num_users=1] = call_function[target=torch.ops.aten.cos.default](args = (%x,), kwargs = {})
+    %add_tensor_1 : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%add_tensor, %cos_default_1), kwargs = {})
+    return (add_tensor_1,)""",
         )
 
         self.assertEqual(gm(inp), Foo()(inp))
@@ -16076,12 +16088,12 @@ def forward(self, x):
                 str(ep.graph_module.code).strip(),
                 """\
 def forward(self, x):
-    foo_functional = torch.ops.testlib.foo_functional.default(x);  x = None
-    cos = torch.ops.aten.cos.default(foo_functional)
-    auto_functionalized_v2 = torch.ops.higher_order.auto_functionalized_v2(torch.ops.testlib.foo.default, _x_base_index = 0, _z_base_index = 1, _all_bases = [foo_functional, cos]);  foo_functional = cos = None
-    getitem_3 = auto_functionalized_v2[3];  auto_functionalized_v2 = None
-    cos_1 = torch.ops.aten.cos.default(getitem_3)
-    return (getitem_3, cos_1)""",
+    foo_functional_default = torch.ops.testlib.foo_functional.default(x);  x = None
+    cos_default = torch.ops.aten.cos.default(foo_functional_default)
+    auto_functionalized_v2 = torch.ops.higher_order.auto_functionalized_v2(torch.ops.testlib.foo.default, _x_base_index = 0, _z_base_index = 1, _all_bases = [foo_functional_default, cos_default]);  foo_functional_default = cos_default = None
+    getitem = auto_functionalized_v2[3];  auto_functionalized_v2 = None
+    cos_default_1 = torch.ops.aten.cos.default(getitem)
+    return (getitem, cos_default_1)""",
             )
 
     @testing.expectedFailureStrictV2
@@ -16798,29 +16810,23 @@ def forward(self, x):
             """\
 class GraphModule(torch.nn.Module):
     def forward(self, x: "f32[2, 4]", y: "f32[4]"):
-        add: "f32[2, 4]" = torch.ops.aten.add.Tensor(x, y);  x = None
-
+        add_tensor: "f32[2, 4]" = torch.ops.aten.add.Tensor(x, y);  x = None
         hints_wrapper_body_graph_0 = self.hints_wrapper_body_graph_0
-        hints_wrapper = torch.ops.higher_order.hints_wrapper(hints_wrapper_body_graph_0, (add, y), {}, hints = {'outer_body': True});  hints_wrapper_body_graph_0 = add = y = None
+        hints_wrapper = torch.ops.higher_order.hints_wrapper(hints_wrapper_body_graph_0, (add_tensor, y), {}, hints = {'outer_body': True});  hints_wrapper_body_graph_0 = add_tensor = y = None
         getitem: "f32[2, 4]" = hints_wrapper[0];  hints_wrapper = None
         return (getitem,)
-
     class hints_wrapper_body_graph_0(torch.nn.Module):
         def forward(self, arg0_1: "f32[2, 4]", arg1_1: "f32[4]"):
             hints_wrapper_body_graph_0 = self.hints_wrapper_body_graph_0
             hints_wrapper = torch.ops.higher_order.hints_wrapper(hints_wrapper_body_graph_0, (arg0_1, arg1_1), {}, hints = {'inner_body': True});  hints_wrapper_body_graph_0 = arg0_1 = arg1_1 = None
             getitem: "f32[2, 4]" = hints_wrapper[0];  hints_wrapper = None
-
-            abs_1: "f32[2, 4]" = torch.ops.aten.abs.default(getitem);  getitem = None
-            return (abs_1,)
-
+            abs_default: "f32[2, 4]" = torch.ops.aten.abs.default(getitem);  getitem = None
+            return (abs_default,)
         class hints_wrapper_body_graph_0(torch.nn.Module):
             def forward(self, arg0_1: "f32[2, 4]", arg1_1: "f32[4]"):
-                relu: "f32[2, 4]" = torch.ops.aten.relu.default(arg0_1);  arg0_1 = None
-
-                add: "f32[2, 4]" = torch.ops.aten.add.Tensor(relu, arg1_1);  relu = arg1_1 = None
-                return (add,)
-""",
+                relu_default: "f32[2, 4]" = torch.ops.aten.relu.default(arg0_1);  arg0_1 = None
+                add_tensor: "f32[2, 4]" = torch.ops.aten.add.Tensor(relu_default, arg1_1);  relu_default = arg1_1 = None
+                return (add_tensor,)""",
             ignore_empty_lines=True,
         )
 
@@ -16833,27 +16839,23 @@ class GraphModule(torch.nn.Module):
             """\
 class GraphModule(torch.nn.Module):
     def forward(self, x: "f32[2, 4]", y: "f32[4]"):
-        add: "f32[2, 4]" = torch.ops.aten.add.Tensor(x, y);  x = None
-
+        add_tensor: "f32[2, 4]" = torch.ops.aten.add.Tensor(x, y);  x = None
         hints_wrapper_body_graph_0 = self.hints_wrapper_body_graph_0
-        hints_wrapper = torch.ops.higher_order.hints_wrapper(hints_wrapper_body_graph_0, (add, y), {}, hints = {'outer_body': True});  hints_wrapper_body_graph_0 = add = y = None
+        hints_wrapper = torch.ops.higher_order.hints_wrapper(hints_wrapper_body_graph_0, (add_tensor, y), {}, hints = {'outer_body': True});  hints_wrapper_body_graph_0 = add_tensor = y = None
         getitem: "f32[2, 4]" = hints_wrapper[0];  hints_wrapper = None
         return (getitem,)
-
     class hints_wrapper_body_graph_0(torch.nn.Module):
         def forward(self, arg0_1: "f32[2, 4]", arg1_1: "f32[4]"):
             hints_wrapper_body_graph_0 = self.hints_wrapper_body_graph_0
             hints_wrapper = torch.ops.higher_order.hints_wrapper(hints_wrapper_body_graph_0, (arg0_1, arg1_1), {}, hints = {'inner_body': True});  hints_wrapper_body_graph_0 = arg0_1 = arg1_1 = None
             getitem: "f32[2, 4]" = hints_wrapper[0];  hints_wrapper = None
-            abs_1: "f32[2, 4]" = torch.ops.aten.abs.default(getitem);  getitem = None
-            return (abs_1,)
-
+            abs_default: "f32[2, 4]" = torch.ops.aten.abs.default(getitem);  getitem = None
+            return (abs_default,)
         class hints_wrapper_body_graph_0(torch.nn.Module):
             def forward(self, arg0_1: "f32[2, 4]", arg1_1: "f32[4]"):
-                relu: "f32[2, 4]" = torch.ops.aten.relu.default(arg0_1);  arg0_1 = None
-                add: "f32[2, 4]" = torch.ops.aten.add.Tensor(relu, arg1_1);  relu = arg1_1 = None
-                return (add,)
-""",
+                relu_default: "f32[2, 4]" = torch.ops.aten.relu.default(arg0_1);  arg0_1 = None
+                add_tensor: "f32[2, 4]" = torch.ops.aten.add.Tensor(relu_default, arg1_1);  relu_default = arg1_1 = None
+                return (add_tensor,)""",
             ignore_empty_lines=True,
         )
 
@@ -16900,20 +16902,20 @@ def forward(self, x):
     args_0, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
     mod_embedding_weight = self.mod.embedding.weight
     _guards_fn = self._guards_fn(args_0);  _guards_fn = None
-    empty = torch.ops.aten.empty.memory_format([10, 8], dtype = torch.float32, device = device(type='xpu', index=0), pin_memory = False)
-    detach = torch.ops.aten.detach.default(empty);  empty = None
-    submod_6 = self.submod_1
-    to = torch.ops.higher_order.wrap_with_set_grad_enabled(False, submod_6, mod_embedding_weight);  submod_6 = mod_embedding_weight = None
-    getitem = to[0];  to = None
-    set_ = torch.ops.aten.set_.source_Tensor(detach, getitem);  detach = getitem = None
-    view_as = torch.ops.aten.view_as.default(set_, set_);  set_ = None
-    ones = torch.ops.aten.ones.default([4], dtype = torch.int64, device = device(type='xpu', index=0), pin_memory = False)
-    embedding = torch.ops.aten.embedding.default(view_as, ones);  view_as = ones = None
-    sum_1 = torch.ops.aten.sum.default(embedding);  embedding = None
-    sum_2 = torch.ops.aten.sum.default(args_0);  args_0 = None
-    sum_3 = torch.ops.aten.sum.default(sum_1);  sum_1 = None
-    add = torch.ops.aten.add.Tensor(sum_2, sum_3);  sum_2 = sum_3 = None
-    return pytree.tree_unflatten((add,), self._out_spec)""",
+    empty_memory_format = torch.ops.aten.empty.memory_format([10, 8], dtype = torch.float32, device = device(type='xpu', index=0), pin_memory = False)
+    detach_default = torch.ops.aten.detach.default(empty_memory_format);  empty_memory_format = None
+    submod_1 = self.submod_1
+    wrap_with_set_grad_enabled = torch.ops.higher_order.wrap_with_set_grad_enabled(False, submod_1, mod_embedding_weight);  submod_1 = mod_embedding_weight = None
+    getitem = wrap_with_set_grad_enabled[0];  wrap_with_set_grad_enabled = None
+    set__source_tensor = torch.ops.aten.set_.source_Tensor(detach_default, getitem);  detach_default = getitem = None
+    view_as_default = torch.ops.aten.view_as.default(set__source_tensor, set__source_tensor);  set__source_tensor = None
+    ones_default = torch.ops.aten.ones.default([4], dtype = torch.int64, device = device(type='xpu', index=0), pin_memory = False)
+    embedding_default = torch.ops.aten.embedding.default(view_as_default, ones_default);  view_as_default = ones_default = None
+    sum_default = torch.ops.aten.sum.default(embedding_default);  embedding_default = None
+    sum_default_1 = torch.ops.aten.sum.default(args_0);  args_0 = None
+    sum_default_2 = torch.ops.aten.sum.default(sum_default);  sum_default = None
+    add_tensor = torch.ops.aten.add.Tensor(sum_default_1, sum_default_2);  sum_default_1 = sum_default_2 = None
+    return pytree.tree_unflatten((add_tensor,), self._out_spec)""",
             )
 
             inp = torch.randn(4, 4, 4, device=device_type)
@@ -17399,8 +17401,8 @@ def forward(self, x):
             str(ep.graph_module.code).strip(),
             """\
 def forward(self, args_0):
-    abs_1 = torch.ops.aten.abs.default(args_0);  args_0 = None
-    return (abs_1,)""",
+    abs_default = torch.ops.aten.abs.default(args_0);  args_0 = None
+    return (abs_default,)""",
         )
 
     @testing.expectedFailureStrictV2
@@ -17421,37 +17423,37 @@ def forward(self, args_0):
                 ep_math.graph_module.code.strip(),
                 """\
 def forward(self, q, k, v):
-    mul = torch.ops.aten.mul.Scalar(q, 0.29730177875068026);  q = None
-    unsqueeze = torch.ops.aten.unsqueeze.default(k, 2);  k = None
-    expand = torch.ops.aten.expand.default(unsqueeze, [1, 8, 4, 256, 128]);  unsqueeze = None
-    clone = torch.ops.aten.clone.default(expand, memory_format = torch.contiguous_format);  expand = None
-    view = torch.ops.aten.view.default(clone, [1, 32, 256, 128]);  clone = None
-    unsqueeze_1 = torch.ops.aten.unsqueeze.default(v, 2);  v = None
-    expand_1 = torch.ops.aten.expand.default(unsqueeze_1, [1, 8, 4, 256, 128]);  unsqueeze_1 = None
-    clone_1 = torch.ops.aten.clone.default(expand_1, memory_format = torch.contiguous_format);  expand_1 = None
-    view_1 = torch.ops.aten.view.default(clone_1, [1, 32, 256, 128]);  clone_1 = None
-    permute = torch.ops.aten.permute.default(view, [0, 1, 3, 2]);  view = None
-    mul_1 = torch.ops.aten.mul.Scalar(permute, 0.29730177875068026);  permute = None
-    expand_2 = torch.ops.aten.expand.default(mul, [1, 32, 256, 128]);  mul = None
-    view_2 = torch.ops.aten.view.default(expand_2, [32, 256, 128]);  expand_2 = None
-    expand_3 = torch.ops.aten.expand.default(mul_1, [1, 32, 128, 256]);  mul_1 = None
-    view_3 = torch.ops.aten.view.default(expand_3, [32, 128, 256]);  expand_3 = None
-    bmm = torch.ops.aten.bmm.default(view_2, view_3);  view_2 = view_3 = None
-    view_4 = torch.ops.aten.view.default(bmm, [1, 32, 256, 256]);  bmm = None
-    _softmax = torch.ops.aten._softmax.default(view_4, -1, False)
-    eq = torch.ops.aten.eq.Scalar(view_4, -inf);  view_4 = None
-    logical_not = torch.ops.aten.logical_not.default(eq);  eq = None
-    any_1 = torch.ops.aten.any.dim(logical_not, -1, True);  logical_not = None
-    logical_not_1 = torch.ops.aten.logical_not.default(any_1);  any_1 = None
-    full_like = torch.ops.aten.full_like.default(_softmax, 0, pin_memory = False, memory_format = torch.preserve_format)
-    where = torch.ops.aten.where.self(logical_not_1, full_like, _softmax);  logical_not_1 = full_like = _softmax = None
-    expand_4 = torch.ops.aten.expand.default(where, [1, 32, 256, 256]);  where = None
-    view_5 = torch.ops.aten.view.default(expand_4, [32, 256, 256]);  expand_4 = None
-    expand_5 = torch.ops.aten.expand.default(view_1, [1, 32, 256, 128]);  view_1 = None
-    view_6 = torch.ops.aten.view.default(expand_5, [32, 256, 128]);  expand_5 = None
-    bmm_1 = torch.ops.aten.bmm.default(view_5, view_6);  view_5 = view_6 = None
-    view_7 = torch.ops.aten.view.default(bmm_1, [1, 32, 256, 128]);  bmm_1 = None
-    return (view_7,)""",
+    mul_scalar = torch.ops.aten.mul.Scalar(q, 0.29730177875068026);  q = None
+    expand_default = torch.ops.aten.expand.default(mul_scalar, [1, 32, 256, 128]);  mul_scalar = None
+    unsqueeze_default = torch.ops.aten.unsqueeze.default(k, 2);  k = None
+    expand_default_1 = torch.ops.aten.expand.default(unsqueeze_default, [1, 8, 4, 256, 128]);  unsqueeze_default = None
+    clone_default = torch.ops.aten.clone.default(expand_default_1, memory_format = torch.contiguous_format);  expand_default_1 = None
+    unsqueeze_default_1 = torch.ops.aten.unsqueeze.default(v, 2);  v = None
+    expand_default_2 = torch.ops.aten.expand.default(unsqueeze_default_1, [1, 8, 4, 256, 128]);  unsqueeze_default_1 = None
+    clone_default_1 = torch.ops.aten.clone.default(expand_default_2, memory_format = torch.contiguous_format);  expand_default_2 = None
+    view_default = torch.ops.aten.view.default(expand_default, [32, 256, 128]);  expand_default = None
+    view_default_1 = torch.ops.aten.view.default(clone_default, [1, 32, 256, 128]);  clone_default = None
+    permute_default = torch.ops.aten.permute.default(view_default_1, [0, 1, 3, 2]);  view_default_1 = None
+    mul_scalar_1 = torch.ops.aten.mul.Scalar(permute_default, 0.29730177875068026);  permute_default = None
+    expand_default_3 = torch.ops.aten.expand.default(mul_scalar_1, [1, 32, 128, 256]);  mul_scalar_1 = None
+    view_default_2 = torch.ops.aten.view.default(clone_default_1, [1, 32, 256, 128]);  clone_default_1 = None
+    expand_default_4 = torch.ops.aten.expand.default(view_default_2, [1, 32, 256, 128]);  view_default_2 = None
+    view_default_3 = torch.ops.aten.view.default(expand_default_3, [32, 128, 256]);  expand_default_3 = None
+    bmm_default = torch.ops.aten.bmm.default(view_default, view_default_3);  view_default = view_default_3 = None
+    view_default_4 = torch.ops.aten.view.default(expand_default_4, [32, 256, 128]);  expand_default_4 = None
+    view_default_5 = torch.ops.aten.view.default(bmm_default, [1, 32, 256, 256]);  bmm_default = None
+    _softmax_default = torch.ops.aten._softmax.default(view_default_5, -1, False)
+    eq_scalar = torch.ops.aten.eq.Scalar(view_default_5, -inf);  view_default_5 = None
+    full_like_default = torch.ops.aten.full_like.default(_softmax_default, 0, pin_memory = False, memory_format = torch.preserve_format)
+    logical_not_default = torch.ops.aten.logical_not.default(eq_scalar);  eq_scalar = None
+    any_dim = torch.ops.aten.any.dim(logical_not_default, -1, True);  logical_not_default = None
+    logical_not_default_1 = torch.ops.aten.logical_not.default(any_dim);  any_dim = None
+    where_self = torch.ops.aten.where.self(logical_not_default_1, full_like_default, _softmax_default);  logical_not_default_1 = full_like_default = _softmax_default = None
+    expand_default_5 = torch.ops.aten.expand.default(where_self, [1, 32, 256, 256]);  where_self = None
+    view_default_6 = torch.ops.aten.view.default(expand_default_5, [32, 256, 256]);  expand_default_5 = None
+    bmm_default_1 = torch.ops.aten.bmm.default(view_default_6, view_default_4);  view_default_6 = view_default_4 = None
+    view_default_7 = torch.ops.aten.view.default(bmm_default_1, [1, 32, 256, 128]);  bmm_default_1 = None
+    return (view_default_7,)""",
             )
         with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
             ep_flash = export(Foo(), (q, k, v))
@@ -17460,40 +17462,40 @@ def forward(self, q, k, v):
                 ep_flash.graph_module.code.strip(),
                 """\
 def forward(self, q, k, v):
-    mul = torch.ops.aten.mul.Scalar(q, 0.29730177875068026);  q = None
-    unsqueeze = torch.ops.aten.unsqueeze.default(k, 2);  k = None
-    expand = torch.ops.aten.expand.default(unsqueeze, [1, 8, 4, 256, 128]);  unsqueeze = None
-    clone = torch.ops.aten.clone.default(expand, memory_format = torch.contiguous_format);  expand = None
-    view = torch.ops.aten.view.default(clone, [1, 32, 256, 128]);  clone = None
-    unsqueeze_1 = torch.ops.aten.unsqueeze.default(v, 2);  v = None
-    expand_1 = torch.ops.aten.expand.default(unsqueeze_1, [1, 8, 4, 256, 128]);  unsqueeze_1 = None
-    clone_1 = torch.ops.aten.clone.default(expand_1, memory_format = torch.contiguous_format);  expand_1 = None
-    view_1 = torch.ops.aten.view.default(clone_1, [1, 32, 256, 128]);  clone_1 = None
-    permute = torch.ops.aten.permute.default(view, [0, 1, 3, 2]);  view = None
-    mul_1 = torch.ops.aten.mul.Scalar(permute, 0.29730177875068026);  permute = None
-    expand_2 = torch.ops.aten.expand.default(mul, [1, 32, 256, 128]);  mul = None
-    view_2 = torch.ops.aten.view.default(expand_2, [32, 256, 128]);  expand_2 = None
-    expand_3 = torch.ops.aten.expand.default(mul_1, [1, 32, 128, 256]);  mul_1 = None
-    view_3 = torch.ops.aten.view.default(expand_3, [32, 128, 256]);  expand_3 = None
-    bmm = torch.ops.aten.bmm.default(view_2, view_3);  view_2 = view_3 = None
-    view_4 = torch.ops.aten.view.default(bmm, [1, 32, 256, 256]);  bmm = None
-    _softmax = torch.ops.aten._softmax.default(view_4, -1, False)
-    eq = torch.ops.aten.eq.Scalar(view_4, -inf);  view_4 = None
-    logical_not = torch.ops.aten.logical_not.default(eq);  eq = None
-    any_1 = torch.ops.aten.any.dim(logical_not, -1, True);  logical_not = None
-    logical_not_1 = torch.ops.aten.logical_not.default(any_1);  any_1 = None
-    full_like = torch.ops.aten.full_like.default(_softmax, 0, pin_memory = False, memory_format = torch.preserve_format)
-    where = torch.ops.aten.where.self(logical_not_1, full_like, _softmax);  logical_not_1 = full_like = _softmax = None
-    expand_4 = torch.ops.aten.expand.default(where, [1, 32, 256, 256]);  where = None
-    view_5 = torch.ops.aten.view.default(expand_4, [32, 256, 256]);  expand_4 = None
-    expand_5 = torch.ops.aten.expand.default(view_1, [1, 32, 256, 128]);  view_1 = None
-    view_6 = torch.ops.aten.view.default(expand_5, [32, 256, 128]);  expand_5 = None
-    bmm_1 = torch.ops.aten.bmm.default(view_5, view_6);  view_5 = view_6 = None
-    view_7 = torch.ops.aten.view.default(bmm_1, [1, 32, 256, 128]);  bmm_1 = None
-    permute_1 = torch.ops.aten.permute.default(view_7, [2, 0, 1, 3]);  view_7 = None
-    clone_2 = torch.ops.aten.clone.default(permute_1, memory_format = torch.contiguous_format);  permute_1 = None
-    permute_2 = torch.ops.aten.permute.default(clone_2, [1, 2, 0, 3]);  clone_2 = None
-    return (permute_2,)""",
+    mul_scalar = torch.ops.aten.mul.Scalar(q, 0.29730177875068026);  q = None
+    expand_default = torch.ops.aten.expand.default(mul_scalar, [1, 32, 256, 128]);  mul_scalar = None
+    unsqueeze_default = torch.ops.aten.unsqueeze.default(k, 2);  k = None
+    expand_default_1 = torch.ops.aten.expand.default(unsqueeze_default, [1, 8, 4, 256, 128]);  unsqueeze_default = None
+    clone_default = torch.ops.aten.clone.default(expand_default_1, memory_format = torch.contiguous_format);  expand_default_1 = None
+    unsqueeze_default_1 = torch.ops.aten.unsqueeze.default(v, 2);  v = None
+    expand_default_2 = torch.ops.aten.expand.default(unsqueeze_default_1, [1, 8, 4, 256, 128]);  unsqueeze_default_1 = None
+    clone_default_1 = torch.ops.aten.clone.default(expand_default_2, memory_format = torch.contiguous_format);  expand_default_2 = None
+    view_default = torch.ops.aten.view.default(expand_default, [32, 256, 128]);  expand_default = None
+    view_default_1 = torch.ops.aten.view.default(clone_default, [1, 32, 256, 128]);  clone_default = None
+    permute_default = torch.ops.aten.permute.default(view_default_1, [0, 1, 3, 2]);  view_default_1 = None
+    mul_scalar_1 = torch.ops.aten.mul.Scalar(permute_default, 0.29730177875068026);  permute_default = None
+    expand_default_3 = torch.ops.aten.expand.default(mul_scalar_1, [1, 32, 128, 256]);  mul_scalar_1 = None
+    view_default_2 = torch.ops.aten.view.default(clone_default_1, [1, 32, 256, 128]);  clone_default_1 = None
+    expand_default_4 = torch.ops.aten.expand.default(view_default_2, [1, 32, 256, 128]);  view_default_2 = None
+    view_default_3 = torch.ops.aten.view.default(expand_default_3, [32, 128, 256]);  expand_default_3 = None
+    bmm_default = torch.ops.aten.bmm.default(view_default, view_default_3);  view_default = view_default_3 = None
+    view_default_4 = torch.ops.aten.view.default(expand_default_4, [32, 256, 128]);  expand_default_4 = None
+    view_default_5 = torch.ops.aten.view.default(bmm_default, [1, 32, 256, 256]);  bmm_default = None
+    _softmax_default = torch.ops.aten._softmax.default(view_default_5, -1, False)
+    eq_scalar = torch.ops.aten.eq.Scalar(view_default_5, -inf);  view_default_5 = None
+    full_like_default = torch.ops.aten.full_like.default(_softmax_default, 0, pin_memory = False, memory_format = torch.preserve_format)
+    logical_not_default = torch.ops.aten.logical_not.default(eq_scalar);  eq_scalar = None
+    any_dim = torch.ops.aten.any.dim(logical_not_default, -1, True);  logical_not_default = None
+    logical_not_default_1 = torch.ops.aten.logical_not.default(any_dim);  any_dim = None
+    where_self = torch.ops.aten.where.self(logical_not_default_1, full_like_default, _softmax_default);  logical_not_default_1 = full_like_default = _softmax_default = None
+    expand_default_5 = torch.ops.aten.expand.default(where_self, [1, 32, 256, 256]);  where_self = None
+    view_default_6 = torch.ops.aten.view.default(expand_default_5, [32, 256, 256]);  expand_default_5 = None
+    bmm_default_1 = torch.ops.aten.bmm.default(view_default_6, view_default_4);  view_default_6 = view_default_4 = None
+    view_default_7 = torch.ops.aten.view.default(bmm_default_1, [1, 32, 256, 128]);  bmm_default_1 = None
+    permute_default_1 = torch.ops.aten.permute.default(view_default_7, [2, 0, 1, 3]);  view_default_7 = None
+    clone_default_2 = torch.ops.aten.clone.default(permute_default_1, memory_format = torch.contiguous_format);  permute_default_1 = None
+    permute_default_2 = torch.ops.aten.permute.default(clone_default_2, [1, 2, 0, 3]);  clone_default_2 = None
+    return (permute_default_2,)""",
             )
         # test backend check for invalid inputs
         error_type = (

--- a/test/xpu/export/test_export_xpu.py
+++ b/test/xpu/export/test_export_xpu.py
@@ -5231,6 +5231,7 @@ def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, b_
             self.assertFalse(torch.ops.mylib.foo123.default in table)
             table.materialize()
             self.assertFalse(torch.ops.mylib.foo123.default in table)
+
     def test_if_post_autograd_op_preserved(self):
         class Foo(torch.nn.Module):
             def forward(self, x):
@@ -15930,6 +15931,7 @@ graph():
             dynamo_graph_capture_for_export(Foo())(
                 Block(torch.randn(4, 4), torch.randn(4, 4))
             )
+
     def test_enum_str(self):
         class TensorDim(str, enum.Enum):
             DDP = "ddp"

--- a/test/xpu/export/test_export_xpu.py
+++ b/test/xpu/export/test_export_xpu.py
@@ -2742,28 +2742,28 @@ class GraphModule(torch.nn.Module):
         x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
         _guards_fn = self._guards_fn(x);  _guards_fn = None
 
-        sum_1: "f32[]" = torch.ops.aten.sum.default(x)
-        gt: "b8[]" = torch.ops.aten.gt.Scalar(sum_1, 3);  sum_1 = None
+        sum_default: "f32[]" = torch.ops.aten.sum.default(x)
+        gt_scalar: "b8[]" = torch.ops.aten.gt.Scalar(sum_default, 3);  sum_default = None
 
-        true_graph_0 = self.true_graph_0
         false_graph_0 = self.false_graph_0
-        cond = torch.ops.higher_order.cond(gt, true_graph_0, false_graph_0, ());  gt = true_graph_0 = false_graph_0 = None
-        getitem_1: "Sym(u0)" = cond[0];  cond = None
-        ge_1: "Sym(u0 >= 0)" = getitem_1 >= 0
-        _assert_scalar_default = torch.ops.aten._assert_scalar.default(ge_1, "Runtime assertion failed for expression u0 >= 0 on node 'ge_1'");  ge_1 = _assert_scalar_default = None
-        le_1: "Sym(u0 <= 1)" = getitem_1 <= 1
-        _assert_scalar_default_1 = torch.ops.aten._assert_scalar.default(le_1, "Runtime assertion failed for expression u0 <= 1 on node 'le_1'");  le_1 = _assert_scalar_default_1 = None
+        true_graph_0 = self.true_graph_0
+        cond = torch.ops.higher_order.cond(gt_scalar, true_graph_0, false_graph_0, ());  gt_scalar = true_graph_0 = false_graph_0 = None
+        getitem: "Sym(u0)" = cond[0];  cond = None
+        ge: "Sym(u0 >= 0)" = getitem >= 0
+        _assert_scalar_default = torch.ops.aten._assert_scalar.default(ge, "Runtime assertion failed for expression u0 >= 0 on node 'ge_1'");  ge = _assert_scalar_default = None
+        le: "Sym(u0 <= 1)" = getitem <= 1
+        _assert_scalar_default_1 = torch.ops.aten._assert_scalar.default(le, "Runtime assertion failed for expression u0 <= 1 on node 'le_1'");  le = _assert_scalar_default_1 = None
 
-        select: "f32[3]" = torch.ops.aten.select.int(x, 0, getitem_1);  x = getitem_1 = None
-        return pytree.tree_unflatten((select,), self._out_spec)
-
-    class true_graph_0(torch.nn.Module):
-        def forward(self):
-            return (0,)
+        select_int: "f32[3]" = torch.ops.aten.select.int(x, 0, getitem);  x = getitem = None
+        return pytree.tree_unflatten((select_int,), self._out_spec)
 
     class false_graph_0(torch.nn.Module):
         def forward(self):
             return (1,)
+
+    class true_graph_0(torch.nn.Module):
+        def forward(self):
+            return (0,)
 """,  # noqa: B950
             )
         self.assertEqual(m(*args), ep.module()(*args))
@@ -2817,22 +2817,22 @@ class GraphModule(torch.nn.Module):
         x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
         _guards_fn = self._guards_fn(x);  _guards_fn = None
 
-        sum_1: "f32[]" = torch.ops.aten.sum.default(x)
-        gt: "b8[]" = torch.ops.aten.gt.Scalar(sum_1, 3);  sum_1 = None
+        sum_default: "f32[]" = torch.ops.aten.sum.default(x)
+        gt_scalar: "b8[]" = torch.ops.aten.gt.Scalar(sum_default, 3);  sum_default = None
 
-        true_graph_0 = self.true_graph_0
         false_graph_0 = self.false_graph_0
-        cond = torch.ops.higher_order.cond(gt, true_graph_0, false_graph_0, ());  gt = true_graph_0 = false_graph_0 = None
+        true_graph_0 = self.true_graph_0
+        cond = torch.ops.higher_order.cond(gt_scalar, true_graph_0, false_graph_0, ());  gt_scalar = true_graph_0 = false_graph_0 = None
         getitem = cond[0];  cond = getitem = None
 
-        select: "f32[3]" = torch.ops.aten.select.int(x, 0, 0);  x = None
-        return pytree.tree_unflatten((select,), self._out_spec)
+        select_int: "f32[3]" = torch.ops.aten.select.int(x, 0, 0);  x = None
+        return pytree.tree_unflatten((select_int,), self._out_spec)
 
-    class true_graph_0(torch.nn.Module):
+    class false_graph_0(torch.nn.Module):
         def forward(self):
             return (0,)
 
-    class false_graph_0(torch.nn.Module):
+    class true_graph_0(torch.nn.Module):
         def forward(self):
             return (0,)
 """,  # noqa: B950
@@ -3460,18 +3460,18 @@ def forward(self, add_tensor):
             str(ep.graph_module.code).strip(),
             """\
 def forward(self, x, y):
-    foo = torch.ops.export.foo.default(x, y);  x = None
-    sym_size_int = torch.ops.aten.sym_size.int(foo, 0)
-    sym_size_int_1 = torch.ops.aten.sym_size.int(foo, 1)
+    foo_default = torch.ops.export.foo.default(x, y);  x = None
+    sym_size_int = torch.ops.aten.sym_size.int(foo_default, 0)
     ge = sym_size_int >= 0;  sym_size_int = None
+    sym_size_int_1 = torch.ops.aten.sym_size.int(foo_default, 1)
     _assert_scalar_default = torch.ops.aten._assert_scalar.default(ge, "Runtime assertion failed for expression u0 >= 0 on node 'ge'");  ge = _assert_scalar_default = None
     ge_1 = sym_size_int_1 >= 0;  sym_size_int_1 = None
     _assert_scalar_default_1 = torch.ops.aten._assert_scalar.default(ge_1, "Runtime assertion failed for expression u1 >= 0 on node 'ge_1'");  ge_1 = _assert_scalar_default_1 = None
-    bar = torch.ops.export.bar.default(y);  y = None
-    sym_size_int_2 = torch.ops.aten.sym_size.int(bar, 0)
+    bar_default = torch.ops.export.bar.default(y);  y = None
+    sym_size_int_2 = torch.ops.aten.sym_size.int(bar_default, 0)
     ge_2 = sym_size_int_2 >= 0;  sym_size_int_2 = None
     _assert_scalar_default_2 = torch.ops.aten._assert_scalar.default(ge_2, "Runtime assertion failed for expression u2 >= 0 on node 'ge_2'");  ge_2 = _assert_scalar_default_2 = None
-    return (foo, bar)""",
+    return (foo_default, bar_default)""",
         )
 
     def test_draft_export_fake_kernel_inference_errors(self):
@@ -17682,8 +17682,8 @@ class TestOneOffModelExportResult(TestCase):
         ).run_decompositions()
         code_str = """\
 def forward(self, q, k, v):
-    _scaled_dot_product_flash_attention = torch.ops.aten._scaled_dot_product_flash_attention.default(q, k, v, 0.0, True, scale = 0.125);  q = k = v = None
-    getitem = _scaled_dot_product_flash_attention[0];  _scaled_dot_product_flash_attention = None
+    _scaled_dot_product_flash_attention_default = torch.ops.aten._scaled_dot_product_flash_attention.default(q, k, v, 0.0, True, scale = 0.125);  q = k = v = None
+    getitem = _scaled_dot_product_flash_attention_default[0];  _scaled_dot_product_flash_attention_default = None
     return (getitem,)"""
         try:
             self.assertExpectedInline(
@@ -17693,8 +17693,8 @@ def forward(self, q, k, v):
         except AssertionError:
             code_str = """\
 def forward(self, q, k, v):
-    _scaled_dot_product_cudnn_attention = torch.ops.aten._scaled_dot_product_cudnn_attention.default(q, k, v, None, False, 0.0, True);  q = k = v = None
-    getitem = _scaled_dot_product_cudnn_attention[0];  _scaled_dot_product_cudnn_attention = None
+    _scaled_dot_product_cudnn_attention_default = torch.ops.aten._scaled_dot_product_cudnn_attention.default(q, k, v, None, False, 0.0, True);  q = k = v = None
+    getitem = _scaled_dot_product_cudnn_attention_default[0];  _scaled_dot_product_cudnn_attention_default = None
     return (getitem,)"""
             try:
                 self.assertExpectedInline(
@@ -17705,8 +17705,8 @@ def forward(self, q, k, v):
                 # XPU uses _scaled_dot_product_fused_attention_overrideable
                 code_str = """\
 def forward(self, q, k, v):
-    _scaled_dot_product_fused_attention_overrideable = torch.ops.aten._scaled_dot_product_fused_attention_overrideable.default(q, k, v, None, 0.0, True);  q = k = v = None
-    getitem = _scaled_dot_product_fused_attention_overrideable[0];  _scaled_dot_product_fused_attention_overrideable = None
+    _scaled_dot_product_fused_attention_overrideable_default = torch.ops.aten._scaled_dot_product_fused_attention_overrideable.default(q, k, v, None, 0.0, True);  q = k = v = None
+    getitem = _scaled_dot_product_fused_attention_overrideable_default[0];  _scaled_dot_product_fused_attention_overrideable_default = None
     return (getitem,)"""
                 self.assertExpectedInline(
                     ep.graph_module.code.strip(),
@@ -17845,10 +17845,10 @@ def forward(self, q, k, v):
             gm.code.strip(),
             """\
 def forward(self, x):
-    add = torch.ops.aten.add.Tensor(x, x);  x = None
-    mul = torch.ops.aten.mul.Tensor(add, add)
-    add_1 = torch.ops.aten.add.Tensor(mul, mul);  mul = None
-    return (add, add_1)""",
+    add_tensor = torch.ops.aten.add.Tensor(x, x);  x = None
+    mul_tensor = torch.ops.aten.mul.Tensor(add_tensor, add_tensor)
+    add_tensor_1 = torch.ops.aten.add.Tensor(mul_tensor, mul_tensor);  mul_tensor = None
+    return (add_tensor, add_tensor_1)""",
         )
 
     def test_print_graph_signature(self):
@@ -17871,7 +17871,7 @@ b_buf: BUFFER target='buf' persistent=True
 x: USER_INPUT
 
 # outputs
-add: USER_OUTPUT""",
+add_tensor: USER_OUTPUT""",
         )
 
         ep = ep.run_decompositions({})
@@ -17883,9 +17883,9 @@ b_buf: BUFFER target='buf' persistent=True
 x: USER_INPUT
 
 # outputs
-add_1: BUFFER_MUTATION target='buf'
-add: USER_INPUT_MUTATION target='x'
-add_2: USER_OUTPUT""",
+add_tensor_1: BUFFER_MUTATION target='buf'
+add_tensor: USER_INPUT_MUTATION target='x'
+add_tensor_2: USER_OUTPUT""",
         )
 
     @unittest.skipIf(not TEST_TRANSFORMERS, "No transformers")
@@ -17926,8 +17926,8 @@ def forward(self, x):
             gm.code.strip(),
             """\
 def forward(self, x):
-    add = torch.ops.aten.add.Tensor(x, x);  x = None
-    return (add,)""",
+    add_tensor = torch.ops.aten.add.Tensor(x, x);  x = None
+    return (add_tensor,)""",
         )
 
     def test_logging_logger(self):
@@ -17949,10 +17949,10 @@ def forward(self, x):
             gm.code.strip(),
             """\
 def forward(self, x):
-    add = torch.ops.aten.add.Tensor(x, x);  x = None
-    mul = torch.ops.aten.mul.Tensor(add, add)
-    add_1 = torch.ops.aten.add.Tensor(mul, mul);  mul = None
-    return (add, add_1)""",
+    add_tensor = torch.ops.aten.add.Tensor(x, x);  x = None
+    mul_tensor = torch.ops.aten.mul.Tensor(add_tensor, add_tensor)
+    add_tensor_1 = torch.ops.aten.add.Tensor(mul_tensor, mul_tensor);  mul_tensor = None
+    return (add_tensor, add_tensor_1)""",
         )
 
     def test_constant_fqn(self):

--- a/test/xpu/export/test_export_xpu.py
+++ b/test/xpu/export/test_export_xpu.py
@@ -18357,7 +18357,8 @@ class TestExportCustomClass(TorchTestCase):
                 raise AssertionError(f"Key {k} already exists in ep.constants")
             ep._constants[k] = v
         serialized_vals = serialize(ep)
-        deserialized_ep = deserialize(serialized_vals)
+        with torch.serialization.safe_globals([torch.ScriptObject]):
+            deserialized_ep = deserialize(serialized_vals)
 
         for node in deserialized_ep.graph.nodes:
             if (

--- a/test/xpu/export/test_export_xpu.py
+++ b/test/xpu/export/test_export_xpu.py
@@ -5231,8 +5231,6 @@ def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, b_
             self.assertFalse(torch.ops.mylib.foo123.default in table)
             table.materialize()
             self.assertFalse(torch.ops.mylib.foo123.default in table)
-
-    @testing.expectedFailureStrictV2
     def test_if_post_autograd_op_preserved(self):
         class Foo(torch.nn.Module):
             def forward(self, x):
@@ -10534,7 +10532,6 @@ def forward(self, p_lin_weight, p_lin_bias, x):
         )
 
     @unittest.skipIf(IS_FBCODE, "We can't customize decomp in fbcode")
-    @testing.expectedFailureStrictV2
     def test_export_decomp_torture_case_2(self):
         class MyLinear(torch.nn.Module):
             def __init__(self) -> None:
@@ -15933,8 +15930,6 @@ graph():
             dynamo_graph_capture_for_export(Foo())(
                 Block(torch.randn(4, 4), torch.randn(4, 4))
             )
-
-    @testing.expectedFailureStrictV2
     def test_enum_str(self):
         class TensorDim(str, enum.Enum):
             DDP = "ddp"

--- a/test/xpu/export/test_export_xpu.py
+++ b/test/xpu/export/test_export_xpu.py
@@ -9970,8 +9970,8 @@ def forward(self, x):
                 ep.graph_module.code.strip(),
                 """\
 def forward(self, b_a_buffer, x):
-    sym_size_int_1 = torch.ops.aten.sym_size.int(x, 0)
-    gt = sym_size_int_1 > 4;  sym_size_int_1 = None
+    sym_size_int = torch.ops.aten.sym_size.int(x, 0)
+    gt = sym_size_int > 4;  sym_size_int = None
     true_graph_0 = self.true_graph_0
     false_graph_0 = self.false_graph_0
     cond = torch.ops.higher_order.cond(gt, true_graph_0, false_graph_0, [x, b_a_buffer]);  gt = true_graph_0 = false_graph_0 = x = b_a_buffer = None

--- a/test/xpu/export/test_serdes_xpu.py
+++ b/test/xpu/export/test_serdes_xpu.py
@@ -12,7 +12,11 @@
 
 # Owner(s): ["module: intel"]
 
+import inspect
 import io
+
+import torch
+from torch._export.serde import serialize as serde_serialize
 
 try:
     import testing_xpu as testing
@@ -27,6 +31,23 @@ from torch.export import export, load, save
 test_classes = {}
 
 
+def _module_safe_globals():
+    # SerDes round-trips can contain test helper classes and torch.nn module classes.
+    test_classes = [
+        obj
+        for _, obj in inspect.getmembers(test_export_xpu, inspect.isclass)
+        if obj.__module__ == test_export_xpu.__name__
+    ]
+    nn_classes = [obj for _, obj in inspect.getmembers(torch.nn, inspect.isclass)]
+    serde_helpers = [serde_serialize._reconstruct_fake_tensor]
+    return test_classes + nn_classes + serde_helpers
+
+
+def _load_with_safe_globals(buffer):
+    with torch.serialization.safe_globals(_module_safe_globals()):
+        return load(buffer)
+
+
 def mocked_serder_export_strict(*args, **kwargs):
     if "strict" not in kwargs:
         ep = export(*args, **kwargs, strict=True)
@@ -36,7 +57,7 @@ def mocked_serder_export_strict(*args, **kwargs):
     buffer = io.BytesIO()
     save(ep, buffer)
     buffer.seek(0)
-    loaded_ep = load(buffer)
+    loaded_ep = _load_with_safe_globals(buffer)
     return loaded_ep
 
 
@@ -45,7 +66,7 @@ def mocked_serder_export_non_strict(*args, **kwargs):
     buffer = io.BytesIO()
     save(ep, buffer)
     buffer.seek(0)
-    loaded_ep = load(buffer)
+    loaded_ep = _load_with_safe_globals(buffer)
     return loaded_ep
 
 


### PR DESCRIPTION
Fixed issues with functions in tests not using safeglobals (`_module_safe_globals()`)
Fixes: https://github.com/intel/torch-xpu-ops/issues/4746 https://github.com/intel/torch-xpu-ops/issues/4749

Updated node names with new ones added in upstream.
Fixes: https://github.com/intel/torch-xpu-ops/issues/4747 https://github.com/intel/torch-xpu-ops/issues/4748  https://github.com/intel/torch-xpu-ops/issues/4750 https://github.com/intel/torch-xpu-ops/issues/4752


