### PR TITLE
[CI] Use ARC Ubuntu runner for hosted workflow jobs

### DIFF
--- a/.ci/docker/ubuntu/Dockerfile
+++ b/.ci/docker/ubuntu/Dockerfile
@@ -77,11 +77,12 @@ COPY ./common/install_xpu.sh /tmp/install_xpu.sh
 RUN bash /tmp/install_xpu.sh && \
     rm -f /tmp/install_xpu.sh
 
-# Install Conda
+# Install Conda to skip RC to avoid issues with non-interactive shells
+ENV CONDA_INIT_NO_RC=1
 RUN wget -qO /tmp/Miniforge3.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-$(uname -m).sh && \
-    bash /tmp/Miniforge3.sh -b -p /opt/conda && \
+    bash /tmp/Miniforge3.sh -b -u -p /opt/conda && \
     rm /tmp/Miniforge3.sh && \
-    /opt/conda/bin/conda clean -all -y
+    /opt/conda/bin/conda clean -afy
 
 ENV PATH=/opt/conda/bin:$PATH
 

--- a/.claude/skills/action/runner/arc-runner/SKILL.md
+++ b/.claude/skills/action/runner/arc-runner/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: arc-runner-solution
+description: Use for the ARC + K8s GitHub Actions runner solution for intel/torch-xpu-ops, including why it is used, what it provides, how to implement it, and how it works.
+---
+
+# ARC Runner Solution
+
+## 1. Why To Use
+
+Use ARC + K8s to provide stable, elastic GitHub Actions runners for `intel/torch-xpu-ops` on the local node.
+
+This solution is preferred because it:
+
+- Runs jobs in clean ephemeral runner pods.
+- Scales from zero idle runners to the required job capacity while leaving node headroom for ARC and K8s control components.
+- Avoids managing many long-running runner services by hand.
+- Uses Kubernetes scheduling, isolation, lifecycle management, and resource limits.
+- Bakes common tools into the runner image to avoid installing them during every job.
+- Reuses selected cache directories across ephemeral pods to reduce setup time.
+- Keeps `ubuntu-24.04` GitHub-hosted runners separate from the local self-hosted label.
+
+## 2. What Can Do
+
+The active setup provides:
+
+- Repository: `https://github.com/intel/torch-xpu-ops`
+- Workflow label: `xpu-ubuntu-24.04`
+- Helm release: `xpu-ubuntu-24-04`
+- Runner namespace: `arc-runners`
+- Controller namespace: `arc-systems`
+- Runner image: `arc-xpu-runner:ubuntu-24.04-tools`
+- Preinstalled tools: `git`, `gh`, `curl`, `wget`, `rsync`, `ca-certificates`
+- Default timezone: UTC
+- Runner OS: Ubuntu 24.04
+- Minimum runners: `0`
+- Maximum runners: `12`
+- Per-runner resources: `4` CPU and `16Gi` memory
+- Total runner CPU budget: `48` whole CPUs, below the node physical-core count so controller and system processes keep reserved headroom
+- Target node: `skx3725`
+- Runner pods use host-aligned UID/GID `1000:1000`, are non-privileged, use RuntimeDefault seccomp, drop Linux capabilities, and do not mount a K8s service account token.
+- Cache mounts: `/home/runner/.cache` and `/opt/hostedtoolcache`
+
+Workflows that should use this node must set:
+
+```yaml
+runs-on: xpu-ubuntu-24.04
+```
+
+## 3. How To Implement
+
+Store the scale set configuration in `arc-xpu-ubuntu-24.04-values.yaml`:
+
+```yaml
+githubConfigUrl: https://github.com/intel/torch-xpu-ops
+githubConfigSecret: github-token
+
+runnerScaleSetName: xpu-ubuntu-24.04
+scaleSetLabels:
+  - ubuntu-24.04
+
+minRunners: 0
+maxRunners: 12
+
+template:
+  spec:
+    automountServiceAccountToken: false
+    nodeSelector:
+      kubernetes.io/hostname: skx3725
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+    initContainers:
+      - name: prepare-runner-cache
+        image: busybox:1.36
+        command:
+          - sh
+          - -c
+          - chown -R 1000:1000 /home-cache /tool-cache
+        securityContext:
+          privileged: false
+          allowPrivilegeEscalation: false
+          runAsUser: 0
+          runAsGroup: 0
+          capabilities:
+            drop:
+              - ALL
+            add:
+              - CHOWN
+        volumeMounts:
+          - name: runner-home-cache
+            mountPath: /home-cache
+          - name: runner-tool-cache
+            mountPath: /tool-cache
+    containers:
+      - name: runner
+        image: arc-xpu-runner:ubuntu-24.04-tools
+        imagePullPolicy: IfNotPresent
+        command:
+          - /home/runner/run.sh
+        env:
+          - name: ACTIONS_RUNNER_TOOL_CACHE
+            value: /opt/hostedtoolcache
+        securityContext:
+          privileged: false
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          capabilities:
+            drop:
+              - ALL
+        resources:
+          requests:
+            cpu: "4"
+            memory: 16Gi
+          limits:
+            cpu: "4"
+            memory: 16Gi
+        volumeMounts:
+          - name: runner-home-cache
+            mountPath: /home/runner/.cache
+          - name: runner-tool-cache
+            mountPath: /opt/hostedtoolcache
+    volumes:
+      - name: runner-home-cache
+        hostPath:
+          path: /var/cache/arc/xpu-ubuntu-24.04/home-cache
+          type: DirectoryOrCreate
+      - name: runner-tool-cache
+        hostPath:
+          path: /var/cache/arc/xpu-ubuntu-24.04/tool-cache
+          type: DirectoryOrCreate
+```
+
+Build and import the custom image on the node before deploying the scale set:
+
+```bash
+docker build -t arc-xpu-runner:ubuntu-24.04-tools -f Dockerfile.arc-runner-ubuntu-24.04 .
+docker save arc-xpu-runner:ubuntu-24.04-tools -o /tmp/arc-xpu-runner-ubuntu-24.04-tools.tar
+sudo -n ctr images import /tmp/arc-xpu-runner-ubuntu-24.04-tools.tar
+rm -f /tmp/arc-xpu-runner-ubuntu-24.04-tools.tar
+```
+
+Deploy or update the scale set:
+
+```bash
+export KUBECONFIG=/path/to/k8s/k8s.yaml
+helm upgrade --install xpu-ubuntu-24-04 \
+  oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set \
+  --namespace arc-runners \
+  --create-namespace \
+  -f arc-xpu-ubuntu-24.04-values.yaml \
+  --set controllerServiceAccount.name=arc-gha-rs-controller \
+  --set controllerServiceAccount.namespace=arc-systems \
+  --timeout 10m
+```
+
+Credential material must never be printed, logged, pasted, diffed, or committed. Keep the ARC credential object in K8s while the scale set is installed.
+
+## 4. How To Work
+
+ARC creates runners only when GitHub Actions has matching queued jobs.
+
+Normal flow:
+
+1. A workflow job requests `runs-on: xpu-ubuntu-24.04`.
+2. The ARC listener detects queued demand for the scale set.
+3. The ARC controller creates an ephemeral runner pod in `arc-runners`.
+4. The runner registers to `intel/torch-xpu-ops` and executes one job.
+5. After the job finishes, the runner pod exits and is removed.
+6. When no jobs are queued, the scale set returns to zero runner pods.
+
+Healthy idle state:
+
+- Controller pod is running in `arc-systems`.
+- Listener pod is running in `arc-runners`.
+- `AutoscalingRunnerSet/xpu-ubuntu-24.04` has minimum `0` and maximum `12`.
+- No runner pods are running when no matching jobs are queued.

