### PR TITLE
Remove skip for TestHopSchema

### DIFF
--- a/test/xpu/functorch/test_control_flow_xpu.py
+++ b/test/xpu/functorch/test_control_flow_xpu.py
@@ -7904,7 +7904,6 @@ _hop_schema_test_schema_types = [
 
 
 @skipIfTorchDynamo("We don't expect users to torch.compile hop schema generation.")
-@unittest.skipIf(IS_WINDOWS, "Windows not supported for this test")
 class TestHopSchema(TestCase):
     def _get_example_val(self, ty: str):
         from torch.fx.experimental.sym_node import SymNode


### PR DESCRIPTION
Fixes issue found: https://github.com/intel/torch-xpu-ops/issues/4105
Do not merge before: https://github.com/pytorch/pytorch/pull/193122
Upstream change now tries to load the library and only if it fails skips the test. 
There is no longer need to have the skip hard-coded for windows.
