### PR TITLE
Remove xfail entries for nn.functional.max_unpool2d in test_ops_xpu.py

### DIFF
--- a/test/xpu/functorch/test_ops_xpu.py
+++ b/test/xpu/functorch/test_ops_xpu.py
@@ -1032,17 +1032,6 @@ class TestOperators(TestCase):
                 xfail(
                     "nn.functional.layer_norm"
                 ),  # vmap: inplace into a regular tensor
-                # RuntimeError: NYI: querying is_contiguous inside of vmap
-                # for memory_format other than torch.contiguous_formats
-                xfail("nn.functional.max_pool2d"),
-                # RuntimeError: NYI: Tensor.clone(memory_format) inside vmap is only
-                # supported with memory_format torch.preserve_format or
-                # torch.contiguous_format (got ChannelsLast)
-                xfail("nn.functional.max_unpool2d"),
-                # RuntimeError: NYI: Tensor.clone(memory_format) inside vmap is only
-                # supported with memory_format torch.preserve_format
-                # or torch.contiguous_format (got ChannelsLast)s
-                xfail("nn.functional.max_unpool2d", "grad"),
                 xfail(
                     "nn.functional.rrelu"
                 ),  # RuntimeError: vmap: we do not yet support aten::rrelu_with_noise.
@@ -1206,9 +1195,6 @@ class TestOperators(TestCase):
             xfail("scatter_reduce", "prod"),  # item call
             # Batching rule not implemented for aten::_use_cudnn_ctc_loss.Tensor
             xfail("nn.functional.ctc_loss", device_type="cuda"),
-            # NYI: querying is_contiguous inside of vmap for memory_format other than torch.contiguous_format
-            xfail("nn.functional.max_unpool2d"),
-            xfail("nn.functional.max_unpool2d", "grad"),
             xfail("sparse.sampled_addmm", ""),
             xfail("sparse.mm", "reduce"),
             xfail("as_strided_scatter", ""),  # calls as_strided
@@ -2011,10 +1997,6 @@ class TestOperators(TestCase):
                 # running_mean or running_var, which will be updated in place,
                 # were not batched.
                 xfail("nn.functional.instance_norm"),
-                # NYI: Tensor.clone(memory_format) inside vmap is only supported with
-                # memory_format torch.preserve_format or torch.contiguous_format (got ChannelsLast)
-                xfail("nn.functional.max_unpool2d"),
-                xfail("nn.functional.max_unpool2d", "grad"),
                 xfail(
                     "nn.functional.multi_margin_loss"
                 ),  # Forward AD not implemented and no decomposition
@@ -2357,8 +2339,6 @@ class TestOperators(TestCase):
         {
             # The size of tensor a (4) must match the size of tensor b (10) at non-singleton dimension 0
             xfail("masked_select"),
-            xfail("nn.functional.max_unpool2d", "grad"),  # contiguous call
-            xfail("nn.functional.max_unpool2d"),  # contiguous call
             xfail("to_sparse"),  # dispatch key issue
             xfail("torch.ops.aten._efficient_attention_forward"),  # outputs ints
             # https://github.com/pytorch/pytorch/issues/96560#issuecomment-2151063723


### PR DESCRIPTION
Fixes #4780

## Summary

11 `TestOperatorsXPU` cases in `test/xpu/functorch/test_ops_xpu.py` fail with `Unexpected success`. This removes the obsolete `xfail` entries causing it.

## Root cause

`test_ops_xpu.py` is a fork of upstream `test/functorch/test_ops.py`. Upstream [pytorch#191678](https://github.com/pytorch/pytorch/pull/191678) (`c75d48c`) fixed `max_pool_double_backward`, which called `grad.contiguous(indices.suggest_memory_format())` and threw `NYI: querying is_contiguous inside of vmap` for channels_last inputs; it now uses `reshape`. That commit deleted the corresponding xfails from its own copy of the test file, but the XPU fork still carried them, so the newly-passing tests report `Unexpected success`.

This is test-side staleness, not an XPU kernel bug.

## Fix

Delete exactly the four xfail blocks upstream removed, covering the four affected `@skipOps` decorator lists:

| Test method | xfails removed |
|---|---|
| `test_vmapvjpvjp` | `max_pool2d`, `max_unpool2d`, `max_unpool2d`/`grad` |
| `test_vmapvjp` | `max_unpool2d`, `max_unpool2d`/`grad` |
| `test_vmapjvpvjp` | `max_unpool2d`, `max_unpool2d`/`grad` |
| `test_vmap_autograd_grad` | `max_unpool2d`/`grad`, `max_unpool2d` |

Deletions only (-20 lines), byte-for-byte identical to upstream's.

Note: the `max_unpool2d` xfails in `test_vmapjvpall_has_batch_rule` and `test_vmapvjp_has_batch_rule` are intentionally **kept** — upstream still has them, as the batching rule is still missing there.