--- a/.claude/skills/action/runner/arc-runner/SKILL.md
+++ b/.claude/skills/action/runner/arc-runner/SKILL.md
@@ -29,7 +29,7 @@ The active setup provides:
 - Runner namespace: `arc-runners`
 - Controller namespace: `arc-systems`
 - Runner image: `arc-xpu-runner:ubuntu-24.04-tools`
-- Preinstalled tools: `git`, `gh`, `curl`, `wget`, `rsync`, `ca-certificates`
+- Preinstalled tools: `git`, `gh`, `curl`, `wget`, `rsync`, `ca-certificates`, `clang`, `clang-tidy`
 - Default timezone: UTC
 - Runner OS: Ubuntu 24.04
 - Minimum runners: `0`

--- a/.github/workflows/_linux_build.yml
+++ b/.github/workflows/_linux_build.yml
@@ -244,7 +244,7 @@ jobs:
   build-status-check:
     needs: [build]
     if: ${{ always() }}
-    runs-on: ubuntu-24.04
+    runs-on: xpu-ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Check build result

--- a/.github/workflows/_linux_e2e_summary.yml
+++ b/.github/workflows/_linux_e2e_summary.yml
@@ -21,7 +21,7 @@ defaults:
 
 jobs:
   summary:
-    runs-on: ubuntu-24.04
+    runs-on: xpu-ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/_linux_op_benchmark.yml
+++ b/.github/workflows/_linux_op_benchmark.yml
@@ -82,7 +82,7 @@ jobs:
 
   op_benchmark_test_results_check:
     needs: op_benchmark
