### PR TITLE
Skip test_side_stream_backward_overlap_xpu pending oneAPI timing-event fix

### DIFF
--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -79,6 +79,10 @@ skip_dict = {
         "test_view_copy_xpu",
         "test_autograd_multiple_dispatch_registrations_xpu",
         "test_foward_mode_AD_xpu",
+        # skipped due to #4951: XPU enable_timing events (submit_profiling_tag)
+        # serialize otherwise-concurrent streams, so the backward-stream overlap
+        # this test measures cannot be observed. Pending an oneAPI runtime fix.
+        "test_side_stream_backward_overlap_xpu",
     ),
     "test_binary_ufuncs_xpu.py": ("_jiterator_",),
     "test_comparison_utils_xpu.py": None,


### PR DESCRIPTION
### Summary
This PR fixes #3243 by adding `test_side_stream_backward_overlap_xpu` to the autograd skip list.
This test measures backward-stream overlap using `torch.Event(enable_timing=True)`, but XPU timing events are implemented via `sycl::ext::oneapi::experimental::submit_profiling_tag()`, which serializes otherwise-concurrent streams. Therefore recording the timing events destroys the very overlap the test is trying to observe, so it cannot pass on XPU today...
This issue is tracked in https://github.com/intel/torch-xpu-ops/issues/4951 which should remove this skip and confirm `test_side_stream_backward_overlap_xpu` passes once the timing-event serialization is fixed (oneAPI runtime, or reworking XPU timing events to use per-event profiling).

### Context
The original blocker: missing XPU sleep primitive (#1986) is now resolved, and the accompanying PyTorch change (https://github.com/pytorch/pytorch/pull/193379) generalizes the test sleep helper (`_sleep_if_cuda` → `_sleep_if_supported`) so the stream-sync correctness tests now genuinely exercise the sleep and pass on XPU.

**The PyTorch PR should be merged before this PR.**

### Verification (Arc B580)
With this skip in place, `TestAutogradStreamSynchronizationXPU` is green (2 passed, 4 skipped for lack of a 2nd device).
Root-cause evidence: the same two-stream sleep workload runs concurrently with no events or with non-timing events (~704 ms) but serializes (~1405 ms) once `enable_timing` events are recorded.