### PR TITLE
Order the norm global-reduce handoff and drop its unused buffers

### DIFF
--- a/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
@@ -1179,8 +1179,7 @@ void layer_norm_backward_kernel_impl(
           M,
           N);
       Tensor semaphores, scratchpad;
-      config.template init_global_reduce<accscalar_t>(
-          X, semaphores, scratchpad);
+      config.init_global_reduce(X, semaphores, scratchpad);
       rowwise_moments_kernel<
           scalar_t,
           mean_t,

--- a/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
@@ -27,7 +27,8 @@ namespace native {
 namespace xpu {
 
 template <typename scalar_t, typename mean_t, typename weight_t, bool rms_norm>
-class LayerNormBackward : public NormBackward<scalar_t, mean_t, weight_t> {
+class LayerNormBackward
+    : public NormBackward<scalar_t, mean_t, weight_t, rms_norm> {
  public:
   using accscalar_t = acc_type_device<scalar_t, kXPU>;
   LayerNormBackward() = delete;
@@ -40,7 +41,7 @@ class LayerNormBackward : public NormBackward<scalar_t, mean_t, weight_t> {
       const weight_t* gamma_data,
       int64_t M,
       int64_t N)
-      : NormBackward<scalar_t, mean_t, weight_t>(
+      : NormBackward<scalar_t, mean_t, weight_t, rms_norm>(
             X_data,
             dY_data,
             dX_data,
@@ -63,7 +64,7 @@ class LayerNormBackward : public NormBackward<scalar_t, mean_t, weight_t> {
       accscalar_t* b_data,
       int64_t M,
       int64_t N)
-      : NormBackward<scalar_t, mean_t, weight_t>(
+      : NormBackward<scalar_t, mean_t, weight_t, rms_norm>(
             X_data,
             dY_data,
             dX_data,
@@ -74,7 +75,7 @@ class LayerNormBackward : public NormBackward<scalar_t, mean_t, weight_t> {
             b_data),
         M(M),
         N(N) {}
-  using NB = NormBackward<scalar_t, mean_t, weight_t>;
+  using NB = NormBackward<scalar_t, mean_t, weight_t, rms_norm>;
 
   template <
       int vec_size,
@@ -1159,9 +1160,10 @@ void layer_norm_backward_kernel_impl(
           (X.scalar_type() == kHalf || X.scalar_type() == kBFloat16)
           ? kFloat
           : X.scalar_type();
-      Tensor a = at::empty({M}, X.options().dtype(kAccType));
+      Tensor a =
+          rms_norm ? Tensor() : at::empty({M}, X.options().dtype(kAccType));
+      accscalar_t* a_data = rms_norm ? nullptr : a.data_ptr<accscalar_t>();
       Tensor b = at::empty({M}, X.options().dtype(kAccType));
-      accscalar_t* a_data = a.data_ptr<accscalar_t>();
       accscalar_t* b_data = b.data_ptr<accscalar_t>();
 
       LayerNormBackward<scalar_t, mean_t, weight_t, rms_norm> norm(
@@ -1176,7 +1178,7 @@ void layer_norm_backward_kernel_impl(
           M,
           N);
       Tensor semaphores, scratchpad;
-      config.init_global_reduce(X, semaphores, scratchpad);
+      config.template init_global_reduce<rms_norm>(X, semaphores, scratchpad);
       rowwise_moments_kernel<
           scalar_t,
           mean_t,

--- a/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
@@ -27,7 +27,8 @@ namespace native {
 namespace xpu {
 
 template <typename scalar_t, typename mean_t, typename weight_t, bool rms_norm>
-class LayerNormBackward : public NormBackward<scalar_t, mean_t, weight_t> {
+class LayerNormBackward
+    : public NormBackward<scalar_t, mean_t, weight_t, rms_norm> {
  public:
   using accscalar_t = acc_type_device<scalar_t, kXPU>;
   LayerNormBackward() = delete;
@@ -40,7 +41,7 @@ class LayerNormBackward : public NormBackward<scalar_t, mean_t, weight_t> {
       const weight_t* gamma_data,
       int64_t M,
       int64_t N)
-      : NormBackward<scalar_t, mean_t, weight_t>(
+      : NormBackward<scalar_t, mean_t, weight_t, rms_norm>(
             X_data,
             dY_data,
             dX_data,
@@ -65,7 +66,7 @@ class LayerNormBackward : public NormBackward<scalar_t, mean_t, weight_t> {
       accscalar_t* b_data,
       int64_t M,
       int64_t N)
-      : NormBackward<scalar_t, mean_t, weight_t>(
+      : NormBackward<scalar_t, mean_t, weight_t, rms_norm>(
             X_data,
             dY_data,
             dX_data,
@@ -76,7 +77,7 @@ class LayerNormBackward : public NormBackward<scalar_t, mean_t, weight_t> {
             b_data),
         M(M),
         N(N) {}
-  using NB = NormBackward<scalar_t, mean_t, weight_t>;
+  using NB = NormBackward<scalar_t, mean_t, weight_t, rms_norm>;
 
   template <
       int vec_size,
@@ -1162,10 +1163,15 @@ void layer_norm_backward_kernel_impl(
           (X.scalar_type() == kHalf || X.scalar_type() == kBFloat16)
           ? kFloat
           : X.scalar_type();
-      Tensor a = at::empty({M}, X.options().dtype(kAccType));
+      // rms_norm has no first moment; reduce_project skips a_data.
+      Tensor a;
+      accscalar_t* a_data = nullptr;
+      if constexpr (!rms_norm) {
+        a = at::empty({M}, X.options().dtype(kAccType));
+        a_data = a.mutable_data_ptr<accscalar_t>();
+      }
       Tensor b = at::empty({M}, X.options().dtype(kAccType));
-      accscalar_t* a_data = a.data_ptr<accscalar_t>();
-      accscalar_t* b_data = b.data_ptr<accscalar_t>();
+      accscalar_t* b_data = b.mutable_data_ptr<accscalar_t>();
 
       LayerNormBackward<scalar_t, mean_t, weight_t, rms_norm> norm(
           X_data,
@@ -1179,7 +1185,7 @@ void layer_norm_backward_kernel_impl(
           M,
           N);
       Tensor semaphores, scratchpad;
-      config.init_global_reduce(X, semaphores, scratchpad);
+      config.init_global_reduce(X, rms_norm, semaphores, scratchpad);
       rowwise_moments_kernel<
           scalar_t,
           mean_t,

--- a/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
@@ -1176,8 +1176,7 @@ void layer_norm_backward_kernel_impl(
           M,
           N);
       Tensor semaphores, scratchpad;
-      config.template init_global_reduce<accscalar_t>(
-          X, semaphores, scratchpad);
+      config.init_global_reduce(X, semaphores, scratchpad);
       rowwise_moments_kernel<
           scalar_t,
           mean_t,

--- a/src/ATen/native/xpu/sycl/Norm.h
+++ b/src/ATen/native/xpu/sycl/Norm.h
@@ -266,6 +266,7 @@ class NormConfig {
 
   void init_global_reduce(
       const Tensor& X,
+      bool rms_norm,
       Tensor& semaphores,
       Tensor& scratchpad) {
     if (workgroup_num_foreach > 1) {
@@ -275,9 +276,9 @@ class NormConfig {
           (X.scalar_type() == kHalf || X.scalar_type() == kBFloat16)
           ? kFloat
           : X.scalar_type();
-      // Non-rms keeps two accumulators per slot, rms one; every slot the last
-      // workgroup reads is written by its producer first.
-      int scratchpad_size = 2 * workgroup_num * workgroup_num_foreach;
+      // One accumulator per slot for rms, two otherwise; all get written.
+      int scratchpad_size =
+          (rms_norm ? 1 : 2) * workgroup_num * workgroup_num_foreach;
       scratchpad = at::empty(scratchpad_size, X.options().dtype(kAccType));
       semaphores_ptr = semaphores.mutable_data_ptr<int>();
       scratchpad_ptr = scratchpad.mutable_data_ptr();
@@ -372,11 +373,7 @@ class NormConfig {
   }
 };
 
-template <
-    typename scalar_t,
-    typename mean_t,
-    typename weight_t,
-    bool one_moment = false>
+template <typename scalar_t, typename mean_t, typename weight_t, bool rms_norm>
 class NormBackward {
  public:
   using accscalar_t = acc_type_device<scalar_t, kXPU>;
@@ -470,7 +467,9 @@ class NormBackward {
       accscalar_t sum2,
       const NormConfig& cfg) const {
     auto group_id = item_id.get_group(0);
-    a_data[group_id] = sum1;
+    if constexpr (!rms_norm) {
+      a_data[group_id] = sum1;
+    }
     b_data[group_id] = sum2;
   };
 };

--- a/src/ATen/native/xpu/sycl/Norm.h
+++ b/src/ATen/native/xpu/sycl/Norm.h
@@ -191,13 +191,15 @@ static void norm_global_reduce(
 
   if (local_id == 0) {
     sycl_atomic_ref_rlx_dev_global_t<int> count(semaphores_ptr[group_id]);
-    int prev_groups_finished = count.fetch_add(1);
+    int prev_groups_finished = count.fetch_add(1, sycl_mem_odr_acq_rel);
     last_workgroup[0] = (prev_groups_finished == workgroup_num_foreach - 1);
   }
   sycl::group_barrier(item.get_group());
 
   // use the last workgroup for reduction
   if (last_workgroup[0]) {
+    // Only local_id 0 acquired; fence so the whole workgroup sees the stores.
+    sycl::atomic_fence(sycl_mem_odr_acq, sycl_mem_scp_dev);
     if constexpr (rms_norm) {
       sum2 = accscalar_t(0);
       for (int i = local_id; i < workgroup_num_foreach; i += workgroup_size) {

--- a/src/ATen/native/xpu/sycl/Norm.h
+++ b/src/ATen/native/xpu/sycl/Norm.h
@@ -190,7 +190,7 @@ static void norm_global_reduce(
   sycl::group_barrier(item.get_group());
 
   if (local_id == 0) {
-    sycl_atomic_ref_rlx_dev_global_t<int> count(semaphores_ptr[group_id]);
+    sycl_atomic_ref_acq_rel_dev_global_t<int> count(semaphores_ptr[group_id]);
     int prev_groups_finished = count.fetch_add(1);
     last_workgroup[0] = (prev_groups_finished == workgroup_num_foreach - 1);
   }
@@ -198,6 +198,8 @@ static void norm_global_reduce(
 
   // use the last workgroup for reduction
   if (last_workgroup[0]) {
+    // Only local_id 0 acquired; fence so the whole workgroup sees the stores.
+    sycl::atomic_fence(sycl_mem_odr_acq, sycl_mem_scp_dev);
     if constexpr (rms_norm) {
       sum2 = accscalar_t(0);
       for (int i = local_id; i < workgroup_num_foreach; i += workgroup_size) {

--- a/src/ATen/native/xpu/sycl/Norm.h
+++ b/src/ATen/native/xpu/sycl/Norm.h
@@ -264,7 +264,6 @@ class NormConfig {
   void* scratchpad_ptr;
   int sub_group_num_global;
 
-  template <typename scalar_t>
   void init_global_reduce(
       const Tensor& X,
       Tensor& semaphores,
@@ -276,11 +275,12 @@ class NormConfig {
           (X.scalar_type() == kHalf || X.scalar_type() == kBFloat16)
           ? kFloat
           : X.scalar_type();
-      int scratchpad_size = 2 * batch_size * workgroup_num_foreach *
-          sizeof(acc_type_device<scalar_t, kXPU>);
-      scratchpad = at::zeros(scratchpad_size, X.options().dtype(kAccType));
-      semaphores_ptr = semaphores.data_ptr<int>();
-      scratchpad_ptr = scratchpad.data_ptr();
+      // Non-rms keeps two accumulators per slot, rms one; every slot the last
+      // workgroup reads is written by its producer first.
+      int scratchpad_size = 2 * workgroup_num * workgroup_num_foreach;
+      scratchpad = at::empty(scratchpad_size, X.options().dtype(kAccType));
+      semaphores_ptr = semaphores.mutable_data_ptr<int>();
+      scratchpad_ptr = scratchpad.mutable_data_ptr();
       sub_group_num_global = (workgroup_num_foreach + SIMD - 1) / SIMD;
     }
   }

--- a/src/ATen/native/xpu/sycl/Norm.h
+++ b/src/ATen/native/xpu/sycl/Norm.h
@@ -260,7 +260,6 @@ class NormConfig {
   void* scratchpad_ptr = nullptr;
   int sub_group_num_global = 1;
 
-  template <typename scalar_t>
   void init_global_reduce(
       const Tensor& X,
       Tensor& semaphores,
@@ -272,9 +271,10 @@ class NormConfig {
           (X.scalar_type() == kHalf || X.scalar_type() == kBFloat16)
           ? kFloat
           : X.scalar_type();
-      int scratchpad_size = 2 * batch_size * workgroup_num_foreach *
-          sizeof(acc_type_device<scalar_t, kXPU>);
-      scratchpad = at::zeros(scratchpad_size, X.options().dtype(kAccType));
+      // Non-rms keeps two accumulators per slot, rms one; every slot the last
+      // workgroup reads is written by its producer first.
+      int scratchpad_size = 2 * workgroup_num * workgroup_num_foreach;
+      scratchpad = at::empty(scratchpad_size, X.options().dtype(kAccType));
       semaphores_ptr = semaphores.data_ptr<int>();
       scratchpad_ptr = scratchpad.data_ptr();
       sub_group_num_global = (workgroup_num_foreach + SIMD - 1) / SIMD;

--- a/src/ATen/native/xpu/sycl/Norm.h
+++ b/src/ATen/native/xpu/sycl/Norm.h
@@ -260,6 +260,7 @@ class NormConfig {
   void* scratchpad_ptr = nullptr;
   int sub_group_num_global = 1;
 
+  template <bool rms_norm>
   void init_global_reduce(
       const Tensor& X,
       Tensor& semaphores,
@@ -271,9 +272,9 @@ class NormConfig {
           (X.scalar_type() == kHalf || X.scalar_type() == kBFloat16)
           ? kFloat
           : X.scalar_type();
-      // Non-rms keeps two accumulators per slot, rms one; every slot the last
-      // workgroup reads is written by its producer first.
-      int scratchpad_size = 2 * workgroup_num * workgroup_num_foreach;
+      // Every slot is written before it is read, so no zero-init.
+      int scratchpad_size =
+          (rms_norm ? 1 : 2) * workgroup_num * workgroup_num_foreach;
       scratchpad = at::empty(scratchpad_size, X.options().dtype(kAccType));
       semaphores_ptr = semaphores.data_ptr<int>();
       scratchpad_ptr = scratchpad.data_ptr();
@@ -368,11 +369,7 @@ class NormConfig {
   }
 };
 
-template <
-    typename scalar_t,
-    typename mean_t,
-    typename weight_t,
-    bool one_moment = false>
+template <typename scalar_t, typename mean_t, typename weight_t, bool rms_norm>
 class NormBackward {
  public:
   using accscalar_t = acc_type_device<scalar_t, kXPU>;
@@ -466,7 +463,9 @@ class NormBackward {
       accscalar_t sum2,
       const NormConfig& cfg) const {
     auto group_id = item_id.get_group(0);
-    a_data[group_id] = sum1;
+    if constexpr (!rms_norm) {
+      a_data[group_id] = sum1;
+    }
     b_data[group_id] = sum2;
   };
 };

--- a/src/comm/SYCLHelpers.h
+++ b/src/comm/SYCLHelpers.h
@@ -54,6 +54,11 @@ template <typename T>
 using sycl_atomic_ref_rlx_dev_global_t =
     sycl::atomic_ref<T, sycl_mem_odr_rlx, sycl_mem_scp_dev, sycl_global_space>;
 
+// For cooperative handoffs, where the ordering is load-bearing.
+template <typename T>
+using sycl_atomic_ref_acq_rel_dev_global_t = sycl::
+    atomic_ref<T, sycl_mem_odr_acq_rel, sycl_mem_scp_dev, sycl_global_space>;
+
 template <typename ker_t, int dim>
 static inline void sycl_kernel_submit(
     ::sycl::range<dim> range,


### PR DESCRIPTION
The norm backward global reduce handed off its scratchpad through a semaphore
`fetch_add` with no memory order, so the last workgroup could read stale slots.
Adds an `acq_rel`-default alias plus the device-scope acquire the rest of the
workgroup needs. Also drops two buffers sized for a first moment the rms path
never reads: the scratchpad applied `sizeof(acc_t)` twice (4-8x over-allocation),
and `reduce_project` wrote `a_data` unconditionally.

Not validated on hardware.

Test: **upstream PyTorch tests** — `pytest -v test/xpu/test_nn_xpu.py -k "layer_norm or rms_norm"`

Authored with Claude Code.
