### PR TITLE
Refactor clamp kernel to use AT_DISPATCH_V2 for improved type handling

### DIFF
--- a/src/ATen/native/xpu/sycl/MaxMinElementwiseKernels.cpp
+++ b/src/ATen/native/xpu/sycl/MaxMinElementwiseKernels.cpp
@@ -9,7 +9,7 @@
  */
 
 #include <ATen/AccumulateType.h>
-#include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/TensorIterator.h>
 
@@ -52,20 +52,25 @@ void maximum_kernel(TensorIteratorBase& iter) {
     opmath_symmetric_gpu_kernel_with_scalars<bool>(
         iter, MaximumIntFunctor<bool>());
   } else if (isIntegralType(iter.dtype(), /*includeBool=*/false)) {
-    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "max_elementwise_xpu", [&]() {
-      opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(
-          iter, MaximumIntFunctor<scalar_t>());
-    });
-  } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(
-        at::ScalarType::Half,
-        at::ScalarType::BFloat16,
+    AT_DISPATCH_V2(
         iter.dtype(),
         "max_elementwise_xpu",
-        [&]() {
+        AT_WRAP([&]() {
+          opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(
+              iter, MaximumIntFunctor<scalar_t>());
+        }),
+        AT_EXPAND(AT_INTEGRAL_TYPES_V2));
+  } else {
+    AT_DISPATCH_V2(
+        iter.dtype(),
+        "max_elementwise_xpu",
+        AT_WRAP([&]() {
           opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(
               iter, MaximumFunctor<scalar_t>());
-        });
+        }),
+        AT_EXPAND(AT_FLOATING_TYPES),
+        kHalf,
+        kBFloat16);
   }
 }
 
@@ -102,20 +107,25 @@ void minimum_kernel(TensorIteratorBase& iter) {
     opmath_symmetric_gpu_kernel_with_scalars<bool>(
         iter, MinimumIntFunctor<bool>());
   } else if (isIntegralType(iter.dtype(), /*includeBool=*/false)) {
-    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "min_elementwise_xpu", [&]() {
-      opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(
-          iter, MinimumIntFunctor<scalar_t>());
-    });
-  } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(
-        at::ScalarType::Half,
-        at::ScalarType::BFloat16,
+    AT_DISPATCH_V2(
         iter.dtype(),
         "min_elementwise_xpu",
-        [&]() {
+        AT_WRAP([&]() {
+          opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(
+              iter, MinimumIntFunctor<scalar_t>());
+        }),
+        AT_EXPAND(AT_INTEGRAL_TYPES_V2));
+  } else {
+    AT_DISPATCH_V2(
+        iter.dtype(),
+        "min_elementwise_xpu",
+        AT_WRAP([&]() {
           opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(
               iter, MinimumFunctor<scalar_t>());
-        });
+        }),
+        AT_EXPAND(AT_FLOATING_TYPES),
+        kHalf,
+        kBFloat16);
   }
 }
 
