### PR TITLE
[SYCL free func] migrate EembeddingBag kernels

### DIFF
--- a/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
+++ b/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
@@ -65,7 +65,7 @@ void embedding_bag(
   using vec_t = memory::aligned_vector<scalar_t, vec_size>;
   using vec_acc_t = memory::aligned_vector<accscalar_t, vec_size>;
   using vec_idx_t = memory::aligned_vector<index_t, vec_size>;
-  using KernelClass = EmbeddingBagKernelFunctor<
+  constexpr auto kfn = embedding_bag_kernel<
       scalar_t,
       accscalar_t,
       index_t,
@@ -89,7 +89,11 @@ void embedding_bag(
       static_cast<int64_t>(work_group_size));
 
   index_t fixing_bag_size = ignore_offsets ? index_size / bag_num : 0;
-  auto kfn = KernelClass(
+  sycl_kernel_submit<kfn>(
+      num_work_group * work_group_size,
+      work_group_size,
+      getCurrentSYCLQueue(),
+      0,
       index,
       offset,
       offset2bag,
@@ -106,11 +110,6 @@ void embedding_bag(
       max_idx_vec,
       fixing_bag_size,
       num_row);
-  sycl_kernel_submit(
-      num_work_group * work_group_size,
-      work_group_size,
-      getCurrentSYCLQueue(),
-      kfn);
 }
 
 #define EMBBAG_KERNEL_ACC(                                                     \
@@ -616,55 +615,39 @@ Tensor embedding_bag_backward_xpu_sum_avg(
 }
 
 template <typename scalar_t, typename index_t>
-struct EmbeddingBagAccGradParametersKernelMaxFunctor {
-  void operator()(sycl::nd_item<2> item) const {
-    auto max_indices_ptr = max_indices_data_;
-    auto gradOutput_ptr = gradOutput_data_;
-    auto gradWeight_ptr = gradWeight_data_;
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<2>))
+void embedding_bag_acc_grad_parameters_kernel_max(
+    const index_t* max_indices_data,
+    const scalar_t* gradOutput_data,
+    scalar_t* gradWeight_data,
+    int64_t stride,
+    int64_t chunksPerBag,
+    int64_t numChunks) {
+  auto max_indices_ptr = max_indices_data;
+  auto gradOutput_ptr = gradOutput_data;
+  auto gradWeight_ptr = gradWeight_data;
+  auto item = syclext::this_work_item::get_nd_item<2>();
+  auto chunkOffset =
+      item.get_group()[0] * item.get_local_range()[1] + item.get_local_id()[1];
 
-    auto chunkOffset = item.get_group()[0] * item.get_local_range()[1] +
-        item.get_local_id()[1];
+  for (auto chunk = chunkOffset; chunk < numChunks;
+       chunk += item.get_group_range()[0] * item.get_global_range()[1]) {
+    auto featureDim =
+        (chunk % chunksPerBag) * item.get_local_range(0) + item.get_local_id(0);
+    if (featureDim < stride) {
+      auto bag = chunk / chunksPerBag;
 
-    for (auto chunk = chunkOffset; chunk < numChunks_;
-         chunk += item.get_group_range()[0] * item.get_global_range()[1]) {
-      auto featureDim = (chunk % chunksPerBag_) * item.get_local_range(0) +
-          item.get_local_id(0);
-      if (featureDim < stride_) {
-        auto bag = chunk / chunksPerBag_;
-
-        auto word_idx = max_indices_ptr[bag * stride_ + featureDim];
-        if (word_idx >= 0) {
-          // If bag is empty, we have max_indices[idx] set to -1 in forward.
-          atomicAdd(
-              (sycl_global_ptr<
-                  scalar_t>)(&gradWeight_ptr[word_idx * stride_ + featureDim]),
-              gradOutput_ptr[bag * stride_ + featureDim]);
-        }
+      auto word_idx = max_indices_ptr[bag * stride + featureDim];
+      if (word_idx >= 0) {
+        // If bag is empty, we have max_indices[idx] set to -1 in forward.
+        atomicAdd(
+            (sycl_global_ptr<
+                scalar_t>)(&gradWeight_ptr[word_idx * stride + featureDim]),
+            gradOutput_ptr[bag * stride + featureDim]);
       }
     }
   }
-  EmbeddingBagAccGradParametersKernelMaxFunctor(
-      const index_t* max_indices_data,
-      const scalar_t* gradOutput_data,
-      scalar_t* gradWeight_data,
-      int64_t stride,
-      int64_t chunksPerBag,
-      int64_t numChunks)
-      : max_indices_data_(max_indices_data),
-        gradOutput_data_(gradOutput_data),
-        gradWeight_data_(gradWeight_data),
-        stride_(stride),
-        chunksPerBag_(chunksPerBag),
-        numChunks_(numChunks) {}
-
- private:
-  const index_t* max_indices_data_;
-  const scalar_t* gradOutput_data_;
-  scalar_t* gradWeight_data_;
-  int64_t stride_;
-  int64_t chunksPerBag_;
-  int64_t numChunks_;
-};
+}
 
 template <typename scalar_t, typename index_t>
 void EmbeddingBag_accGradParametersKernel_max(
@@ -681,18 +664,22 @@ void EmbeddingBag_accGradParametersKernel_max(
   auto gradOutput_data = gradOutput;
   auto gradWeight_data = gradWeight;
 
-  auto caller =
-      EmbeddingBagAccGradParametersKernelMaxFunctor<scalar_t, index_t>(
-          max_indices_data,
-          gradOutput_data,
-          gradWeight_data,
-          stride,
-          chunksPerBag,
-          numChunks);
+  constexpr auto kfn =
+      embedding_bag_acc_grad_parameters_kernel_max<scalar_t, index_t>;
 
   auto global_range = sycl::range<2>(kernel_range, 4);
   auto local_range = sycl::range<2>(64, 4);
-  sycl_kernel_submit(global_range, local_range, getCurrentSYCLQueue(), caller);
+  sycl_kernel_submit<kfn>(
+      global_range,
+      local_range,
+      getCurrentSYCLQueue(),
+      0,
+      max_indices_data,
+      gradOutput_data,
+      gradWeight_data,
+      stride,
+      chunksPerBag,
+      numChunks);
 }
 
 template <typename scalar_t, typename index_t>
@@ -734,18 +721,22 @@ void _embedding_bag_per_sample_weights_backward_impl(
     index_t padding_idx) {
   using accscalar_t = at::acc_type<scalar_t, true>;
 
-  using Kernel = EmbeddingBagPerSampleWeightsBackwardKernelFunctor<
+  constexpr auto kfn = embedding_bag_per_sample_weights_backward_kernel<
       scalar_t,
       index_t,
       accscalar_t>;
 
-  int64_t max_group_size = syclMaxWorkGroupSize<Kernel>();
+  int64_t max_group_size = syclMaxWorkGroupSize<kfn>();
 
   int64_t num_group = (num_samples + max_group_size - 1) / max_group_size;
   auto global_range{num_group * max_group_size};
   auto local_range{max_group_size};
 
-  auto caller = Kernel(
+  sycl_kernel_submit<kfn>(
+      global_range,
+      local_range,
+      getCurrentSYCLQueue(),
+      0,
       grad,
       grad_stride0,
       grad_stride1,
@@ -760,8 +751,6 @@ void _embedding_bag_per_sample_weights_backward_impl(
       padding_idx,
       num_group,
       max_group_size);
-
-  sycl_kernel_submit(global_range, local_range, getCurrentSYCLQueue(), caller);
 }
 
 std::tuple<Tensor, Tensor, Tensor, Tensor> _embedding_bag_kernel(

--- a/src/ATen/native/xpu/sycl/EmbeddingBag.h
+++ b/src/ATen/native/xpu/sycl/EmbeddingBag.h
@@ -23,6 +23,13 @@ constexpr int MODE_SUM = 0;
 constexpr int MODE_MEAN = 1;
 constexpr int MODE_MAX = 2;
 
+template <typename index_t>
+struct EmbeddingBagBackwardSumAvgFunctor {
+  auto operator()(index_t a, index_t b) const {
+    return a == b;
+  }
+};
+
 template <
     typename scalar_t,
     typename accscalar_t,
@@ -34,268 +41,190 @@ template <
     typename vec_idx_t,
     bool per_sample_weights_defined,
     bool padding_idx_defined>
-struct EmbeddingBagKernelFunctor {
-  void operator()(sycl::nd_item<1> item) const {
-    auto thread_id = item.get_global_linear_id();
-    if (thread_id < bag_num_ * vectorized_feature_dim_len_) {
-      auto current_feature = thread_id % vectorized_feature_dim_len_;
-      auto current_bag = thread_id / vectorized_feature_dim_len_;
-      index_t start, end;
-      bool last_bag = current_bag == bag_num_ - 1;
-      if (!ignore_offsets_) {
-        start = offset_[current_bag];
-        end = last_bag ? index_size_ : offset_[current_bag + 1];
-      } else {
-        start = current_bag * fixing_bag_size_;
-        end = start + fixing_bag_size_;
-      }
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
+void embedding_bag_kernel(
+    const index_t* const index,
+    const index_t* const offset,
+    index_t* const offset2bag,
+    index_t* const bag_size,
+    index_t* const max_index,
+    const scalar_t* const per_sample_weights,
+    int64_t index_size,
+    int64_t bag_num,
+    int64_t vectorized_feature_dim_len,
+    index_t padding_idx,
+    bool ignore_offsets,
+    vec_t* o_vec,
+    const vec_t* w_vec,
+    vec_idx_t* max_idx_vec,
+    index_t fixing_bag_size,
+    index_t num_row) {
+  auto item = syclext::this_work_item::get_nd_item<1>();
+  auto thread_id = item.get_global_linear_id();
+  if (thread_id < bag_num * vectorized_feature_dim_len) {
+    auto current_feature = thread_id % vectorized_feature_dim_len;
+    auto current_bag = thread_id / vectorized_feature_dim_len;
+    index_t start, end;
+    bool last_bag = current_bag == bag_num - 1;
+    if (!ignore_offsets) {
+      start = offset[current_bag];
+      end = last_bag ? index_size : offset[current_bag + 1];
+    } else {
+      start = current_bag * fixing_bag_size;
+      end = start + fixing_bag_size;
+    }
 
-      vec_acc_t value, value_max;
-      vec_idx_t index_max;
-      index_t padding_cnt = 0;
+    vec_acc_t value, value_max;
+    vec_idx_t index_max;
+    index_t padding_cnt = 0;
 
+#pragma unroll
+    for (int i = 0; i < vec_size; i++) {
+      value[i] = 0;
+    }
+    if constexpr (mode == MODE_MAX) {
 #pragma unroll
       for (int i = 0; i < vec_size; i++) {
-        value[i] = 0;
+        value_max[i] = at::numeric_limits<accscalar_t>::lower_bound();
+        index_max[i] = -1;
       }
-      if constexpr (mode == MODE_MAX) {
-#pragma unroll
-        for (int i = 0; i < vec_size; i++) {
-          value_max[i] = at::numeric_limits<accscalar_t>::lower_bound();
-          index_max[i] = -1;
-        }
-      }
-      index_t index_offset, weight_index;
-      vec_t wei_load;
-      auto handle_non_padding = [&]() {
-        wei_load = w_vec_
-            [weight_index * vectorized_feature_dim_len_ + current_feature];
+    }
+    index_t index_offset, weight_index;
+    vec_t wei_load;
+    auto handle_non_padding = [&]() {
+      wei_load =
+          w_vec[weight_index * vectorized_feature_dim_len + current_feature];
 
-        if constexpr (mode == MODE_SUM) {
-#pragma unroll
-          for (int i = 0; i < vec_size; i++) {
-            if constexpr (per_sample_weights_defined) {
-              wei_load[i] *= per_sample_weights_[index_offset];
-            }
-            value[i] += wei_load[i];
-          }
-        } else if constexpr (mode == MODE_MEAN) {
-#pragma unroll
-          for (int i = 0; i < vec_size; i++) {
-            value[i] += wei_load[i];
-          }
-        } else if constexpr (mode == MODE_MAX) {
-#pragma unroll
-          for (int i = 0; i < vec_size; i++) {
-            if (wei_load[i] > value_max[i]) {
-              value_max[i] = wei_load[i];
-              if (max_index_) {
-                index_max[i] = weight_index;
-              }
-            }
-          }
-        }
-      };
-
-      for (index_t offset_in_bag = start; offset_in_bag < end;
-           offset_in_bag++) {
-        index_offset = offset_in_bag;
-        weight_index = index_[index_offset];
-        SYCL_KERNEL_ASSERT(weight_index < num_row_);
-
-        if (current_feature == 0)
-          offset2bag_[index_offset] = current_bag;
-
-        if constexpr (padding_idx_defined) {
-          if (padding_idx_ != weight_index) {
-            handle_non_padding();
-          } else {
-            padding_cnt++;
-          }
-        } else {
-          handle_non_padding();
-        }
-      }
-
-      int64_t bsize = end - start - padding_cnt;
-      if (current_feature == 0) {
-        bag_size_[current_bag] = bsize;
-      }
-
-      index_t o_off =
-          current_bag * vectorized_feature_dim_len_ + current_feature;
       if constexpr (mode == MODE_SUM) {
-        vec_t o;
 #pragma unroll
         for (int i = 0; i < vec_size; i++) {
-          o[i] = value[i];
+          if constexpr (per_sample_weights_defined) {
+            wei_load[i] *= per_sample_weights[index_offset];
+          }
+          value[i] += wei_load[i];
         }
-        o_vec_[o_off] = o;
       } else if constexpr (mode == MODE_MEAN) {
-        vec_t o;
-        bsize = bsize == 0 ? 1 : bsize;
 #pragma unroll
         for (int i = 0; i < vec_size; i++) {
-          o[i] = value[i] / bsize;
+          value[i] += wei_load[i];
         }
-        o_vec_[o_off] = o;
       } else if constexpr (mode == MODE_MAX) {
-        vec_t padding;
 #pragma unroll
         for (int i = 0; i < vec_size; i++) {
-          padding[i] = 0;
+          if (wei_load[i] > value_max[i]) {
+            value_max[i] = wei_load[i];
+            if (max_index) {
+              index_max[i] = weight_index;
+            }
+          }
         }
-        o_vec_[o_off] =
-            value_max[0] == at::numeric_limits<accscalar_t>::lower_bound()
-            ? padding
-            : value_max;
-        if (max_index_) {
-          max_idx_vec_[o_off] = index_max;
+      }
+    };
+
+    for (index_t offset_in_bag = start; offset_in_bag < end; offset_in_bag++) {
+      index_offset = offset_in_bag;
+      weight_index = index[index_offset];
+      SYCL_KERNEL_ASSERT(weight_index < num_row);
+
+      if (current_feature == 0)
+        offset2bag[index_offset] = current_bag;
+
+      if constexpr (padding_idx_defined) {
+        if (padding_idx != weight_index) {
+          handle_non_padding();
+        } else {
+          padding_cnt++;
         }
+      } else {
+        handle_non_padding();
+      }
+    }
+
+    int64_t bsize = end - start - padding_cnt;
+    if (current_feature == 0) {
+      bag_size[current_bag] = bsize;
+    }
+
+    index_t o_off = current_bag * vectorized_feature_dim_len + current_feature;
+    if constexpr (mode == MODE_SUM) {
+      vec_t o;
+#pragma unroll
+      for (int i = 0; i < vec_size; i++) {
+        o[i] = value[i];
+      }
+      o_vec[o_off] = o;
+    } else if constexpr (mode == MODE_MEAN) {
+      vec_t o;
+      bsize = bsize == 0 ? 1 : bsize;
+#pragma unroll
+      for (int i = 0; i < vec_size; i++) {
+        o[i] = value[i] / bsize;
+      }
+      o_vec[o_off] = o;
+    } else if constexpr (mode == MODE_MAX) {
+      vec_t padding;
+#pragma unroll
+      for (int i = 0; i < vec_size; i++) {
+        padding[i] = 0;
+      }
+      o_vec[o_off] =
+          value_max[0] == at::numeric_limits<accscalar_t>::lower_bound()
+          ? padding
+          : value_max;
+      if (max_index) {
+        max_idx_vec[o_off] = index_max;
       }
     }
   }
-  EmbeddingBagKernelFunctor(
-      const index_t* const index,
-      const index_t* const offset,
-      index_t* const offset2bag,
-      index_t* const bag_size,
-      index_t* const max_index,
-      const scalar_t* const per_sample_weights,
-      int64_t index_size,
-      int64_t bag_num,
-      int64_t vectorized_feature_dim_len,
-      index_t padding_idx,
-      bool ignore_offsets,
-      vec_t* o_vec,
-      const vec_t* w_vec,
-      vec_idx_t* max_idx_vec,
-      index_t fixing_bag_size,
-      index_t num_row)
-      : index_(index),
-        offset_(offset),
-        offset2bag_(offset2bag),
-        bag_size_(bag_size),
-        max_index_(max_index),
-        per_sample_weights_(per_sample_weights),
-        index_size_(index_size),
-        bag_num_(bag_num),
-        vectorized_feature_dim_len_(vectorized_feature_dim_len),
-        padding_idx_(padding_idx),
-        ignore_offsets_(ignore_offsets),
-        o_vec_(o_vec),
-        w_vec_(w_vec),
-        max_idx_vec_(max_idx_vec),
-        fixing_bag_size_(fixing_bag_size),
-        num_row_(num_row) {}
-
- private:
-  const index_t* const index_;
-  const index_t* const offset_;
-  index_t* const offset2bag_;
-  index_t* const bag_size_;
-  index_t* const max_index_;
-  const scalar_t* const per_sample_weights_;
-  int64_t index_size_;
-  int64_t bag_num_;
-  int64_t vectorized_feature_dim_len_;
-  index_t padding_idx_;
-  bool ignore_offsets_;
-  vec_t* o_vec_;
-  const vec_t* w_vec_;
-  vec_idx_t* max_idx_vec_;
-  index_t fixing_bag_size_;
-  index_t num_row_;
-};
-
-template <typename index_t>
-struct EmbeddingBagBackwardSumAvgFunctor {
-  auto operator()(index_t a, index_t b) const {
-    return a == b;
-  }
-};
+}
 
 template <typename scalar_t, typename index_t, typename accscalar_t>
-struct EmbeddingBagPerSampleWeightsBackwardKernelFunctor {
-  void operator()(sycl::nd_item<1> item_id) const {
-    int idx = item_id.get_global_linear_id();
-    auto sg = item_id.get_sub_group();
-    int sgSize = static_cast<int>(
-        sg.get_local_range()[0]); // number of work-items in this sub-group
-    int sgId = idx / sgSize; // subgroup index
-    int sglid = static_cast<int>(
-        sg.get_local_id()[0]); // index of the work-item in this sub-group
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
+void embedding_bag_per_sample_weights_backward_kernel(
+    const scalar_t* grad,
+    int64_t grad_stride0,
+    int64_t grad_stride1,
+    const scalar_t* weight,
+    int64_t weight_stride0,
+    int64_t weight_stride1,
+    const index_t* indices,
+    const index_t* offset2bag,
+    int64_t num_samples,
+    int64_t embedding_features,
+    scalar_t* output,
+    index_t padding_idx,
+    int64_t num_group,
+    int64_t max_group_size) {
+  auto item = syclext::this_work_item::get_nd_item<1>();
+  int idx = item.get_global_linear_id();
+  auto sg = item.get_sub_group();
+  int sgSize = static_cast<int>(
+      sg.get_local_range()[0]); // number of work-items in this sub-group
+  int sgId = idx / sgSize; // subgroup index
+  int sglid = static_cast<int>(
+      sg.get_local_id()[0]); // index of the work-item in this sub-group
 
-    int num_sg = num_group_ * max_group_size_ / sgSize; // number of sub-groups
-    for (int sample_idx = sgId; sample_idx < num_samples_;
-         sample_idx += num_sg) {
-      accscalar_t result = 0.;
-      const int bag_idx = (int)offset2bag_[sample_idx];
-      const int embedding_idx = (int)indices_[sample_idx];
-      if (embedding_idx != padding_idx_) {
-        for (int feature_idx = sglid; feature_idx < embedding_features_;
-             feature_idx += sgSize) {
-          result +=
-              grad_[grad_stride0_ * bag_idx + grad_stride1_ * feature_idx] *
-              weight_
-                  [weight_stride0_ * embedding_idx +
-                   weight_stride1_ * feature_idx];
-        }
-      }
-      // subgroup reduce sum
-      for (int offset = sgSize / 2; offset > 0; offset /= 2) {
-        result += sycl::shift_group_left(sg, result, offset);
-      };
-      if (sglid == 0) {
-        output_[sample_idx] = result;
+  int num_sg = num_group * max_group_size / sgSize; // number of sub-groups
+  for (int sample_idx = sgId; sample_idx < num_samples; sample_idx += num_sg) {
+    accscalar_t result = 0.;
+    const int bag_idx = (int)offset2bag[sample_idx];
+    const int embedding_idx = (int)indices[sample_idx];
+    if (embedding_idx != padding_idx) {
+      for (int feature_idx = sglid; feature_idx < embedding_features;
+           feature_idx += sgSize) {
+        result += grad[grad_stride0 * bag_idx + grad_stride1 * feature_idx] *
+            weight[weight_stride0 * embedding_idx +
+                   weight_stride1 * feature_idx];
       }
     }
+    // subgroup reduce sum
+    for (int offset = sgSize / 2; offset > 0; offset /= 2) {
+      result += sycl::shift_group_left(sg, result, offset);
+    };
+    if (sglid == 0) {
+      output[sample_idx] = result;
+    }
   }
-  EmbeddingBagPerSampleWeightsBackwardKernelFunctor(
-      const scalar_t* grad,
-      int64_t grad_stride0,
-      int64_t grad_stride1,
-      const scalar_t* weight,
-      int64_t weight_stride0,
-      int64_t weight_stride1,
-      const index_t* indices,
-      const index_t* offset2bag,
-      int64_t num_samples,
-      int64_t embedding_features,
-      scalar_t* output,
-      index_t padding_idx,
-      int64_t num_group,
-      int64_t max_group_size)
-      : grad_(grad),
-        grad_stride0_(grad_stride0),
-        grad_stride1_(grad_stride1),
-        weight_(weight),
-        weight_stride0_(weight_stride0),
-        weight_stride1_(weight_stride1),
-        indices_(indices),
-        offset2bag_(offset2bag),
-        num_samples_(num_samples),
-        embedding_features_(embedding_features),
-        output_(output),
-        padding_idx_(padding_idx),
-        num_group_(num_group),
-        max_group_size_(max_group_size) {}
-
- private:
-  const scalar_t* grad_;
-  int64_t grad_stride0_;
-  int64_t grad_stride1_;
-  const scalar_t* weight_;
-  int64_t weight_stride0_;
-  int64_t weight_stride1_;
-  const index_t* indices_;
-  const index_t* offset2bag_;
-  int64_t num_samples_;
-  int64_t embedding_features_;
-  scalar_t* output_;
-  index_t padding_idx_;
-  int64_t num_group_;
-  int64_t max_group_size_;
-};
+}
 
 } // namespace at::native::xpu


### PR DESCRIPTION

Verified the two updated EmbeddingBag files: all SYCL kernel functors in  src/ATen/native/xpu/sycl/EmbeddingBag.h  and  EmbeddingBag.cpp  were migrated to SYCL free functions ( embedding_bag_kernel  and  embedding_bag_per_sample_weights_backward_kernel ). The remaining EmbeddingBagBackwardSumAvgFunctor  is a non-kernel comparator used by  pstl::count_by_segment , so it is correctly left as a struct.                                                                                                                              
                                                                                                                                                             
     Ran changed-kernel related embedding UTs in both repositories:                                                                                          
                                                                                                                                                             
      -  third_party/torch-xpu-ops/test/xpu/test_torch_xpu.py -k "embedding or Embedding" : 1 passed                                                         
      -  third_party/torch-xpu-ops/test/xpu/test_nn_xpu.py -k "embedding or Embedding" : 25 passed, 31 skipped                                               
      -  third_party/torch-xpu-ops/test/xpu/extended/test_ops_xpu.py -k "embedding_bag or EmbeddingBag" : 3 passed, 14 skipped                               
      -  pytorch/test/nn/test_embedding.py -k "embedding_bag or EmbeddingBag" : 232 passed, 32 skipped, 63 deselected                                        
                                                                                                                                                             
     No test failures observed.