### PR TITLE
Remove stale xfail("clamp") from functorch test_vjpvmap

### DIFF
--- a/test/xpu/functorch/test_ops_xpu.py
+++ b/test/xpu/functorch/test_ops_xpu.py
@@ -1634,7 +1634,6 @@ class TestOperators(TestCase):
                 xfail("nn.functional.dropout2d", ""),
                 xfail("svd_lowrank", ""),
                 xfail("pca_lowrank", ""),
-                xfail("clamp"),
                 # something weird happening with channels_last
                 xfail("bfloat16"),
                 xfail("double"),


### PR DESCRIPTION
Problem: test_vjpvmap_clamp_xpu_float32 reported "Unexpected success' Root cause: test_vjpvmap skipOps xfailed "clamp" on XPU but the test is passing
Fix: Remove the xfail("clamp")

Fixes: https://github.com/intel/torch-xpu-ops/issues/4809