### PR TITLE
Re-syncs `test_unbacked_sources_scalar` in `test/xpu/dynamo/test_misc_xpu.py` with upstream `test/dynamo/test_misc.py`

### DIFF
--- a/test/xpu/dynamo/test_misc_xpu.py
+++ b/test/xpu/dynamo/test_misc_xpu.py
@@ -9092,7 +9092,7 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
 
         @torch.compile(backend=counter)
         def fn(x):
-            return x * x
+            return torch.ones(2) * x
 
         fn(0)
         fn(1)


### PR DESCRIPTION
Fixes #4782

Upstream pytorch/pytorch#189642 added `ComputedLazyConstantVariable`, which folds constant ops whose result never reaches graph computation and skips their value guards. With the fork's old body `return x * x` on an int `x`, nothing reaches a tensor, so Dynamo emits no frame and `frame_count` is 0 instead of 1. That commit also rewrote the body to keep the scalar flowing into the graph; this fork kept the old one. Applying the same body change (rather than lowering the expected count) keeps the test covering `unbacked_sources` instead of the new folding behavior. Not an XPU bug.

### Test Plan
```
      pytest -sxv dynamo/test_misc_xpu.py -k "test_unbacked_sources_scalar"
      pytest -q dynamo/test_misc_xpu.py -k "unbacked_sources or dynamic_sources"
```
Target test passes, as do the 9 neighboring source tests. Full-file run: 5 failed, 658 passed, 19 skipped, 3 xfailed; all 5 failures reproduce with this change stashed and are unrelated (likely further splits off #4773).
