### PR TITLE
[Cherry-pick release/2.14] Fix TopK AOT (#4907)

### DIFF
--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernelImpl.h
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernelImpl.h
@@ -273,6 +273,11 @@ struct SubgroupTopKFunctor {
     }
   }
 
+  auto get(syclex::properties_tag) const {
+    return syclex::properties{
+        syclex::sub_group_size<SG_SIZE>, intelex::grf_size<128>};
+  }
+
   SubgroupTopKFunctor(
       const scalar_t* inputData,
       scalar_t* topKData,
@@ -315,12 +320,7 @@ inline void sbtopk_launch_impl(
       input, topK, indices, numSlices, sliceSize, k);
 
   sycl_kernel_submit(
-      num_wgs * WG_SIZE,
-      WG_SIZE,
-      at::xpu::getCurrentSYCLQueue(),
-      syclex::properties{
-          syclex::sub_group_size<SG_SIZE>, intelex::grf_size<128>},
-      functor);
+      num_wgs * WG_SIZE, WG_SIZE, at::xpu::getCurrentSYCLQueue(), functor);
 }
 
 // Vec-size dispatch: picks the largest VEC_SIZE compatible with

--- a/src/ATen/native/xpu/sycl/TensorTopKSingleWgKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorTopKSingleWgKernel.cpp
@@ -44,6 +44,9 @@
 
 namespace at::native::xpu {
 
+namespace syclex = sycl::ext::oneapi::experimental;
+namespace intelex = sycl::ext::intel::experimental;
+
 // Uses RADIX_BITS=4 (16 digits per pass), halving radix passes for fp32.
 // Cannot reuse RADIX_BITS/SIZE/MASK from SortingRadixSelect.h (constexpr int,
 // can't #undef).
@@ -537,6 +540,11 @@ struct SbtopkGatherFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
     }
   }
 
+  auto get(syclex::properties_tag) const {
+    return syclex::properties{
+        syclex::sub_group_size<SIMD>, intelex::grf_size<128>};
+  }
+
   SbtopkGatherFunctor(
       const scalar_t* inputData,
       scalar_t* topKData,
@@ -583,9 +591,6 @@ static void single_wg_launch_impl(
     IndexT sliceSize,
     int k,
     bool largest) {
-  namespace syclex = sycl::ext::oneapi::experimental;
-  namespace intelex = sycl::ext::intel::experimental;
-
   constexpr int SIMD = 32;
   using Functor =
       SbtopkGatherFunctor<scalar_t, VEC_SIZE, ELEMS_PER_THREAD, SIMD, IndexT>;
@@ -596,7 +601,6 @@ static void single_wg_launch_impl(
       static_cast<int64_t>(numSlices) * SBTOPK_BLOCK,
       static_cast<int64_t>(SBTOPK_BLOCK),
       at::xpu::getCurrentSYCLQueue(),
-      syclex::properties{syclex::sub_group_size<SIMD>, intelex::grf_size<128>},
       functor);
 }
 


### PR DESCRIPTION
Cherry-pick of #4907 to `release/2.14`.

Looks like these kernels will trigger JIT compile at runtime. Should fix
https://github.com/pytorch/pytorch/issues/191871#issuecomment-5243111385

Cherry-picked from commit ffdf468edb1266383f390c5bb5ce2798a0aaa402.