### PR TITLE
Add tests for zero-length scans in scan and associative scan functions (upstream alignment)

### DIFF
--- a/test/xpu/functorch/test_control_flow_xpu.py
+++ b/test/xpu/functorch/test_control_flow_xpu.py
@@ -2325,25 +2325,63 @@ def forward(self, pred_1, x_1):
             self.assertEqual(cnt.frame_count, 6)
 
     @skipIfTorchDynamo("don't test compile on compile")
-    def test_scan_init_scanned_0(self):
-        # Only init and no input
-        x = torch.randn(3, 1, 2, device=torch.device("cpu"))
-        init = torch.randn(3, 2, device=torch.device("cpu"))
-        dim = 1
+    @parametrize("reverse", [False, True])
+    @parametrize("compile_mode", ["none", "eager", "compile", "compile_dynamic_shape"])
+    def test_scan_zero_length(self, reverse, compile_mode):
+        def body_same(c, x):
+            y = c + x
+            return y, y.clone()
 
-        # Scan dimension is 0
-        init = torch._ops.ops.aten.slice(x, dim, 0, 1, 1)
-        inp = torch._ops.ops.aten.slice(x, dim, 1, None, 1)
+        def body_reduce(c, x):
+            # y shape and dtype both differ from the xs slice.
+            y = c + x
+            return y, y.sum(dim=-1).to(torch.float64).clone()
+
+        def body_struct(c, x):
+            # xs is a 2-tuple, but the body emits a single ys leaf.
+            x0, x1 = x
+            y = c + x0 + x1
+            return y, y.clone()
+
+        cases = [
+            (body_same, torch.tensor([0.0, 1.0]), torch.zeros(0, 2), 0),
+            (body_reduce, torch.arange(6.0).reshape(2, 3), torch.ones(0, 2, 3), 0),
+            (body_reduce, torch.arange(6.0).reshape(2, 3), torch.ones(2, 0, 3), 1),
+            (body_struct, torch.zeros(2), (torch.ones(0, 2), torch.ones(0, 2)), 0),
+        ]
+        scan_fct = compile_mode_helper(scan, compile_mode)
+        for body, init, xs, dim in cases:
+            result = scan_fct(body, init, xs, dim=dim, reverse=reverse)
+            expected = _fake_scan(body, init, xs, dim=dim, reverse=reverse)
+            self.assertEqual(result, expected)
+
+    @skipIfTorchDynamo("don't test compile on compile")
+    @parametrize("reverse", [False, True])
+    def test_scan_zero_length_autograd(self, reverse):
+        init = torch.randn(2, 3, requires_grad=True)
+        xs = torch.randn(0, 2, 3, requires_grad=True)
+
+        def body(c, x):
+            y = torch.sin(c + x)
+            return y, y.clone()
+
+        carry, ys = scan(body, init, xs, reverse=reverse)
+        (carry.sum() + ys.sum()).backward()
+        # No steps run, so the carry passes through to init (grad of ones) and xs
+        # receives a correctly-shaped zero-length gradient.
+        self.assertEqual(init.grad, torch.ones_like(init))
+        self.assertEqual(xs.grad.shape, xs.shape)
+
+    def test_scan_unequal_scan_dim_size(self):
+        def body(c, x):
+            x0, x1 = x
+            y = c + x0 + x1
+            return y, y.clone()
+
         with self.assertRaisesRegex(
-            RuntimeError,
-            "All xs leaves must at least have.*",
+            RuntimeError, "All xs leaves must have the same scan dimension size"
         ):
-            scan(
-                get_scan_combine_fn("add", False),
-                init,
-                inp,
-                dim=dim,
-            )
+            scan(body, torch.zeros(2), (torch.ones(0, 2), torch.ones(5, 2)))
 
     @skipIfTorchDynamo("don't test compile on compile")
     def test_scan_init_non_tensor(self):
