### PR TITLE
Remove what() call in rethrow exception on Windows

### DIFF
--- a/src/ATen/native/xpu/mkl/BatchLinearAlgebra.cpp
+++ b/src/ATen/native/xpu/mkl/BatchLinearAlgebra.cpp
@@ -58,16 +58,33 @@ void error_handle(
   auto ids = be.ids();
 
   for (size_t i = 0; i < errs.size(); ++i) {
+    if (!errs[i]) {
+      info_cpu[ids[i]] = -1;
+      continue;
+    }
     try {
       std::rethrow_exception(errs[i]);
     } catch (const oneapi::mkl::lapack::exception& e) {
+#ifdef _WIN32
+      // what() returns a char* into mkl_sycl_lapack.dll's CRT heap; unsafe
+      // across DLL boundaries on Windows. info() and detail() return plain
+      // integers, safe.
       TORCH_WARN(
-          "Caught lapack exception:\nWhat: ",
+          "Caught lapack exception:",
+          "\nInfo: ",
+          e.info(),
+          "\nDetail: ",
+          e.detail());
+#else
+      TORCH_WARN(
+          "Caught lapack exception:",
+          "\nWhat: ",
           e.what(),
           "\nInfo: ",
           e.info(),
           "\nDetail: ",
           e.detail());
+#endif
       info_cpu[ids[i]] = e.info();
     } catch (const sycl::exception& e) {
       TORCH_WARN("Caught SYCL exception:\nWhat: ", e.what(), "\nInfo: -1");

--- a/test/xpu/test_linalg_xpu.py
+++ b/test/xpu/test_linalg_xpu.py
@@ -789,7 +789,7 @@ def cond_errors_and_warnings(self, device, dtype):
     a = torch.ones(3, 3, dtype=dtype, device=device)
     for p in ["wrong_norm", 5]:
         with self.assertRaisesRegex(
-            RuntimeError, f"linalg.cond got an invalid norm type: {p}"
+            ValueError, f"linalg.cond got an invalid norm type: {p}"
         ):
             torch.linalg.cond(a, p)
 


### PR DESCRIPTION
Calling what() on rethrow_exception cause access violation on Windows. This is because of passing objects or memory allocations across dynamic-link library. Issue: https://github.com/intel/torch-xpu-ops/issues/4048