### PR TITLE
Align dynamo tests with upstream changes

### DIFF
--- a/test/xpu/dynamo/test_misc_xpu.py
+++ b/test/xpu/dynamo/test_misc_xpu.py
@@ -102,6 +102,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_FBCODE,
     parametrize,
+    recover_orig_fp32_precision,
     scoped_load_inline,
     set_default_dtype,
     skipIfHpu,
@@ -9242,6 +9243,7 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         torch.compile(my_dyn_fn, backend=counter)(x012)
         self.assertEqual(counter.frame_count, 3)
 
+    @recover_orig_fp32_precision
     def test_recompile_on_global_state_change(self):
         last_state = []
         cnt = 0

--- a/test/xpu/dynamo/test_regional_inductor_xpu.py
+++ b/test/xpu/dynamo/test_regional_inductor_xpu.py
@@ -1015,7 +1015,7 @@ def forward(self, primals_0, primals_1, primals_2, primals_3, primals_4, primals
         import torch._inductor.config as inductor_config
 
         nested_config = get_invoke_subgraph_compile_options(
-            inductor_config_patches={
+            fw_inductor_config_patches={
                 "max_autotune": True,
                 "triton.cudagraphs": False,
             }
@@ -1080,7 +1080,7 @@ def forward(self, primals_0, primals_1, primals_2, primals_3, primals_4, primals
             "Invalid inductor config key 'invalid_config_key'",
         ):
             get_invoke_subgraph_compile_options(
-                inductor_config_patches={
+                fw_inductor_config_patches={
                     "invalid_config_key": True,
                 }
             )


### PR DESCRIPTION
Fixes issues reported in: https://github.com/intel/torch-xpu-ops/issues/4438

Test cases fixed:
```
dynamo.test_misc_xpu.MiscTests,test_recompile_on_global_state_change
dynamo.test_regional_inductor_xpu.RegionalInductorInvokeSubgraphTests,test_max_autotune_no_cudagraphs_serialize_False
dynamo.test_regional_inductor_xpu.RegionalInductorInvokeSubgraphTests,test_invalid_inductor_config
```
`test_misc_xpu` changed upstream in https://github.com/pytorch/pytorch/pull/185236
`test_regional_inductor_xpu` changed upstream in https://github.com/pytorch/pytorch/pull/190068