@@ -3499,12 +3537,12 @@ class GraphModule(torch.nn.Module):
             """\
 def forward(self, fct_1, init_1, xs_1):
     flip = torch.ops.aten.flip.default(xs_1, [0])
-    sym_size_int_1 = torch.ops.aten.sym_size.int(init_1, 1)
-    sym_size_int_2 = torch.ops.aten.sym_size.int(init_1, 2)
-    sym_size_int_3 = torch.ops.aten.sym_size.int(xs_1, 1)
-    sym_size_int_4 = torch.ops.aten.sym_size.int(xs_1, 2);  xs_1 = None
+    sym_size_int = torch.ops.aten.sym_size.int(init_1, 1)
+    sym_size_int_1 = torch.ops.aten.sym_size.int(init_1, 2)
+    sym_size_int_2 = torch.ops.aten.sym_size.int(xs_1, 1)
+    sym_size_int_3 = torch.ops.aten.sym_size.int(xs_1, 2);  xs_1 = None
     scan_combine_graph_0 = self.scan_combine_graph_0
-    scan = torch.ops.higher_order.scan(scan_combine_graph_0, [init_1], [flip], (sym_size_int_1, sym_size_int_2, sym_size_int_3, sym_size_int_4));  scan_combine_graph_0 = init_1 = flip = sym_size_int_1 = sym_size_int_2 = sym_size_int_3 = sym_size_int_4 = None
+    scan = torch.ops.higher_order.scan(scan_combine_graph_0, [init_1], [flip], (sym_size_int, sym_size_int_1, sym_size_int_2, sym_size_int_3));  scan_combine_graph_0 = init_1 = flip = sym_size_int = sym_size_int_1 = sym_size_int_2 = sym_size_int_3 = None
     getitem = scan[0]
     getitem_1 = scan[1];  scan = None
     flip_1 = torch.ops.aten.flip.default(getitem_1, [0]);  getitem_1 = None
@@ -3816,6 +3854,50 @@ class AssociativeScanTests(TestCase):
     @parametrize("combine_mode", ["pointwise", "generic"])
     @parametrize("device", [torch.device("cpu"), torch.device(DEVICE_TYPE)])
     @parametrize("autograd", [False, True])
+    @parametrize("dim", [0, 1])
+    # pointwise only supports accelerator devices and does not support
+    # compile_dynamic_shape (lifted arguments), so skip those combinations as in
+    # test_associative_scan_compile.
+    @decorateIf(
+        unittest.skip,
+        lambda params: (
+            params["combine_mode"] == "pointwise"
+            and (
+                params["device"] == torch.device("cpu")
+                or params["compile_mode"] == "compile_dynamic_shape"
+            )
+        ),
+    )
+    def test_associative_scan_zero_length(
+        self, combine_mode, reverse, compile_mode, device, autograd, dim
+    ):
+        shape = [2, 4, 3]
+        shape[dim] = 0
+        x = torch.randn(*shape, device=device, requires_grad=autograd)
+        kwargs = {
+            "dim": dim,
+            "reverse": reverse,
+            "compile_mode": compile_mode,
+            "combine_mode": combine_mode,
+        }
+        kwargs_fake = self._prepare_fake_kwargs(kwargs)
+        self._run_test(
+            model=AssociativeScanModels.Simple(**kwargs),
+            model_fake=AssociativeScanModels.Simple(**kwargs_fake),
+            inputs=x,
+            autograd_param=None if not autograd else (x,),
+        )
+
+    @unittest.skipIf(
+        DEVICE_TYPE == "cuda" and not SM70OrLater,
+        "triton requires CUDA with SM>=7.0",
+    )
+    @requires_accelerator
+    @parametrize("reverse", [False, True])
+    @parametrize("compile_mode", ["none", "eager", "compile", "compile_dynamic_shape"])
+    @parametrize("combine_mode", ["pointwise", "generic"])
+    @parametrize("device", [torch.device("cpu"), torch.device(DEVICE_TYPE)])
+    @parametrize("autograd", [False, True])
     # Skipping the combination of combine_mode=pointwise and device=cpu
     # as the current implementation of pointwise does only support CUDA device
     # Skipping the combination of combine_mode=pointwise and compile_mode=compile_dynamic_shape
@@ -3830,18 +3912,6 @@ class AssociativeScanTests(TestCase):
             )
         ),
     )
-    # # Skipping this combination as there is a CPP compilation failure that
-    # # may be unrelated to associative_scan itself. There is a dedicated tests for
-    # # this case below.
-    # @decorateIf(
-    #     unittest.skip,
-    #     lambda params: (
-    #         params["compile_mode"] == "compile_dynamic_shape"
-    #         and params["combine_mode"] == "generic"
-    #         and params["device"] == torch.device("cpu")
-    #         and params["autograd"]
-    #     ),
-    # )
     def test_associative_scan_compile(
         self, combine_mode, reverse, compile_mode, device, autograd
     ):
@@ -4852,7 +4922,7 @@ class GraphModule(torch.nn.Module):
 
         with self.assertRaisesRegex(
             ValueError,
-            "All xs leaves must at least have.*",
+            "All xs leaves must have at least 'dim \\+ 1' dimensions",
         ):
             associative_scan(
                 get_scan_combine_fn("different_input_size_operator", True),


### PR DESCRIPTION
Resolves https://github.com/intel/torch-xpu-ops/issues/4781

Align `test_control_flow_xpu.py` with upstream PyTorch after pytorch/pytorch#188348 ("[HOP] Fixes for zero-length scan dim"), which made a zero-length scan dimension valid for `scan` and `associative_scan` and changed two error messages.

Mirrors the test changes from that commit:

- `test_scan_init_scanned_0` is removed. It asserted that a zero-length scan dim raises `"All xs leaves must at least have.*"`; that case is now supported, so there is no error left to assert. Upstream deleted it for the same reason. 
- New `test_scan_zero_length`, `test_scan_zero_length_autograd` and `test_associative_scan_zero_length` cover the now-supported behavior, and `test_scan_unequal_scan_dim_size` keeps error-path coverage for the check that is still an error (mismatched scan dim sizes across `xs` leaves).
- `test_scan_simple_graph`: updated the `sym_size_int*` numbering in the golden graph string.
- `test_associative_scan_different_input_size_wrong_dim`: updated the regex to the new exact message, `"All xs leaves must have at least 'dim + 1' dimensions"`.
- Dropped the commented-out `decorateIf` block that upstream removed from `test_associative_scan_compile`.

The new `test_associative_scan_zero_length` uses this file's `DEVICE_TYPE` / `requires_accelerator` conventions instead of upstream's CUDA-specific decorators.