### PR TITLE
Widen chalf tolerance for ConvTranspose1d cpu_gpu_parity on XPU

### DIFF
--- a/test/xpu/xpu_test_utils.py
+++ b/test/xpu/xpu_test_utils.py
@@ -356,6 +356,7 @@ _cuda_xfail_xpu_pass = [
     ("nn.LazyConv2d", "test_memory_format"),
     ("nn.Conv2d", "test_memory_format"),
     ("nn.ConvTranspose2d", "test_memory_format"),
+    ("nn.ConvTranspose1d", "test_cpu_gpu_parity"),
     ("nn.LazyConvTranspose2d", "test_memory_format"),
     ("narrow_copy", "test_meta_outplace"),
     ("narrow_copy", "test_dispatch_meta_outplace"),
@@ -473,6 +474,17 @@ _xpu_tolerance_override = {
     "nn.ConvTranspose3d": {
         ("TestModule", "test_non_contiguous_tensors"): {
             torch.float32: tol(atol=2e-5, rtol=5e-5),
+        }
+    },
+    "nn.ConvTranspose1d": {
+        # https://github.com/intel/torch-xpu-ops/issues/4889
+        # chalf has an 11-bit mantissa, so CPU-vs-XPU accumulation order alone
+        # exceeds the default 1e-05 atol. The XPU output is closer to a complex64
+        # reference than the CPU output is, so this is a dtype precision limit,
+        # not an XPU accuracy defect. Bounds are ~2x the worst error measured
+        # over 40 seeds (abs 1.75e-2, rel 5.1e-3).
+        ("TestModule", "test_cpu_gpu_parity"): {
+            torch.chalf: tol(atol=3e-2, rtol=1.5e-2),
         }
     },
     "test_modules_xpu.py": {


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/4889

`test_cpu_gpu_parity_nn_ConvTranspose1d_xpu_complex32` failed with `Tensor-likes are not close!` (4/50 elements mismatched, greatest absolute difference `0.005523681640625` against an allowed `1e-05`). The root cause is the test tolerance, not XPU accuracy.

## Why this is a tolerance issue and not an XPU accuracy defect

I built a `complex64` CPU reference using the *same* chalf-rounded parameters and inputs, then measured both backends against it:

| module_input | `max\|cpu-ref\|` | `max\|gpu-ref\|` | output magnitude | chalf resolution (`2^-11 * mag`) |
|---|---|---|---|---|
| `[0]` (numel 50) | 0.0057285517 | **0.0026866083** | 6.3852096 | 0.0031177781 |
| `[1]` (numel 25) | 0.0050604218 | **0.0026073421** | 5.0099397 | 0.0024462596 |

**XPU is roughly 2x closer to the high-precision reference than CPU is**, in both cases — so XPU is not the inaccurate side. The observed CPU-vs-XPU gap (~0.006) is the same order as chalf's own representable resolution at that output magnitude (~0.003).

`complex32`/chalf carries an 11-bit mantissa, so the float32-oriented default `atol=1e-05` used by `test_cpu_gpu_parity` is not achievable for accumulated convolution sums; differing CPU-vs-XPU accumulation order alone exceeds it.

Worst case over 40 random seeds: `max|cpu-gpu|` abs = **0.017469281**, worst relative error on significant elements = **0.0050533726** (chalf machine eps = `0.00048828125`).

Note that the `dependency component: oneDNN` label on the issue appears to be a red herring given the above — the divergence is not attributable to a oneDNN convolution defect.

## Why two changes are needed

The two hunks are coupled: the first is what allows the second to take effect at all.

`align_db_decorators()` rewrites `DecorateInfo` entries with `device_type="cuda"` to `device_type="xpu"` unless the `(op_name, test_name)` pair appears in `_cuda_xfail_xpu_pass`. `nn.ConvTranspose1d` carries a CUDA-scoped chalf `unittest.expectedFailure` for `test_cpu_gpu_parity`, so that xfail was being remapped onto XPU.

Consequence: on this repo's harness path the case reported **XFAIL, not FAILED** — it was "passing" for the wrong reason and masking the real signal. (The `FAILED` in the issue report comes from running upstream `test/test_modules.py` directly.)

1. The `_cuda_xfail_xpu_pass` entry drops the remapped xfail so the test actually runs on XPU.
2. The `_xpu_tolerance_override` entry then supplies a chalf bound, mirroring the existing `nn.ConvTranspose3d` and `nn.LazyConvTranspose3d` entries in the same table.

Bounds are `atol=3e-2, rtol=1.5e-2` — approximately 1.7x and 2.9x margin over the measured 40-seed worst case, consistent with the 1.4x-4x margins used by other entries in that table. Deliberately not looser than the evidence supports, so a genuine future regression still trips the test.

## Alternative considered

Upstream `torch/testing/_internal/common_modules.py` gives both `ConvTranspose2d` and `ConvTranspose3d` an explicit `DecorateInfo(skipIfXpu, 'TestModule', 'test_cpu_gpu_parity', dtypes=(torch.chalf,), device_type='xpu')` guard, which `ConvTranspose1d` lacks. Adding that guard upstream would also silence the failure, but it was not taken here: it lives in `pytorch/pytorch` rather than this repo, and a tolerance override preserves test coverage where a skip discards it.

## Note for reviewers

`_cuda_xfail_xpu_pass` membership is keyed only by `(op_name, test_name)` with **no dtype dimension**, so an entry suppresses xpu-promotion of *every* CUDA `expectedFailure` for that pair. This is correctly scoped today (`ConvTranspose1d` has exactly one such entry for `test_cpu_gpu_parity`, chalf-only, verified in `common_modules.py`), but a future upstream sync adding a second dtype-scoped CUDA xfail for the same pair would be silently passed through. Pre-existing harness limitation, not introduced by this PR — flagging as a possible follow-up.

## Test

**The failing test lives in PyTorch** (`test/test_modules.py`), exercised through this repo's `test/xpu/test_modules_xpu.py` wrapper. No new reproducer file is added, since the existing test covers the fix directly.

Target case — **before: `1 xfailed`, after: `1 passed`**:

```bash
cd <pytorch_root>/third_party/torch-xpu-ops/test/xpu
python -m pytest test_modules_xpu.py -v --timeout 600 --timeout_method=thread \
    -k "test_cpu_gpu_parity_nn_ConvTranspose1d and complex32"
```

Run 3x consecutively to check for seed flakiness at the tighter bound; passed all 3.

Regression sweeps, both clean:

```bash
python -m pytest test_modules_xpu.py --timeout 600 --timeout_method=thread \
    -k "ConvTranspose" -q
# 207 passed, 23 skipped, 10 xfailed

python -m pytest test_modules_xpu.py --timeout 600 --timeout_method=thread \
    -k "test_cpu_gpu_parity" -q
# 256 passed, 8 skipped, 2 xfailed (both pre-existing)
```

Lint: `ruff check test/xpu/xpu_test_utils.py` clean; `ruff format --diff` flags only pre-existing lines elsewhere in the file, not these hunks.

Environment: `torch 2.14.0.dev20260726+xpu`, Intel Data Center GPU Max 1550 (PVC), driver `1.6.33578+57`.

Test: test/xpu/test_modules_xpu.py (upstream test/test_modules.py::TestModuleXPU::test_cpu_gpu_parity_nn_ConvTranspose1d_xpu_complex32)

---

*This PR was authored with an AI assistant.*
