### PR TITLE
ci: fix dpclang workflow build stage on scheduled events

### DIFF
--- a/.github/workflows/pull_dpclang.yml
+++ b/.github/workflows/pull_dpclang.yml
@@ -107,7 +107,7 @@ jobs:
     with:
       category: dpclang
       runner: build
-      pytorch: ${{ github.base_ref }}
+      pytorch: ${{ github.base_ref || github.ref_name }}
 
   linux-ut:
     needs: build-wheels
@@ -124,6 +124,6 @@ jobs:
     with:
       category: dpclang
       runner: pvc
-      pytorch: ${{ github.base_ref }}
+      pytorch: ${{ github.base_ref || github.ref_name }}
       torch_xpu_ops: ${{ 'main' }}
       ut: ${{ matrix.ut_name }}


### PR DESCRIPTION
In 6d394788 we overlooked that dpclang workflow does not explicitly set pytorch commit id on scheduled events. Before 6d394788 it was handled in the scripts by having default pytorch commit pinned as 'main', but this got modified in 6d394788 due to different evaluation of environment variables in bash (old version) and python (new version): python queried for the `PYTHON_COMMIT` which was set to empty value.

Fixes: https://github.com/intel/torch-xpu-ops/issues/4786
Fixes: 6d394788 (Refactor CI build to reuse PyTorch upstream build scripts (#4357))

CC: @mengfei25 @chuanqi129 