### PR TITLE
[test/xpu] Guard sparse CSR mul-scalar against experimental BComplex32

### DIFF
--- a/test/xpu/test_sparse_csr_xpu.py
+++ b/test/xpu/test_sparse_csr_xpu.py
@@ -3220,8 +3220,8 @@ class TestSparseCSR(TestCase):
             for scalar_dtype in all_types_and_complex_and(
                 torch.bool, torch.bfloat16, torch.half
             ):
-                # ComplexHalf is experimental
-                if dtype is torch.half and scalar_dtype.is_complex:
+                # ComplexHalf/BComplex32 is experimental
+                if dtype in (torch.half, torch.bfloat16) and scalar_dtype.is_complex:
                     continue
 
                 scalar_t = torch.tensor(2, dtype=scalar_dtype)


### PR DESCRIPTION
Partially addresses #3976 (sparse CSR `mul_scalar_*_bfloat16` sub-issue; mirror: CuiYifeng/torch-xpu-ops-sandbox#29)

## Summary

Sync the sparse CSR `test_mul_scalar` guard so `bfloat16 x complex_scalar`
combinations are skipped, matching upstream. Unblocks 8 previously failing
`test_mul_scalar_*_bfloat16` variants on XPU.

## Root cause

`TestSparseCSR.test_mul_scalar` iterates every scalar dtype (including
complex) for every base dtype. When the base dtype is `bfloat16` and the
scalar is complex, the operation promotes to the experimental
`torch.bcomplex32` type. `bcomplex32`'s `to_dense` / `index_add` / `mul`
comparison path is not implemented, so the test crashes in the reference
comparison.

Upstream already guards BOTH `torch.half` and `torch.bfloat16` promotions
against complex scalars. The XPU-vendored copy only guarded `torch.half`,
leaving 8 `test_mul_scalar_*_bfloat16` variants uncovered.

## Why CUDA works but XPU failed

Identical to CUDA behavior — the failure is not a kernel gap. CUDA does
not run the XPU-vendored copy. The XPU copy was simply one guard line
stale relative to upstream. No misalignment with CUDA logic.

## Verification

Verified PASS on `torch==2.14.0.dev20260725+xpu` (PVC single tile).

```
pytest -v test/xpu/test_sparse_csr_xpu.py -k 'test_mul_scalar_enable_hybrid_False and bfloat16'
```

Test: **test/xpu/test_sparse_csr_xpu.py** (existing vendored suite; 8 `test_mul_scalar_*_bfloat16` variants).

Authored with assistance from an AI coding agent.

