### PR TITLE
[test/xpu] Widen BComplex32 outputs to complex64 in extended CPU/XPU parity

### DIFF
--- a/test/xpu/extended/test_ops_xpu.py
+++ b/test/xpu/extended/test_ops_xpu.py
@@ -141,6 +141,21 @@ class Namespace:
                 xpu_results = sample.output_process_fn_grad(xpu_results)
                 cpu_results = cpu_sample.output_process_fn_grad(cpu_results)
 
+                # assertEqual cannot consume experimental BComplex32 (many
+                # ops it dispatches to, e.g. isclose/sub/abs, are not
+                # implemented for it). complex64 is a lossless widening, so
+                # the parity check still runs. Widen only when both sides
+                # agree, so a one-sided promotion still fails on dtype.
+                # Track: https://github.com/pytorch/pytorch/issues/177859
+                if (
+                    isinstance(xpu_results, torch.Tensor)
+                    and isinstance(cpu_results, torch.Tensor)
+                    and xpu_results.dtype is torch.bcomplex32
+                    and cpu_results.dtype is torch.bcomplex32
+                ):
+                    xpu_results = xpu_results.to(torch.complex64)
+                    cpu_results = cpu_results.to(torch.complex64)
+
                 # CHANGED: Use 1e-3 for all dtypes on XPU
                 self.assertEqual(xpu_results, cpu_results, atol=1e-3, rtol=1e-3)
 

--- a/test/xpu/extended/test_ops_xpu.py
+++ b/test/xpu/extended/test_ops_xpu.py
@@ -147,6 +147,7 @@ class Namespace:
                 # the parity check still runs. Widen only when both sides
                 # agree, so a one-sided promotion still fails on dtype.
                 # Track: https://github.com/pytorch/pytorch/issues/177859
+                # TODO: Remove this widening after BComplex32 support is ready.
                 if (
                     isinstance(xpu_results, torch.Tensor)
                     and isinstance(cpu_results, torch.Tensor)


### PR DESCRIPTION
Fixes #3994 (`test_compare_cpu_where_xpu_bfloat16` sub-issue; mirror: CuiYifeng/torch-xpu-ops-sandbox#32)

## Summary

When both XPU and CPU outputs are `torch.bcomplex32` in the extended
CPU-vs-XPU parity harness, widen both to `complex64` before
`assertEqual`. Unblocks `test_compare_cpu_where_xpu_bfloat16` without
losing parity coverage.

## Root cause

`where` on the vendored `reference_inputs` for `bfloat16` promotes to
`torch.bcomplex32` on the `bfloat16 x complex scalar` block in
`reference_inputs_where`. `assertEqual(xpu_results, cpu_results)` then
dispatches to ops such as `isclose`/`sub`/`abs`, none of which are
implemented for `BComplex32`, so the test crashes with
`NotImplementedError` before it can compare anything.

The kernel is fine. Only the comparison harness cannot consume the
promoted output.

## Fix

Widen both sides to `complex64` before `assertEqual` when both are
`bcomplex32`:

- `bcomplex32 -> complex64` is a lossless widening, so parity is
  preserved for the exact `bfloat16 x complex scalar` samples this
  test is meant to guard.
- Cast only when both sides agree. A one-sided promotion (e.g. XPU
  `bcomplex32` vs CPU `complex64`) still falls through to
  `assertEqual` and fails on dtype rather than being silently masked.

Upstream tracking: [pytorch/pytorch#177859](https://github.com/pytorch/pytorch/issues/177859) — the guard can be
dropped once `BComplex32` gains the ops `assertEqual` dispatches to.

## Rejected alternative

Silent `continue` on any `bcomplex32` output. It drops parity coverage
on the exact promotion path most likely to diverge across backends and
reports green having compared nothing.

## Why CUDA works but XPU failed

CUDA does not run this extended CPU-vs-XPU parity harness at all; the
failure is specific to how the vendored XPU harness compares outputs,
not a kernel behavior difference. Not a kernel change.

## Verification

Verified PASS on `torch==2.14.0.dev20260809+xpu` (PVC, 1 tile via
`ZE_AFFINITY_MASK=0`).

```
PYTHONPATH=<pytorch_src>/test ZE_AFFINITY_MASK=0 PYTORCH_TEST_WITH_SLOW=1 \
    pytest -v test/xpu/extended/test_ops_xpu.py::TestCommonXPU::test_compare_cpu_where_xpu_bfloat16
```

Additionally instrumented the harness locally to count how many
`where` reference-input samples take the widening branch on
`bfloat16`: **2 samples widened to `complex64`, 2 successfully
compared via `assertEqual`** (no samples silently skipped).

Test: **test/xpu/extended/test_ops_xpu.py::TestCommonXPU::test_compare_cpu_where_xpu_bfloat16** (existing extended parity test).

Authored with assistance from an AI coding agent.