### PR TITLE
Reduce op count in sparse softmax get_offsets

### DIFF
--- a/src/ATen/native/sparse/xpu/sycl/SparseSoftmaxKernels.cpp
+++ b/src/ATen/native/sparse/xpu/sycl/SparseSoftmaxKernels.cpp
@@ -447,16 +447,16 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> compute_pool_max(
   SortFunctor<int64_t> sfn;
   pstl::sort<int64_t, int64_t>(offsets_sort_ptr, sorted_indices_ptr, nnz, sfn);
 
-  auto pool_sizes = at::ones({nnz}, indices.options());
+  auto pool_sizes = at::empty({nnz}, indices.options());
   auto constant_it = at::ones({nnz}, indices.options());
-  auto discard_it = at::zeros({nnz}, indices.options());
+  auto discard_it = at::empty({nnz}, indices.options());
   // sorted_indices_ptr = sorted_indices.data_ptr<int64_t>();
 
   auto new_end = pstl::reduce_by_key<int64_t>(
       sorted_indices_ptr,
       sorted_indices_ptr + nnz,
       constant_it.data_ptr<int64_t>(),
-      discard_it.data_ptr<int64_t>(),
+      discard_it.mutable_data_ptr<int64_t>(),
       pool_sizes.data_ptr<int64_t>(),
       ReducePred<int64_t>(offsets_ptr));
   auto new_sz = std::distance(pool_sizes.data_ptr<int64_t>(), new_end);

--- a/src/ATen/native/sparse/xpu/sycl/SparseSoftmaxKernels.cpp
+++ b/src/ATen/native/sparse/xpu/sycl/SparseSoftmaxKernels.cpp
@@ -437,8 +437,9 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> compute_pool_max(
 
   auto offsets = get_offsets(indices, sizes, dim);
   int64_t* offsets_ptr = offsets.data_ptr<int64_t>();
-  auto offsets_sort = get_offsets(indices, sizes, dim);
-  int64_t* offsets_sort_ptr = offsets_sort.data_ptr<int64_t>();
+  // Same values as offsets, but pstl::sort permutes it in place below.
+  auto offsets_sort = offsets.clone();
+  int64_t* offsets_sort_ptr = offsets_sort.mutable_data_ptr<int64_t>();
 
   auto sorted_indices = at::empty({nnz}, indices.options());
   auto sorted_indices_ptr = sorted_indices.data_ptr<int64_t>();

--- a/src/ATen/native/sparse/xpu/sycl/SparseSoftmaxKernels.cpp
+++ b/src/ATen/native/sparse/xpu/sycl/SparseSoftmaxKernels.cpp
@@ -56,7 +56,6 @@
 #include <ATen/ops/ones_like.h>
 #include <ATen/ops/softmax.h>
 #include <ATen/ops/softmax_native.h>
-#include <ATen/ops/zeros.h>
 #include <ATen/ops/zeros_like.h>
 #endif
 
@@ -391,28 +390,10 @@ Tensor get_offsets(
       host_strides[i] = host_strides[i + 1] * (i + 1 == dim ? 1 : sizes[i + 1]);
     }
   }
-  // auto strides = host_strides;
-  auto strides = at::empty({ndim}, indices.options());
-  // auto strides_ptr = strides.data_ptr<int64_t>();
-
-  // syclMemcpyAsync(
-  //     strides_ptr,
-  //     host_strides.data(),
-  //     host_strides.size() * sizeof(int64_t),
-  //     HostToDevice);
-
-  for (int kk = 0; kk < ndim; kk++) {
-    strides[kk] = host_strides[kk];
-  }
-
-  // auto indices_accessor = indices.packed_accessor64<int64_t, 2>();
   Tensor offsets = at::ones({nnz}, indices.options());
-
-  for (int i = 0; i < nnz; i++) {
-    for (int64_t j = 0; j < ndim; j++) {
-      if (j != dim) {
-        offsets[i] += (strides[j] * indices[j][i]);
-      }
+  for (int64_t j = 0; j < ndim; j++) {
+    if (j != dim) {
+      offsets.add_(indices[j], host_strides[j]);
     }
   }
   return offsets;

--- a/src/ATen/native/xpu/sycl/ForeachReduceKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ForeachReduceKernels.cpp
@@ -674,7 +674,8 @@ std::vector<Tensor> foreach_max_kernel(TensorList tensors) {
       max_chunks_per_tensor = max_chunks_this_tensor;
     }
   }
-  auto output_per_tensor = at::zeros(
+  // Cleanup reads only chunks_per_tensor[t] slots, never the padding.
+  auto output_per_tensor = at::empty(
       {static_cast<int64_t>(ntensors) * max_chunks_per_tensor}, options);
 
   std::vector<at::Tensor> vec_res;

--- a/src/ATen/native/xpu/sycl/pstl/PSTLFunctions.h
+++ b/src/ATen/native/xpu/sycl/pstl/PSTLFunctions.h
@@ -1906,7 +1906,7 @@ OutputIt2 reduce_by_key(
   Tensor scanned_values = at::empty({N}, value_options);
   auto scanned_values_first = scanned_values.data_ptr<ValueType>();
 
-  Tensor scanned_tail_flags = at::ones({N}, flag_options);
+  Tensor scanned_tail_flags = at::empty({N}, flag_options);
   ValueType* scanned_tail_flags_first =
       scanned_tail_flags.data_ptr<ValueType>();
 


### PR DESCRIPTION
`get_offsets` used a host loop over every (element, sparse dim) pair, about five
ATen ops each, to compute a strided sum — `O(nnz * ndim)` dispatches, on all four
call sites. It now folds one dim per `add_` with the host stride as alpha, so the
cost is one add per dim regardless of `nnz`, and the device strides tensor it fed
goes away.

Also drops the prefill on four staging buffers that are fully written before any
read.

Not validated on hardware.

Test: **upstream PyTorch tests** — `pytest -v test/xpu/test_foreach_xpu.py -k max`, `pytest -v test/xpu/test_sparse_xpu.py -k softmax`

Authored with Claude Code.
