### PR TITLE
Update test_store_attr to reflect function attribute mutation behavior

### DIFF
--- a/test/xpu/dynamo/test_ctx_manager_xpu.py
+++ b/test/xpu/dynamo/test_ctx_manager_xpu.py
@@ -1906,8 +1906,9 @@ class GraphModule(torch.nn.Module):
         opt_fn = torch.compile(fn, backend="eager")
         self.assertEqual(fn(inp), opt_fn(inp))
 
-    def test_store_attr_graph_break_key_error(self):
-        # STORE_ATTR on dummy should result in graph break
+    def test_store_attr_on_function(self):
+        # setattr on a function object is traced as a generic attribute
+        # mutation and replayed at runtime -- no graph break.
         def dummy():
             pass
 
@@ -1918,9 +1919,12 @@ class GraphModule(torch.nn.Module):
             return x + 4
 
         inp = torch.ones(3)
-        opt_fn = torch.compile(fn, backend="eager")
-        self.assertEqual(fn(inp), opt_fn(inp))
-        self.assertGreater(len(counters["graph_break"]), 0)
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        # Check the compiled run applied the mutation before the eager run
+        # below overwrites dummy.attr1.
+        compiled_res = opt_fn(inp)
+        self.assertEqual(dummy.attr1, inp + 2)
+        self.assertEqual(fn(inp), compiled_res)
 
 
 class ContextlibContextManagerTests(torch._dynamo.test_case.TestCase):


### PR DESCRIPTION
Fixes #4783

`test_store_attr_graph_break_key_error` asserted that `dummy.attr1 = x` on a plain function inside `torch.no_grad()` graph-breaks, and started failing with `0 not greater than 0`.

Root cause: pytorch commit 7894205ea9f (pytorch/pytorch#187531) extended attribute mutation to VTs beyond `UserDefinedObjectVariable`, including `UserFunctionVariable`. Setattr on a function object is now traced as a generic attribute mutation and replayed at runtime, so no graph break occurs.

That same commit renamed the test to `test_store_attr_on_function` and inverted the assertion: compile with `fullgraph=True` and verify the mutation landed. This ports the rewrite verbatim. The test was renamed, not deleted upstream, so coverage is kept rather than dropped.

The full upstream re-sync suggested in #4783 is out of scope: the fork diverges by ~2740 lines of intentional XPU adaptations and belongs in its own PR.

## Test Plan

```bash
PYTHONPATH=$PYTHONPATH:$PWD/test/dynamo PYTORCH_TEST_WITH_SLOW=1 \
  python -m pytest -v \
  third_party/torch-xpu-ops/test/xpu/dynamo/test_ctx_manager_xpu.py \
  -k "test_store_attr_on_function"

Passes. Full file: 94 passed, 3 failed, 4 skipped, 2 xfailed. The 3 failures are pre-existing and unrelated -- confirmed by reproducing them on clean HEAD with the change stashed.