### PR TITLE
Remove obsolete _test_state_dict_with_cuda_params from test/xpu/test_optim_xpu.py

### DIFF
--- a/test/xpu/test_optim_xpu.py
+++ b/test/xpu/test_optim_xpu.py
@@ -22,14 +22,9 @@ with XPUPatchForImport(False):
 from copy import deepcopy
 
 import torch
-from torch.nn import Parameter
 from torch.testing._internal.common_device_type import TEST_WITH_ROCM
 from torch.testing._internal.common_dtype import floating_types_and
-from torch.testing._internal.common_optimizers import (
-    _get_optim_inputs_including_global_cliquey_kwargs,
-    optim_db,
-    optims,
-)
+from torch.testing._internal.common_optimizers import optim_db, optims
 from torch.testing._internal.common_utils import TEST_WITH_TORCHDYNAMO
 
 for optim in optim_db:
@@ -195,75 +190,6 @@ def _test_peak_memory_foreach(self, device, dtype, optim_info):
 
 TestOptimRenewed.test_peak_memory_foreach = _test_peak_memory_foreach
 
-
-@optims(optim_db, dtypes=[torch.float32])
-def _test_state_dict_with_cuda_params(self, device, dtype, optim_info):
-    optim_cls = optim_info.optim_cls
-
-    # Skip differentiable testing for now, see https://github.com/pytorch/pytorch/issues/116490
-    # We limit our configs to CPU only, because we will be moving them to CUDA later
-    cpu_optim_inputs = _get_optim_inputs_including_global_cliquey_kwargs(
-        "cpu", dtype, optim_info, skip=("differentiable",)
-    )
-
-    # Needed for second order optims like LBFGS
-    closure_loss = torch.rand(1, device=device, dtype=dtype)
-
-    def closure():
-        return closure_loss if optim_info.step_requires_closure else None
-
-    for optim_input in cpu_optim_inputs:
-        if "fused" in optim_input.kwargs and "xpu" not in optim_info.supports_fused_on:
-            self.skipTest(f"xpu is not supported for fused on {optim_cls.__name__}")
-        params = [
-            Parameter(torch.randn(2, 3, device="cpu", dtype=dtype)) for _ in range(2)
-        ]
-        for p in params:
-            p.grad = torch.randn_like(p)
-            if optim_info.only_supports_sparse_grads:
-                # For this test, we naively convert the Tensor layout, which we know does
-                # NOT represent the expected use case for optims like SparseAdam!
-                p.grad = p.grad.to_sparse()
-
-        optimizer = optim_cls(params, **optim_input.kwargs)
-
-        for _ in range(3):
-            optimizer.step(closure)
-
-        with torch.no_grad():
-            params_cuda = [p.to(device="xpu") for p in params]
-            for i, p in enumerate(params_cuda):
-                p.grad = params[i].grad.to(device="xpu")
-        optimizer_cuda = optim_cls(params_cuda, **optim_input.kwargs)
-
-        state_dict_cpu = deepcopy(optimizer.state_dict())
-        state_dict_cuda = deepcopy(optimizer.state_dict())
-        optimizer_cuda.load_state_dict(state_dict_cuda)
-
-        # Make sure state_dict_cuda isn't modified by merely calling load_state_dict
-        self.assertEqual(state_dict_cpu, state_dict_cuda)
-
-        # Make sure that device of state['step'] is still CPU _unless_ torch.compile() added a capturable!
-        capturable = state_dict_cpu["param_groups"][0].get("capturable", False)
-        fused = state_dict_cpu["param_groups"][0].get("fused", False)
-        new_state_dict = optimizer_cuda.state_dict()
-        for state_cpu, state_cuda in zip(
-            state_dict_cpu["state"].values(), new_state_dict["state"].values()
-        ):
-            if "step" in state_cpu and torch.is_tensor(state_cpu["step"]):
-                self.assertEqual(
-                    state_cuda["step"].device.type,
-                    "xpu" if capturable or fused else "cpu",
-                )
-
-        for _ in range(5):
-            optimizer.step(closure)
-            optimizer_cuda.step(closure)
-            self.assertEqual(params, params_cuda)
-            self.assertEqual(optimizer.state_dict(), optimizer_cuda.state_dict())
-
-
-TestOptimRenewed.test_state_dict_with_cuda_params = _test_state_dict_with_cuda_params
 
 instantiate_device_type_tests(
     TestOptimRenewed, globals(), only_for="xpu", allow_xpu=True


### PR DESCRIPTION
As pointed out in https://github.com/pytorch/pytorch/pull/191227 a recent commit https://github.com/pytorch/pytorch/commit/e68908a304d3e0c7de4ebed3d93b7b01a558652d has generalized this test case upstream, which made our version obsolete.