### PR TITLE
Detect the existence of kernel on XPU before registering fallback

### DIFF
--- a/src/ATen/native/xpu/XPUFallback.cpp
+++ b/src/ATen/native/xpu/XPUFallback.cpp
@@ -382,11 +382,14 @@ TORCH_LIBRARY_IMPL(aten, XPU, m) {
     auto op = c10::Dispatcher::singleton().findOp(
         c10::OperatorName("aten::" + base, overload));
     if (op.has_value() && op->hasKernelForDispatchKey(c10::DispatchKey::XPU)) {
-      // Skip fallback to avoid overriding
-      TORCH_WARN_ONCE(
-          "aten::", base, (overload.empty() ? "" : "." + overload),
-          " already has a kernel registered for XPU, skipping fallback. "
-          "Please remove it from the fallback_list in XPUFallback.cpp.");
+      if (DEBUG_XPU_FALLBACK) {
+        TORCH_WARN_ONCE(
+            "aten::",
+            base,
+            (overload.empty() ? "" : "." + overload),
+            " already has a kernel registered for XPU, skipping fallback. "
+            "Please remove it from the fallback_list in XPUFallback.cpp.");
+      }
       continue;
     }
     m.impl(

--- a/src/ATen/native/xpu/XPUFallback.cpp
+++ b/src/ATen/native/xpu/XPUFallback.cpp
@@ -383,6 +383,10 @@ TORCH_LIBRARY_IMPL(aten, XPU, m) {
         c10::OperatorName("aten::" + base, overload));
     if (op.has_value() && op->hasKernelForDispatchKey(c10::DispatchKey::XPU)) {
       // Skip fallback to avoid overriding
+      TORCH_WARN_ONCE(
+          "aten::", base, (overload.empty() ? "" : "." + overload),
+          " already has a kernel registered for XPU, skipping fallback. "
+          "Please remove it from the fallback_list in XPUFallback.cpp.");
       continue;
     }
     m.impl(

--- a/src/ATen/native/xpu/XPUFallback.cpp
+++ b/src/ATen/native/xpu/XPUFallback.cpp
@@ -1,4 +1,5 @@
 #include <ATen/core/Tensor.h>
+#include <ATen/core/dispatch/Dispatcher.h>
 #include <ATen/native/CPUFallback.h>
 
 namespace at {
@@ -372,6 +373,18 @@ TORCH_LIBRARY_IMPL(aten, XPU, m) {
       "_validate_compressed_sparse_indices",
   };
   for (auto& op_name : fallback_list) {
+    // Parse "name" or "name.overload" into an OperatorName
+    auto dot_pos = op_name.find('.');
+    std::string base =
+        (dot_pos == std::string::npos) ? op_name : op_name.substr(0, dot_pos);
+    std::string overload =
+        (dot_pos == std::string::npos) ? "" : op_name.substr(dot_pos + 1);
+    auto op = c10::Dispatcher::singleton().findOp(
+        c10::OperatorName("aten::" + base, overload));
+    if (op.has_value() && op->hasKernelForDispatchKey(c10::DispatchKey::XPU)) {
+      // Skip fallback to avoid overriding
+      continue;
+    }
     m.impl(
         op_name.c_str(),
         torch::CppFunction::makeFromBoxedFunction<&xpu_fallback_impl>());

--- a/test/regressions/test_override_warning.py
+++ b/test/regressions/test_override_warning.py
@@ -1,0 +1,32 @@
+# Copyright 2020-2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Owner(s): ["module: intel"]
+import subprocess
+import sys
+
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestKernelOverrideWarning(TestCase):
+    def test_import_torch_kernel_override_warning(self):
+        """Ensure 'import torch' does not emit kernel override warnings."""
+        result = subprocess.run(
+            [sys.executable, "-W", "all", "-c", "import torch"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotIn(
+            "Overriding a previously registered kernel for the same operator "
+            "and the same dispatch key",
+            result.stderr,
+        )
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
This PR allows the fallback list to safely contain ops that may have gained native XPU support in pytorch without requiring synchronized removal.
Before registering a CPU fallback for an op, query the c10::Dispatcher to check if a kernel is already registered for that op on the XPU dispatch key. If so, skip the fallback registration to avoid the warning of overriding a previously registered kernel.