### PR TITLE
Use const_data_ptr for read-only tensor arguments

### DIFF
--- a/src/ATen/native/sparse/xpu/sycl/SparseCsrTensorAddKernels.cpp
+++ b/src/ATen/native/sparse/xpu/sycl/SparseCsrTensorAddKernels.cpp
@@ -202,12 +202,12 @@ void add_out_sparse_csr_kernel(
               auto a_val = A.values().to(output_values_dtype);
               auto b_val = B.values().to(output_values_dtype);
 
-              const index_t* a_crow_ptr = a_crow.data_ptr<index_t>();
-              const index_t* a_col_ptr = a_col.data_ptr<index_t>();
-              const index_t* b_crow_ptr = b_crow.data_ptr<index_t>();
-              const index_t* b_col_ptr = b_col.data_ptr<index_t>();
-              const scalar_t* a_val_ptr = a_val.data_ptr<scalar_t>();
-              const scalar_t* b_val_ptr = b_val.data_ptr<scalar_t>();
+              const index_t* a_crow_ptr = a_crow.const_data_ptr<index_t>();
+              const index_t* a_col_ptr = a_col.const_data_ptr<index_t>();
+              const index_t* b_crow_ptr = b_crow.const_data_ptr<index_t>();
+              const index_t* b_col_ptr = b_col.const_data_ptr<index_t>();
+              const scalar_t* a_val_ptr = a_val.const_data_ptr<scalar_t>();
+              const scalar_t* b_val_ptr = b_val.const_data_ptr<scalar_t>();
 
               // Pass 1: compute per-row output nnz.
               auto dense_idx_options = at::TensorOptions()

--- a/src/ATen/native/xpu/sycl/DeformConv2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/DeformConv2dKernels.cpp
@@ -302,9 +302,9 @@ void deformable_im2col(
         input.scalar_type(), "deformable_im2col_xpu", ([&] {
           auto kfn = DeformableIm2ColKernel<scalar_t, int64_t>(
               num_kernels,
-              input.data_ptr<scalar_t>(),
-              data_offset.data_ptr<scalar_t>(),
-              data_mask.data_ptr<scalar_t>(),
+              input.const_data_ptr<scalar_t>(),
+              data_offset.const_data_ptr<scalar_t>(),
+              data_mask.const_data_ptr<scalar_t>(),
               height,
               width,
               weight_h,
@@ -333,9 +333,9 @@ void deformable_im2col(
         input.scalar_type(), "deformable_im2col_xpu", ([&] {
           auto kfn = DeformableIm2ColKernel<scalar_t, int>(
               num_kernels,
-              input.data_ptr<scalar_t>(),
-              data_offset.data_ptr<scalar_t>(),
-              data_mask.data_ptr<scalar_t>(),
+              input.const_data_ptr<scalar_t>(),
+              data_offset.const_data_ptr<scalar_t>(),
+              data_mask.const_data_ptr<scalar_t>(),
               height,
               width,
               weight_h,
@@ -548,9 +548,9 @@ void compute_grad_input(
         columns.scalar_type(), "compute_grad_input", ([&] {
           auto kfn = DeformableCol2ImKernel<scalar_t, int64_t>(
               num_kernels,
-              columns.data_ptr<scalar_t>(),
-              offset.data_ptr<scalar_t>(),
-              mask.data_ptr<scalar_t>(),
+              columns.const_data_ptr<scalar_t>(),
+              offset.const_data_ptr<scalar_t>(),
+              mask.const_data_ptr<scalar_t>(),
               channels,
               height,
               width,
@@ -579,9 +579,9 @@ void compute_grad_input(
         columns.scalar_type(), "compute_grad_input", ([&] {
           auto kfn = DeformableCol2ImKernel<scalar_t, int>(
               num_kernels,
-              columns.data_ptr<scalar_t>(),
-              offset.data_ptr<scalar_t>(),
-              mask.data_ptr<scalar_t>(),
+              columns.const_data_ptr<scalar_t>(),
+              offset.const_data_ptr<scalar_t>(),
+              mask.const_data_ptr<scalar_t>(),
               channels,
               height,
               width,
@@ -859,10 +859,10 @@ void compute_grad_offset_and_mask(
         columns.scalar_type(), "compute_grad_offset_and_mask_xpu", ([&] {
           auto kfn = DeformableCol2ImCoordKernel<scalar_t, int64_t>(
               num_kernels,
-              columns.data_ptr<scalar_t>(),
-              input.data_ptr<scalar_t>(),
-              offset.data_ptr<scalar_t>(),
-              mask.data_ptr<scalar_t>(),
+              columns.const_data_ptr<scalar_t>(),
+              input.const_data_ptr<scalar_t>(),
+              offset.const_data_ptr<scalar_t>(),
+              mask.const_data_ptr<scalar_t>(),
               channels,
               height,
               width,
@@ -893,10 +893,10 @@ void compute_grad_offset_and_mask(
         columns.scalar_type(), "compute_grad_offset_and_mask", ([&] {
           auto kfn = DeformableCol2ImCoordKernel<scalar_t, int>(
               num_kernels,
-              columns.data_ptr<scalar_t>(),
-              input.data_ptr<scalar_t>(),
-              offset.data_ptr<scalar_t>(),
-              mask.data_ptr<scalar_t>(),
+              columns.const_data_ptr<scalar_t>(),
+              input.const_data_ptr<scalar_t>(),
+              offset.const_data_ptr<scalar_t>(),
+              mask.const_data_ptr<scalar_t>(),
               channels,
               height,
               width,

--- a/src/ATen/native/xpu/sycl/PsRoiAlignKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PsRoiAlignKernels.cpp
@@ -435,7 +435,7 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_align_kernel(
       input.scalar_type(), "ps_roi_align_forward_kernel_xpu", [&] {
         auto kfn = PsRoiAlignForwardKernel<scalar_t>(
             output_size,
-            input_.data_ptr<scalar_t>(),
+            input_.const_data_ptr<scalar_t>(),
             spatial_scale,
             channels,
             height,
@@ -443,7 +443,7 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_align_kernel(
             pooled_height,
             pooled_width,
             sampling_ratio,
-            rois_.data_ptr<scalar_t>(),
+            rois_.const_data_ptr<scalar_t>(),
             channels_out,
             output.data_ptr<scalar_t>(),
             channel_mapping.data_ptr<int>());
@@ -489,8 +489,8 @@ Tensor ps_roi_align_backward_kernel(
       grad.scalar_type(), "ps_roi_align_backward_kernel_xpu", [&] {
         auto kfn = PsRoiAlignBackwardKernel<scalar_t>(
             grad.numel(),
-            grad_.data_ptr<scalar_t>(),
-            channel_mapping.data_ptr<int>(),
+            grad_.const_data_ptr<scalar_t>(),
+            channel_mapping.const_data_ptr<int>(),
             spatial_scale,
             channels,
             height,
@@ -500,7 +500,7 @@ Tensor ps_roi_align_backward_kernel(
             sampling_ratio,
             channels_out,
             grad_input.data_ptr<scalar_t>(),
-            rois_.data_ptr<scalar_t>());
+            rois_.const_data_ptr<scalar_t>());
         sycl_kernel_submit(
             global_range * local_range,
             local_range,

--- a/src/ATen/native/xpu/sycl/PsRoiPoolKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PsRoiPoolKernels.cpp
@@ -164,14 +164,14 @@ std::tuple<Tensor, Tensor> ps_roi_pool_kernel(
       input.scalar_type(), "ps_roi_pool_forward_kernel_xpu", [&] {
         auto kfn = PsRoiPoolForwardKernel<scalar_t>(
             output_size,
-            input_.data_ptr<scalar_t>(),
+            input_.const_data_ptr<scalar_t>(),
             spatial_scale,
             channels,
             height,
             width,
             pooled_height,
             pooled_width,
-            rois_.data_ptr<scalar_t>(),
+            rois_.const_data_ptr<scalar_t>(),
             channels_out,
             output.data_ptr<scalar_t>(),
             channel_mapping.data_ptr<int>());
@@ -312,8 +312,8 @@ Tensor ps_roi_pool_backward_kernel(
       grad.scalar_type(), "ps_roi_pool_backward_kernel_xpu", [&] {
         auto kfn = PsRoiPoolBackwardKernel<scalar_t>(
             grad.numel(),
-            grad_.data_ptr<scalar_t>(),
-            channel_mapping.data_ptr<int>(),
+            grad_.const_data_ptr<scalar_t>(),
+            channel_mapping.const_data_ptr<int>(),
             spatial_scale,
             channels,
             height,
@@ -322,7 +322,7 @@ Tensor ps_roi_pool_backward_kernel(
             pooled_width,
             channels_out,
             grad_input.data_ptr<scalar_t>(),
-            rois_.data_ptr<scalar_t>());
+            rois_.const_data_ptr<scalar_t>());
         sycl_kernel_submit(
             global_range * local_range,
             local_range,

--- a/src/ATen/native/xpu/sycl/RoiAlignKernels.cpp
+++ b/src/ATen/native/xpu/sycl/RoiAlignKernels.cpp
@@ -489,7 +489,7 @@ Tensor roi_align_kernel(
         int wgs_per_roi = (items_per_roi + local_range - 1) / local_range;
         int64_t global_range = wgs_per_roi * num_rois;
         auto kfn = RoiAlignForwardKernel<scalar_t>(
-            input_.data_ptr<scalar_t>(),
+            input_.const_data_ptr<scalar_t>(),
             spatial_scale,
             items_per_roi,
             wgs_per_roi,
@@ -500,7 +500,7 @@ Tensor roi_align_kernel(
             pooled_width,
             sampling_ratio,
             aligned,
-            rois_.data_ptr<scalar_t>(),
+            rois_.const_data_ptr<scalar_t>(),
             output.data_ptr<scalar_t>());
         sycl_kernel_submit(
             global_range * local_range,
@@ -550,7 +550,7 @@ Tensor roi_align_backward_kernel(
       [&] {
         auto kfn = RoiAlignBackwardKernel<scalar_t>(
             grad.numel(),
-            grad.data_ptr<scalar_t>(),
+            grad.const_data_ptr<scalar_t>(),
             spatial_scale,
             channels,
             height,
@@ -560,7 +560,7 @@ Tensor roi_align_backward_kernel(
             sampling_ratio,
             aligned,
             grad_input.data_ptr<scalar_t>(),
-            rois_.data_ptr<scalar_t>(),
+            rois_.const_data_ptr<scalar_t>(),
             n_stride,
             c_stride,
             h_stride,

--- a/src/ATen/native/xpu/sycl/RoiPoolKernels.cpp
+++ b/src/ATen/native/xpu/sycl/RoiPoolKernels.cpp
@@ -157,14 +157,14 @@ std::tuple<Tensor, Tensor> roi_pool_kernel(
       input.scalar_type(), "roi_pool_forward_kernel_xpu", [&] {
         auto kfn = RoiPoolForwardKernel<scalar_t>(
             output_size,
-            input_.data_ptr<scalar_t>(),
+            input_.const_data_ptr<scalar_t>(),
             spatial_scale,
             channels,
             height,
             width,
             pooled_height,
             pooled_width,
-            rois_.data_ptr<scalar_t>(),
+            rois_.const_data_ptr<scalar_t>(),
             output.data_ptr<scalar_t>(),
             argmax.data_ptr<int>());
         sycl_kernel_submit(
@@ -290,8 +290,8 @@ Tensor roi_pool_backward_kernel(
       grad.scalar_type(), "roi_pool_backward_kernel_xpu", [&] {
         auto kfn = RoiPoolBackwardKernel<scalar_t>(
             grad.numel(),
-            grad.data_ptr<scalar_t>(),
-            argmax_.data_ptr<int>(),
+            grad.const_data_ptr<scalar_t>(),
+            argmax_.const_data_ptr<int>(),
             num_rois,
             spatial_scale,
             channels,
@@ -300,7 +300,7 @@ Tensor roi_pool_backward_kernel(
             pooled_height,
             pooled_width,
             grad_input.data_ptr<scalar_t>(),
-            rois_.data_ptr<scalar_t>(),
+            rois_.const_data_ptr<scalar_t>(),
             n_stride,
             c_stride,
             h_stride,


### PR DESCRIPTION
`data_ptr<T>()` returns a mutable pointer however the tensor is used, so nothing stops a read-only input from being written through. This converts the call sites whose consumer *already* declares the pointer `const`, so the compiler enforces what the code assumes.

| File | Converted | Left alone |
| --- | --- | --- |
| `SparseCsrTensorAddKernels.cpp` | 6 | - |
| `DeformConv2dKernels.cpp` | 20 | `data_col`, `grad_im`, `grad_offset`, `grad_mask` |
| `RoiPoolKernels.cpp` | 5 | `output`, `argmax`, `grad_input` |
| `PsRoiPoolKernels.cpp` | 5 | `output`, `channel_mapping`, `grad_input` |
| `PsRoiAlignKernels.cpp` | 5 | `output`, `channel_mapping`, `grad_input` |
| `RoiAlignKernels.cpp` | 4 | `output`, `grad_input` |

Each conversion was checked against the consuming declaration, not inferred from the name: the sparse CSR sites bind to `const index_t*` / `const scalar_t*` locals, and the deform-conv and ROI functors declare the corresponding members `const`. Note `argmax` / `channel_mapping` differ by direction - `int*` on the forward path (written), `const int*` on the backward one (read) - so only the backward side is converted.

A wrong conversion here cannot change behavior silently; `const T*` where `T*` is expected is a compile error.

This is the first slice; roughly 316 plain `data_ptr` sites remain in `src/`, and follow-ups can take them by op family.

## Test Plan

No local XPU build is available, so compilation rests on CI.

```bash
lintrunner -a --skip CLANGTIDY $(git diff --name-only)   # ok No lint issues
git clang-format --diff HEAD    # clang-format did not modify any files
```

Authored with the assistance of an AI coding agent.
