### PR TITLE
Fix the wheel install in windows-ut

### DIFF
--- a/.github/workflows/_windows_ut.yml
+++ b/.github/workflows/_windows_ut.yml
@@ -179,8 +179,10 @@ jobs:
               cd ../..
             )
           ) else (
-            for /r "%GITHUB_WORKSPACE%\wheel_artifact" %%f in (*.whl) do set "TORCH_WHL=%%f"
-            python -m pip install "%TORCH_WHL%"
+            REM Install in the loop body: %TORCH_WHL% would expand when cmd
+            REM parses this block, before the for has assigned it.
+            for /r "%GITHUB_WORKSPACE%\wheel_artifact" %%f in (*.whl) do python -m pip install "%%f"
+            python -c "import torch" || exit /b 1
           )
           cd %GITHUB_WORKSPACE%\..\pytorch
           python -m pip install -r .ci\docker\requirements-ci.txt


### PR DESCRIPTION
The wheel-install branch set `TORCH_WHL` in a `for /r` loop then used
`%TORCH_WHL%` in the same parenthesised block, so `cmd` expanded it at parse time,
before the loop ran. `pip` got an empty argument, torch was never installed, and
the job failed at the next step with `ModuleNotFoundError`. Delayed expansion
would not help — `!` is also recognised at parse time and the runner sets
`/V:OFF` — so install from the loop variable instead.

Broken since #3274 but rarely seen: `windows-ut` runs only behind the Windows path
filter, and of the last 60 `pull.yml` runs only four reached `ut_test` — all four
failed this way.

Test: none (CI-only; `windows-ut` on this PR is the test).

Authored with Claude Code.
