### PR TITLE
Remove PYTORCH_ENABLE_XPU_FALLBACK=1 from Windows tests

### DIFF
--- a/.github/workflows/_windows_ut.yml
+++ b/.github/workflows/_windows_ut.yml
@@ -200,7 +200,6 @@ jobs:
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
           call conda activate windows_ut
           set PYTORCH_TEST_WITH_SLOW=1
-          set PYTORCH_ENABLE_XPU_FALLBACK=1
           set PYTEST_ADDOPTS=-v --timeout 600 --timeout_method=thread --max-worker-restart 1000000 -n 1
           cd ../pytorch/third_party/torch-xpu-ops/test/xpu/
           python run_test_with_windows_nighltly.py


### PR DESCRIPTION
Because there is a difference between how Linux and Windows tests in CI are configured it can give errors like in this issue: https://github.com/intel/torch-xpu-ops/issues/4460 were originally Windows test was passing but Linux was failing. After fixing Linux  https://github.com/pytorch/pytorch/pull/190644 Windows started to fail. Removing `PYTORCH_ENABLE_XPU_FALLBACK=1` will align more how tests on CI Linux and Windows are executed.