-    runs-on: ubuntu-24.04
+    runs-on: xpu-ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/_linux_reproducer.yml
+++ b/.github/workflows/_linux_reproducer.yml
@@ -125,7 +125,7 @@ jobs:
   summary:
     needs: [reproducer-test]
     if: ${{ ! cancelled() && needs.reproducer-test.result == 'failure' && github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: ubuntu-24.04
+    runs-on: xpu-ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
@@ -195,7 +195,7 @@ jobs:
   reproducer-status-check:
     needs: [reproducer-test]
     if: ${{ always() }}
-    runs-on: ubuntu-24.04
+    runs-on: xpu-ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Check reproducer-test result

--- a/.github/workflows/_linux_test_image.yml
+++ b/.github/workflows/_linux_test_image.yml
@@ -65,7 +65,7 @@ env:
 
 jobs:
   build-image:
-    runs-on: xpu-ubuntu-24.04
+    runs-on: build
     if: ${{ github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Cleanup

--- a/.github/workflows/_linux_test_image.yml
+++ b/.github/workflows/_linux_test_image.yml
@@ -65,7 +65,7 @@ env:
 
 jobs:
   build-image:
-    runs-on: ubuntu-24.04
+    runs-on: xpu-ubuntu-24.04
     if: ${{ github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Cleanup

--- a/.github/workflows/_linux_transformers.yml
+++ b/.github/workflows/_linux_transformers.yml
@@ -301,7 +301,7 @@ jobs:
   report:
     needs: tests
     if: ${{ success() || failure() }}
-    runs-on: ubuntu-24.04
+    runs-on: xpu-ubuntu-24.04
     steps:
       - name: Download reports
         uses: actions/download-artifact@v4

--- a/.github/workflows/_linux_ut.yml
+++ b/.github/workflows/_linux_ut.yml
@@ -144,7 +144,7 @@ jobs:
   summary:
     needs: [test-in-container, test-in-baremetal]
     if: ${{ ! cancelled() && ! (endsWith(needs.test-in-container.result, 'ed') && endsWith(needs.test-in-baremetal.result, 'ed')) && ! inputs.skip_summary }}
-    runs-on: ubuntu-24.04
+    runs-on: xpu-ubuntu-24.04
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/_performance_comparison.yml
+++ b/.github/workflows/_performance_comparison.yml
@@ -20,7 +20,7 @@ jobs:
   Performance-Comparison:
     env:
       GH_TOKEN: ${{ github.token }}
-    runs-on: ubuntu-24.04
+    runs-on: xpu-ubuntu-24.04
     steps:
       - name: Setup python
         uses: actions/setup-python@v5

--- a/.github/workflows/_windows_build.yml
+++ b/.github/workflows/_windows_build.yml
@@ -137,7 +137,7 @@ jobs:
   build-status-check:
     needs: [build]
     if: ${{ always() }}
-    runs-on: ubuntu-24.04
+    runs-on: xpu-ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Check build result

--- a/.github/workflows/_windows_ut.yml
+++ b/.github/workflows/_windows_ut.yml
@@ -260,7 +260,7 @@ jobs:
 
   summary:
     needs: [ut_test]
-    runs-on: ubuntu-24.04
+    runs-on: xpu-ubuntu-24.04
     timeout-minutes: 30
     env:
       GH_TOKEN: ${{ github.token }}
@@ -318,7 +318,7 @@ jobs:
 
   summary_check:
     needs: [summary]
-    runs-on: ubuntu-24.04
+    runs-on: xpu-ubuntu-24.04
     timeout-minutes: 30
     env:
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/acceptance_ondemand.yml
+++ b/.github/workflows/acceptance_ondemand.yml
@@ -164,7 +164,7 @@ jobs:
     name: Compare results
     needs: [target-ut, target-e2e, baseline-ut, baseline-e2e]
     if: ${{ always() && !cancelled() }}
-    runs-on: ubuntu-24.04
+    runs-on: xpu-ubuntu-24.04
     env:
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -27,7 +27,7 @@ jobs:
     if: >-
       ${{ github.repository_owner == 'intel'
       && !contains(github.event.pull_request.labels.*.name, 'disable_auto') }}
-    runs-on: ubuntu-24.04
+    runs-on: xpu-ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/auto_merge_by_comment.yml
+++ b/.github/workflows/auto_merge_by_comment.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   auto-merge:
-    runs-on: ubuntu-latest
+    runs-on: xpu-ubuntu-24.04
     permissions:
       checks: read
       issues: read
@@ -262,7 +262,7 @@ jobs:
   # Dry-run job: triggered by PRs that modify this workflow file.
   # Validates MERGE_TOKEN permissions for each API operation without actually merging.
   token-permission-test:
-    runs-on: ubuntu-latest
+    runs-on: xpu-ubuntu-24.04
     if: github.event_name == 'pull_request'
     steps:
       - name: "Test: Read PR info (pulls.get)"

--- a/.github/workflows/auto_merge_by_comment.yml
+++ b/.github/workflows/auto_merge_by_comment.yml
@@ -263,7 +263,7 @@ jobs:
   # Validates MERGE_TOKEN permissions for each API operation without actually merging.
   token-permission-test:
     runs-on: xpu-ubuntu-24.04
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: "Test: Read PR info (pulls.get)"
         uses: actions/github-script@v7

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -958,7 +958,7 @@ jobs:
 
   token-permission-test:
     runs-on: xpu-ubuntu-24.04
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   parse-command:
-    runs-on: ubuntu-latest
+    runs-on: xpu-ubuntu-24.04
     if: >-
       github.event_name == 'issue_comment'
       && github.event.issue.pull_request
@@ -142,7 +142,7 @@ jobs:
 
   invalid-command:
     needs: parse-command
-    runs-on: ubuntu-latest
+    runs-on: xpu-ubuntu-24.04
     if: needs.parse-command.outputs.command == 'invalid'
     steps:
       - name: Post invalid command message
@@ -159,7 +159,7 @@ jobs:
 
   permission-denied:
     needs: parse-command
-    runs-on: ubuntu-latest
+    runs-on: xpu-ubuntu-24.04
     if: >-
       needs.parse-command.outputs.command != 'invalid'
       && needs.parse-command.outputs.command != 'help'
@@ -187,7 +187,7 @@ jobs:
 
   help:
     needs: parse-command
-    runs-on: ubuntu-latest
+    runs-on: xpu-ubuntu-24.04
     if: needs.parse-command.outputs.command == 'help'
     steps:
       - name: Post help message
@@ -219,7 +219,7 @@ jobs:
 
   merge:
     needs: parse-command
-    runs-on: ubuntu-latest
+    runs-on: xpu-ubuntu-24.04
     if: >-
       needs.parse-command.outputs.command == 'merge'
       && needs.parse-command.outputs.authorized == 'true'
@@ -367,7 +367,7 @@ jobs:
 
   revert:
     needs: parse-command
-    runs-on: ubuntu-latest
+    runs-on: xpu-ubuntu-24.04
     if: >-
       needs.parse-command.outputs.command == 'revert'
       && needs.parse-command.outputs.authorized == 'true'
@@ -405,7 +405,7 @@ jobs:
 
   rebase:
     needs: parse-command
-    runs-on: ubuntu-latest
+    runs-on: xpu-ubuntu-24.04
     if: >-
       needs.parse-command.outputs.command == 'rebase'
       && needs.parse-command.outputs.authorized == 'true'
@@ -501,7 +501,7 @@ jobs:
 
   lint:
     needs: parse-command
-    runs-on: ubuntu-latest
+    runs-on: xpu-ubuntu-24.04
     if: >-
       needs.parse-command.outputs.command == 'lint'
       && needs.parse-command.outputs.authorized == 'true'
@@ -599,7 +599,7 @@ jobs:
 
   rerun:
     needs: parse-command
-    runs-on: ubuntu-latest
+    runs-on: xpu-ubuntu-24.04
     if: >-
       needs.parse-command.outputs.command == 'rerun'
       && needs.parse-command.outputs.authorized == 'true'
@@ -727,7 +727,7 @@ jobs:
 
   review:
     needs: parse-command
-    runs-on: ubuntu-latest
+    runs-on: xpu-ubuntu-24.04
     timeout-minutes: 30
     if: >-
       needs.parse-command.outputs.command == 'review'
@@ -831,7 +831,7 @@ jobs:
 
   ut-check:
     needs: parse-command
-    runs-on: ubuntu-latest
+    runs-on: xpu-ubuntu-24.04
     timeout-minutes: 15
     if: >-
       needs.parse-command.outputs.command == 'ut-check'
@@ -957,7 +957,7 @@ jobs:
             --deterministic
 
   token-permission-test:
-    runs-on: ubuntu-latest
+    runs-on: xpu-ubuntu-24.04
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci_break_monitor.yml
+++ b/.github/workflows/ci_break_monitor.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   ci-monitor:
-    runs-on: ubuntu-latest
+    runs-on: xpu-ubuntu-24.04
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || vars.CI_MONITOR_ENABLED == 'true' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/issue_operator.yml
+++ b/.github/workflows/issue_operator.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   auto-milestone:
-    runs-on: ubuntu-latest
+    runs-on: xpu-ubuntu-24.04
     permissions:
       issues: write
     # Only run when the 'skipped' label is present

--- a/.github/workflows/nightly_ondemand.yml
+++ b/.github/workflows/nightly_ondemand.yml
@@ -59,7 +59,7 @@ jobs:
   Conditions-Filter:
     name: conditions-filter
     if: ${{ github.repository_owner == 'intel' || github.event_name != 'schedule' }}
-    runs-on: ubuntu-24.04
+    runs-on: xpu-ubuntu-24.04
     timeout-minutes: 3
     outputs:
       # Test type, (build or wheel)-(nightly, weekly or ondemand)

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   preci-lint-check:
     if: ${{ github.repository_owner == 'intel' }}
-    runs-on: ubuntu-24.04
+    runs-on: xpu-ubuntu-24.04
     timeout-minutes: 30
     permissions:
       contents: read
@@ -203,7 +203,7 @@ jobs:
 
   conditions-filter-win:
     if: ${{ github.repository_owner == 'intel' && github.event.pull_request.draft == false }}
-    runs-on: ubuntu-24.04
+    runs-on: xpu-ubuntu-24.04
     timeout-minutes: 10
     outputs:
       src_changed: ${{ steps.check-files.outputs.src_changed }}


### PR DESCRIPTION
## Summary
- Replace all explicit GitHub-hosted Ubuntu workflow runner labels (`ubuntu-24.04`, `ubuntu-latest`) with the ARC scale set runner label `xpu-ubuntu-24.04`.
- Keep caller-provided runner inputs and existing container image tags unchanged.
- Cover workflow helper/status jobs as well as CI bot, label, monitor, summary, and comparison jobs that previously ran on GitHub-hosted Ubuntu runners.

## Motivation
GitHub-hosted runners have platform and capacity limitations for this project’s XPU CI usage. Moving these jobs to the ARC-backed `xpu-ubuntu-24.04` runner label keeps CI execution on project-managed self-hosted infrastructure and avoids depending on GitHub-hosted Ubuntu availability for these workflow paths.

If ARC scale set capacity is unavailable, fallback should be handled by the runner infrastructure behind the label or by a future selector workflow. GitHub Actions does not support a true OR fallback directly in one `runs-on` value.


Authored with GitHub Copilot.
