### PR TITLE
Modernize path and policy handling in SYCL CMake modules

### DIFF
--- a/cmake/Modules/FindONEMKL.cmake
+++ b/cmake/Modules/FindONEMKL.cmake
@@ -10,15 +10,14 @@ set(ONEMKL_FOUND FALSE)
 
 set(ONEMKL_LIBRARIES)
 
-# In order to be compatible with various situations of Pytorch development
-# bundle setup, ENV{MKLROOT} and SYCL_ROOT will be checked sequentially to get
-# the root directory of oneMKL.
+# ENV{MKLROOT} is authoritative when set; otherwise fall back to the oneAPI
+# bundle layout next to the SYCL compiler.
 if(DEFINED ENV{MKLROOT})
-  # Directly get the root directory of oneMKL if ENV{MKLROOT} exists.
   set(ONEMKL_ROOT $ENV{MKLROOT})
 elseif(SYCL_FOUND)
-  # oneMKL configuration may not be imported into the build system. Get the root
-  # directory of oneMKL based on the root directory of compiler relatively.
+  # Not cmake_path(NORMAL_PATH): it only recognizes '/' as a separator, and on
+  # Windows SYCL_ROOT arrives backslashed from setvars.bat, which would make
+  # the whole thing one component for ../.. to swallow.
   get_filename_component(ONEMKL_ROOT "${SYCL_ROOT}/../../mkl/latest" REALPATH)
 endif()
 
@@ -30,7 +29,7 @@ if(NOT DEFINED ONEMKL_ROOT)
   return()
 endif()
 
-if(NOT EXISTS ${ONEMKL_ROOT})
+if(NOT EXISTS "${ONEMKL_ROOT}")
   message(
     WARNING
       "${ONEMKL_ROOT} not found, please setup oneAPI environment before building!!"

--- a/cmake/Modules/FindSYCL/run_sycl.cmake
+++ b/cmake/Modules/FindSYCL/run_sycl.cmake
@@ -19,9 +19,10 @@
 #
 # generated_file:STRING=<> File to generate.  This argument must be passed in.
 
-cmake_policy(PUSH)
-cmake_policy(SET CMP0007 NEW)
-cmake_policy(SET CMP0010 NEW)
+# This script runs via `cmake -P`, which does not inherit the project's policy
+# version, so pin it to the same one CMakeLists.txt requires.
+cmake_minimum_required(VERSION 3.27)
+
 if(NOT generated_file)
   message(FATAL_ERROR "You must specify generated_file on the command line")
 endif()
@@ -156,5 +157,3 @@ endif()
 if(verbose)
   message("Generated ${generated_file} successfully.")
 endif()
-
-cmake_policy(POP)

--- a/src/BuildOnLinux.cmake
+++ b/src/BuildOnLinux.cmake
@@ -34,7 +34,7 @@ endmacro()
 if(BUILD_SEPARATE_OPS)
   setup_common_libraries()
   foreach(sycl_src ${ATen_XPU_SYCL_SRCS})
-    get_filename_component(name ${sycl_src} NAME_WLE)
+    cmake_path(GET sycl_src STEM LAST_ONLY name)
     set(sycl_lib torch-xpu-ops-sycl-${name})
     sycl_add_library(
       ${sycl_lib}

--- a/src/BuildOnWindows.cmake
+++ b/src/BuildOnWindows.cmake
@@ -21,7 +21,7 @@ target_compile_definitions(torch_xpu_ops PRIVATE TORCH_XPU_BUILD_MAIN_LIB)
 if(BUILD_SEPARATE_OPS)
   target_link_libraries(torch_xpu_ops PUBLIC torch_xpu torch_cpu c10)
   foreach(sycl_src ${ATen_XPU_SYCL_SRCS})
-    get_filename_component(name ${sycl_src} NAME_WLE)
+    cmake_path(GET sycl_src STEM LAST_ONLY name)
     set(sycl_lib torch-xpu-ops-sycl-${name})
     sycl_add_library(
       ${sycl_lib}


### PR DESCRIPTION
Two independent changes, one per commit so they can be reverted separately.

**`cmake_path` instead of `get_filename_component`** in the per-source library loops. `FindONEMKL` deliberately keeps `REALPATH`: on Windows `SYCL_ROOT` arrives backslashed from `setvars.bat`, and `cmake_path` (which only recognizes `/`) would collapse it to `../mkl/latest` and fail the oneMKL lookup. A comment records this so it isn't "modernized" later.

**Policy pin in `run_sycl.cmake`** — the script runs under `cmake -P`, which inherits no policy version, so it set `CMP0007`/`CMP0010` by hand. Declaring the dialect covers those plus `CMP0054`, which governs the `if()` calls there and was left at OLD.

> Merging the second commit forces one full SYCL rebuild: `FindSYCL.cmake` lists `run_sycl.cmake` in `DEPENDS` for every SYCL object.

## Test Plan

Not built. Verified with `cmake -P`:

- `NAME_WLE` vs `STEM LAST_ONLY` over the real source glob — 377 sources, 0 differences
- `REALPATH` vs `NORMAL_PATH` over POSIX and native-Windows `SYCL_ROOT`, against a replica oneAPI tree with real symlinks — identical for POSIX, divergent for backslashed input

---

Authored with the assistance of an AI coding assistant.
