### PR TITLE
[SYCL free func] migrate CrossKernel kernels

### DIFF
--- a/src/ATen/native/xpu/sycl/CrossKernel.cpp
+++ b/src/ATen/native/xpu/sycl/CrossKernel.cpp
@@ -18,68 +18,44 @@
 
 namespace at::native::xpu {
 template <typename scalar_t>
-struct CrossKernelFunctor {
-  void operator()(sycl::nd_item<1> item) const {
-    int64_t linear_index = item.get_global_id(0);
-    for (int64_t i = linear_index; i < N_;
-         i += work_group_num_ * work_group_size_) {
-      const auto offsets = offset_calculator_.get(i);
-      auto* out_row = out_ + offsets[0];
-      const auto* x_row = x_ + offsets[1];
-      const auto* y_row = y_ + offsets[2];
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
+void cross_ff_kernel(
+    int64_t ostride_,
+    int64_t xstride_,
+    int64_t ystride_,
+    const int64_t N_,
+    int64_t work_group_size_,
+    int64_t work_group_num_,
+    scalar_t* out_,
+    const scalar_t* x_,
+    const scalar_t* y_,
+    OffsetCalculator<3> offset_calculator_) {
+  auto item = syclext::this_work_item::get_nd_item<1>();
+  int64_t linear_index = item.get_global_id(0);
+  for (int64_t i = linear_index; i < N_;
+       i += work_group_num_ * work_group_size_) {
+    const auto offsets = offset_calculator_.get(i);
+    auto* out_row = out_ + offsets[0];
+    const auto* x_row = x_ + offsets[1];
+    const auto* y_row = y_ + offsets[2];
 
-      const scalar_t val0 =
-          (x_row[1 * xstride_] * y_row[2 * ystride_] -
-           x_row[2 * xstride_] * y_row[1 * ystride_]);
+    const scalar_t val0 =
+        (x_row[1 * xstride_] * y_row[2 * ystride_] -
+         x_row[2 * xstride_] * y_row[1 * ystride_]);
 
-      const scalar_t val1 =
-          (x_row[2 * xstride_] * y_row[0 * ystride_] -
-           x_row[0 * xstride_] * y_row[2 * ystride_]);
+    const scalar_t val1 =
+        (x_row[2 * xstride_] * y_row[0 * ystride_] -
+         x_row[0 * xstride_] * y_row[2 * ystride_]);
 
-      const scalar_t val2 =
-          (x_row[0 * xstride_] * y_row[1 * ystride_] -
-           x_row[1 * xstride_] * y_row[0 * ystride_]);
+    const scalar_t val2 =
+        (x_row[0 * xstride_] * y_row[1 * ystride_] -
+         x_row[1 * xstride_] * y_row[0 * ystride_]);
 
-      out_row[0 * ostride_] = val0;
-      out_row[1 * ostride_] = val1;
-      out_row[2 * ostride_] = val2;
-    }
+    out_row[0 * ostride_] = val0;
+    out_row[1 * ostride_] = val1;
+    out_row[2 * ostride_] = val2;
   }
-
-  CrossKernelFunctor(
-      int64_t ostride,
-      int64_t xstride,
-      int64_t ystride,
-      const int64_t N,
-      int64_t work_group_size,
-      int64_t work_group_num,
-      scalar_t* out,
-      const scalar_t* x,
-      const scalar_t* y,
-      OffsetCalculator<3> offset_calculator)
-      : ostride_(ostride),
-        xstride_(xstride),
-        ystride_(ystride),
-        N_(N),
-        work_group_size_(work_group_size),
-        work_group_num_(work_group_num),
-        out_(out),
-        x_(x),
-        y_(y),
-        offset_calculator_(offset_calculator) {}
-
- private:
-  int64_t ostride_;
-  int64_t xstride_;
-  int64_t ystride_;
-  const int64_t N_;
-  int64_t work_group_size_;
-  int64_t work_group_num_;
-  scalar_t* out_;
-  const scalar_t* x_;
-  const scalar_t* y_;
-  OffsetCalculator<3> offset_calculator_;
-};
+}
 
 void launch_cross_kernel(
     const TensorIteratorBase& iter,
@@ -97,13 +73,18 @@ void launch_cross_kernel(
       iter.common_dtype(),
       "cross_xpu",
       [&]() {
-        using KernelClass = CrossKernelFunctor<scalar_t>;
-        int64_t work_group_size = syclMaxWorkGroupSize<KernelClass>();
+        int64_t work_group_size =
+            syclMaxWorkGroupSize<cross_ff_kernel<scalar_t>>();
         int64_t work_group_num = (N + work_group_size - 1) / work_group_size;
         auto out = static_cast<scalar_t*>(iter.data_ptr(0));
         auto x1 = static_cast<const scalar_t*>(iter.data_ptr(1));
         auto x2 = static_cast<const scalar_t*>(iter.data_ptr(2));
-        KernelClass kfn(
+
+        sycl_kernel_submit<cross_ff_kernel<scalar_t>>(
+            work_group_num * work_group_size,
+            work_group_size,
+            getCurrentSYCLQueue(),
+            0,
             ostride,
             x1_stride,
             x2_stride,
@@ -114,12 +95,6 @@ void launch_cross_kernel(
             x1,
             x2,
             offset_calculator);
-
-        sycl_kernel_submit(
-            work_group_num * work_group_size,
-            work_group_size,
-            getCurrentSYCLQueue(),
-            kfn);
       });
 }
 


### PR DESCRIPTION
# CrossKernel.cpp — Kernel UT Report
- SYCL kernel conversion check: In src/ATen/native/xpu/sycl/CrossKernel.cpp, cross_ff_kernel (line 21) is implemented/launched as a free function via SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>)) and sycl_kernel_submit<cross_ff_kernel<scalar_t>>(...) function pointer.
- No remaining *Functor structs in this file — the kernel is fully converted to the free function pattern.
- Changed-kernel related UTs run in both locations:
  1. In PyTorch (/workspace1/minminz/workpath/pytorch-public):
        -   pytest test/test_linalg.py -v -k "test_cross or test_linalg_cross"
        -   Result: 9 passed, 1481 deselected.
  2. In current repo (torch-xpu-ops):
        - PYTHONPATH=test:$PYTHONPATH pytest test/xpu/test_linalg_xpu.py -v -k "test_cross or test_linalg_cross"
        - Result: 9 passed, 1636 deselected.


