### PR TITLE
Write FFT out kernels directly to output

### DIFF
--- a/src/ATen/native/xpu/mkl/SpectralOps.cpp
+++ b/src/ATen/native/xpu/mkl/SpectralOps.cpp
@@ -22,6 +22,7 @@
 #include <ATen/ops/mul.h>
 #include <ATen/ops/real.h>
 #include <ATen/ops/zeros_like.h>
+#include <c10/util/strides.h>
 #include <comm/SYCLContext.h>
 #include <comm/TensorInfo.h>
 #include <oneapi/mkl.hpp>
@@ -306,6 +307,10 @@ static bool _exec_fft_preserves_layout(const Tensor& self, IntArrayRef dim) {
   return true;
 }
 
+static bool _has_exact_contiguous_strides(const Tensor& tensor) {
+  return tensor.strides() == c10::contiguous_strides(tensor.sizes());
+}
+
 // Result type of promote_fft_input, without materializing the promoted tensor.
 ScalarType promote_fft_dtype(ScalarType dtype) {
   if (dtype == ScalarType::Half || dtype == ScalarType::BFloat16)
@@ -329,13 +334,17 @@ static void _fft_c2c_mkl_out_impl(
   auto sorted_dims = impl::_sort_dims(self, dim);
   auto out_sizes = self.sizes();
   auto input_sizes = self.sizes();
+  const auto result_dtype = orig_self.scalar_type();
+  const bool needs_result_conversion = self.scalar_type() != result_dtype;
 
   const auto pass_count =
       (sorted_dims.size() + impl::mkl_max_ndim - 1) / impl::mkl_max_ndim;
   const bool needs_type_conversion = self.scalar_type() != out.scalar_type();
   // A multi-pass transform hands its last pass the outermost dims, so the
   // permutation is no longer the identity even when the full dim set is.
-  const bool can_write_out = !needs_type_conversion && out.is_contiguous() &&
+  const bool can_write_out = !needs_type_conversion &&
+      (!preserve_out_layout || out.scalar_type() == result_dtype) &&
+      impl::_has_exact_contiguous_strides(out) &&
       (!preserve_out_layout ||
        (pass_count == 1 &&
         impl::_exec_fft_preserves_layout(self, sorted_dims)));
@@ -375,9 +384,26 @@ static void _fft_c2c_mkl_out_impl(
     }
   }
 
-  impl::_fft_apply_normalization(fft_out, normalization, input_sizes, dim);
-  if (!fft_out.is_same(out)) {
-    out.copy_(fft_out);
+  // Complex-half results historically normalize after the transform result is
+  // cast back down. The functional wrapper performs that finalization itself;
+  // public out= must additionally preserve functional-result-then-copy when
+  // the caller supplied a wider output dtype.
+  if (needs_result_conversion) {
+    if (preserve_out_layout) {
+      if (out.scalar_type() == result_dtype) {
+        out.copy_(fft_out);
+        impl::_fft_apply_normalization(out, normalization, input_sizes, dim);
+      } else {
+        auto result = fft_out.to(result_dtype);
+        impl::_fft_apply_normalization(result, normalization, input_sizes, dim);
+        out.copy_(result);
+      }
+    }
+  } else {
+    impl::_fft_apply_normalization(fft_out, normalization, input_sizes, dim);
+    if (!fft_out.is_same(out)) {
+      out.copy_(fft_out);
+    }
   }
 }
 
@@ -397,7 +423,12 @@ Tensor _fft_c2c_mkl(
   auto out = at::empty(self.sizes(), self.options().dtype(fft_dtype));
   _fft_c2c_mkl_out_impl(
       self, dim, normalization, forward, out, /*preserve_out_layout=*/false);
-  return out.to(self.scalar_type());
+  if (fft_dtype != self.scalar_type()) {
+    auto result = out.to(self.scalar_type());
+    impl::_fft_apply_normalization(result, normalization, self.sizes(), dim);
+    return result;
+  }
+  return out;
 }
 
 Tensor& _fft_c2c_mkl_out(
@@ -479,9 +510,14 @@ static void _fft_c2r_mkl_out_impl(
   auto in_sizes = input.sizes();
   DimVector out_sizes(in_sizes.begin(), in_sizes.end());
   out_sizes[dim.back()] = last_dim_size;
+  const auto result_dtype = c10::toRealValueType(orig_self.scalar_type());
+  const bool needs_result_conversion =
+      c10::toRealValueType(self.scalar_type()) != result_dtype;
   const bool needs_type_conversion =
       c10::toRealValueType(self.scalar_type()) != out.scalar_type();
-  const bool can_write_out = !needs_type_conversion && out.is_contiguous() &&
+  const bool can_write_out = !needs_type_conversion &&
+      (!preserve_out_layout || out.scalar_type() == result_dtype) &&
+      impl::_has_exact_contiguous_strides(out) &&
       (!preserve_out_layout ||
        impl::_exec_fft_preserves_layout(input, dim.back()));
   Tensor fft_out = can_write_out
@@ -500,9 +536,24 @@ static void _fft_c2r_mkl_out_impl(
       /*onesided=*/true,
       /*forward=*/false);
 
-  impl::_fft_apply_normalization(fft_out, normalization, out_sizes, dim);
-  if (!fft_out.is_same(out)) {
-    out.copy_(fft_out);
+  // Match the complex-half functional result's cast-then-normalize ordering.
+  // See the corresponding c2c finalization above.
+  if (needs_result_conversion) {
+    if (preserve_out_layout) {
+      if (out.scalar_type() == result_dtype) {
+        out.copy_(fft_out);
+        impl::_fft_apply_normalization(out, normalization, out_sizes, dim);
+      } else {
+        auto result = fft_out.to(result_dtype);
+        impl::_fft_apply_normalization(result, normalization, out_sizes, dim);
+        out.copy_(result);
+      }
+    }
+  } else {
+    impl::_fft_apply_normalization(fft_out, normalization, out_sizes, dim);
+    if (!fft_out.is_same(out)) {
+      out.copy_(fft_out);
+    }
   }
 }
 
@@ -526,7 +577,13 @@ Tensor _fft_c2r_mkl(
       last_dim_size,
       out,
       /*preserve_out_layout=*/false);
-  return out.to(c10::toRealValueType(self.scalar_type()));
+  const auto result_dtype = c10::toRealValueType(self.scalar_type());
+  if (fft_dtype != result_dtype) {
+    auto result = out.to(result_dtype);
+    impl::_fft_apply_normalization(result, normalization, out_sizes, dim);
+    return result;
+  }
+  return out;
 }
 
 Tensor& _fft_c2r_mkl_out(
@@ -585,6 +642,9 @@ static void _fft_r2c_mkl_out_impl(
   auto last_dim_halfsize = (input_sizes[last_dim]) / 2 + 1;
   auto out_sizes = _fft_r2c_out_sizes(self, dim, onesided);
   const auto fft_dtype = c10::toComplexType(self.scalar_type());
+  const auto result_dtype = orig_self.scalar_type() == ScalarType::Half
+      ? ScalarType::ComplexHalf
+      : fft_dtype;
 
   const auto c2c_pass_count =
       (dim.size() - 1 + impl::mkl_max_ndim - 1) / impl::mkl_max_ndim;
@@ -593,7 +653,9 @@ static void _fft_r2c_mkl_out_impl(
   const bool needs_type_conversion = fft_dtype != out.scalar_type();
   // The transform runs on a contiguous copy of self, so _exec_fft leaves a
   // contiguous layout only when the single pass acts on the innermost dim.
-  const bool can_write_out = !needs_type_conversion && out.is_contiguous() &&
+  const bool can_write_out = !needs_type_conversion &&
+      (!preserve_out_layout || out.scalar_type() == result_dtype) &&
+      impl::_has_exact_contiguous_strides(out) &&
       (!preserve_out_layout || (pass_count == 1 && last_dim == self.dim() - 1));
   Tensor fft_out = can_write_out
       ? out
@@ -658,7 +720,11 @@ static void _fft_r2c_mkl_out_impl(
   }
 
   if (!fft_out.is_same(out)) {
-    out.copy_(fft_out);
+    if (preserve_out_layout && out.scalar_type() != result_dtype) {
+      out.copy_(fft_out.to(result_dtype));
+    } else {
+      out.copy_(fft_out);
+    }
   }
 }
 

--- a/src/ATen/native/xpu/mkl/SpectralOps.cpp
+++ b/src/ATen/native/xpu/mkl/SpectralOps.cpp
@@ -649,14 +649,15 @@ static void _fft_r2c_mkl_out_impl(
   const auto c2c_pass_count =
       (dim.size() - 1 + impl::mkl_max_ndim - 1) / impl::mkl_max_ndim;
   const auto pass_count = 1 + c2c_pass_count;
+  auto working_tensor = self.contiguous();
 
   const bool needs_type_conversion = fft_dtype != out.scalar_type();
-  // The transform runs on a contiguous copy of self, so _exec_fft leaves a
-  // contiguous layout only when the single pass acts on the innermost dim.
   const bool can_write_out = !needs_type_conversion &&
       (!preserve_out_layout || out.scalar_type() == result_dtype) &&
       impl::_has_exact_contiguous_strides(out) &&
-      (!preserve_out_layout || (pass_count == 1 && last_dim == self.dim() - 1));
+      (!preserve_out_layout ||
+       (pass_count == 1 &&
+        impl::_exec_fft_preserves_layout(working_tensor, last_dim)));
   Tensor fft_out = can_write_out
       ? out
       : at::empty(out_sizes, self.options().dtype(fft_dtype));
@@ -667,8 +668,6 @@ static void _fft_r2c_mkl_out_impl(
   if (pass_count > 1) {
     scratch = at::empty(out_sizes, self.options().dtype(fft_dtype));
   }
-
-  auto working_tensor = self.contiguous();
 
   // First do the R2C transform on the last dimension
   Tensor& first_pass_out = pass_count % 2 == 1 ? fft_out : scratch;

--- a/src/ATen/native/xpu/mkl/SpectralOps.cpp
+++ b/src/ATen/native/xpu/mkl/SpectralOps.cpp
@@ -332,58 +332,73 @@ Tensor promote_fft_input(const Tensor& input) {
 
 } // namespace impl
 
-Tensor _fft_c2c_mkl(
+static void _fft_c2c_mkl_out_impl(
     const Tensor& orig_self,
     IntArrayRef dim,
     int64_t normalization,
-    bool forward) {
-  if (dim.empty()) {
-    return orig_self.clone();
-  }
+    bool forward,
+    Tensor& out) {
   auto self = impl::promote_fft_input(orig_self);
 
   auto sorted_dims = impl::_sort_dims(self, dim);
   auto out_sizes = self.sizes();
-  auto out = at::empty(out_sizes, self.options());
   auto input_sizes = self.sizes();
+  const bool needs_type_conversion = self.scalar_type() != out.scalar_type();
+  Tensor fft_out = needs_type_conversion || !out.is_contiguous()
+      ? at::empty(out_sizes, self.options())
+      : out;
+
+  const auto pass_count =
+      (sorted_dims.size() + impl::mkl_max_ndim - 1) / impl::mkl_max_ndim;
+  Tensor scratch;
+  if (pass_count > 1) {
+    scratch = at::empty(out_sizes, self.options());
+  }
+
   auto working_tensor = self;
+  size_t pass = 0;
 
   while (!sorted_dims.empty()) {
     const auto max_dims =
         std::min(static_cast<size_t>(impl::mkl_max_ndim), sorted_dims.size());
     auto fft_dims =
         IntArrayRef(sorted_dims).slice(sorted_dims.size() - max_dims, max_dims);
+    const auto remaining_passes = pass_count - pass;
+    Tensor* pass_out = remaining_passes % 2 == 1 ? &fft_out : &scratch;
 
     impl::_exec_fft(
-        out,
+        *pass_out,
         working_tensor,
         out_sizes,
         fft_dims,
         /*onesided=*/false,
         forward);
 
+    working_tensor = *pass_out;
     sorted_dims.resize(sorted_dims.size() - max_dims);
-
-    if (sorted_dims.empty()) {
-      break;
-    }
-
-    sorted_dims = impl::_sort_dims(self, sorted_dims);
-
-    if (working_tensor.is_same(self)) {
-      working_tensor = std::move(out);
-      out = at::empty(out_sizes, self.options());
-    } else {
-      std::swap(out, working_tensor);
+    ++pass;
+    if (!sorted_dims.empty()) {
+      sorted_dims = impl::_sort_dims(self, sorted_dims);
     }
   }
 
-  if (orig_self.scalar_type() == ScalarType::ComplexHalf) {
-    Tensor result = out.to(ScalarType::ComplexHalf);
-    impl::_fft_apply_normalization(result, normalization, input_sizes, dim);
-    return result;
+  impl::_fft_apply_normalization(fft_out, normalization, input_sizes, dim);
+  if (!fft_out.is_same(out)) {
+    out.copy_(fft_out);
   }
-  impl::_fft_apply_normalization(out, normalization, input_sizes, dim);
+}
+
+Tensor _fft_c2c_mkl(
+    const Tensor& self,
+    IntArrayRef dim,
+    int64_t normalization,
+    bool forward) {
+  if (dim.empty()) {
+    return self.clone();
+  }
+
+  auto out = at::empty(self.sizes(), self.options());
+  _fft_c2c_mkl_out_impl(self, dim, normalization, forward, out);
   return out;
 }
 
@@ -393,9 +408,15 @@ Tensor& _fft_c2c_mkl_out(
     int64_t normalization,
     bool forward,
     Tensor& out) {
-  auto result = _fft_c2c_mkl(self, dim, normalization, forward);
-  at::native::resize_output(out, result.sizes());
-  out.copy_(result);
+  if (dim.empty() || out.is_alias_of(self)) {
+    auto result = _fft_c2c_mkl(self, dim, normalization, forward);
+    at::native::resize_output(out, result.sizes());
+    out.copy_(result);
+    return out;
+  }
+
+  at::native::resize_output(out, self.sizes());
+  _fft_c2c_mkl_out_impl(self, dim, normalization, forward, out);
   return out;
 }
 
@@ -419,14 +440,21 @@ void HermitSymm(Tensor& input, int64_t dim, int64_t out_size) {
     HermitSymmImpl(input, dim, -1);
 }
 
-Tensor _fft_c2r_mkl(
+static DimVector _fft_c2r_out_sizes(
+    const Tensor& self,
+    IntArrayRef dim,
+    int64_t last_dim_size) {
+  DimVector out_sizes(self.sizes().begin(), self.sizes().end());
+  out_sizes[dim.back()] = last_dim_size;
+  return out_sizes;
+}
+
+static void _fft_c2r_mkl_out_impl(
     const Tensor& orig_self,
     IntArrayRef dim,
     int64_t normalization,
-    int64_t last_dim_size) {
-  if (dim.empty()) {
-    return orig_self.clone();
-  }
+    int64_t last_dim_size,
+    Tensor& out) {
   auto self = impl::promote_fft_input(orig_self);
 
   auto input = self;
@@ -452,27 +480,44 @@ Tensor _fft_c2r_mkl(
   auto in_sizes = input.sizes();
   DimVector out_sizes(in_sizes.begin(), in_sizes.end());
   out_sizes[dim.back()] = last_dim_size;
-
-  auto out = at::empty(
-      out_sizes,
-      self.options().dtype(c10::toRealValueType(self.scalar_type())));
+  const bool needs_type_conversion =
+      c10::toRealValueType(self.scalar_type()) != out.scalar_type();
+  Tensor fft_out = needs_type_conversion || !out.is_contiguous()
+      ? at::empty(
+            out_sizes,
+            self.options().dtype(c10::toRealValueType(self.scalar_type())))
+      : out;
 
   HermitSymm(input, dim.back(), out_sizes[dim.back()]);
 
   impl::_exec_fft(
-      out,
+      fft_out,
       input,
       out_sizes,
       dim.back(),
       /*onesided=*/true,
       /*forward=*/false);
 
-  if (orig_self.scalar_type() == ScalarType::ComplexHalf) {
-    Tensor result = out.to(ScalarType::Half);
-    impl::_fft_apply_normalization(result, normalization, out_sizes, dim);
-    return result;
+  impl::_fft_apply_normalization(fft_out, normalization, out_sizes, dim);
+  if (!fft_out.is_same(out)) {
+    out.copy_(fft_out);
   }
-  impl::_fft_apply_normalization(out, normalization, out_sizes, dim);
+}
+
+Tensor _fft_c2r_mkl(
+    const Tensor& self,
+    IntArrayRef dim,
+    int64_t normalization,
+    int64_t last_dim_size) {
+  if (dim.empty()) {
+    return self.clone();
+  }
+
+  auto out_sizes = _fft_c2r_out_sizes(self, dim, last_dim_size);
+  auto out = at::empty(
+      out_sizes,
+      self.options().dtype(c10::toRealValueType(self.scalar_type())));
+  _fft_c2r_mkl_out_impl(self, dim, normalization, last_dim_size, out);
   return out;
 }
 
@@ -482,9 +527,16 @@ Tensor& _fft_c2r_mkl_out(
     int64_t normalization,
     int64_t last_dim_size,
     Tensor& out) {
-  auto result = _fft_c2r_mkl(self, dim, normalization, last_dim_size);
-  at::native::resize_output(out, result.sizes());
-  out.copy_(result);
+  if (dim.empty() || out.is_alias_of(self)) {
+    auto result = _fft_c2r_mkl(self, dim, normalization, last_dim_size);
+    at::native::resize_output(out, result.sizes());
+    out.copy_(result);
+    return out;
+  }
+
+  auto out_sizes = _fft_c2r_out_sizes(self, dim, last_dim_size);
+  at::native::resize_output(out, out_sizes);
+  _fft_c2r_mkl_out_impl(self, dim, normalization, last_dim_size, out);
   return out;
 }
 
@@ -492,76 +544,116 @@ REGISTER_XPU_DISPATCH(
     fft_fill_with_conjugate_symmetry_stub,
     &_fft_fill_with_conjugate_symmetry_xpu);
 
-Tensor _fft_r2c_mkl(
+static DimVector _fft_r2c_out_sizes(
+    const Tensor& self,
+    IntArrayRef dim,
+    bool onesided) {
+  DimVector out_sizes(self.sizes().begin(), self.sizes().end());
+  if (onesided) {
+    auto last_dim = dim.back();
+    out_sizes[last_dim] = self.size(last_dim) / 2 + 1;
+  }
+  return out_sizes;
+}
+
+static void _fft_r2c_mkl_out_impl(
     const Tensor& orig_self,
     IntArrayRef dim,
     int64_t normalization,
-    bool onesided) {
-  if (dim.empty()) {
-    return orig_self.clone();
-  }
+    bool onesided,
+    Tensor& out) {
   auto self = impl::promote_fft_input(orig_self);
 
   auto input_sizes = self.sizes();
-  DimVector onesided_sizes(input_sizes.begin(), input_sizes.end());
   auto last_dim = dim.back();
   auto last_dim_halfsize = (input_sizes[last_dim]) / 2 + 1;
-  onesided_sizes[last_dim] = last_dim_halfsize;
+  auto out_sizes = _fft_r2c_out_sizes(self, dim, onesided);
+  const auto fft_dtype = c10::toComplexType(self.scalar_type());
+  const bool needs_type_conversion = fft_dtype != out.scalar_type();
+  Tensor fft_out = needs_type_conversion || !out.is_contiguous()
+      ? at::empty(out_sizes, self.options().dtype(fft_dtype))
+      : out;
 
-  IntArrayRef out_sizes = onesided ? onesided_sizes : input_sizes;
-
-  auto out = at::empty(
-      out_sizes, self.options().dtype(c10::toComplexType(self.scalar_type())));
+  const auto c2c_pass_count =
+      (dim.size() - 1 + impl::mkl_max_ndim - 1) / impl::mkl_max_ndim;
+  const auto pass_count = 1 + c2c_pass_count;
+  Tensor scratch;
+  if (pass_count > 1) {
+    scratch = at::empty(out_sizes, self.options().dtype(fft_dtype));
+  }
 
   auto working_tensor = self.contiguous();
 
   // First do the R2C transform on the last dimension
+  Tensor* pass_out = pass_count % 2 == 1 ? &fft_out : &scratch;
   impl::_exec_fft(
-      out, working_tensor, out_sizes, last_dim, onesided, /*forward=*/true);
-
-  if (dim.size() > 1) {
-    working_tensor = at::empty(
-        out_sizes,
-        self.options().dtype(c10::toComplexType(self.scalar_type())));
-  }
+      *pass_out,
+      working_tensor,
+      out_sizes,
+      last_dim,
+      onesided,
+      /*forward=*/true);
+  working_tensor = *pass_out;
 
   DimVector sorted_dims(dim.begin(), dim.end() - 1);
+  size_t pass = 1;
 
   while (!sorted_dims.empty()) {
     sorted_dims = impl::_sort_dims(self, sorted_dims);
-
-    std::swap(out, working_tensor);
 
     const auto max_dims =
         std::min(static_cast<size_t>(impl::mkl_max_ndim), sorted_dims.size());
     auto fft_dims =
         IntArrayRef(sorted_dims).slice(sorted_dims.size() - max_dims, max_dims);
+    const auto remaining_passes = pass_count - pass;
+    pass_out = remaining_passes % 2 == 1 ? &fft_out : &scratch;
     impl::_exec_fft(
-        out,
+        *pass_out,
         working_tensor,
         out_sizes,
         fft_dims,
         onesided,
         /*forward=*/true);
+    working_tensor = *pass_out;
     sorted_dims.resize(sorted_dims.size() - max_dims);
+    ++pass;
   }
 
   // Only need to normalize the onesided slice since data in the other half is
   // overwritten
-  auto out_slice = out.slice(last_dim, 0, last_dim_halfsize);
+  auto out_slice = fft_out.slice(last_dim, 0, last_dim_halfsize);
   impl::_fft_apply_normalization(out_slice, normalization, input_sizes, dim);
 
   if (!onesided) {
-    if (out.sizes()[last_dim] != out_sizes[last_dim]) {
-      working_tensor.resize_(out_sizes, MemoryFormat::Contiguous);
-      working_tensor.slice(last_dim, 0, last_dim_halfsize).copy_(out);
-      out = std::move(working_tensor);
+    if (fft_out.sizes()[last_dim] != out_sizes[last_dim]) {
+      auto full_out = at::empty(out_sizes, self.options().dtype(fft_dtype));
+      full_out.slice(last_dim, 0, last_dim_halfsize).copy_(fft_out);
+      fft_out = std::move(full_out);
     }
-    at::native::_fft_fill_with_conjugate_symmetry_(out, dim);
+    at::native::_fft_fill_with_conjugate_symmetry_(fft_out, dim);
   }
 
-  if (orig_self.scalar_type() == ScalarType::Half)
-    return out.to(ScalarType::ComplexHalf);
+  if (!fft_out.is_same(out)) {
+    out.copy_(fft_out);
+  }
+}
+
+Tensor _fft_r2c_mkl(
+    const Tensor& self,
+    IntArrayRef dim,
+    int64_t normalization,
+    bool onesided) {
+  if (dim.empty()) {
+    return self.clone();
+  }
+
+  auto promoted = impl::promote_fft_input(self);
+  auto out_sizes = _fft_r2c_out_sizes(self, dim, onesided);
+  auto out_dtype = self.scalar_type() == ScalarType::Half
+      ? ScalarType::ComplexHalf
+      : c10::toComplexType(promoted.scalar_type());
+  auto out = at::empty(out_sizes, self.options().dtype(out_dtype));
+  _fft_r2c_mkl_out_impl(self, dim, normalization, onesided, out);
   return out;
 }
 
@@ -571,10 +663,16 @@ Tensor& _fft_r2c_mkl_out(
     int64_t normalization,
     bool onesided,
     Tensor& out) {
-  auto result = _fft_r2c_mkl(self, dim, normalization, onesided);
+  if (dim.empty() || out.is_alias_of(self)) {
+    auto result = _fft_r2c_mkl(self, dim, normalization, onesided);
+    at::native::resize_output(out, result.sizes());
+    out.copy_(result);
+    return out;
+  }
 
-  at::native::resize_output(out, result.sizes());
-  out.copy_(result);
+  auto out_sizes = _fft_r2c_out_sizes(self, dim, onesided);
+  at::native::resize_output(out, out_sizes);
+  _fft_r2c_mkl_out_impl(self, dim, normalization, onesided, out);
   return out;
 }
 

--- a/src/ATen/native/xpu/mkl/SpectralOps.cpp
+++ b/src/ATen/native/xpu/mkl/SpectralOps.cpp
@@ -282,6 +282,39 @@ Tensor& _exec_fft(
 // _sort_dims, _dft_scale, _fft_apply_normalization, and promote_fft_input are
 // defined in sycl/FFTKernelFunctor.cpp and declared in sycl/FFTKernelFunctor.h
 
+// _exec_fft rewrites the destination metadata via resize_/as_strided_. The
+// layout it leaves behind only matches a contiguous destination when the
+// batch/signal permutation it computes is the identity, so a caller-provided
+// output may only be used directly when this holds.
+static bool _exec_fft_preserves_layout(const Tensor& self, IntArrayRef dim) {
+  const auto ndim = self.dim();
+  const auto signal_ndim = static_cast<int64_t>(dim.size());
+  const auto batch_dims = ndim - signal_ndim;
+
+  for (const auto i : c10::irange(signal_ndim)) {
+    if (dim[i] != batch_dims + i) {
+      return false;
+    }
+  }
+
+  auto self_strides = self.strides();
+  for (const auto i : c10::irange(int64_t{1}, batch_dims)) {
+    if (self_strides[i - 1] <= self_strides[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Result type of promote_fft_input, without materializing the promoted tensor.
+ScalarType promote_fft_dtype(ScalarType dtype) {
+  if (dtype == ScalarType::Half || dtype == ScalarType::BFloat16)
+    return ScalarType::Float;
+  if (dtype == ScalarType::ComplexHalf)
+    return ScalarType::ComplexFloat;
+  return dtype;
+}
+
 } // namespace impl
 
 static void _fft_c2c_mkl_out_impl(
@@ -289,19 +322,25 @@ static void _fft_c2c_mkl_out_impl(
     IntArrayRef dim,
     int64_t normalization,
     bool forward,
-    Tensor& out) {
+    Tensor& out,
+    bool preserve_out_layout) {
   auto self = impl::promote_fft_input(orig_self);
 
   auto sorted_dims = impl::_sort_dims(self, dim);
   auto out_sizes = self.sizes();
   auto input_sizes = self.sizes();
-  const bool needs_type_conversion = self.scalar_type() != out.scalar_type();
-  Tensor fft_out = needs_type_conversion || !out.is_contiguous()
-      ? at::empty(out_sizes, self.options())
-      : out;
 
   const auto pass_count =
       (sorted_dims.size() + impl::mkl_max_ndim - 1) / impl::mkl_max_ndim;
+  const bool needs_type_conversion = self.scalar_type() != out.scalar_type();
+  // A multi-pass transform hands its last pass the outermost dims, so the
+  // permutation is no longer the identity even when the full dim set is.
+  const bool can_write_out = !needs_type_conversion && out.is_contiguous() &&
+      (!preserve_out_layout ||
+       (pass_count == 1 &&
+        impl::_exec_fft_preserves_layout(self, sorted_dims)));
+  Tensor fft_out = can_write_out ? out : at::empty(out_sizes, self.options());
+
   Tensor scratch;
   if (pass_count > 1) {
     scratch = at::empty(out_sizes, self.options());
@@ -316,17 +355,17 @@ static void _fft_c2c_mkl_out_impl(
     auto fft_dims =
         IntArrayRef(sorted_dims).slice(sorted_dims.size() - max_dims, max_dims);
     const auto remaining_passes = pass_count - pass;
-    Tensor* pass_out = remaining_passes % 2 == 1 ? &fft_out : &scratch;
+    Tensor& pass_out = remaining_passes % 2 == 1 ? fft_out : scratch;
 
     impl::_exec_fft(
-        *pass_out,
+        pass_out,
         working_tensor,
         out_sizes,
         fft_dims,
         /*onesided=*/false,
         forward);
 
-    working_tensor = *pass_out;
+    working_tensor = pass_out;
     sorted_dims.resize(sorted_dims.size() - max_dims);
     ++pass;
     if (!sorted_dims.empty()) {
@@ -349,9 +388,14 @@ Tensor _fft_c2c_mkl(
     return self.clone();
   }
 
-  auto out = at::empty(self.sizes(), self.options());
-  _fft_c2c_mkl_out_impl(self, dim, normalization, forward, out);
-  return out;
+  // Allocate at the transform's own precision so the impl can write straight
+  // into out; converting afterwards preserves the layout _exec_fft left behind
+  // and keeps the conversion a linear pass.
+  const auto fft_dtype = impl::promote_fft_dtype(self.scalar_type());
+  auto out = at::empty(self.sizes(), self.options().dtype(fft_dtype));
+  _fft_c2c_mkl_out_impl(
+      self, dim, normalization, forward, out, /*preserve_out_layout=*/false);
+  return out.to(self.scalar_type());
 }
 
 Tensor& _fft_c2c_mkl_out(
@@ -368,7 +412,8 @@ Tensor& _fft_c2c_mkl_out(
   }
 
   at::native::resize_output(out, self.sizes());
-  _fft_c2c_mkl_out_impl(self, dim, normalization, forward, out);
+  _fft_c2c_mkl_out_impl(
+      self, dim, normalization, forward, out, /*preserve_out_layout=*/true);
   return out;
 }
 
@@ -406,7 +451,8 @@ static void _fft_c2r_mkl_out_impl(
     IntArrayRef dim,
     int64_t normalization,
     int64_t last_dim_size,
-    Tensor& out) {
+    Tensor& out,
+    bool preserve_out_layout) {
   auto self = impl::promote_fft_input(orig_self);
 
   auto input = self;
@@ -434,11 +480,14 @@ static void _fft_c2r_mkl_out_impl(
   out_sizes[dim.back()] = last_dim_size;
   const bool needs_type_conversion =
       c10::toRealValueType(self.scalar_type()) != out.scalar_type();
-  Tensor fft_out = needs_type_conversion || !out.is_contiguous()
-      ? at::empty(
+  const bool can_write_out = !needs_type_conversion && out.is_contiguous() &&
+      (!preserve_out_layout ||
+       impl::_exec_fft_preserves_layout(input, dim.back()));
+  Tensor fft_out = can_write_out
+      ? out
+      : at::empty(
             out_sizes,
-            self.options().dtype(c10::toRealValueType(self.scalar_type())))
-      : out;
+            self.options().dtype(c10::toRealValueType(self.scalar_type())));
 
   HermitSymm(input, dim.back(), out_sizes[dim.back()]);
 
@@ -466,11 +515,17 @@ Tensor _fft_c2r_mkl(
   }
 
   auto out_sizes = _fft_c2r_out_sizes(self, dim, last_dim_size);
-  auto out = at::empty(
-      out_sizes,
-      self.options().dtype(c10::toRealValueType(self.scalar_type())));
-  _fft_c2r_mkl_out_impl(self, dim, normalization, last_dim_size, out);
-  return out;
+  const auto fft_dtype =
+      c10::toRealValueType(impl::promote_fft_dtype(self.scalar_type()));
+  auto out = at::empty(out_sizes, self.options().dtype(fft_dtype));
+  _fft_c2r_mkl_out_impl(
+      self,
+      dim,
+      normalization,
+      last_dim_size,
+      out,
+      /*preserve_out_layout=*/false);
+  return out.to(c10::toRealValueType(self.scalar_type()));
 }
 
 Tensor& _fft_c2r_mkl_out(
@@ -488,7 +543,13 @@ Tensor& _fft_c2r_mkl_out(
 
   auto out_sizes = _fft_c2r_out_sizes(self, dim, last_dim_size);
   at::native::resize_output(out, out_sizes);
-  _fft_c2r_mkl_out_impl(self, dim, normalization, last_dim_size, out);
+  _fft_c2r_mkl_out_impl(
+      self,
+      dim,
+      normalization,
+      last_dim_size,
+      out,
+      /*preserve_out_layout=*/true);
   return out;
 }
 
@@ -513,7 +574,9 @@ static void _fft_r2c_mkl_out_impl(
     IntArrayRef dim,
     int64_t normalization,
     bool onesided,
-    Tensor& out) {
+    Tensor& out,
+    bool preserve_out_layout) {
+  TORCH_INTERNAL_ASSERT(!dim.empty());
   auto self = impl::promote_fft_input(orig_self);
 
   auto input_sizes = self.sizes();
@@ -521,14 +584,20 @@ static void _fft_r2c_mkl_out_impl(
   auto last_dim_halfsize = (input_sizes[last_dim]) / 2 + 1;
   auto out_sizes = _fft_r2c_out_sizes(self, dim, onesided);
   const auto fft_dtype = c10::toComplexType(self.scalar_type());
-  const bool needs_type_conversion = fft_dtype != out.scalar_type();
-  Tensor fft_out = needs_type_conversion || !out.is_contiguous()
-      ? at::empty(out_sizes, self.options().dtype(fft_dtype))
-      : out;
 
   const auto c2c_pass_count =
       (dim.size() - 1 + impl::mkl_max_ndim - 1) / impl::mkl_max_ndim;
   const auto pass_count = 1 + c2c_pass_count;
+
+  const bool needs_type_conversion = fft_dtype != out.scalar_type();
+  // The transform runs on a contiguous copy of self, so _exec_fft leaves a
+  // contiguous layout only when the single pass acts on the innermost dim.
+  const bool can_write_out = !needs_type_conversion && out.is_contiguous() &&
+      (!preserve_out_layout || (pass_count == 1 && last_dim == self.dim() - 1));
+  Tensor fft_out = can_write_out
+      ? out
+      : at::empty(out_sizes, self.options().dtype(fft_dtype));
+
   Tensor scratch;
   if (pass_count > 1) {
     scratch = at::empty(out_sizes, self.options().dtype(fft_dtype));
@@ -537,15 +606,15 @@ static void _fft_r2c_mkl_out_impl(
   auto working_tensor = self.contiguous();
 
   // First do the R2C transform on the last dimension
-  Tensor* pass_out = pass_count % 2 == 1 ? &fft_out : &scratch;
+  Tensor& first_pass_out = pass_count % 2 == 1 ? fft_out : scratch;
   impl::_exec_fft(
-      *pass_out,
+      first_pass_out,
       working_tensor,
       out_sizes,
       last_dim,
       onesided,
       /*forward=*/true);
-  working_tensor = *pass_out;
+  working_tensor = first_pass_out;
 
   DimVector sorted_dims(dim.begin(), dim.end() - 1);
   size_t pass = 1;
@@ -558,15 +627,15 @@ static void _fft_r2c_mkl_out_impl(
     auto fft_dims =
         IntArrayRef(sorted_dims).slice(sorted_dims.size() - max_dims, max_dims);
     const auto remaining_passes = pass_count - pass;
-    pass_out = remaining_passes % 2 == 1 ? &fft_out : &scratch;
+    Tensor& pass_out = remaining_passes % 2 == 1 ? fft_out : scratch;
     impl::_exec_fft(
-        *pass_out,
+        pass_out,
         working_tensor,
         out_sizes,
         fft_dims,
         onesided,
         /*forward=*/true);
-    working_tensor = *pass_out;
+    working_tensor = pass_out;
     sorted_dims.resize(sorted_dims.size() - max_dims);
     ++pass;
   }
@@ -599,14 +668,18 @@ Tensor _fft_r2c_mkl(
     return self.clone();
   }
 
-  auto promoted = impl::promote_fft_input(self);
   auto out_sizes = _fft_r2c_out_sizes(self, dim, onesided);
+  const auto fft_dtype =
+      c10::toComplexType(impl::promote_fft_dtype(self.scalar_type()));
+  // Not toComplexType(self.scalar_type()): that maps bfloat16 to complex
+  // bfloat16, while the transform runs at float and reports complex float.
   auto out_dtype = self.scalar_type() == ScalarType::Half
       ? ScalarType::ComplexHalf
-      : c10::toComplexType(promoted.scalar_type());
-  auto out = at::empty(out_sizes, self.options().dtype(out_dtype));
-  _fft_r2c_mkl_out_impl(self, dim, normalization, onesided, out);
-  return out;
+      : fft_dtype;
+  auto out = at::empty(out_sizes, self.options().dtype(fft_dtype));
+  _fft_r2c_mkl_out_impl(
+      self, dim, normalization, onesided, out, /*preserve_out_layout=*/false);
+  return out.to(out_dtype);
 }
 
 Tensor& _fft_r2c_mkl_out(
@@ -624,7 +697,8 @@ Tensor& _fft_r2c_mkl_out(
 
   auto out_sizes = _fft_r2c_out_sizes(self, dim, onesided);
   at::native::resize_output(out, out_sizes);
-  _fft_r2c_mkl_out_impl(self, dim, normalization, onesided, out);
+  _fft_r2c_mkl_out_impl(
+      self, dim, normalization, onesided, out, /*preserve_out_layout=*/true);
   return out;
 }
 

--- a/src/ATen/native/xpu/mkl/SpectralOps.cpp
+++ b/src/ATen/native/xpu/mkl/SpectralOps.cpp
@@ -341,6 +341,8 @@ static void _fft_c2c_mkl_out_impl(
         impl::_exec_fft_preserves_layout(self, sorted_dims)));
   Tensor fft_out = can_write_out ? out : at::empty(out_sizes, self.options());
 
+  // The final pass always lands in fft_out, so a single-pass transform never
+  // selects scratch and can leave it undefined.
   Tensor scratch;
   if (pass_count > 1) {
     scratch = at::empty(out_sizes, self.options());
@@ -466,9 +468,8 @@ static void _fft_c2r_mkl_out_impl(
         /*forward=*/false);
   }
 
-  // HermitSymm mutates in-place; avoid mutating user-visible input when
-  // aliased.
-  if (input.is_same(self)) {
+  // HermitSymm mutates in-place; a promoted input is already a private copy.
+  if (input.is_same(orig_self)) {
     auto input_copy =
         at::empty_strided(input.sizes(), input.strides(), input.options());
     input_copy.copy_(input);
@@ -598,6 +599,8 @@ static void _fft_r2c_mkl_out_impl(
       ? out
       : at::empty(out_sizes, self.options().dtype(fft_dtype));
 
+  // The final pass always lands in fft_out, so a single-pass transform never
+  // selects scratch and can leave it undefined.
   Tensor scratch;
   if (pass_count > 1) {
     scratch = at::empty(out_sizes, self.options().dtype(fft_dtype));

--- a/src/ATen/native/xpu/mkl/SpectralOps.cpp
+++ b/src/ATen/native/xpu/mkl/SpectralOps.cpp
@@ -284,58 +284,73 @@ Tensor& _exec_fft(
 
 } // namespace impl
 
-Tensor _fft_c2c_mkl(
+static void _fft_c2c_mkl_out_impl(
     const Tensor& orig_self,
     IntArrayRef dim,
     int64_t normalization,
-    bool forward) {
-  if (dim.empty()) {
-    return orig_self.clone();
-  }
+    bool forward,
+    Tensor& out) {
   auto self = impl::promote_fft_input(orig_self);
 
   auto sorted_dims = impl::_sort_dims(self, dim);
   auto out_sizes = self.sizes();
-  auto out = at::empty(out_sizes, self.options());
   auto input_sizes = self.sizes();
+  const bool needs_type_conversion = self.scalar_type() != out.scalar_type();
+  Tensor fft_out = needs_type_conversion || !out.is_contiguous()
+      ? at::empty(out_sizes, self.options())
+      : out;
+
+  const auto pass_count =
+      (sorted_dims.size() + impl::mkl_max_ndim - 1) / impl::mkl_max_ndim;
+  Tensor scratch;
+  if (pass_count > 1) {
+    scratch = at::empty(out_sizes, self.options());
+  }
+
   auto working_tensor = self;
+  size_t pass = 0;
 
   while (!sorted_dims.empty()) {
     const auto max_dims =
         std::min(static_cast<size_t>(impl::mkl_max_ndim), sorted_dims.size());
     auto fft_dims =
         IntArrayRef(sorted_dims).slice(sorted_dims.size() - max_dims, max_dims);
+    const auto remaining_passes = pass_count - pass;
+    Tensor* pass_out = remaining_passes % 2 == 1 ? &fft_out : &scratch;
 
     impl::_exec_fft(
-        out,
+        *pass_out,
         working_tensor,
         out_sizes,
         fft_dims,
         /*onesided=*/false,
         forward);
 
+    working_tensor = *pass_out;
     sorted_dims.resize(sorted_dims.size() - max_dims);
-
-    if (sorted_dims.empty()) {
-      break;
-    }
-
-    sorted_dims = impl::_sort_dims(self, sorted_dims);
-
-    if (working_tensor.is_same(self)) {
-      working_tensor = std::move(out);
-      out = at::empty(out_sizes, self.options());
-    } else {
-      std::swap(out, working_tensor);
+    ++pass;
+    if (!sorted_dims.empty()) {
+      sorted_dims = impl::_sort_dims(self, sorted_dims);
     }
   }
 
-  if (orig_self.scalar_type() == ScalarType::ComplexHalf) {
-    Tensor result = out.to(ScalarType::ComplexHalf);
-    impl::_fft_apply_normalization(result, normalization, input_sizes, dim);
-    return result;
+  impl::_fft_apply_normalization(fft_out, normalization, input_sizes, dim);
+  if (!fft_out.is_same(out)) {
+    out.copy_(fft_out);
   }
-  impl::_fft_apply_normalization(out, normalization, input_sizes, dim);
+}
+
+Tensor _fft_c2c_mkl(
+    const Tensor& self,
+    IntArrayRef dim,
+    int64_t normalization,
+    bool forward) {
+  if (dim.empty()) {
+    return self.clone();
+  }
+
+  auto out = at::empty(self.sizes(), self.options());
+  _fft_c2c_mkl_out_impl(self, dim, normalization, forward, out);
   return out;
 }
 
@@ -345,9 +360,15 @@ Tensor& _fft_c2c_mkl_out(
     int64_t normalization,
     bool forward,
     Tensor& out) {
-  auto result = _fft_c2c_mkl(self, dim, normalization, forward);
-  at::native::resize_output(out, result.sizes());
-  out.copy_(result);
+  if (dim.empty() || out.is_alias_of(self)) {
+    auto result = _fft_c2c_mkl(self, dim, normalization, forward);
+    at::native::resize_output(out, result.sizes());
+    out.copy_(result);
+    return out;
+  }
+
+  at::native::resize_output(out, self.sizes());
+  _fft_c2c_mkl_out_impl(self, dim, normalization, forward, out);
   return out;
 }
 
@@ -371,14 +392,21 @@ void HermitSymm(Tensor& input, int64_t dim, int64_t out_size) {
     HermitSymmImpl(input, dim, -1);
 }
 
-Tensor _fft_c2r_mkl(
+static DimVector _fft_c2r_out_sizes(
+    const Tensor& self,
+    IntArrayRef dim,
+    int64_t last_dim_size) {
+  DimVector out_sizes(self.sizes().begin(), self.sizes().end());
+  out_sizes[dim.back()] = last_dim_size;
+  return out_sizes;
+}
+
+static void _fft_c2r_mkl_out_impl(
     const Tensor& orig_self,
     IntArrayRef dim,
     int64_t normalization,
-    int64_t last_dim_size) {
-  if (dim.empty()) {
-    return orig_self.clone();
-  }
+    int64_t last_dim_size,
+    Tensor& out) {
   auto self = impl::promote_fft_input(orig_self);
 
   auto input = self;
@@ -404,27 +432,44 @@ Tensor _fft_c2r_mkl(
   auto in_sizes = input.sizes();
   DimVector out_sizes(in_sizes.begin(), in_sizes.end());
   out_sizes[dim.back()] = last_dim_size;
-
-  auto out = at::empty(
-      out_sizes,
-      self.options().dtype(c10::toRealValueType(self.scalar_type())));
+  const bool needs_type_conversion =
+      c10::toRealValueType(self.scalar_type()) != out.scalar_type();
+  Tensor fft_out = needs_type_conversion || !out.is_contiguous()
+      ? at::empty(
+            out_sizes,
+            self.options().dtype(c10::toRealValueType(self.scalar_type())))
+      : out;
 
   HermitSymm(input, dim.back(), out_sizes[dim.back()]);
 
   impl::_exec_fft(
-      out,
+      fft_out,
       input,
       out_sizes,
       dim.back(),
       /*onesided=*/true,
       /*forward=*/false);
 
-  if (orig_self.scalar_type() == ScalarType::ComplexHalf) {
-    Tensor result = out.to(ScalarType::Half);
-    impl::_fft_apply_normalization(result, normalization, out_sizes, dim);
-    return result;
+  impl::_fft_apply_normalization(fft_out, normalization, out_sizes, dim);
+  if (!fft_out.is_same(out)) {
+    out.copy_(fft_out);
   }
-  impl::_fft_apply_normalization(out, normalization, out_sizes, dim);
+}
+
+Tensor _fft_c2r_mkl(
+    const Tensor& self,
+    IntArrayRef dim,
+    int64_t normalization,
+    int64_t last_dim_size) {
+  if (dim.empty()) {
+    return self.clone();
+  }
+
+  auto out_sizes = _fft_c2r_out_sizes(self, dim, last_dim_size);
+  auto out = at::empty(
+      out_sizes,
+      self.options().dtype(c10::toRealValueType(self.scalar_type())));
+  _fft_c2r_mkl_out_impl(self, dim, normalization, last_dim_size, out);
   return out;
 }
 
@@ -434,9 +479,16 @@ Tensor& _fft_c2r_mkl_out(
     int64_t normalization,
     int64_t last_dim_size,
     Tensor& out) {
-  auto result = _fft_c2r_mkl(self, dim, normalization, last_dim_size);
-  at::native::resize_output(out, result.sizes());
-  out.copy_(result);
+  if (dim.empty() || out.is_alias_of(self)) {
+    auto result = _fft_c2r_mkl(self, dim, normalization, last_dim_size);
+    at::native::resize_output(out, result.sizes());
+    out.copy_(result);
+    return out;
+  }
+
+  auto out_sizes = _fft_c2r_out_sizes(self, dim, last_dim_size);
+  at::native::resize_output(out, out_sizes);
+  _fft_c2r_mkl_out_impl(self, dim, normalization, last_dim_size, out);
   return out;
 }
 
@@ -444,76 +496,116 @@ REGISTER_XPU_DISPATCH(
     fft_fill_with_conjugate_symmetry_stub,
     &_fft_fill_with_conjugate_symmetry_xpu);
 
-Tensor _fft_r2c_mkl(
+static DimVector _fft_r2c_out_sizes(
+    const Tensor& self,
+    IntArrayRef dim,
+    bool onesided) {
+  DimVector out_sizes(self.sizes().begin(), self.sizes().end());
+  if (onesided) {
+    auto last_dim = dim.back();
+    out_sizes[last_dim] = self.size(last_dim) / 2 + 1;
+  }
+  return out_sizes;
+}
+
+static void _fft_r2c_mkl_out_impl(
     const Tensor& orig_self,
     IntArrayRef dim,
     int64_t normalization,
-    bool onesided) {
-  if (dim.empty()) {
-    return orig_self.clone();
-  }
+    bool onesided,
+    Tensor& out) {
   auto self = impl::promote_fft_input(orig_self);
 
   auto input_sizes = self.sizes();
-  DimVector onesided_sizes(input_sizes.begin(), input_sizes.end());
   auto last_dim = dim.back();
   auto last_dim_halfsize = (input_sizes[last_dim]) / 2 + 1;
-  onesided_sizes[last_dim] = last_dim_halfsize;
+  auto out_sizes = _fft_r2c_out_sizes(self, dim, onesided);
+  const auto fft_dtype = c10::toComplexType(self.scalar_type());
+  const bool needs_type_conversion = fft_dtype != out.scalar_type();
+  Tensor fft_out = needs_type_conversion || !out.is_contiguous()
+      ? at::empty(out_sizes, self.options().dtype(fft_dtype))
+      : out;
 
-  IntArrayRef out_sizes = onesided ? onesided_sizes : input_sizes;
-
-  auto out = at::empty(
-      out_sizes, self.options().dtype(c10::toComplexType(self.scalar_type())));
+  const auto c2c_pass_count =
+      (dim.size() - 1 + impl::mkl_max_ndim - 1) / impl::mkl_max_ndim;
+  const auto pass_count = 1 + c2c_pass_count;
+  Tensor scratch;
+  if (pass_count > 1) {
+    scratch = at::empty(out_sizes, self.options().dtype(fft_dtype));
+  }
 
   auto working_tensor = self.contiguous();
 
   // First do the R2C transform on the last dimension
+  Tensor* pass_out = pass_count % 2 == 1 ? &fft_out : &scratch;
   impl::_exec_fft(
-      out, working_tensor, out_sizes, last_dim, onesided, /*forward=*/true);
-
-  if (dim.size() > 1) {
-    working_tensor = at::empty(
-        out_sizes,
-        self.options().dtype(c10::toComplexType(self.scalar_type())));
-  }
+      *pass_out,
+      working_tensor,
+      out_sizes,
+      last_dim,
+      onesided,
+      /*forward=*/true);
+  working_tensor = *pass_out;
 
   DimVector sorted_dims(dim.begin(), dim.end() - 1);
+  size_t pass = 1;
 
   while (!sorted_dims.empty()) {
     sorted_dims = impl::_sort_dims(self, sorted_dims);
-
-    std::swap(out, working_tensor);
 
     const auto max_dims =
         std::min(static_cast<size_t>(impl::mkl_max_ndim), sorted_dims.size());
     auto fft_dims =
         IntArrayRef(sorted_dims).slice(sorted_dims.size() - max_dims, max_dims);
+    const auto remaining_passes = pass_count - pass;
+    pass_out = remaining_passes % 2 == 1 ? &fft_out : &scratch;
     impl::_exec_fft(
-        out,
+        *pass_out,
         working_tensor,
         out_sizes,
         fft_dims,
         onesided,
         /*forward=*/true);
+    working_tensor = *pass_out;
     sorted_dims.resize(sorted_dims.size() - max_dims);
+    ++pass;
   }
 
   // Only need to normalize the onesided slice since data in the other half is
   // overwritten
-  auto out_slice = out.slice(last_dim, 0, last_dim_halfsize);
+  auto out_slice = fft_out.slice(last_dim, 0, last_dim_halfsize);
   impl::_fft_apply_normalization(out_slice, normalization, input_sizes, dim);
 
   if (!onesided) {
-    if (out.sizes()[last_dim] != out_sizes[last_dim]) {
-      working_tensor.resize_(out_sizes, MemoryFormat::Contiguous);
-      working_tensor.slice(last_dim, 0, last_dim_halfsize).copy_(out);
-      out = std::move(working_tensor);
+    if (fft_out.sizes()[last_dim] != out_sizes[last_dim]) {
+      auto full_out = at::empty(out_sizes, self.options().dtype(fft_dtype));
+      full_out.slice(last_dim, 0, last_dim_halfsize).copy_(fft_out);
+      fft_out = std::move(full_out);
     }
-    at::native::_fft_fill_with_conjugate_symmetry_(out, dim);
+    at::native::_fft_fill_with_conjugate_symmetry_(fft_out, dim);
   }
 
-  if (orig_self.scalar_type() == ScalarType::Half)
-    return out.to(ScalarType::ComplexHalf);
+  if (!fft_out.is_same(out)) {
+    out.copy_(fft_out);
+  }
+}
+
+Tensor _fft_r2c_mkl(
+    const Tensor& self,
+    IntArrayRef dim,
+    int64_t normalization,
+    bool onesided) {
+  if (dim.empty()) {
+    return self.clone();
+  }
+
+  auto promoted = impl::promote_fft_input(self);
+  auto out_sizes = _fft_r2c_out_sizes(self, dim, onesided);
+  auto out_dtype = self.scalar_type() == ScalarType::Half
+      ? ScalarType::ComplexHalf
+      : c10::toComplexType(promoted.scalar_type());
+  auto out = at::empty(out_sizes, self.options().dtype(out_dtype));
+  _fft_r2c_mkl_out_impl(self, dim, normalization, onesided, out);
   return out;
 }
 
@@ -523,10 +615,16 @@ Tensor& _fft_r2c_mkl_out(
     int64_t normalization,
     bool onesided,
     Tensor& out) {
-  auto result = _fft_r2c_mkl(self, dim, normalization, onesided);
+  if (dim.empty() || out.is_alias_of(self)) {
+    auto result = _fft_r2c_mkl(self, dim, normalization, onesided);
+    at::native::resize_output(out, result.sizes());
+    out.copy_(result);
+    return out;
+  }
 
-  at::native::resize_output(out, result.sizes());
-  out.copy_(result);
+  auto out_sizes = _fft_r2c_out_sizes(self, dim, onesided);
+  at::native::resize_output(out, out_sizes);
+  _fft_r2c_mkl_out_impl(self, dim, normalization, onesided, out);
   return out;
 }
 

--- a/test/regressions/test_fft_out.py
+++ b/test/regressions/test_fft_out.py
@@ -1,0 +1,209 @@
+# Copyright 2020-2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Owner(s): ["module: intel"]
+#
+# The XPU MKL FFT out variants write into the caller-provided output whenever
+# that is safe. _exec_fft rewrites its destination metadata with
+# resize_/as_strided_, so the direct-write path must be restricted to the cases
+# where the resulting layout still matches a contiguous output. These tests pin
+# both the returned values and the output tensor identity/layout.
+
+import itertools
+
+import torch
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestFftOut(TestCase):
+    def test_fft_c2c_out_matches_cpu(self, device):
+        real_cpu = torch.randn(2, 3, 4, 5)
+        complex_cpu = torch.complex(real_cpu, torch.randn_like(real_cpu))
+        complex_xpu = complex_cpu.to(device)
+
+        for dims in ([3], [2, 3], [0], [1], [0, 1], [0, 1, 2], [0, 1, 2, 3]):
+            expected = torch.ops.aten._fft_c2c.default(complex_cpu, dims, 0, True)
+            out = torch.empty_like(complex_xpu)
+            result = torch.ops.aten._fft_c2c.out(complex_xpu, dims, 0, True, out=out)
+            self.assertIs(result, out)
+            self.assertEqual(out.cpu(), expected)
+
+    def test_fft_out_preserves_contiguous_layout(self, device):
+        # Regression: _exec_fft permutes batch/signal dims and re-applies the
+        # permuted strides to its destination. Feeding a caller-provided out
+        # straight into it corrupts the layout for 55 of the 78 combinations
+        # below, so every one of them must keep both its strides and its values.
+        for ndim in range(1, 5):
+            shape = (2, 3, 4, 5)[-ndim:]
+            complex_xpu = torch.randn(*shape, dtype=torch.complex128, device=device)
+            real_xpu = torch.randn(*shape, dtype=torch.float64, device=device)
+            complex_cpu = complex_xpu.cpu()
+            real_cpu = real_xpu.cpu()
+
+            for k in range(1, ndim + 1):
+                for dims in itertools.combinations(range(ndim), k):
+                    dims = list(dims)
+                    msg = f"ndim={ndim} dims={dims}"
+
+                    c2c_ref = torch.ops.aten._fft_c2c.default(
+                        complex_xpu, dims, 0, True
+                    )
+                    # The out= variant is compared against the functional one,
+                    # which shares its implementation, so anchor that reference
+                    # to CPU to catch an error common to both.
+                    self.assertEqual(
+                        c2c_ref.cpu(),
+                        torch.ops.aten._fft_c2c.default(complex_cpu, dims, 0, True),
+                        msg=f"c2c functional {msg}",
+                    )
+                    # empty_like would inherit the functional result's permuted
+                    # strides, so allocate a fresh contiguous buffer instead.
+                    out = torch.empty(c2c_ref.shape, dtype=c2c_ref.dtype, device=device)
+                    stride = out.stride()
+                    torch.ops.aten._fft_c2c.out(complex_xpu, dims, 0, True, out=out)
+                    self.assertEqual(out.stride(), stride, f"c2c {msg}")
+                    self.assertEqual(out, c2c_ref, msg=f"c2c {msg}")
+
+                    r2c_ref = torch.ops.aten._fft_r2c.default(real_xpu, dims, 0, True)
+                    r2c_cpu = torch.ops.aten._fft_r2c.default(real_cpu, dims, 0, True)
+                    self.assertEqual(
+                        r2c_ref.cpu(), r2c_cpu, msg=f"r2c functional {msg}"
+                    )
+                    out = torch.empty(r2c_ref.shape, dtype=r2c_ref.dtype, device=device)
+                    stride = out.stride()
+                    torch.ops.aten._fft_r2c.out(real_xpu, dims, 0, True, out=out)
+                    self.assertEqual(out.stride(), stride, f"r2c {msg}")
+                    self.assertEqual(out, r2c_ref, msg=f"r2c {msg}")
+
+                    last_dim_size = real_xpu.size(dims[-1])
+                    c2r_ref = torch.ops.aten._fft_c2r.default(
+                        r2c_ref, dims, 0, last_dim_size
+                    )
+                    self.assertEqual(
+                        c2r_ref.cpu(),
+                        torch.ops.aten._fft_c2r.default(
+                            r2c_cpu, dims, 0, last_dim_size
+                        ),
+                        msg=f"c2r functional {msg}",
+                    )
+                    out = torch.empty(c2r_ref.shape, dtype=c2r_ref.dtype, device=device)
+                    stride = out.stride()
+                    torch.ops.aten._fft_c2r.out(
+                        r2c_ref, dims, 0, last_dim_size, out=out
+                    )
+                    self.assertEqual(out.stride(), stride, f"c2r {msg}")
+                    self.assertEqual(out, c2r_ref, msg=f"c2r {msg}")
+
+    def test_fft_out_noncontiguous_input(self, device):
+        # The direct-write predicate inspects the batch strides of the input, so
+        # a transposed input has to keep both its values and the out layout.
+        x = torch.randn(4, 3, 8, dtype=torch.complex128, device=device).transpose(0, 1)
+        for dims in ([2], [1, 2], [0, 1, 2]):
+            expected = torch.ops.aten._fft_c2c.default(x, dims, 0, True)
+            out = torch.empty(expected.shape, dtype=expected.dtype, device=device)
+            stride = out.stride()
+            result = torch.ops.aten._fft_c2c.out(x, dims, 0, True, out=out)
+            self.assertIs(result, out)
+            self.assertEqual(out.stride(), stride, f"dims={dims}")
+            self.assertEqual(out, expected, msg=f"dims={dims}")
+
+    def test_fft_out_noncontiguous_output(self, device):
+        complex_xpu = torch.randn(2, 3, 4, 5, dtype=torch.complex64, device=device)
+        expected = torch.ops.aten._fft_c2c.default(complex_xpu, [2, 3], 0, True)
+
+        out = torch.empty(5, 4, 3, 2, dtype=torch.complex64, device=device).permute(
+            3, 2, 1, 0
+        )
+        stride = out.stride()
+        result = torch.ops.aten._fft_c2c.out(complex_xpu, [2, 3], 0, True, out=out)
+        self.assertIs(result, out)
+        self.assertEqual(out.stride(), stride)
+        self.assertEqual(out, expected)
+
+    def test_fft_out_aliased_input(self, device):
+        x = torch.randn(2, 3, 4, dtype=torch.complex64, device=device)
+        expected = torch.ops.aten._fft_c2c.default(x, [2], 0, True)
+        result = torch.ops.aten._fft_c2c.out(x, [2], 0, True, out=x)
+        self.assertIs(result, x)
+        self.assertEqual(x, expected)
+
+    def test_fft_out_empty_dim(self, device):
+        # An empty dim list short-circuits to a clone in the functional variant,
+        # so the out variants must reach it too rather than the impl, whose
+        # r2c form asserts the dim list is non-empty.
+        x = torch.randn(2, 3, dtype=torch.complex64, device=device)
+        out = torch.empty_like(x)
+        result = torch.ops.aten._fft_c2c.out(x, [], 0, True, out=out)
+        self.assertIs(result, out)
+        self.assertEqual(out, x)
+
+        # The clone keeps the input dtype, so r2c reports a real result here.
+        real_x = torch.randn(2, 3, device=device)
+        functional = torch.ops.aten._fft_r2c.default(real_x, [], 0, True)
+        out = torch.empty(0, dtype=functional.dtype, device=device)
+        result = torch.ops.aten._fft_r2c.out(real_x, [], 0, True, out=out)
+        self.assertIs(result, out)
+        self.assertEqual(out, functional)
+
+        functional = torch.ops.aten._fft_c2r.default(x, [], 0, 4)
+        out = torch.empty(0, dtype=functional.dtype, device=device)
+        result = torch.ops.aten._fft_c2r.out(x, [], 0, 4, out=out)
+        self.assertIs(result, out)
+        self.assertEqual(out, functional)
+
+    def test_fft_r2c_out_dtype_promotion(self, device):
+        # promote_fft_input promotes half/bfloat16 to float. The functional
+        # variant must keep reporting the same output dtype as before the out
+        # variants started sharing its implementation.
+        for dtype, expected_dtype in (
+            (torch.float32, torch.complex64),
+            (torch.float64, torch.complex128),
+            (torch.half, torch.complex32),
+            (torch.bfloat16, torch.complex64),
+        ):
+            x = torch.randn(8, 16, device=device, dtype=dtype)
+            functional = torch.ops.aten._fft_r2c.default(x, [1], 0, True)
+            self.assertEqual(functional.dtype, expected_dtype)
+
+            out = torch.empty(functional.shape, dtype=expected_dtype, device=device)
+            result = torch.ops.aten._fft_r2c.out(x, [1], 0, True, out=out)
+            self.assertIs(result, out)
+            self.assertEqual(out.dtype, expected_dtype)
+            self.assertEqual(out, functional)
+
+    def test_fft_half_normalization(self, device):
+        # The functional variants normalize at the promoted precision and
+        # downcast afterwards, so every normalization mode has to stay within
+        # half's own resolution of the double reference.
+        x = torch.randn(8, 16, dtype=torch.complex64, device=device).to(torch.complex32)
+        reference = x.to(torch.complex128)
+
+        for normalization in (0, 1, 2):
+            got = torch.ops.aten._fft_c2c.default(x, [1], normalization, True)
+            self.assertEqual(got.dtype, torch.complex32)
+            expected = torch.ops.aten._fft_c2c.default(
+                reference, [1], normalization, True
+            )
+            self.assertEqual(
+                got.to(torch.complex128),
+                expected,
+                atol=1e-2,
+                rtol=1e-2,
+                msg=f"normalization={normalization}",
+            )
+
+            out = torch.empty(got.shape, dtype=torch.complex32, device=device)
+            torch.ops.aten._fft_c2c.out(x, [1], normalization, True, out=out)
+            self.assertEqual(out, got, msg=f"normalization={normalization}")
+
+
+instantiate_device_type_tests(TestFftOut, globals(), only_for="xpu", allow_xpu=True)
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/regressions/test_fft_out.py
+++ b/test/regressions/test_fft_out.py
@@ -22,18 +22,6 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 class TestFftOut(TestCase):
-    def test_fft_c2c_out_matches_cpu(self, device):
-        real_cpu = torch.randn(2, 3, 4, 5)
-        complex_cpu = torch.complex(real_cpu, torch.randn_like(real_cpu))
-        complex_xpu = complex_cpu.to(device)
-
-        for dims in ([3], [2, 3], [0], [1], [0, 1], [0, 1, 2], [0, 1, 2, 3]):
-            expected = torch.ops.aten._fft_c2c.default(complex_cpu, dims, 0, True)
-            out = torch.empty_like(complex_xpu)
-            result = torch.ops.aten._fft_c2c.out(complex_xpu, dims, 0, True, out=out)
-            self.assertIs(result, out)
-            self.assertEqual(out.cpu(), expected)
-
     def test_fft_out_preserves_contiguous_layout(self, device):
         # Regression: _exec_fft permutes batch/signal dims and re-applies the
         # permuted strides to its destination. Feeding a caller-provided out
@@ -339,29 +327,19 @@ class TestFftOut(TestCase):
 
     def test_fft_out_resizes_output(self, device):
         complex_xpu = torch.randn(4, 8, dtype=torch.complex128, device=device)
-        expected = torch.ops.aten._fft_c2c.default(complex_xpu, [1], 0, True)
-        out = torch.empty(0, dtype=torch.complex128, device=device)
-        torch.ops.aten._fft_c2c.out(complex_xpu, [1], 0, True, out=out)
-        self.assertEqual(out.shape, expected.shape)
-        self.assertTrue(out.is_contiguous())
-        self.assertEqual(out, expected)
-
         real_xpu = torch.randn(4, 8, dtype=torch.float64, device=device)
-        expected = torch.ops.aten._fft_r2c.default(real_xpu, [1], 0, True)
-        out = torch.empty(0, dtype=torch.complex128, device=device)
-        torch.ops.aten._fft_r2c.out(real_xpu, [1], 0, True, out=out)
-        self.assertEqual(out.shape, expected.shape)
-        self.assertTrue(out.is_contiguous())
-        self.assertEqual(out, expected)
-
-        expected = torch.ops.aten._fft_c2r.default(expected, [1], 0, 8)
-        out = torch.empty(0, dtype=torch.float64, device=device)
-        torch.ops.aten._fft_c2r.out(
-            torch.ops.aten._fft_r2c.default(real_xpu, [1], 0, True), [1], 0, 8, out=out
-        )
-        self.assertEqual(out.shape, expected.shape)
-        self.assertTrue(out.is_contiguous())
-        self.assertEqual(out, expected)
+        complex_input = torch.ops.aten._fft_r2c.default(real_xpu, [1], 0, True)
+        for op, input_tensor, args, out_dtype in (
+            (torch.ops.aten._fft_c2c, complex_xpu, ([1], 0, True), torch.complex128),
+            (torch.ops.aten._fft_r2c, real_xpu, ([1], 0, True), torch.complex128),
+            (torch.ops.aten._fft_c2r, complex_input, ([1], 0, 8), torch.float64),
+        ):
+            expected = op.default(input_tensor, *args)
+            out = torch.empty(0, dtype=out_dtype, device=device)
+            result = op.out(input_tensor, *args, out=out)
+            self.assertIs(result, out)
+            self.assertTrue(out.is_contiguous())
+            self.assertEqual(out, expected)
 
     def test_fft_out_empty_batch(self, device):
         # An empty batch short-circuits inside _exec_fft, which resizes the

--- a/test/regressions/test_fft_out.py
+++ b/test/regressions/test_fft_out.py
@@ -202,6 +202,65 @@ class TestFftOut(TestCase):
             torch.ops.aten._fft_c2c.out(x, [1], normalization, True, out=out)
             self.assertEqual(out, got, msg=f"normalization={normalization}")
 
+    def test_fft_r2c_out_twosided(self, device):
+        # onesided=False mirrors the second half in place, the one path that
+        # replaces the destination after the transform has already run.
+        for ndim, dims in ((1, [0]), (2, [1]), (2, [0, 1]), (3, [2]), (3, [0, 1, 2])):
+            shape = (2, 3, 4)[-ndim:]
+            x = torch.randn(*shape, dtype=torch.float64, device=device)
+            expected = torch.fft.fftn(x.to(torch.complex128), dim=dims)
+            msg = f"ndim={ndim} dims={dims}"
+
+            functional = torch.ops.aten._fft_r2c.default(x, dims, 0, False)
+            self.assertEqual(functional, expected, msg=msg)
+
+            out = torch.empty(functional.shape, dtype=functional.dtype, device=device)
+            stride = out.stride()
+            result = torch.ops.aten._fft_r2c.out(x, dims, 0, False, out=out)
+            self.assertIs(result, out)
+            self.assertEqual(out.stride(), stride, f"stride {msg}")
+            self.assertEqual(out, expected, msg=msg)
+
+    def test_fft_c2r_does_not_mutate_input(self, device):
+        # HermitSymm writes in place, so the caller's tensor has to be copied
+        # first while a promoted input is already private.
+        for dtype in (torch.complex64, torch.complex32):
+            x = torch.randn(4, 5, dtype=torch.complex64, device=device).to(dtype)
+            before = x.clone()
+            expected = torch.ops.aten._fft_c2r.default(x, [1], 0, 8)
+            self.assertEqual(x, before, msg=f"functional {dtype}")
+
+            out = torch.empty(expected.shape, dtype=expected.dtype, device=device)
+            torch.ops.aten._fft_c2r.out(x, [1], 0, 8, out=out)
+            self.assertEqual(x, before, msg=f"out {dtype}")
+            self.assertEqual(out, expected, msg=str(dtype))
+
+    def test_fft_out_resizes_output(self, device):
+        complex_xpu = torch.randn(4, 8, dtype=torch.complex128, device=device)
+        expected = torch.ops.aten._fft_c2c.default(complex_xpu, [1], 0, True)
+        out = torch.empty(0, dtype=torch.complex128, device=device)
+        torch.ops.aten._fft_c2c.out(complex_xpu, [1], 0, True, out=out)
+        self.assertEqual(out.shape, expected.shape)
+        self.assertTrue(out.is_contiguous())
+        self.assertEqual(out, expected)
+
+        real_xpu = torch.randn(4, 8, dtype=torch.float64, device=device)
+        expected = torch.ops.aten._fft_r2c.default(real_xpu, [1], 0, True)
+        out = torch.empty(0, dtype=torch.complex128, device=device)
+        torch.ops.aten._fft_r2c.out(real_xpu, [1], 0, True, out=out)
+        self.assertEqual(out.shape, expected.shape)
+        self.assertTrue(out.is_contiguous())
+        self.assertEqual(out, expected)
+
+        expected = torch.ops.aten._fft_c2r.default(expected, [1], 0, 8)
+        out = torch.empty(0, dtype=torch.float64, device=device)
+        torch.ops.aten._fft_c2r.out(
+            torch.ops.aten._fft_r2c.default(real_xpu, [1], 0, True), [1], 0, 8, out=out
+        )
+        self.assertEqual(out.shape, expected.shape)
+        self.assertTrue(out.is_contiguous())
+        self.assertEqual(out, expected)
+
 
 instantiate_device_type_tests(TestFftOut, globals(), only_for="xpu", allow_xpu=True)
 

--- a/test/regressions/test_fft_out.py
+++ b/test/regressions/test_fft_out.py
@@ -261,6 +261,38 @@ class TestFftOut(TestCase):
         self.assertTrue(out.is_contiguous())
         self.assertEqual(out, expected)
 
+    def test_fft_out_empty_batch(self, device):
+        # An empty batch short-circuits inside _exec_fft, which resizes the
+        # destination it was handed. On the direct-write path that destination
+        # is the caller's out, so its shape and layout still have to survive.
+        for shape, dims in (((0, 1, 1), [1, 2]), ((0, 4), [1]), ((2, 0, 4), [2])):
+            msg = f"shape={shape} dims={dims}"
+            xc = torch.randn(*shape, dtype=torch.complex128, device=device)
+            xr = torch.randn(*shape, dtype=torch.float64, device=device)
+
+            expected = torch.ops.aten._fft_c2c.default(xc, dims, 0, True)
+            out = torch.empty(expected.shape, dtype=expected.dtype, device=device)
+            stride = out.stride()
+            result = torch.ops.aten._fft_c2c.out(xc, dims, 0, True, out=out)
+            self.assertIs(result, out)
+            self.assertEqual(out.shape, expected.shape, msg=f"c2c {msg}")
+            self.assertEqual(out.stride(), stride, f"c2c stride {msg}")
+
+            expected = torch.ops.aten._fft_r2c.default(xr, dims, 0, True)
+            out = torch.empty(expected.shape, dtype=expected.dtype, device=device)
+            stride = out.stride()
+            torch.ops.aten._fft_r2c.out(xr, dims, 0, True, out=out)
+            self.assertEqual(out.shape, expected.shape, msg=f"r2c {msg}")
+            self.assertEqual(out.stride(), stride, f"r2c stride {msg}")
+
+            last_dim_size = shape[dims[-1]]
+            expected = torch.ops.aten._fft_c2r.default(xc, dims, 0, last_dim_size)
+            out = torch.empty(expected.shape, dtype=expected.dtype, device=device)
+            stride = out.stride()
+            torch.ops.aten._fft_c2r.out(xc, dims, 0, last_dim_size, out=out)
+            self.assertEqual(out.shape, expected.shape, msg=f"c2r {msg}")
+            self.assertEqual(out.stride(), stride, f"c2r stride {msg}")
+
 
 instantiate_device_type_tests(TestFftOut, globals(), only_for="xpu", allow_xpu=True)
 

--- a/test/regressions/test_fft_out.py
+++ b/test/regressions/test_fft_out.py
@@ -126,6 +126,34 @@ class TestFftOut(TestCase):
         self.assertEqual(out.stride(), stride)
         self.assertEqual(out, expected)
 
+    def test_fft_out_preserves_size_one_strides(self, device):
+        xc = torch.randn(2, 1, 4, dtype=torch.complex64, device=device)
+        xr = torch.randn(2, 1, 4, device=device)
+
+        c2c_expected = torch.ops.aten._fft_c2c.default(xc, [2], 0, True)
+        c2c_out = torch.empty_strided(
+            c2c_expected.shape, (4, 99, 1), dtype=torch.complex64, device=device
+        )
+        torch.ops.aten._fft_c2c.out(xc, [2], 0, True, out=c2c_out)
+        self.assertEqual(c2c_out.stride(), (4, 99, 1))
+        self.assertEqual(c2c_out, c2c_expected)
+
+        r2c_expected = torch.ops.aten._fft_r2c.default(xr, [2], 0, True)
+        r2c_out = torch.empty_strided(
+            r2c_expected.shape, (3, 99, 1), dtype=torch.complex64, device=device
+        )
+        torch.ops.aten._fft_r2c.out(xr, [2], 0, True, out=r2c_out)
+        self.assertEqual(r2c_out.stride(), (3, 99, 1))
+        self.assertEqual(r2c_out, r2c_expected)
+
+        c2r_expected = torch.ops.aten._fft_c2r.default(r2c_expected, [2], 0, 4)
+        c2r_out = torch.empty_strided(
+            c2r_expected.shape, (4, 99, 1), dtype=torch.float32, device=device
+        )
+        torch.ops.aten._fft_c2r.out(r2c_expected, [2], 0, 4, out=c2r_out)
+        self.assertEqual(c2r_out.stride(), (4, 99, 1))
+        self.assertEqual(c2r_out, c2r_expected)
+
     def test_fft_out_aliased_input(self, device):
         x = torch.randn(2, 3, 4, dtype=torch.complex64, device=device)
         expected = torch.ops.aten._fft_c2c.default(x, [2], 0, True)
@@ -177,29 +205,85 @@ class TestFftOut(TestCase):
             self.assertEqual(out.dtype, expected_dtype)
             self.assertEqual(out, functional)
 
-    def test_fft_half_normalization(self, device):
-        # The functional variants normalize at the promoted precision and
-        # downcast afterwards, so every normalization mode has to stay within
-        # half's own resolution of the double reference.
-        x = torch.randn(8, 16, dtype=torch.complex64, device=device).to(torch.complex32)
-        reference = x.to(torch.complex128)
+    def test_fft_out_casts_from_the_functional_result_dtype(self, device):
+        # The out= contract is functional-result-then-copy: an out tensor with
+        # a wider dtype must contain the low-precision functional result cast
+        # to that dtype, rather than a result computed directly at the wider
+        # transform precision.
+        xc = torch.randn(4, 16, dtype=torch.complex64, device=device).to(
+            torch.complex32
+        )
+        xr = torch.randn(4, 16, dtype=torch.float16, device=device)
 
         for normalization in (0, 1, 2):
+            c2c_expected = torch.ops.aten._fft_c2c.default(xc, [1], normalization, True)
+            c2c_out = torch.empty_like(c2c_expected, dtype=torch.complex64)
+            torch.ops.aten._fft_c2c.out(xc, [1], normalization, True, out=c2c_out)
+            self.assertEqual(
+                c2c_out,
+                c2c_expected.to(c2c_out.dtype),
+                msg=f"c2c normalization={normalization}",
+            )
+
+            r2c_expected = torch.ops.aten._fft_r2c.default(xr, [1], normalization, True)
+            r2c_out = torch.empty_like(r2c_expected, dtype=torch.complex64)
+            torch.ops.aten._fft_r2c.out(xr, [1], normalization, True, out=r2c_out)
+            self.assertEqual(
+                r2c_out,
+                r2c_expected.to(r2c_out.dtype),
+                msg=f"r2c normalization={normalization}",
+            )
+
+            c2r_expected = torch.ops.aten._fft_c2r.default(xc, [1], normalization, 30)
+            c2r_out = torch.empty_like(c2r_expected, dtype=torch.float32)
+            torch.ops.aten._fft_c2r.out(xc, [1], normalization, 30, out=c2r_out)
+            self.assertEqual(
+                c2r_out,
+                c2r_expected.to(c2r_out.dtype),
+                msg=f"c2r normalization={normalization}",
+            )
+
+    def test_fft_half_normalization(self, device):
+        # Preserve the established MKL ordering for complex-half c2c/c2r:
+        # execute at the promoted precision, cast to the functional result
+        # dtype, and normalize that low-precision result in place.
+        generator = torch.Generator().manual_seed(0)
+        x = torch.randn(2, 3, dtype=torch.complex64, generator=generator).to(
+            device=device, dtype=torch.complex32
+        )
+        c2c_unnormalized = torch.ops.aten._fft_c2c.default(x, [1], 0, True)
+        c2r_unnormalized = torch.ops.aten._fft_c2r.default(x, [0, 1], 0, 4)
+
+        for normalization, scale in ((1, 1 / 3**0.5), (2, 1 / 3)):
             got = torch.ops.aten._fft_c2c.default(x, [1], normalization, True)
             self.assertEqual(got.dtype, torch.complex32)
-            expected = torch.ops.aten._fft_c2c.default(
-                reference, [1], normalization, True
-            )
+            expected = c2c_unnormalized.clone().mul_(scale)
             self.assertEqual(
-                got.to(torch.complex128),
+                got,
                 expected,
-                atol=1e-2,
-                rtol=1e-2,
-                msg=f"normalization={normalization}",
+                rtol=0,
+                atol=0,
+                msg=f"c2c normalization={normalization}",
             )
 
             out = torch.empty(got.shape, dtype=torch.complex32, device=device)
             torch.ops.aten._fft_c2c.out(x, [1], normalization, True, out=out)
+            self.assertEqual(out, got, msg=f"normalization={normalization}")
+
+        for normalization, scale in ((1, 1 / 8**0.5), (2, 1 / 8)):
+            got = torch.ops.aten._fft_c2r.default(x, [0, 1], normalization, 4)
+            self.assertEqual(got.dtype, torch.float16)
+            expected = c2r_unnormalized.clone().mul_(scale)
+            self.assertEqual(
+                got,
+                expected,
+                rtol=0,
+                atol=0,
+                msg=f"c2r normalization={normalization}",
+            )
+
+            out = torch.empty(got.shape, dtype=torch.float16, device=device)
+            torch.ops.aten._fft_c2r.out(x, [0, 1], normalization, 4, out=out)
             self.assertEqual(out, got, msg=f"normalization={normalization}")
 
     def test_fft_r2c_out_twosided(self, device):

--- a/test/regressions/test_fft_out.py
+++ b/test/regressions/test_fft_out.py
@@ -113,6 +113,24 @@ class TestFftOut(TestCase):
             self.assertEqual(out.stride(), stride, f"dims={dims}")
             self.assertEqual(out, expected, msg=f"dims={dims}")
 
+    def test_fft_r2c_out_preserves_layout_for_size_one_input_strides(self, device):
+        # A size-one dimension may have an arbitrary stride while the tensor is
+        # still contiguous. The out path must not propagate that input layout to
+        # the caller-provided output.
+        source = torch.randn(2, 1, 4, device=device)
+        x = torch.empty_strided((2, 1, 4), (4, 999, 1), device=device)
+        x.copy_(source)
+        self.assertTrue(x.is_contiguous())
+
+        for onesided in (True, False):
+            expected = torch.ops.aten._fft_r2c.default(x, [2], 0, onesided)
+            out = torch.empty(expected.shape, dtype=expected.dtype, device=device)
+            stride = out.stride()
+            result = torch.ops.aten._fft_r2c.out(x, [2], 0, onesided, out=out)
+            self.assertIs(result, out)
+            self.assertEqual(out.stride(), stride, f"onesided={onesided}")
+            self.assertEqual(out, expected, msg=f"onesided={onesided}")
+
     def test_fft_out_noncontiguous_output(self, device):
         complex_xpu = torch.randn(2, 3, 4, 5, dtype=torch.complex64, device=device)
         expected = torch.ops.aten._fft_c2c.default(complex_xpu, [2, 3], 0, True)

--- a/test/xpu/test_spectral_ops_xpu.py
+++ b/test/xpu/test_spectral_ops_xpu.py
@@ -138,54 +138,11 @@ def _compare_xpu_cpu(self, xpu_result, cpu_result, t):
     self.assertEqual(xpu_result, cpu_result, exact_dtype=False)
 
 
-def _test_fft_out_variants(self, device):
-    dims = [0, 1, 2, 3]
-    real_cpu = torch.randn(2, 3, 4, 5)
-    complex_cpu = torch.complex(real_cpu, torch.randn_like(real_cpu))
-
-    complex_input = complex_cpu.to(device)
-    c2c_expected = torch.ops.aten._fft_c2c.default(complex_cpu, dims, 0, True)
-    c2c_out = torch.empty_like(complex_input)
-    c2c_result = torch.ops.aten._fft_c2c.out(complex_input, dims, 0, True, out=c2c_out)
-    self.assertIs(c2c_result, c2c_out)
-    self.assertEqual(c2c_out.cpu(), c2c_expected)
-
-    real_input = real_cpu.to(device)
-    r2c_expected = torch.ops.aten._fft_r2c.default(real_cpu, dims, 0, True)
-    r2c_out = torch.empty_like(r2c_expected, device=device)
-    r2c_result = torch.ops.aten._fft_r2c.out(real_input, dims, 0, True, out=r2c_out)
-    self.assertIs(r2c_result, r2c_out)
-    self.assertEqual(r2c_out.cpu(), r2c_expected)
-
-    c2r_input = r2c_expected.to(device)
-    c2r_expected = torch.ops.aten._fft_c2r.default(
-        r2c_expected, dims, 0, real_cpu.size(-1)
-    )
-    c2r_out = torch.empty_like(real_input)
-    c2r_result = torch.ops.aten._fft_c2r.out(
-        c2r_input, dims, 0, real_cpu.size(-1), out=c2r_out
-    )
-    self.assertIs(c2r_result, c2r_out)
-    self.assertEqual(c2r_out.cpu(), c2r_expected, atol=2e-5, rtol=2e-5)
-
-    noncontiguous_out = torch.empty(
-        5, 4, 3, 2, device=device, dtype=complex_input.dtype
-    ).permute(3, 2, 1, 0)
-    original_stride = noncontiguous_out.stride()
-    result = torch.ops.aten._fft_c2c.out(
-        complex_input, dims, 0, True, out=noncontiguous_out
-    )
-    self.assertIs(result, noncontiguous_out)
-    self.assertEqual(noncontiguous_out.stride(), original_stride)
-    self.assertEqual(noncontiguous_out.cpu(), c2c_expected)
-
-
 TestFFT.test_reference_1d = _test_reference_1d
 TestFFT._compare_xpu_cpu = _compare_xpu_cpu
 TestFFT.test_fft_half_and_chalf_not_power_of_two_error = (
     _test_fft_half_and_chalf_not_power_of_two
 )
-TestFFT.test_fft_out_variants = _test_fft_out_variants
 
 instantiate_device_type_tests(TestFFT, globals(), only_for=("xpu"), allow_xpu=True)
 

--- a/test/xpu/test_spectral_ops_xpu.py
+++ b/test/xpu/test_spectral_ops_xpu.py
@@ -138,11 +138,54 @@ def _compare_xpu_cpu(self, xpu_result, cpu_result, t):
     self.assertEqual(xpu_result, cpu_result, exact_dtype=False)
 
 
+def _test_fft_out_variants(self, device):
+    dims = [0, 1, 2, 3]
+    real_cpu = torch.randn(2, 3, 4, 5)
+    complex_cpu = torch.complex(real_cpu, torch.randn_like(real_cpu))
+
+    complex_input = complex_cpu.to(device)
+    c2c_expected = torch.ops.aten._fft_c2c.default(complex_cpu, dims, 0, True)
+    c2c_out = torch.empty_like(complex_input)
+    c2c_result = torch.ops.aten._fft_c2c.out(complex_input, dims, 0, True, out=c2c_out)
+    self.assertIs(c2c_result, c2c_out)
+    self.assertEqual(c2c_out.cpu(), c2c_expected)
+
+    real_input = real_cpu.to(device)
+    r2c_expected = torch.ops.aten._fft_r2c.default(real_cpu, dims, 0, True)
+    r2c_out = torch.empty_like(r2c_expected, device=device)
+    r2c_result = torch.ops.aten._fft_r2c.out(real_input, dims, 0, True, out=r2c_out)
+    self.assertIs(r2c_result, r2c_out)
+    self.assertEqual(r2c_out.cpu(), r2c_expected)
+
+    c2r_input = r2c_expected.to(device)
+    c2r_expected = torch.ops.aten._fft_c2r.default(
+        r2c_expected, dims, 0, real_cpu.size(-1)
+    )
+    c2r_out = torch.empty_like(real_input)
+    c2r_result = torch.ops.aten._fft_c2r.out(
+        c2r_input, dims, 0, real_cpu.size(-1), out=c2r_out
+    )
+    self.assertIs(c2r_result, c2r_out)
+    self.assertEqual(c2r_out.cpu(), c2r_expected, atol=2e-5, rtol=2e-5)
+
+    noncontiguous_out = torch.empty(
+        5, 4, 3, 2, device=device, dtype=complex_input.dtype
+    ).permute(3, 2, 1, 0)
+    original_stride = noncontiguous_out.stride()
+    result = torch.ops.aten._fft_c2c.out(
+        complex_input, dims, 0, True, out=noncontiguous_out
+    )
+    self.assertIs(result, noncontiguous_out)
+    self.assertEqual(noncontiguous_out.stride(), original_stride)
+    self.assertEqual(noncontiguous_out.cpu(), c2c_expected)
+
+
 TestFFT.test_reference_1d = _test_reference_1d
 TestFFT._compare_xpu_cpu = _compare_xpu_cpu
 TestFFT.test_fft_half_and_chalf_not_power_of_two_error = (
     _test_fft_half_and_chalf_not_power_of_two
 )
+TestFFT.test_fft_out_variants = _test_fft_out_variants
 
 instantiate_device_type_tests(TestFFT, globals(), only_for=("xpu"), allow_xpu=True)
 


### PR DESCRIPTION
Related to [#2140](https://github.com/intel/torch-xpu-ops/issues/2140).

### Why

The XPU MKL FFT `c2c`, `r2c`, and `c2r` `out=` paths previously computed into a new tensor, then copied the result to the caller's `out`. That extra allocation and device copy are avoidable when the FFT can safely use `out` as its destination.

### What changed

The functional and `out=` paths now share implementations that place the final FFT pass in `out` when its dtype and contiguous strides match, the input does not alias it, and the transform preserves its layout. Multi-pass transforms use scratch storage as needed. Other cases retain the old result-then-copy behavior, including conversions, unsupported layouts, and aliases. ComplexHalf cast/normalization order is preserved. The follow-up also makes `promote_fft_input` reuse the single dtype mapping in `promote_fft_dtype`.

**Before:** FFT → allocated result → `copy_` to `out`  
**After (eligible cases):** FFT final pass → `out`, without the final copy.

### Measured results

On an Intel Data Center GPU Max 1100, implementation commit [`e68217d2`](https://github.com/intel/torch-xpu-ops/commit/e68217d25f0a20cf42fef982db4354079b6b7ff8) was compared with base [`cedc716c`](https://github.com/intel/torch-xpu-ops/commit/cedc716cf3cbdb62e7e02a683daac1255ebb3541) using the same PyTorch/toolchain and four order-balanced rounds. Across 15 representative `out=` cases, the geometric mean of paired wall-time ratios was:

| Operation | Cases | Time vs base |
| --- | ---: | ---: |
| c2c | 6 | -8.35% |
| c2r | 4 | -11.96% |
| r2c | 5 | -4.87% |

`unitrace` confirmed the removed work in representative direct-write cases (single-pair Level Zero device times):

| `out=` workload | Base → candidate µs/op | Copies/op |
| --- | ---: | ---: |
| c2c complex128, 65536×64 | 297.187 → 122.195 | 1 → 0 |
| r2c float32, 256×256×256 | 311.792 → 148.984 | 1 → 0 |
| c2r complex32, 256×256×129 | 727.914 → 521.226 | 6 → 4 |

A prime-size r2c float32 1000×1021 `out=` case measured +4.02% wall time with 12.71% within-run spread; unitrace measured +0.13% device time while removing one copy. This noisy case does not prove the absence of a regression.

Correctness tests on [`23a2479a`](https://github.com/intel/torch-xpu-ops/commit/23a2479ab89944bf3d82517a71d4e87682a1bceb): FFT `out=` regressions 14 passed; hfft2 references 8 passed; spectral suite 340 passed, 6 skipped, 1 deselected.
