### PR TITLE
[WIN] Skip slow forward-AD composite-compliance test on Windows

### DIFF
--- a/test/xpu/run_test_with_windows_nighltly.py
+++ b/test/xpu/run_test_with_windows_nighltly.py
@@ -107,9 +107,7 @@ for key in skip_dict:
         print(f"\n=== Skipping test file: {key} ===")
         continue
 
-    skip_list = skip_dict.get(key)
-    if skip_list is None:
-        skip_list = []
+    skip_list = list(skip_dict.get(key) or [])
 
     if IS_WINDOWS and key in skip_dict_win:
         win_skip_list = skip_dict_win[key]

--- a/test/xpu/skip_list_win.py
+++ b/test/xpu/skip_list_win.py
@@ -86,4 +86,7 @@ skip_dict = {
         "test_reference_numerics_large_sin_xpu_complex64",
         "test_reference_numerics_small_acos_xpu_complex32",
     ),
+    "test_ops_xpu.py": (
+        "test_forward_ad_nn_functional_multi_head_attention_forward_xpu_float32",
+    ),
 }


### PR DESCRIPTION
Problem: TestCompositeComplianceXPU.test_forward_ad_nn_functional_multi_ head_attention_forward_xpu_float32 ran >7h on the MTL Windows CI runner, hanging the "Run OP UT" job. The thread-based 600s tiemout cannot preempt the GIL-holding (Global Interpreter Lock) native XPU call, so the test never times out.

Root cause: composite_compliance.check_forward_ad_formula wraps 2^(num_tensor_args) subclass combinations at two nesting levels (args x tangent_args). Multi_head_attention_forward's require_grad sample has 10 tensor-like args -> 2^20 = 1.048.576 forward executions plus 2 assertEqual each. This is an intrinsic upstream test-infra cost; it only becomes a CI timeout on the slow Meteor Lake integrated GPU, and doesn't hand the non-Windows runners.

Fix:
- skip_list_win.py: skip that single forward-AD variant on Windows only, so non-Windows coverage is preserved.
- run_test_with_windows_nightly.py: copy the merged skip list into a fresh list. The skip_list_common value for test_ops_xpu.py is a tuple, so the existing skip_list.extend(...) raised AttributeError (and mutated the shared dict for list values). This fix is required for the Windows skip to take effect on the nightly runner.

Fixes: https://github.com/intel/torch-xpu-ops/issues/4835