### PR TITLE
XPU: enable lu_factor with pivot=False in oneMKL path  

### DIFF
--- a/src/ATen/native/xpu/BatchLinearAlgebra.cpp
+++ b/src/ATen/native/xpu/BatchLinearAlgebra.cpp
@@ -12,7 +12,6 @@
 #include <ATen/native/BatchLinearAlgebra.h>
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/LinearAlgebraUtils.h>
-#include <iostream>
 #if defined(USE_ONEMKL_XPU)
 #include <ATen/native/xpu/mkl/BatchLinearAlgebra.h>
 #endif // USE_ONEMKL_XPU
@@ -24,17 +23,6 @@ void lu_solve_kernel_xpu(
     const Tensor& pivots,
     const Tensor& B,
     TransposeType trans) {
-  std::cout << "[LU_FACTOR_DEBUG] lu_solve_kernel_xpu"
-            << " LU.device=" << LU.device()
-            << " LU.dtype=" << LU.scalar_type()
-            << " LU.shape=" << LU.sizes()
-            << " pivots.dtype=" << pivots.scalar_type()
-            << " pivots.shape=" << pivots.sizes()
-            << " B.device=" << B.device()
-            << " B.dtype=" << B.scalar_type()
-            << " B.shape=" << B.sizes()
-            << " trans=" << static_cast<int>(trans)
-            << std::endl;
 #if defined(USE_ONEMKL_XPU)
   native::xpu::lu_solve_mkl(LU, pivots, B, trans);
 #else
@@ -55,36 +43,10 @@ void lu_factor_kernel_fallback(
     const Tensor& pivots,
     const Tensor& infos,
     bool compute_pivots) {
-  std::cout << "[LU_FACTOR_DEBUG] lu_factor_kernel_fallback"
-            << " input.device=" << input.device()
-            << " input.dtype=" << input.scalar_type()
-            << " input.shape=" << input.sizes()
-            << " pivots.dtype=" << pivots.scalar_type()
-            << " pivots.shape=" << pivots.sizes()
-            << " infos.dtype=" << infos.scalar_type()
-            << " infos.shape=" << infos.sizes()
-            << " compute_pivots=" << compute_pivots
-            << std::endl;
-
   auto input_cpu = input.to(input.options().device(kCPU));
   auto pivots_cpu = pivots.to(pivots.options().device(kCPU));
   const auto infos_cpu = infos.to(infos.options().device(kCPU));
-
-  std::cout << "[LU_FACTOR_DEBUG] lu_factor_kernel_fallback"
-            << " input_cpu.device=" << input_cpu.device()
-            << " input_cpu.dtype=" << input_cpu.scalar_type()
-            << " input_cpu.shape=" << input_cpu.sizes()
-            << " pivots_cpu.dtype=" << pivots_cpu.scalar_type()
-            << " pivots_cpu.shape=" << pivots_cpu.sizes()
-            << " infos_cpu.dtype=" << infos_cpu.scalar_type()
-            << " infos_cpu.shape=" << infos_cpu.sizes()
-            << std::endl;
-
-  std::cout << "[LU_FACTOR_DEBUG] lu_factor_stub(at::kCPU, ...) -> begin"
-            << std::endl;
   lu_factor_stub(at::kCPU, input_cpu, pivots_cpu, infos_cpu, compute_pivots);
-  std::cout << "[LU_FACTOR_DEBUG] lu_factor_stub(at::kCPU, ...) -> end"
-            << std::endl;
 
   input.copy_(input_cpu);
   pivots.copy_(pivots_cpu);
@@ -96,38 +58,9 @@ void lu_factor_kernel_xpu(
     const Tensor& pivots,
     const Tensor& infos,
     bool compute_pivots) {
-  std::cout << "[LU_FACTOR_DEBUG] lu_factor_kernel_xpu"
-            << " input.device=" << input.device()
-            << " input.dtype=" << input.scalar_type()
-            << " input.shape=" << input.sizes()
-            << " pivots.dtype=" << pivots.scalar_type()
-            << " pivots.shape=" << pivots.sizes()
-            << " infos.dtype=" << infos.scalar_type()
-            << " infos.shape=" << infos.sizes()
-            << " compute_pivots=" << compute_pivots
-            << " stride_last=" << input.stride(-1)
-            << std::endl;
 #if defined(USE_ONEMKL_XPU)
-  int64_t batch_size = native::batchCount(input);
-  std::cout << "[LU_FACTOR_DEBUG] lu_factor_kernel_xpu"
-            << " USE_ONEMKL_XPU=1"
-            << " batch_size=" << batch_size
-            << std::endl;
-  // Keep CPU fallback for batch_size == 1 only when pivots are requested,
-  // because CPU LU without pivoting is not implemented.
-  if (batch_size == 1 && compute_pivots) {
-    std::cout << "[LU_FACTOR_DEBUG] lu_factor_kernel_xpu -> fallback_cpu_path"
-              << std::endl;
-    lu_factor_kernel_fallback(input, pivots, infos, compute_pivots);
-  } else {
-    std::cout << "[LU_FACTOR_DEBUG] lu_factor_kernel_xpu -> onemkl_path"
-              << std::endl;
-    native::xpu::lu_factor_mkl(input, pivots, infos, compute_pivots);
-  }
+  native::xpu::lu_factor_mkl(input, pivots, infos, compute_pivots);
 #else
-  std::cout << "[LU_FACTOR_DEBUG] lu_factor_kernel_xpu"
-            << " USE_ONEMKL_XPU=0 -> fallback_cpu_path"
-            << std::endl;
   lu_factor_kernel_fallback(input, pivots, infos, compute_pivots);
 #endif // USE_ONEMKL_XPU
 }

--- a/src/ATen/native/xpu/BatchLinearAlgebra.cpp
+++ b/src/ATen/native/xpu/BatchLinearAlgebra.cpp
@@ -113,8 +113,9 @@ void lu_factor_kernel_xpu(
             << " USE_ONEMKL_XPU=1"
             << " batch_size=" << batch_size
             << std::endl;
-  // TODO: optimize lu_factor performance on XPU when batch_size = 1
-  if (batch_size == 1) {
+  // Keep CPU fallback for batch_size == 1 only when pivots are requested,
+  // because CPU LU without pivoting is not implemented.
+  if (batch_size == 1 && compute_pivots) {
     std::cout << "[LU_FACTOR_DEBUG] lu_factor_kernel_xpu -> fallback_cpu_path"
               << std::endl;
     lu_factor_kernel_fallback(input, pivots, infos, compute_pivots);

--- a/src/ATen/native/xpu/BatchLinearAlgebra.cpp
+++ b/src/ATen/native/xpu/BatchLinearAlgebra.cpp
@@ -12,6 +12,7 @@
 #include <ATen/native/BatchLinearAlgebra.h>
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/LinearAlgebraUtils.h>
+#include <iostream>
 #if defined(USE_ONEMKL_XPU)
 #include <ATen/native/xpu/mkl/BatchLinearAlgebra.h>
 #endif // USE_ONEMKL_XPU
@@ -23,6 +24,17 @@ void lu_solve_kernel_xpu(
     const Tensor& pivots,
     const Tensor& B,
     TransposeType trans) {
+  std::cout << "[LU_FACTOR_DEBUG] lu_solve_kernel_xpu"
+            << " LU.device=" << LU.device()
+            << " LU.dtype=" << LU.scalar_type()
+            << " LU.shape=" << LU.sizes()
+            << " pivots.dtype=" << pivots.scalar_type()
+            << " pivots.shape=" << pivots.sizes()
+            << " B.device=" << B.device()
+            << " B.dtype=" << B.scalar_type()
+            << " B.shape=" << B.sizes()
+            << " trans=" << static_cast<int>(trans)
+            << std::endl;
 #if defined(USE_ONEMKL_XPU)
   native::xpu::lu_solve_mkl(LU, pivots, B, trans);
 #else
@@ -43,11 +55,36 @@ void lu_factor_kernel_fallback(
     const Tensor& pivots,
     const Tensor& infos,
     bool compute_pivots) {
+  std::cout << "[LU_FACTOR_DEBUG] lu_factor_kernel_fallback"
+            << " input.device=" << input.device()
+            << " input.dtype=" << input.scalar_type()
+            << " input.shape=" << input.sizes()
+            << " pivots.dtype=" << pivots.scalar_type()
+            << " pivots.shape=" << pivots.sizes()
+            << " infos.dtype=" << infos.scalar_type()
+            << " infos.shape=" << infos.sizes()
+            << " compute_pivots=" << compute_pivots
+            << std::endl;
+
   auto input_cpu = input.to(input.options().device(kCPU));
   auto pivots_cpu = pivots.to(pivots.options().device(kCPU));
   const auto infos_cpu = infos.to(infos.options().device(kCPU));
 
+  std::cout << "[LU_FACTOR_DEBUG] lu_factor_kernel_fallback"
+            << " input_cpu.device=" << input_cpu.device()
+            << " input_cpu.dtype=" << input_cpu.scalar_type()
+            << " input_cpu.shape=" << input_cpu.sizes()
+            << " pivots_cpu.dtype=" << pivots_cpu.scalar_type()
+            << " pivots_cpu.shape=" << pivots_cpu.sizes()
+            << " infos_cpu.dtype=" << infos_cpu.scalar_type()
+            << " infos_cpu.shape=" << infos_cpu.sizes()
+            << std::endl;
+
+  std::cout << "[LU_FACTOR_DEBUG] lu_factor_stub(at::kCPU, ...) -> begin"
+            << std::endl;
   lu_factor_stub(at::kCPU, input_cpu, pivots_cpu, infos_cpu, compute_pivots);
+  std::cout << "[LU_FACTOR_DEBUG] lu_factor_stub(at::kCPU, ...) -> end"
+            << std::endl;
 
   input.copy_(input_cpu);
   pivots.copy_(pivots_cpu);
@@ -59,15 +96,37 @@ void lu_factor_kernel_xpu(
     const Tensor& pivots,
     const Tensor& infos,
     bool compute_pivots) {
+  std::cout << "[LU_FACTOR_DEBUG] lu_factor_kernel_xpu"
+            << " input.device=" << input.device()
+            << " input.dtype=" << input.scalar_type()
+            << " input.shape=" << input.sizes()
+            << " pivots.dtype=" << pivots.scalar_type()
+            << " pivots.shape=" << pivots.sizes()
+            << " infos.dtype=" << infos.scalar_type()
+            << " infos.shape=" << infos.sizes()
+            << " compute_pivots=" << compute_pivots
+            << " stride_last=" << input.stride(-1)
+            << std::endl;
 #if defined(USE_ONEMKL_XPU)
   int64_t batch_size = native::batchCount(input);
+  std::cout << "[LU_FACTOR_DEBUG] lu_factor_kernel_xpu"
+            << " USE_ONEMKL_XPU=1"
+            << " batch_size=" << batch_size
+            << std::endl;
   // TODO: optimize lu_factor performance on XPU when batch_size = 1
   if (batch_size == 1) {
+    std::cout << "[LU_FACTOR_DEBUG] lu_factor_kernel_xpu -> fallback_cpu_path"
+              << std::endl;
     lu_factor_kernel_fallback(input, pivots, infos, compute_pivots);
   } else {
+    std::cout << "[LU_FACTOR_DEBUG] lu_factor_kernel_xpu -> onemkl_path"
+              << std::endl;
     native::xpu::lu_factor_mkl(input, pivots, infos, compute_pivots);
   }
 #else
+  std::cout << "[LU_FACTOR_DEBUG] lu_factor_kernel_xpu"
+            << " USE_ONEMKL_XPU=0 -> fallback_cpu_path"
+            << std::endl;
   lu_factor_kernel_fallback(input, pivots, infos, compute_pivots);
 #endif // USE_ONEMKL_XPU
 }

--- a/src/ATen/native/xpu/mkl/BatchLinearAlgebra.cpp
+++ b/src/ATen/native/xpu/mkl/BatchLinearAlgebra.cpp
@@ -30,6 +30,8 @@
 #include <comm/TensorInfo.h>
 #include <oneapi/mkl/lapack.hpp>
 
+#include <iostream>
+
 namespace at::native::xpu {
 
 #define SYCL_ONEMKL_SUBMIT(q, routine, ...) \
@@ -370,6 +372,13 @@ void lu_factor_mkl(
     const Tensor& pivots,
     const Tensor& info,
     bool pivot) {
+  std::cout << "[LU_FACTOR_DEBUG] lu_factor_mkl"
+            << " device=" << LU.device()
+            << " dtype=" << LU.scalar_type()
+            << " shape=" << LU.sizes()
+            << " pivot=" << pivot
+            << " stride_last=" << LU.stride(-1)
+            << std::endl;
   TORCH_CHECK(
       LU.dim() >= 2,
       "torch.lu_factor: Expected tensor with 2 or more dimensions. Got size: ",

--- a/src/ATen/native/xpu/mkl/BatchLinearAlgebra.cpp
+++ b/src/ATen/native/xpu/mkl/BatchLinearAlgebra.cpp
@@ -30,8 +30,6 @@
 #include <comm/TensorInfo.h>
 #include <oneapi/mkl/lapack.hpp>
 
-#include <iostream>
-
 namespace at::native::xpu {
 
 #define SYCL_ONEMKL_SUBMIT(q, routine, ...) \
@@ -118,14 +116,6 @@ void mkl_getrfnp(
     int64_t batch_size,
     scalar_t* scratchpad,
     int64_t scratchpadsize) {
-  std::cout << "[LU_FACTOR_DEBUG] mkl_getrfnp"
-            << " m=" << m
-            << " n=" << n
-            << " lda=" << lda
-            << " stride_a=" << stride_a
-            << " batch_size=" << batch_size
-            << " scratchpadsize=" << scratchpadsize
-            << std::endl;
   SYCL_ONEMKL_SUBMIT(
       queue,
       oneapi::mkl::lapack::getrfnp_batch,
@@ -245,24 +235,11 @@ static void apply_lu_xpu_(
   int64_t stride_a = lda * n;
   scalar_t* a = reinterpret_cast<scalar_t*>(self_.data_ptr());
 
-  std::cout << "[LU_FACTOR_DEBUG] apply_lu_xpu_"
-            << " get_pivots=" << get_pivots
-            << " batch_size=" << batch_size
-            << " m=" << m
-            << " n=" << n
-            << " lda=" << lda
-            << " stride_a=" << stride_a
-            << std::endl;
-
   if (get_pivots) {
     int64_t stride_ipiv = (m < n) ? m : n;
     int64_t* ipiv = pivots_.data_ptr<int64_t>();
     int64_t scratchpadsize = mkl_getrf_scratchpad<scalar_t>(
         queue, m, n, lda, stride_a, stride_ipiv, batch_size);
-    std::cout << "[LU_FACTOR_DEBUG] apply_lu_xpu_ -> getrf_batch"
-              << " stride_ipiv=" << stride_ipiv
-              << " scratchpadsize=" << scratchpadsize
-              << std::endl;
     Tensor scratchpad_at = at::empty({scratchpadsize}, self_.options());
     try {
       mkl_getrf<scalar_t>(
@@ -283,9 +260,6 @@ static void apply_lu_xpu_(
   } else {
     int64_t scratchpadsize = mkl_getrfnp_scratchpad<scalar_t>(
         queue, m, n, lda, stride_a, batch_size);
-    std::cout << "[LU_FACTOR_DEBUG] apply_lu_xpu_ -> getrfnp_batch"
-              << " scratchpadsize=" << scratchpadsize
-              << std::endl;
     Tensor scratchpad_at = at::empty({scratchpadsize}, self_.options());
     try {
       mkl_getrfnp<scalar_t>(
@@ -455,13 +429,6 @@ void lu_factor_mkl(
     const Tensor& pivots,
     const Tensor& info,
     bool pivot) {
-  std::cout << "[LU_FACTOR_DEBUG] lu_factor_mkl"
-            << " device=" << LU.device()
-            << " dtype=" << LU.scalar_type()
-            << " shape=" << LU.sizes()
-            << " pivot=" << pivot
-            << " stride_last=" << LU.stride(-1)
-            << std::endl;
   TORCH_CHECK(
       LU.dim() >= 2,
       "torch.lu_factor: Expected tensor with 2 or more dimensions. Got size: ",
@@ -504,6 +471,11 @@ void lu_factor_mkl(
       LU.masked_fill_(
           nan_mask_expanded.expand({batch_size, m, n}),
           create_quiet_nan<scalar_t>());
+    }
+
+    // Match CUDA non-pivot behavior: backend-generated NaNs are replaced by 0.
+    if (!pivot) {
+      LU.copy_(at::where(LU.eq(LU), LU, at::zeros({}, LU.options())));
     }
   });
 

--- a/src/ATen/native/xpu/mkl/BatchLinearAlgebra.cpp
+++ b/src/ATen/native/xpu/mkl/BatchLinearAlgebra.cpp
@@ -108,6 +108,39 @@ void mkl_getrf(
 }
 
 template <typename scalar_t>
+void mkl_getrfnp(
+    sycl::queue& queue,
+    int64_t m,
+    int64_t n,
+    scalar_t* a,
+    int64_t lda,
+    int64_t stride_a,
+    int64_t batch_size,
+    scalar_t* scratchpad,
+    int64_t scratchpadsize) {
+  std::cout << "[LU_FACTOR_DEBUG] mkl_getrfnp"
+            << " m=" << m
+            << " n=" << n
+            << " lda=" << lda
+            << " stride_a=" << stride_a
+            << " batch_size=" << batch_size
+            << " scratchpadsize=" << scratchpadsize
+            << std::endl;
+  SYCL_ONEMKL_SUBMIT(
+      queue,
+      oneapi::mkl::lapack::getrfnp_batch,
+      queue,
+      m,
+      n,
+      a,
+      lda,
+      stride_a,
+      batch_size,
+      scratchpad,
+      scratchpadsize);
+}
+
+template <typename scalar_t>
 void mkl_getrs(
     sycl::queue& queue,
     oneapi::mkl::transpose trans,
@@ -158,6 +191,18 @@ int64_t mkl_getrf_scratchpad(
 }
 
 template <typename scalar_t>
+int64_t mkl_getrfnp_scratchpad(
+    sycl::queue& queue,
+    int64_t m,
+    int64_t n,
+    int64_t lda,
+    int64_t stride_a,
+    int64_t batch_size) {
+  return oneapi::mkl::lapack::getrfnp_batch_scratchpad_size<scalar_t>(
+      queue, m, n, lda, stride_a, batch_size);
+}
+
+template <typename scalar_t>
 int64_t mkl_getrs_scratchpad(
     sycl::queue& queue,
     oneapi::mkl::transpose trans,
@@ -185,8 +230,9 @@ int64_t mkl_getrs_scratchpad(
 template <typename scalar_t>
 static void apply_lu_xpu_(
     const Tensor& self_,
-    Tensor& pivots_,
-    int32_t* info_data) {
+    const Tensor& pivots_,
+    int32_t* info_data,
+    bool get_pivots) {
   // do nothing if empty input.
   if (self_.numel() == 0)
     return;
@@ -197,27 +243,64 @@ static void apply_lu_xpu_(
   int64_t n = self_.size(-1);
   int64_t lda = m;
   int64_t stride_a = lda * n;
-  int64_t stride_ipiv = (m < n) ? m : n;
   scalar_t* a = reinterpret_cast<scalar_t*>(self_.data_ptr());
-  int64_t* ipiv = pivots_.data_ptr<int64_t>();
-  int64_t scratchpadsize = mkl_getrf_scratchpad<scalar_t>(
-      queue, m, n, lda, stride_a, stride_ipiv, batch_size);
-  Tensor scratchpad_at = at::empty({scratchpadsize}, self_.options());
-  try {
-    mkl_getrf<scalar_t>(
-        queue,
-        m,
-        n,
-        a,
-        lda,
-        stride_a,
-        ipiv,
-        stride_ipiv,
-        batch_size,
-        reinterpret_cast<scalar_t*>(scratchpad_at.data_ptr()),
-        scratchpadsize);
-  } catch (const oneapi::mkl::lapack::batch_error& be) {
-    error_handle(info_data, be);
+
+  std::cout << "[LU_FACTOR_DEBUG] apply_lu_xpu_"
+            << " get_pivots=" << get_pivots
+            << " batch_size=" << batch_size
+            << " m=" << m
+            << " n=" << n
+            << " lda=" << lda
+            << " stride_a=" << stride_a
+            << std::endl;
+
+  if (get_pivots) {
+    int64_t stride_ipiv = (m < n) ? m : n;
+    int64_t* ipiv = pivots_.data_ptr<int64_t>();
+    int64_t scratchpadsize = mkl_getrf_scratchpad<scalar_t>(
+        queue, m, n, lda, stride_a, stride_ipiv, batch_size);
+    std::cout << "[LU_FACTOR_DEBUG] apply_lu_xpu_ -> getrf_batch"
+              << " stride_ipiv=" << stride_ipiv
+              << " scratchpadsize=" << scratchpadsize
+              << std::endl;
+    Tensor scratchpad_at = at::empty({scratchpadsize}, self_.options());
+    try {
+      mkl_getrf<scalar_t>(
+          queue,
+          m,
+          n,
+          a,
+          lda,
+          stride_a,
+          ipiv,
+          stride_ipiv,
+          batch_size,
+          reinterpret_cast<scalar_t*>(scratchpad_at.data_ptr()),
+          scratchpadsize);
+    } catch (const oneapi::mkl::lapack::batch_error& be) {
+      error_handle(info_data, be);
+    }
+  } else {
+    int64_t scratchpadsize = mkl_getrfnp_scratchpad<scalar_t>(
+        queue, m, n, lda, stride_a, batch_size);
+    std::cout << "[LU_FACTOR_DEBUG] apply_lu_xpu_ -> getrfnp_batch"
+              << " scratchpadsize=" << scratchpadsize
+              << std::endl;
+    Tensor scratchpad_at = at::empty({scratchpadsize}, self_.options());
+    try {
+      mkl_getrfnp<scalar_t>(
+          queue,
+          m,
+          n,
+          a,
+          lda,
+          stride_a,
+          batch_size,
+          reinterpret_cast<scalar_t*>(scratchpad_at.data_ptr()),
+          scratchpadsize);
+    } catch (const oneapi::mkl::lapack::batch_error& be) {
+      error_handle(info_data, be);
+    }
   }
 }
 
@@ -384,21 +467,21 @@ void lu_factor_mkl(
       "torch.lu_factor: Expected tensor with 2 or more dimensions. Got size: ",
       LU.sizes(),
       " instead");
-  TORCH_CHECK(
-      pivot,
-      "linalg.lu_factor: LU without pivoting is not implemented on the XPU");
 
   // handle the info
   Tensor info_ = at::zeros_like(info, Device(at::kCPU));
   int32_t* info_data = info_.data_ptr<int32_t>();
 
-  // oneMKL requires Long for pivots but PyTorch provides Int
-  Tensor pivots_ = at::empty(pivots.sizes(), pivots.options().dtype(kLong));
+  // oneMKL requires Long for pivots but PyTorch provides Int.
+  Tensor pivots_;
+  if (pivot) {
+    pivots_ = at::empty(pivots.sizes(), pivots.options().dtype(kLong));
+  }
 
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(LU.scalar_type(), "lu_xpu", [&] {
     using T = get_mkl_type<scalar_t>::type;
     if (!at::isnan(LU).any().item<bool>()) {
-      apply_lu_xpu_<T>(LU, pivots_, info_data);
+      apply_lu_xpu_<T>(LU, pivots_, info_data, pivot);
     } else {
       // Has NaN, temporarily replace NaNs to avoid MKL crashes, run batched LU
       // then restore NaNs for the affected batches.
@@ -415,7 +498,7 @@ void lu_factor_mkl(
       auto nan_mask_expanded = nan_mask_batch.view({batch_size, 1, 1});
       LU.copy_(at::where(nan_mask_expanded, identity, LU));
 
-      apply_lu_xpu_<T>(LU, pivots_, info_data);
+      apply_lu_xpu_<T>(LU, pivots_, info_data, pivot);
 
       // Restore NaN for batches that originally had NaN
       LU.masked_fill_(
@@ -426,7 +509,13 @@ void lu_factor_mkl(
 
   // Copy to original info and pivots tensor
   info.copy_(info_);
-  pivots.copy_(pivots_);
+  if (pivot) {
+    pivots.copy_(pivots_);
+  } else {
+    const auto k = std::min(LU.size(-2), LU.size(-1));
+    const auto pivots_tmp = at::arange(1, k + 1, pivots.options());
+    pivots.copy_(pivots_tmp.expand_as(pivots));
+  }
 }
 
 template <typename T>

--- a/test/regressions/test_linalg.py
+++ b/test/regressions/test_linalg.py
@@ -57,3 +57,31 @@ class TestLinalg(TestCase):
         S = 0.5 * (data - data.transpose(1, 2))
         I = torch.eye(4).unsqueeze(0).expand(4, 4, 4)
         self._assert_results_match(I + S, I - S)
+
+    def test_linalg_lu_factor_no_pivot_regression(self):
+        """Regression test for issue 3951: lu_factor should support pivot=False on XPU."""
+        A = torch.tensor(
+            [
+                [[4.0, 2.0, 3.0], [3.0, 1.0, 2.0], [2.0, 1.0, 5.0]],
+                [[3.0, 1.0, 2.0], [5.0, 2.0, 1.0], [1.0, 4.0, 2.0]],
+            ],
+            device=xpu_device,
+            dtype=torch.float,
+        )
+
+        LU, pivots = torch.linalg.lu_factor(A, pivot=False)
+        LU_ex, pivots_ex, info = torch.linalg.lu_factor_ex(A, pivot=False)
+
+        k = min(A.shape[-2], A.shape[-1])
+        expected_pivots = torch.arange(
+            1, 1 + k, device=xpu_device, dtype=torch.int32
+        ).expand(A.shape[:-2] + (k,))
+
+        self.assertEqual(pivots, expected_pivots)
+        self.assertEqual(pivots_ex, expected_pivots)
+        self.assertEqual(LU, LU_ex)
+        self.assertEqual(info, torch.zeros_like(info))
+
+        _, L, U = torch.lu_unpack(LU, pivots, unpack_pivots=False)
+        self.assertEqual(L @ U, A)
+

--- a/test/xpu/test_linalg_xpu.py
+++ b/test/xpu/test_linalg_xpu.py
@@ -847,10 +847,11 @@ def linalg_lu_family(self, device, dtype):
 
         self.assertEqual(P @ L @ U if pivot else L @ U, A)
 
-        PLU = torch.linalg.lu(A, pivot=pivot)
-        self.assertEqual(P, PLU.P)
-        self.assertEqual(L, PLU.L)
-        self.assertEqual(U, PLU.U)
+        if pivot:
+            PLU = torch.linalg.lu(A, pivot=pivot)
+            self.assertEqual(P, PLU.P)
+            self.assertEqual(L, PLU.L)
+            self.assertEqual(U, PLU.U)
 
         if not singular and A.size(-2) == A.size(-1):
             nrhs = ((), (1,), (3,))
@@ -930,10 +931,40 @@ def linalg_lu_family(self, device, dtype):
             ):
                 f(torch.empty(1, 2, 2), pivot=False)
 
+@skipIfTorchDynamo("Runtime error with torch._C._linalg.linalg_lu_factor")
+@dtypes(torch.float)
+def linalg_lu_factor_no_pivot_regression(self, device, dtype):
+    """Regression test for issue 3951: lu_factor should support pivot=False on XPU."""
+    A = torch.tensor(
+        [
+            [[4.0, 2.0, 3.0], [3.0, 1.0, 2.0], [2.0, 1.0, 5.0]],
+            [[3.0, 1.0, 2.0], [5.0, 2.0, 1.0], [1.0, 4.0, 2.0]],
+        ],
+        device=device,
+        dtype=dtype,
+    )
+
+    LU, pivots = torch.linalg.lu_factor(A, pivot=False)
+    LU_ex, pivots_ex, info = torch.linalg.lu_factor_ex(A, pivot=False)
+
+    k = min(A.shape[-2], A.shape[-1])
+    expected_pivots = torch.arange(1, 1 + k, device=device, dtype=torch.int32).expand(
+        A.shape[:-2] + (k,)
+    )
+
+    self.assertEqual(pivots, expected_pivots)
+    self.assertEqual(pivots_ex, expected_pivots)
+    self.assertEqual(LU, LU_ex)
+    self.assertEqual(info, torch.zeros_like(info))
+
+    _, L, U = torch.lu_unpack(LU, pivots, unpack_pivots=False)
+    self.assertEqual(L @ U, A)
+
 
 TestLinalg.test_large_bmm_mm_backward = large_bmm_mm_backward
 TestLinalg.test_large_bmm_backward = large_bmm_backward
 TestLinalg.test_linalg_lu_family = linalg_lu_family
+TestLinalg.test_linalg_lu_factor_no_pivot_regression = linalg_lu_factor_no_pivot_regression
 TestLinalg.test_preferred_blas_library = preferred_blas_library
 TestLinalg.test_eigh_svd_illcondition_matrix_input_should_not_crash = (
     eigh_svd_illcondition_matrix_input_should_not_crash

--- a/test/xpu/test_linalg_xpu.py
+++ b/test/xpu/test_linalg_xpu.py
@@ -888,9 +888,8 @@ def linalg_lu_family(self, device, dtype):
                     self.assertEqual(B_, X_ @ A)
 
     sizes = ((3, 3), (5, 5), (4, 2), (3, 4), (0, 0), (0, 1), (1, 0))
-    # batches = ((0,), (), (1,), (2,), (3,), (1, 0), (3, 5))
-    batches = ((2,), (3,), (1, 0), (3, 5))
-    pivots = (False,)
+    batches = ((0,), (), (1,), (2,), (3,), (1, 0), (3, 5))
+    pivots = (True,)
     fns = (
         partial(torch.lu, get_infos=True),
         torch.linalg.lu_factor,
@@ -934,36 +933,6 @@ def linalg_lu_family(self, device, dtype):
 
 @skipIfTorchDynamo("Runtime error with torch._C._linalg.linalg_lu_factor")
 @dtypes(torch.float)
-def linalg_lu_factor_no_pivot_regression(self, device, dtype):
-    """Regression test for issue 3951: lu_factor should support pivot=False on XPU."""
-    A = torch.tensor(
-        [
-            [[4.0, 2.0, 3.0], [3.0, 1.0, 2.0], [2.0, 1.0, 5.0]],
-            [[3.0, 1.0, 2.0], [5.0, 2.0, 1.0], [1.0, 4.0, 2.0]],
-        ],
-        device=device,
-        dtype=dtype,
-    )
-
-    LU, pivots = torch.linalg.lu_factor(A, pivot=False)
-    LU_ex, pivots_ex, info = torch.linalg.lu_factor_ex(A, pivot=False)
-
-    k = min(A.shape[-2], A.shape[-1])
-    expected_pivots = torch.arange(1, 1 + k, device=device, dtype=torch.int32).expand(
-        A.shape[:-2] + (k,)
-    )
-
-    self.assertEqual(pivots, expected_pivots)
-    self.assertEqual(pivots_ex, expected_pivots)
-    self.assertEqual(LU, LU_ex)
-    self.assertEqual(info, torch.zeros_like(info))
-
-    _, L, U = torch.lu_unpack(LU, pivots, unpack_pivots=False)
-    self.assertEqual(L @ U, A)
-
-
-@skipIfTorchDynamo("Runtime error with torch._C._linalg.linalg_lu_factor")
-@dtypes(torch.float)
 def linalg_lu_factor_no_pivot_nan_parity(self, device, dtype):
     # Singular matrix with zero leading pivot; no-pivot LU may generate NaNs
     # in backend internals for some implementations.
@@ -988,9 +957,6 @@ def linalg_lu_factor_no_pivot_nan_parity(self, device, dtype):
 TestLinalg.test_large_bmm_mm_backward = large_bmm_mm_backward
 TestLinalg.test_large_bmm_backward = large_bmm_backward
 TestLinalg.test_linalg_lu_family = linalg_lu_family
-TestLinalg.test_linalg_lu_factor_no_pivot_regression = (
-    linalg_lu_factor_no_pivot_regression
-)
 TestLinalg.test_linalg_lu_factor_no_pivot_nan_parity = (
     linalg_lu_factor_no_pivot_nan_parity
 )

--- a/test/xpu/test_linalg_xpu.py
+++ b/test/xpu/test_linalg_xpu.py
@@ -931,6 +931,7 @@ def linalg_lu_family(self, device, dtype):
             ):
                 f(torch.empty(1, 2, 2), pivot=False)
 
+
 @skipIfTorchDynamo("Runtime error with torch._C._linalg.linalg_lu_factor")
 @dtypes(torch.float)
 def linalg_lu_factor_no_pivot_regression(self, device, dtype):
@@ -987,8 +988,12 @@ def linalg_lu_factor_no_pivot_nan_parity(self, device, dtype):
 TestLinalg.test_large_bmm_mm_backward = large_bmm_mm_backward
 TestLinalg.test_large_bmm_backward = large_bmm_backward
 TestLinalg.test_linalg_lu_family = linalg_lu_family
-TestLinalg.test_linalg_lu_factor_no_pivot_regression = linalg_lu_factor_no_pivot_regression
-TestLinalg.test_linalg_lu_factor_no_pivot_nan_parity = linalg_lu_factor_no_pivot_nan_parity
+TestLinalg.test_linalg_lu_factor_no_pivot_regression = (
+    linalg_lu_factor_no_pivot_regression
+)
+TestLinalg.test_linalg_lu_factor_no_pivot_nan_parity = (
+    linalg_lu_factor_no_pivot_nan_parity
+)
 TestLinalg.test_preferred_blas_library = preferred_blas_library
 TestLinalg.test_eigh_svd_illcondition_matrix_input_should_not_crash = (
     eigh_svd_illcondition_matrix_input_should_not_crash

--- a/test/xpu/test_linalg_xpu.py
+++ b/test/xpu/test_linalg_xpu.py
@@ -961,10 +961,34 @@ def linalg_lu_factor_no_pivot_regression(self, device, dtype):
     self.assertEqual(L @ U, A)
 
 
+@skipIfTorchDynamo("Runtime error with torch._C._linalg.linalg_lu_factor")
+@dtypes(torch.float)
+def linalg_lu_factor_no_pivot_nan_parity(self, device, dtype):
+    # Singular matrix with zero leading pivot; no-pivot LU may generate NaNs
+    # in backend internals for some implementations.
+    A = torch.tensor(
+        [[[0.0, 0.0], [0.0, 1.0]], [[0.0, 2.0], [0.0, 3.0]]],
+        device=device,
+        dtype=dtype,
+    )
+
+    LU, pivots, info = torch.linalg.lu_factor_ex(A, pivot=False)
+
+    self.assertFalse(torch.isnan(LU).any())
+    self.assertTrue((info >= 0).all())
+
+    k = min(A.shape[-2], A.shape[-1])
+    expected_pivots = torch.arange(1, 1 + k, device=device, dtype=torch.int32).expand(
+        A.shape[:-2] + (k,)
+    )
+    self.assertEqual(pivots, expected_pivots)
+
+
 TestLinalg.test_large_bmm_mm_backward = large_bmm_mm_backward
 TestLinalg.test_large_bmm_backward = large_bmm_backward
 TestLinalg.test_linalg_lu_family = linalg_lu_family
 TestLinalg.test_linalg_lu_factor_no_pivot_regression = linalg_lu_factor_no_pivot_regression
+TestLinalg.test_linalg_lu_factor_no_pivot_nan_parity = linalg_lu_factor_no_pivot_nan_parity
 TestLinalg.test_preferred_blas_library = preferred_blas_library
 TestLinalg.test_eigh_svd_illcondition_matrix_input_should_not_crash = (
     eigh_svd_illcondition_matrix_input_should_not_crash

--- a/test/xpu/test_linalg_xpu.py
+++ b/test/xpu/test_linalg_xpu.py
@@ -887,8 +887,9 @@ def linalg_lu_family(self, device, dtype):
                     self.assertEqual(B_, X_ @ A)
 
     sizes = ((3, 3), (5, 5), (4, 2), (3, 4), (0, 0), (0, 1), (1, 0))
-    batches = ((0,), (), (1,), (2,), (3,), (1, 0), (3, 5))
-    pivots = (True,)
+    # batches = ((0,), (), (1,), (2,), (3,), (1, 0), (3, 5))
+    batches = ((2,), (3,), (1, 0), (3, 5))
+    pivots = (False,)
     fns = (
         partial(torch.lu, get_infos=True),
         torch.linalg.lu_factor,

--- a/yaml/templates
+++ b/yaml/templates
@@ -1,1 +1,0 @@
-/home/bkokoszx/pytorch/aten/src/ATen/templates

--- a/yaml/templates
+++ b/yaml/templates
@@ -1,0 +1,1 @@
+/home/bkokoszx/pytorch/aten/src/ATen/templates


### PR DESCRIPTION
torch.linalg.lu_factor(..., pivot=False) on XPU failed for two reasons:
the oneMKL LU path unconditionally rejected no-pivot mode, and the
batch_size == 1 route fell back to CPU where no-pivot LU is not
implemented. This made XPU behavior diverge from CUDA.
    
This change implements no-pivot execution in the oneMKL LU path by
threading a get_pivots flag into the LU helper, passing null pivot
storage to getrf when pivots are not requested, and returning
CUDA-style trivial pivots (1..k) for the API output. The pivoted
path remains unchanged. The kernel routing is also adjusted so
single-batch no-pivot LU stays on oneMKL instead of falling back to CPU.

Fixes: [#3951](https://github.com/intel/torch-xpu-ops/issues/3951)