### PR TITLE
Add half support to torch.polar on XPU

### DIFF
--- a/src/ATen/native/xpu/sycl/ComplexKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ComplexKernels.cpp
@@ -36,15 +36,19 @@ void complex_kernel(TensorIterator& iter) {
 template <typename scalar_t>
 struct PolarFunctor {
   c10::complex<scalar_t> operator()(scalar_t a, scalar_t b) const {
-    return c10::complex<scalar_t>(a * sycl::cos(b), a * sycl::sin(b));
+    using opmath_t = at::opmath_type<scalar_t>;
+    return c10::complex<scalar_t>(
+        static_cast<scalar_t>(opmath_t(a) * sycl::cos(opmath_t(b))),
+        static_cast<scalar_t>(opmath_t(a) * sycl::sin(opmath_t(b))));
   }
 };
 
 void polar_kernel(TensorIterator& iter) {
-  AT_DISPATCH_FLOATING_TYPES(iter.input_dtype(0), "polar_xpu", [&]() {
-    PolarFunctor<scalar_t> f;
-    gpu_kernel(iter, f);
-  });
+  AT_DISPATCH_FLOATING_TYPES_AND(
+      kHalf, iter.input_dtype(0), "polar_xpu", [&]() {
+        PolarFunctor<scalar_t> f;
+        gpu_kernel(iter, f);
+      });
 }
 
 } // namespace at::native::xpu


### PR DESCRIPTION
# Motivation

Align to CPU/CUDA (added in https://github.com/pytorch/pytorch/pull/192311), the test will be covered by `test/test_tensor_creation_ops.py::test_torch_polar`

# Additional Context
Without this, PyTorch XPU CI failed.
<img width="1161" height="206" alt="image" src="https://github.com/user-attachments/assets/ec0da927-03ba-4ab6-a050-d9f546c9523b" />
With this fix, all pass:
<img width="1106" height="556" alt="image" src="https://github.com/user-attachments/assets/6b098f89-cb78-402d-8ceb-7a24e3c01567" />
