### PR TITLE
Optimize contiguous cat with vectorized stores

### DIFF
--- a/src/ATen/native/xpu/sycl/Shape.cpp
+++ b/src/ATen/native/xpu/sycl/Shape.cpp
@@ -27,6 +27,9 @@
 #include <ATen/ops/narrow.h>
 #include <ATen/ops/size_native.h>
 
+#include <algorithm>
+#include <vector>
+
 #include <ATen/native/xpu/sycl/Philox4x32.h>
 #include <ATen/native/xpu/sycl/ShapeKernels.h>
 
@@ -506,31 +509,75 @@ void parallel_cat(
       : fitsVector(ALIGNED_VEC_LOAD_BYTES_8)  ? ALIGNED_VEC_LOAD_BYTES_8
                                               : 0;
 
+  // Inputs are batched in size order rather than in argument order. A batch's
+  // launch range covers its largest input, so mixing a large input with much
+  // smaller ones leaves most of the smaller inputs' work items idle. Every
+  // input carries its own output offset, so any batching order is equivalent
+  // as long as the offsets are resolved in argument order up front.
+  const unsigned nInputs = static_cast<unsigned>(inputs.size());
+  std::vector<int64_t> inputOffset(nInputs);
+  std::vector<unsigned> order(nInputs);
+  {
+    int64_t running = 0;
+    for (unsigned k = 0; k < nInputs; ++k) {
+      order[k] = k;
+      inputOffset[k] = running;
+      // There is a legacy case where a 1-D empty tensor can be concat with
+      // high-dimensional tensor
+      if (inputs[k].get().numel() > 0) {
+        running += inputs[k].get().size(logical_dimension);
+      }
+    }
+    std::stable_sort(order.begin(), order.end(), [&](unsigned a, unsigned b) {
+      return inputs[a].get().numel() > inputs[b].get().numel();
+    });
+  }
+
   // Now we loop
   int batchCounter = 0;
-  int64_t offset = 0;
-  for (unsigned i = 0; i < inputs.size(); i += batch_size) {
+  unsigned i = 0;
+  while (i < nInputs) {
+    // The largest input comes first and fixes the launch range. Close the
+    // batch once the idle work items it would accumulate outweigh the useful
+    // ones; what is left starts a new, smaller batch. A uniformly sized input
+    // list never splits, so the common case keeps a single launch.
+    const int64_t batchMax = inputs[order[i]].get().numel();
+    int64_t usefulElements = batchMax;
+    int64_t idleElements = 0;
+    unsigned batchEnd = i + 1;
+    while (batchEnd < nInputs &&
+           (batchEnd - i) < static_cast<unsigned>(batch_size)) {
+      const int64_t n = inputs[order[batchEnd]].get().numel();
+      if (idleElements + (batchMax - n) > usefulElements + n)
+        break;
+      idleElements += batchMax - n;
+      usefulElements += n;
+      ++batchEnd;
+    }
+    const unsigned batchStart = i;
+    // Advanced ahead of the launch, which ends the iteration early.
+    i = batchEnd;
+
     bool isContig = true;
     bool isAligned = true;
     // OR of the batch's input addresses; one modulo then tests them all.
     // Unlike the geometry above, alignment may vary from batch to batch.
     uintptr_t inputAddressBits = 0;
     unsigned int max_elements_per_tensor = 0;
-    for (batchCounter = 0;
-         batchCounter < batch_size && (i + batchCounter) < inputs.size();
+    for (batchCounter = 0; batchStart + batchCounter < batchEnd;
          ++batchCounter) {
+      const unsigned inputIndex = order[batchStart + batchCounter];
       int64_t dimSize = 0;
       // There is a legacy case where a 1-D empty tensor can be concat with
       // high-dimensional tensor
-      if (inputs[i + batchCounter].get().numel() > 0) {
-        dimSize = inputs[i + batchCounter].get().size(logical_dimension);
+      if (inputs[inputIndex].get().numel() > 0) {
+        dimSize = inputs[inputIndex].get().size(logical_dimension);
       }
       catMetaData.input[batchCounter] = static_cast<const scalar_t*>(
-          inputs[i + batchCounter].get().const_data_ptr());
-      catMetaData.offset[batchCounter] = offset;
+          inputs[inputIndex].get().const_data_ptr());
+      catMetaData.offset[batchCounter] = inputOffset[inputIndex];
       catMetaData.dimSize[batchCounter] = dimSize;
-      catMetaData.nElements[batchCounter] =
-          inputs[i + batchCounter].get().numel();
+      catMetaData.nElements[batchCounter] = inputs[inputIndex].get().numel();
 
       // If at least one of the inputs is not aligned, we can't call the
       // CatArrayBatchedCopy_alignedK_contig
@@ -539,8 +586,8 @@ void parallel_cat(
           reinterpret_cast<uintptr_t>(catMetaData.input[batchCounter]);
 
       if (stride_size > 1) {
-        auto strides = inputs[i + batchCounter].get().strides();
-        auto sizes = inputs[i + batchCounter].get().sizes();
+        auto strides = inputs[inputIndex].get().strides();
+        auto sizes = inputs[inputIndex].get().sizes();
         if (memory_format == c10::MemoryFormat::Contiguous) {
           for (int j = 0; j < nDims; j++) {
             catMetaData.tensorStride[batchCounter].tensorSize[j] = sizes[j];
@@ -565,15 +612,13 @@ void parallel_cat(
         catMetaData.isContiguous[batchCounter] = true;
       }
 
-      // Update offset
-      offset += dimSize;
-
       // We need max elements per tensor to compute range parameters
       max_elements_per_tensor = std::max(
           max_elements_per_tensor, catMetaData.nElements[batchCounter]);
     }
 
-    // Skip if the tensor is empty. Otherwise, the range dim is invalid
+    // Skip if every input in the batch is empty. Otherwise the range dim is
+    // invalid. Sorting puts the empty inputs last, so this ends the loop.
     if (max_elements_per_tensor == 0)
       continue;
 

--- a/src/ATen/native/xpu/sycl/Shape.cpp
+++ b/src/ATen/native/xpu/sycl/Shape.cpp
@@ -43,6 +43,10 @@ inline bool is_aligned_vec4(const void* ptr) {
   return !(iptr % alignof(uint4));
 }
 
+inline bool is_aligned_to(const void* ptr, int64_t bytes) {
+  return !(reinterpret_cast<uintptr_t>(ptr) % static_cast<uintptr_t>(bytes));
+}
+
 inline std::tuple<sycl::range<2>, sycl::range<2>> getCatRange(
     unsigned int max_elements_per_tensor,
     ptrdiff_t nTensors) {
@@ -337,6 +341,76 @@ struct CatArrayBatchedCopy_alignedK_contig {
   IndexType dimStride;
 };
 
+// Like CatArrayBatchedCopy_alignedK_contig, but vectorizes both loads and
+// stores.
+//
+// When each input slice and the output row pitch are multiples of the vector
+// width, each input vector maps to one contiguous output vector. This allows a
+// single wide store and a simple direct output-offset calculation.
+template <
+    typename T,
+    typename IndexType,
+    int batch_size,
+    int stride_size,
+    int aligned_vec_load_bytes>
+struct CatArrayBatchedCopy_vectorized {
+  void operator()(sycl::nd_item<2> item) const {
+    static_assert(
+        aligned_vec_load_bytes % sizeof(T) == 0,
+        "the vector width must be a whole number of elements");
+    constexpr int kILP = aligned_vec_load_bytes / sizeof(T);
+    using LT = memory::aligned_vector<T, kILP>;
+
+    const IndexType group = item.get_group(0);
+
+    // Exact: the host guarantees whole vectors per slice.
+    const IndexType nVectors = inputs.nElements[group] / kILP;
+    // Empty inputs are legal, and skipping them keeps the division by
+    // inputSliceVectors below well defined (it would be 0).
+    if (nVectors == 0)
+      return;
+
+    IndexType vectorIndex =
+        item.get_group(1) * item.get_local_range(1) + item.get_local_id(1);
+    if (vectorIndex >= nVectors)
+      return;
+
+    const IndexType inputSliceVectors =
+        inputs.dimSize[group] * dimStride / kILP;
+    const IndexType outputSliceVectors = outputDimSize * dimStride / kILP;
+    const IndexType outputOffsetVectors =
+        inputs.offset[group] * dimStride / kILP;
+    const IndexType stride = item.get_group_range(1) * item.get_local_range(1);
+
+    const LT* in = reinterpret_cast<const LT*>(inputs.input[group]);
+    LT* out = reinterpret_cast<LT*>(output);
+
+    while (vectorIndex < nVectors) {
+      const IndexType outerIndex = vectorIndex / inputSliceVectors;
+      const IndexType innerIndex = vectorIndex - outerIndex * inputSliceVectors;
+      out[outerIndex * outputSliceVectors + outputOffsetVectors + innerIndex] =
+          in[vectorIndex];
+      vectorIndex += stride;
+    }
+  }
+
+  CatArrayBatchedCopy_vectorized(
+      T* output,
+      CatArrInputTensorMetadata<T, IndexType, batch_size, stride_size> inputs,
+      IndexType outputDimSize,
+      IndexType dimStride)
+      : output(output),
+        inputs(inputs),
+        outputDimSize(outputDimSize),
+        dimStride(dimStride) {}
+
+ private:
+  T* output;
+  CatArrInputTensorMetadata<T, IndexType, batch_size, stride_size> inputs;
+  IndexType outputDimSize;
+  IndexType dimStride;
+};
+
 template <typename scalar_t, int batch_size, int stride_size>
 void parallel_cat(
     const Tensor& out,
@@ -398,12 +472,46 @@ void parallel_cat(
                kAlignedKernelBytes ==
            0);
 
+  // Wide stores must not cross input-slice boundaries. Require every input
+  // slice and the output row pitch to be multiples of the vector width;
+  // prefix-sum offsets are then aligned automatically. Check this across all
+  // inputs because the output row pitch is global, not per batch.
+  const int64_t dimStride = outputParam.tensorStride[mapped_dimension];
+  const int64_t outputSliceBytes =
+      static_cast<int64_t>(outputParam.tensorSize[mapped_dimension]) *
+      dimStride * static_cast<int64_t>(sizeof(scalar_t));
+  auto fitsVector = [&](int64_t bytes) {
+    if (bytes < static_cast<int64_t>(sizeof(scalar_t)) ||
+        !is_aligned_to(data, bytes) || outputSliceBytes % bytes != 0) {
+      return false;
+    }
+    for (unsigned k = 0; k < inputs.size(); ++k) {
+      const int64_t dimSize = inputs[k].get().numel() > 0
+          ? inputs[k].get().size(logical_dimension)
+          : 0;
+      if ((dimSize * dimStride * static_cast<int64_t>(sizeof(scalar_t))) %
+              bytes !=
+          0) {
+        return false;
+      }
+    }
+    return true;
+  };
+  // The strided instantiation cannot address its inputs linearly.
+  const int64_t vectorBytes = stride_size > 1 ? 0
+      : fitsVector(ALIGNED_VEC_LOAD_BYTES_16) ? ALIGNED_VEC_LOAD_BYTES_16
+      : fitsVector(ALIGNED_VEC_LOAD_BYTES_8)  ? ALIGNED_VEC_LOAD_BYTES_8
+                                              : 0;
+
   // Now we loop
   int batchCounter = 0;
   int64_t offset = 0;
   for (unsigned i = 0; i < inputs.size(); i += batch_size) {
     bool isContig = true;
     bool isAligned = true;
+    // OR of the batch's input addresses; one modulo then tests them all.
+    // Unlike the geometry above, alignment may vary from batch to batch.
+    uintptr_t inputAddressBits = 0;
     unsigned int max_elements_per_tensor = 0;
     for (batchCounter = 0;
          batchCounter < batch_size && (i + batchCounter) < inputs.size();
@@ -424,6 +532,8 @@ void parallel_cat(
       // If at least one of the inputs is not aligned, we can't call the
       // CatArrayBatchedCopy_alignedK_contig
       isAligned &= is_aligned_vec4(catMetaData.input[batchCounter]);
+      inputAddressBits |=
+          reinterpret_cast<uintptr_t>(catMetaData.input[batchCounter]);
 
       if (stride_size > 1) {
         auto strides = inputs[i + batchCounter].get().strides();
@@ -463,6 +573,40 @@ void parallel_cat(
     // Skip if the tensor is empty. Otherwise, the range dim is invalid
     if (max_elements_per_tensor == 0)
       continue;
+
+      // Independent of Dims, so dispatched ahead of the HANDLE_CASE switch.
+#define LAUNCH_VECTORIZED(VEC_BYTES)                                       \
+  {                                                                        \
+    sycl::range<2> vecGroup, vecRange;                                     \
+    std::tie(vecRange, vecGroup) = getCatRangeContig<scalar_t, VEC_BYTES>( \
+        max_elements_per_tensor, batchCounter);                            \
+    CatArrayBatchedCopy_vectorized<                                        \
+        scalar_t,                                                          \
+        unsigned int,                                                      \
+        batch_size,                                                        \
+        stride_size,                                                       \
+        VEC_BYTES>                                                         \
+        kfn(data,                                                          \
+            catMetaData,                                                   \
+            outputParam.tensorSize[mapped_dimension],                      \
+            outputParam.tensorStride[mapped_dimension]);                   \
+    auto& q = getCurrentSYCLQueue();                                       \
+    sycl_kernel_submit(vecRange, vecGroup, q, kfn);                        \
+    continue;                                                              \
+  }
+
+    if (isContig && vectorBytes > 0 &&
+        !(inputAddressBits % static_cast<uintptr_t>(vectorBytes))) {
+      if constexpr (ALIGNED_VEC_LOAD_BYTES_16 % sizeof(scalar_t) == 0) {
+        if (vectorBytes == ALIGNED_VEC_LOAD_BYTES_16)
+          LAUNCH_VECTORIZED(ALIGNED_VEC_LOAD_BYTES_16);
+      }
+      if constexpr (ALIGNED_VEC_LOAD_BYTES_8 % sizeof(scalar_t) == 0) {
+        if (vectorBytes == ALIGNED_VEC_LOAD_BYTES_8)
+          LAUNCH_VECTORIZED(ALIGNED_VEC_LOAD_BYTES_8);
+      }
+    }
+#undef LAUNCH_VECTORIZED
 
     sycl::range<2> applyGroup, catRange;
     if (isContig && sizeof(scalar_t) > 2) {

--- a/src/ATen/native/xpu/sycl/Shape.cpp
+++ b/src/ATen/native/xpu/sycl/Shape.cpp
@@ -509,11 +509,11 @@ void parallel_cat(
       : fitsVector(ALIGNED_VEC_LOAD_BYTES_8)  ? ALIGNED_VEC_LOAD_BYTES_8
                                               : 0;
 
-  // Inputs are batched in size order rather than in argument order. A batch's
-  // launch range covers its largest input, so mixing a large input with much
-  // smaller ones leaves most of the smaller inputs' work items idle. Every
-  // input carries its own output offset, so any batching order is equivalent
-  // as long as the offsets are resolved in argument order up front.
+  // Batch inputs by size to reduce idle work items. A batch's launch range is
+  // determined by its largest input, so grouping similarly sized inputs avoids
+  // overprovisioning smaller ones. Output offsets are computed in argument
+  // order, allowing inputs to be reordered for batching without changing the
+  // result.
   const unsigned nInputs = static_cast<unsigned>(inputs.size());
   std::vector<int64_t> inputOffset(nInputs);
   std::vector<unsigned> order(nInputs);
@@ -537,10 +537,10 @@ void parallel_cat(
   int batchCounter = 0;
   unsigned i = 0;
   while (i < nInputs) {
-    // The largest input comes first and fixes the launch range. Close the
-    // batch once the idle work items it would accumulate outweigh the useful
-    // ones; what is left starts a new, smaller batch. A uniformly sized input
-    // list never splits, so the common case keeps a single launch.
+    // Inputs are sorted by size, so the first input determines the batch's
+    // maximum workload. Extend the batch while the estimated idle work does not
+    // exceed the useful work; otherwise, start a new batch with the remaining
+    // inputs.
     const int64_t batchMax = inputs[order[i]].get().numel();
     int64_t usefulElements = batchMax;
     int64_t idleElements = 0;

--- a/src/ATen/native/xpu/sycl/Shape.cpp
+++ b/src/ATen/native/xpu/sycl/Shape.cpp
@@ -52,13 +52,16 @@ inline std::tuple<sycl::range<2>, sycl::range<2>> getCatRange(
     ptrdiff_t nTensors) {
   constexpr unsigned int items_per_group = 256;
   constexpr unsigned int elements_per_item = 8;
-  constexpr unsigned int max_group_per_eu = 32;
 
   unsigned int max_items = ceil_div(max_elements_per_tensor, elements_per_item);
   unsigned int item_groups = ceil_div(max_items, items_per_group);
 
-  const unsigned int num_eu = syclGpuEUCountPerSubslice();
-  item_groups = std::min(num_eu * max_group_per_eu, item_groups);
+  // One wave is enough to saturate the tile. The kernel is grid-strided, so
+  // additional groups do not increase parallelism and can increase idle work
+  // for smaller tensors in the batch.
+  const unsigned int max_item_groups =
+      static_cast<unsigned int>(syclMaxWorkItemsPerTile() / items_per_group);
+  item_groups = std::min(max_item_groups, item_groups);
 
   sycl::range<2> global_range(
       (long long)nTensors, items_per_group * item_groups);
@@ -72,15 +75,15 @@ inline std::tuple<sycl::range<2>, sycl::range<2>> getCatRangeContig(
     ptrdiff_t nTensors) {
   constexpr unsigned int items_per_group = 256;
   constexpr unsigned int min_aligned_vec_per_item = 1;
-  constexpr unsigned int max_group_per_eu = 32;
 
   unsigned int elements_per_item =
       aligned_vec_load_bytes / sizeof(T) * min_aligned_vec_per_item;
   unsigned int max_items = ceil_div(max_elements_per_tensor, elements_per_item);
   unsigned int item_groups = ceil_div(max_items, items_per_group);
 
-  const unsigned int num_eu = syclGpuEUCountPerSubslice();
-  item_groups = std::min(num_eu * max_group_per_eu, item_groups);
+  const unsigned int max_item_groups =
+      static_cast<unsigned int>(syclMaxWorkItemsPerTile() / items_per_group);
+  item_groups = std::min(max_item_groups, item_groups);
 
   sycl::range<2> global_range(
       (long long)nTensors, item_groups * items_per_group);

--- a/src/ATen/native/xpu/sycl/Shape.cpp
+++ b/src/ATen/native/xpu/sycl/Shape.cpp
@@ -370,10 +370,6 @@ struct CatArrayBatchedCopy_vectorized {
 
     // Exact: the host guarantees whole vectors per slice.
     const IndexType nVectors = inputs.nElements[group] / kILP;
-    // Empty inputs are valid and require no work. Return early to avoid
-    // dividing by inputSliceVectors, which is zero in this case.
-    if (nVectors == 0)
-      return;
 
     IndexType vectorIndex =
         item.get_group(1) * item.get_local_range(1) + item.get_local_id(1);
@@ -547,6 +543,8 @@ void parallel_cat(
     while (batchEnd < nInputs &&
            (batchEnd - i) < static_cast<unsigned>(batch_size)) {
       const int64_t n = nElements[order[batchEnd]];
+      if (n == 0)
+        break;
       // Limit batching when the padding overhead becomes too large. Smaller
       // tensors leave idle elements up to batchMax; stop once idle work exceeds
       // useful work.

--- a/src/ATen/native/xpu/sycl/Shape.cpp
+++ b/src/ATen/native/xpu/sycl/Shape.cpp
@@ -19,6 +19,7 @@
 #include <ATen/native/TypeProperties.h>
 #include <ATen/native/xpu/sycl/MemoryAccessUtils.h>
 #include <c10/core/MemoryFormat.h>
+#include <c10/util/SmallVector.h>
 #include <comm/SYCLContext.h>
 #include <comm/xpu_aten.h>
 
@@ -28,7 +29,7 @@
 #include <ATen/ops/size_native.h>
 
 #include <algorithm>
-#include <vector>
+#include <cstddef>
 
 #include <ATen/native/xpu/sycl/Philox4x32.h>
 #include <ATen/native/xpu/sycl/ShapeKernels.h>
@@ -348,11 +349,9 @@ struct CatArrayBatchedCopy_alignedK_contig {
 };
 
 // Like CatArrayBatchedCopy_alignedK_contig, but vectorizes both loads and
-// stores.
-//
-// When each input slice and the output row pitch are multiples of the vector
-// width, each input vector maps to one contiguous output vector. This allows a
-// single wide store and a simple direct output-offset calculation.
+// stores. When each input slice and the output row pitch are multiples of the
+// vector width, each input vector maps to one contiguous output vector. This
+// allows a single wide store and a simple direct output-offset calculation.
 template <
     typename T,
     typename IndexType,
@@ -371,15 +370,13 @@ struct CatArrayBatchedCopy_vectorized {
 
     // Exact: the host guarantees whole vectors per slice.
     const IndexType nVectors = inputs.nElements[group] / kILP;
-    // Empty inputs are legal, and skipping them keeps the division by
-    // inputSliceVectors below well defined (it would be 0).
+    // Empty inputs are valid and require no work. Return early to avoid
+    // dividing by inputSliceVectors, which is zero in this case.
     if (nVectors == 0)
       return;
 
     IndexType vectorIndex =
         item.get_group(1) * item.get_local_range(1) + item.get_local_id(1);
-    if (vectorIndex >= nVectors)
-      return;
 
     const IndexType inputSliceVectors =
         inputs.dimSize[group] * dimStride / kILP;
@@ -478,10 +475,37 @@ void parallel_cat(
                kAlignedKernelBytes ==
            0);
 
-  // Wide stores must not cross input-slice boundaries. Require every input
-  // slice and the output row pitch to be multiples of the vector width;
-  // prefix-sum offsets are then aligned automatically. Check this across all
-  // inputs because the output row pitch is global, not per batch.
+  // Cache per-input geometry for vectorization, sorting, batching, and metadata
+  // setup. Empty tensors are handled here to avoid querying an invalid
+  // dimension.
+  constexpr size_t kInlineInputs = 8;
+  const unsigned nInputs = static_cast<unsigned>(inputs.size());
+  c10::SmallVector<int64_t, kInlineInputs> nElements(nInputs);
+  c10::SmallVector<int64_t, kInlineInputs> dimSize(nInputs);
+  // Keep output offsets in the original input order, independent of batching
+  // order.
+  c10::SmallVector<int64_t, kInlineInputs> inputOffset(nInputs);
+  c10::SmallVector<unsigned, kInlineInputs> order(nInputs);
+  {
+    int64_t running = 0;
+    for (unsigned k = 0; k < nInputs; ++k) {
+      const Tensor& input = inputs[k].get();
+      nElements[k] = input.numel();
+      dimSize[k] = nElements[k] > 0 ? input.size(logical_dimension) : 0;
+      inputOffset[k] = running;
+      running += dimSize[k];
+      order[k] = k;
+    }
+    // Sort inputs by size so tensors with similar workloads are batched
+    // together, reducing idle work from smaller tensors in the same launch.
+    std::stable_sort(order.begin(), order.end(), [&](unsigned a, unsigned b) {
+      return nElements[a] > nElements[b];
+    });
+  }
+
+  // Vectorized stores must stay within each input slice. Require both input
+  // slice sizes and the output slice size to be multiples of the vector width,
+  // so all slice offsets remain aligned.
   const int64_t dimStride = outputParam.tensorStride[mapped_dimension];
   const int64_t outputSliceBytes =
       static_cast<int64_t>(outputParam.tensorSize[mapped_dimension]) *
@@ -491,11 +515,8 @@ void parallel_cat(
         !is_aligned_to(data, bytes) || outputSliceBytes % bytes != 0) {
       return false;
     }
-    for (unsigned k = 0; k < inputs.size(); ++k) {
-      const int64_t dimSize = inputs[k].get().numel() > 0
-          ? inputs[k].get().size(logical_dimension)
-          : 0;
-      if ((dimSize * dimStride * static_cast<int64_t>(sizeof(scalar_t))) %
+    for (unsigned k = 0; k < nInputs; ++k) {
+      if ((dimSize[k] * dimStride * static_cast<int64_t>(sizeof(scalar_t))) %
               bytes !=
           0) {
         return false;
@@ -509,45 +530,26 @@ void parallel_cat(
       : fitsVector(ALIGNED_VEC_LOAD_BYTES_8)  ? ALIGNED_VEC_LOAD_BYTES_8
                                               : 0;
 
-  // Batch inputs by size to reduce idle work items. A batch's launch range is
-  // determined by its largest input, so grouping similarly sized inputs avoids
-  // overprovisioning smaller ones. Output offsets are computed in argument
-  // order, allowing inputs to be reordered for batching without changing the
-  // result.
-  const unsigned nInputs = static_cast<unsigned>(inputs.size());
-  std::vector<int64_t> inputOffset(nInputs);
-  std::vector<unsigned> order(nInputs);
-  {
-    int64_t running = 0;
-    for (unsigned k = 0; k < nInputs; ++k) {
-      order[k] = k;
-      inputOffset[k] = running;
-      // There is a legacy case where a 1-D empty tensor can be concat with
-      // high-dimensional tensor
-      if (inputs[k].get().numel() > 0) {
-        running += inputs[k].get().size(logical_dimension);
-      }
-    }
-    std::stable_sort(order.begin(), order.end(), [&](unsigned a, unsigned b) {
-      return inputs[a].get().numel() > inputs[b].get().numel();
-    });
-  }
-
-  // Now we loop
+  // Process inputs in size-sorted batches.
   int batchCounter = 0;
   unsigned i = 0;
   while (i < nInputs) {
-    // Inputs are sorted by size, so the first input determines the batch's
-    // maximum workload. Extend the batch while the estimated idle work does not
-    // exceed the useful work; otherwise, start a new batch with the remaining
-    // inputs.
-    const int64_t batchMax = inputs[order[i]].get().numel();
+    // The first input is the largest in this batch.
+    const int64_t batchMax = nElements[order[i]];
+    // All remaining inputs are empty, so there is nothing left to launch.
+    if (batchMax == 0)
+      break;
+
+    // Grow the batch while idle work stays within the useful-work budget.
     int64_t usefulElements = batchMax;
     int64_t idleElements = 0;
     unsigned batchEnd = i + 1;
     while (batchEnd < nInputs &&
            (batchEnd - i) < static_cast<unsigned>(batch_size)) {
-      const int64_t n = inputs[order[batchEnd]].get().numel();
+      const int64_t n = nElements[order[batchEnd]];
+      // Limit batching when the padding overhead becomes too large. Smaller
+      // tensors leave idle elements up to batchMax; stop once idle work exceeds
+      // useful work.
       if (idleElements + (batchMax - n) > usefulElements + n)
         break;
       idleElements += batchMax - n;
@@ -555,29 +557,25 @@ void parallel_cat(
       ++batchEnd;
     }
     const unsigned batchStart = i;
-    // Advanced ahead of the launch, which ends the iteration early.
+    // Advance before dispatch since LAUNCH_VECTORIZED may continue the loop,
+    // which would otherwise skip the cursor update.
     i = batchEnd;
 
     bool isContig = true;
     bool isAligned = true;
-    // OR of the batch's input addresses; one modulo then tests them all.
-    // Unlike the geometry above, alignment may vary from batch to batch.
+    // OR input addresses so a single alignment check covers the whole batch.
     uintptr_t inputAddressBits = 0;
-    unsigned int max_elements_per_tensor = 0;
+    // Inputs are sorted by size, so batchMax is the batch maximum.
+    const unsigned int max_elements_per_tensor =
+        static_cast<unsigned int>(batchMax);
     for (batchCounter = 0; batchStart + batchCounter < batchEnd;
          ++batchCounter) {
       const unsigned inputIndex = order[batchStart + batchCounter];
-      int64_t dimSize = 0;
-      // There is a legacy case where a 1-D empty tensor can be concat with
-      // high-dimensional tensor
-      if (inputs[inputIndex].get().numel() > 0) {
-        dimSize = inputs[inputIndex].get().size(logical_dimension);
-      }
       catMetaData.input[batchCounter] = static_cast<const scalar_t*>(
           inputs[inputIndex].get().const_data_ptr());
       catMetaData.offset[batchCounter] = inputOffset[inputIndex];
-      catMetaData.dimSize[batchCounter] = dimSize;
-      catMetaData.nElements[batchCounter] = inputs[inputIndex].get().numel();
+      catMetaData.dimSize[batchCounter] = dimSize[inputIndex];
+      catMetaData.nElements[batchCounter] = nElements[inputIndex];
 
       // If at least one of the inputs is not aligned, we can't call the
       // CatArrayBatchedCopy_alignedK_contig
@@ -611,18 +609,9 @@ void parallel_cat(
       } else {
         catMetaData.isContiguous[batchCounter] = true;
       }
-
-      // We need max elements per tensor to compute range parameters
-      max_elements_per_tensor = std::max(
-          max_elements_per_tensor, catMetaData.nElements[batchCounter]);
     }
 
-    // Skip if every input in the batch is empty. Otherwise the range dim is
-    // invalid. Sorting puts the empty inputs last, so this ends the loop.
-    if (max_elements_per_tensor == 0)
-      continue;
-
-      // Independent of Dims, so dispatched ahead of the HANDLE_CASE switch.
+// Independent of Dims, so dispatched ahead of the HANDLE_CASE switch.
 #define LAUNCH_VECTORIZED(VEC_BYTES)                                       \
   {                                                                        \
     sycl::range<2> vecGroup, vecRange;                                     \

--- a/test/regressions/test_cat.py
+++ b/test/regressions/test_cat.py
@@ -145,6 +145,42 @@ class TestTorchMethod(TestCase):
 
         self.assertEqual(expected, actual.cpu())
 
+    def test_cat_size_skewed_batches(self):
+        # A batch's launch range is sized by its largest input, so widely
+        # different sizes are split into several launches. Inputs are also
+        # reordered by size, so this checks that every input still lands at its
+        # argument-order offset. Sizes are interleaved to force a permutation,
+        # and an empty input is included because those sort to the end.
+        shapes = []
+        for _ in range(6):
+            shapes += [(2, 3, 512, 8), (2, 3, 1, 8), (2, 3, 37, 8)]
+        shapes.append((2, 3, 0, 8))
+        inputs_cpu = [
+            torch.randn(shape, dtype=torch.float32).to(torch.bfloat16)
+            for shape in shapes
+        ]
+
+        expected = torch.cat(inputs_cpu, dim=2)
+        actual = torch.cat([tensor.xpu() for tensor in inputs_cpu], dim=2)
+
+        self.assertEqual(expected, actual.cpu())
+
+    def test_cat_size_skewed_batches_strided(self):
+        # Same skew, but on non-contiguous inputs so the strided kernel runs
+        # and the per-input stride metadata is reordered along with the rest.
+        shapes = []
+        for _ in range(6):
+            shapes += [(2, 3, 512, 8), (2, 3, 1, 8), (2, 3, 37, 8)]
+        inputs_cpu = [
+            torch.randn(shape, dtype=torch.float32).to(torch.bfloat16)[:, :, :, ::2]
+            for shape in shapes
+        ]
+
+        expected = torch.cat(inputs_cpu, dim=2)
+        actual = torch.cat([tensor.xpu() for tensor in inputs_cpu], dim=2)
+
+        self.assertEqual(expected, actual.cpu())
+
     def test_cat_array_2(self, dtype=torch.float):
         shapes = [
             (8, 7, 3, 2),

--- a/test/regressions/test_cat.py
+++ b/test/regressions/test_cat.py
@@ -115,6 +115,36 @@ class TestTorchMethod(TestCase):
         )
         self.assertEqual(res_cpu, res_xpu.cpu())
 
+    def test_cat_contiguous_vectorized_copy(self):
+        # A trailing extent of 8 BF16 values makes every concat slice 16-byte
+        # aligned, which is what the vectorized copy needs.
+        shapes = ((2, 3, 1139, 8), (2, 3, 1, 8), (2, 3, 3, 8))
+        inputs_cpu = [
+            torch.randn(shape, dtype=torch.float32).to(torch.bfloat16)
+            for shape in shapes
+        ]
+
+        expected = torch.cat(inputs_cpu, dim=2)
+        actual = torch.cat([tensor.xpu() for tensor in inputs_cpu], dim=2)
+
+        self.assertEqual(expected, actual.cpu())
+
+    def test_cat_contiguous_vectorized_copy_multi_batch(self):
+        # More inputs than fit in one launch, so the copy is split into several
+        # batches. Only the last input is misaligned, which must disable the
+        # wide store for every batch: an earlier batch that vectorized on its
+        # own would compute wrong offsets once the row pitch narrows.
+        shapes = [(4, 8)] * 2048 + [(4, 4)]
+        inputs_cpu = [
+            torch.randn(shape, dtype=torch.float32).to(torch.bfloat16)
+            for shape in shapes
+        ]
+
+        expected = torch.cat(inputs_cpu, dim=1)
+        actual = torch.cat([tensor.xpu() for tensor in inputs_cpu], dim=1)
+
+        self.assertEqual(expected, actual.cpu())
+
     def test_cat_array_2(self, dtype=torch.float):
         shapes = [
             (8, 7, 3, 2),

--- a/test/regressions/test_cat.py
+++ b/test/regressions/test_cat.py
@@ -131,10 +131,8 @@ class TestTorchMethod(TestCase):
 
     def test_cat_contiguous_vectorized_copy_multi_batch(self):
         # More inputs than fit in one launch, so the copy is split into several
-        # batches. Only the last input is misaligned, which must disable the
-        # wide store for every batch: an earlier batch that vectorized on its
-        # own would compute wrong offsets once the row pitch narrows.
-        shapes = [(4, 8)] * 2048 + [(4, 4)]
+        # batches. The last input forces the 8-byte fallback for every batch.
+        shapes = [(4, 8)] * 64 + [(4, 4)]
         inputs_cpu = [
             torch.randn(shape, dtype=torch.float32).to(torch.bfloat16)
             for shape in shapes


### PR DESCRIPTION
Optimizes the contiguous cat path by adding a vectorized copy kernel that uses wide stores in addition to the existing vectorized loads.

The existing `CatArrayBatchedCopy_alignedK_contig` path loads multiple elements at once, but still computes the output offset and stores each element separately. For layouts where each input slice and the output row pitch are multiples of the vector width, the mapping can be simplified to a direct vector-to-vector copy.

This PR adds `CatArrayBatchedCopy_vectorized`, which:

- Uses 16-byte vector loads/stores when possible, with an 8-byte fallback.
- Computes output offsets per vector instead of per element.
- Checks slice geometry and alignment before selecting the vectorized path.
- Falls back to the existing kernels for unsupported layouts.

**Performance**
KV-cache concat, bf16, [16,16,1139,128] + [16,16,1,128], dim=2
  | Latency | Achieved BW
-- | -- | --
Baseline | 1.00x | 1.00x
This PR | 0.66x | 1.52x
