### PR TITLE
Sync test_sticky_export_dynamic expected graph to upstream

### DIFF
--- a/test/xpu/export/test_experimental_xpu.py
+++ b/test/xpu/export/test_experimental_xpu.py
@@ -726,8 +726,8 @@ def forward(self, x):
     linear_weight = self.linear.weight
     linear_bias = self.linear.bias
     _guards_fn = self._guards_fn(x);  _guards_fn = None
-    linear = torch.ops.aten.linear.default(x, linear_weight, linear_bias);  x = linear_weight = linear_bias = None
-    return pytree.tree_unflatten((linear,), self._out_spec)""",
+    linear_default = torch.ops.aten.linear.default(x, linear_weight, linear_bias);  x = linear_weight = linear_bias = None
+    return pytree.tree_unflatten((linear_default,), self._out_spec)""",
         )
 
     def test_sticky_export_nested_inp(self):


### PR DESCRIPTION
Problem: test_sticky_export_dynamic failed via assertExpectedInline; expected FX var 'linear', graph emitted 'linear_default'. Root cause: upstream PyTorch PR #181780 set
canonicalize_output_graph_node_order=True for export tests, switching FX node names to overload-qualified form (linear_default) Fix: Update the expected inline string to 'linear_default'

Fixes: https://github.com/intel/torch-xpu-ops/issues/4737