@@ -128,15 +138,16 @@ struct FmaxFunctor {
 
 void fmax_kernel(TensorIteratorBase& iter) {
   if (isFloatingType(iter.common_dtype())) {
-    AT_DISPATCH_FLOATING_TYPES_AND2(
-        at::ScalarType::Half,
-        at::ScalarType::BFloat16,
+    AT_DISPATCH_V2(
         iter.common_dtype(),
         "fmax_xpu",
-        [&]() {
+        AT_WRAP([&]() {
           FmaxFunctor<scalar_t> f;
           opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, f);
-        });
+        }),
+        AT_EXPAND(AT_FLOATING_TYPES),
+        kHalf,
+        kBFloat16);
   } else {
     maximum_kernel(iter);
   }
@@ -151,15 +162,16 @@ struct FminFunctor {
 
 void fmin_kernel(TensorIteratorBase& iter) {
   if (isFloatingType(iter.common_dtype())) {
-    AT_DISPATCH_FLOATING_TYPES_AND2(
-        at::ScalarType::Half,
-        at::ScalarType::BFloat16,
+    AT_DISPATCH_V2(
         iter.common_dtype(),
         "fmin_xpu",
-        [&]() {
+        AT_WRAP([&]() {
           FminFunctor<scalar_t> f;
           opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, f);
-        });
+        }),
+        AT_EXPAND(AT_FLOATING_TYPES),
+        kHalf,
+        kBFloat16);
   } else {
     minimum_kernel(iter);
   }

--- a/src/ATen/native/xpu/sycl/TensorCompareKernels.cpp
+++ b/src/ATen/native/xpu/sycl/TensorCompareKernels.cpp
@@ -103,28 +103,34 @@ void where_kernel(TensorIterator& iter) {
 }
 
 void isposinf_kernel(TensorIteratorBase& iter) {
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      at::ScalarType::Half,
-      at::ScalarType::BFloat16,
+  AT_DISPATCH_V2(
       iter.input_dtype(),
       "isposinf_xpu",
-      [&] { gpu_kernel(iter, IsposinfFunctor<scalar_t>()); });
+      AT_WRAP([&] { gpu_kernel(iter, IsposinfFunctor<scalar_t>()); }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      kHalf,
+      kBFloat16);
 }
 
 void isneginf_kernel(TensorIteratorBase& iter) {
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      at::ScalarType::Half,
-      at::ScalarType::BFloat16,
+  AT_DISPATCH_V2(
       iter.input_dtype(),
       "isneginf_xpu",
-      [&] { gpu_kernel(iter, IsneginfFunctor<scalar_t>()); });
+      AT_WRAP([&] { gpu_kernel(iter, IsneginfFunctor<scalar_t>()); }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      kHalf,
+      kBFloat16);
 }
 
 void clamp_kernel(TensorIteratorBase& iter) {
-  AT_DISPATCH_ALL_TYPES_AND2(
-      kHalf, kBFloat16, iter.common_dtype(), "clamp_xpu", [&] {
-        gpu_kernel(iter, ClampFunctor<scalar_t>());
-      });
+  AT_DISPATCH_V2(
+      iter.common_dtype(),
+      "clamp_xpu",
+      AT_WRAP([&] { gpu_kernel(iter, ClampFunctor<scalar_t>()); }),
+      AT_EXPAND(AT_ALL_TYPES),
+      AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES),
+      kHalf,
+      kBFloat16);
 }
 
 void inline launch_clamp_scalar(
@@ -132,14 +138,20 @@ void inline launch_clamp_scalar(
     Scalar lim0,
     Scalar lim1,
     at::native::detail::ClampLimits minmax) {
-  AT_DISPATCH_ALL_TYPES_AND2(
-      kHalf, kBFloat16, iter.common_dtype(), "clamp_scalar_xpu", [&] {
+  AT_DISPATCH_V2(
+      iter.common_dtype(),
+      "clamp_scalar_xpu",
+      AT_WRAP([&] {
         using opmath_t = at::opmath_type<scalar_t>;
         auto lim0_val = lim0.to<opmath_t>();
         auto lim1_val = lim1.to<opmath_t>();
         gpu_kernel(
             iter, ClampScalarFunctor<scalar_t>(lim0_val, lim1_val, minmax));
-      });
+      }),
+      AT_EXPAND(AT_ALL_TYPES),
+      AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES),
+      kHalf,
+      kBFloat16);
 }
 
 void clamp_scalar_kernel(


### PR DESCRIPTION
Fixes #4774

## Summary

`test_shape_ops.py::test_clamp` is parametrized over `barebones_unsigned_types()` (UInt16/UInt32/UInt64) and all three variants failed on XPU. Two dispatch tables were too narrow:

- **Scalar bounds** (`clamp_stub`, `clamp_{,min_,max_}scalar_stub`) used `AT_DISPATCH_ALL_TYPES_AND2`. `AT_ALL_TYPES` predates the barebones unsigned types, so it doesn't cover them. This is the `clamp_scalar_xpu` error in the issue.
- **Tensor bounds** decompose into `maximum`/`minimum`, whose integral branch used `AT_DISPATCH_INTEGRAL_TYPES` -- same gap. It only surfaced as `"max_elementwise_xpu" not implemented for 'UInt16'` after the first fix, at line 382 of the test rather than line 367.

Both now use `AT_DISPATCH_V2` with the missing dtypes added, matching upstream CUDA  (`aten/src/ATen/native/cuda/TensorCompare.cu`, `aten/src/ATen/native/cuda/MaxMinElementwiseKernel.cu`).

No functor changes were needed: `at::_isnan` returns false for integral types, `opmath_type` is the identity for `uint{16,32,64}_t`, and `Scalar::to<uint64_t>()` is already defined.

Widening `maximum`/`minimum` also enables `torch.maximum`, `torch.minimum`, `torch.fmax`, and `torch.fmin` for these dtypes, since fmax/fmin delegate there for non-floating inputs. Broader than this test needs, but it matches CUDA and narrowing it would diverge from upstream for no reason.