### PR TITLE
[test/xpu] Whitelist ConvTranspose1d test_cpu_gpu_parity as CUDA-xfail-XPU-pass

### DIFF
--- a/test/xpu/xpu_test_utils.py
+++ b/test/xpu/xpu_test_utils.py
@@ -357,6 +357,7 @@ _cuda_xfail_xpu_pass = [
     ("nn.Conv2d", "test_memory_format"),
     ("nn.ConvTranspose2d", "test_memory_format"),
     ("nn.LazyConvTranspose2d", "test_memory_format"),
+    ("nn.ConvTranspose1d", "test_cpu_gpu_parity"),
     ("narrow_copy", "test_meta_outplace"),
     ("narrow_copy", "test_dispatch_meta_outplace"),
     ("narrow_copy", "test_dispatch_symbolic_meta_outplace"),


### PR DESCRIPTION
Fixes #3891 (`test_cpu_gpu_parity_nn_ConvTranspose1d_xpu_complex32` sub-issue; mirror: CuiYifeng/torch-xpu-ops-sandbox#18)

## Summary

Whitelist `nn.ConvTranspose1d test_cpu_gpu_parity` in `_cuda_xfail_xpu_pass`
so the XPU harness stops turning the inherited CUDA `expectedFailure` into
an "Unexpected success" on XPU.

## Root cause

The XPU test harness `align_db_decorators` remaps every CUDA
`expectedFailure` decorator onto XPU unless the `(op, test)` pair is
listed in `_cuda_xfail_xpu_pass`. `test_cpu_gpu_parity_nn_ConvTranspose1d_xpu_complex32`
inherits a CUDA `expectedFailure` even though the XPU kernel actually
computes correctly for complex32 ConvTranspose1d, so pytest reports
"Unexpected success".

The sibling ops `nn.ConvTranspose2d` and `nn.LazyConvTranspose2d` are
already whitelisted for their memory-format parity tests. ConvTranspose1d
was simply missing the analogous entry.

## Why CUDA works but XPU failed

The failure mode here is not a computation gap: the XPU kernel produces
the correct result. It is a test-harness gap. CUDA carries the historic
`expectedFailure`; the XPU harness auto-inherits it. Since XPU is now
correct on this case, the fix is a whitelist entry mirroring how the 2D
sibling is handled. Not a kernel change — no misalignment with CUDA
logic.

## Verification

Verified PASS on `torch==2.14.0.dev20260725+xpu` (PVC single tile).

```
pytest -v test/xpu/test_modules_xpu.py::TestModuleXPU::test_cpu_gpu_parity_nn_ConvTranspose1d_xpu_complex32
```

Test: **test/xpu/test_modules_xpu.py::TestModuleXPU::test_cpu_gpu_parity_nn_ConvTranspose1d_xpu_complex32** (existing upstream parity test, exercised via the XPU test harness).

Authored with assistance from an AI coding agent.

