### PR TITLE
Add issue_bot workflow to auto-fix issues via opencode

### DIFF
--- a/.github/actions/setup-opencode/action.yml
+++ b/.github/actions/setup-opencode/action.yml
@@ -1,0 +1,70 @@
+name: Setup opencode
+description: Install the opencode CLI (cached) and write an amazon-bedrock provider config
+
+inputs:
+  version:
+    required: false
+    default: ''
+    description: "opencode version to install (e.g. 0.15.6). Empty installs the latest release."
+  aws_region:
+    required: true
+    description: "AWS region for the amazon-bedrock provider"
+  config_path:
+    required: false
+    default: 'opencode.json'
+    description: "Path to write the generated opencode config"
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve opencode version
+      id: version
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.version }}" ]; then
+          echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+        else
+          v=$(curl -sf https://api.github.com/repos/anomalyco/opencode/releases/latest \
+                | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
+          echo "version=${v:-latest}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Cache opencode
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.opencode/bin
+        key: opencode-${{ runner.os }}-${{ runner.arch }}-${{ steps.version.outputs.version }}
+
+    - name: Install opencode
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: curl -fsSL https://opencode.ai/install | VERSION="${{ steps.version.outputs.version }}" bash
+
+    - name: Add opencode to PATH
+      shell: bash
+      run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
+
+    - name: Write opencode config
+      shell: bash
+      env:
+        AWS_REGION: ${{ inputs.aws_region }}
+        CONFIG_PATH: ${{ inputs.config_path }}
+      run: |
+        cat > "${CONFIG_PATH}" <<EOF
+        {
+          "\$schema": "https://opencode.ai/config.json",
+          "provider": {
+            "amazon-bedrock": {
+              "options": {
+                "region": "${AWS_REGION}"
+              }
+            }
+          }
+        }
+        EOF
+        cat "${CONFIG_PATH}"
+
+    - name: Verify opencode
+      shell: bash
+      run: opencode --version

--- a/.github/workflows/issue_bot.yml
+++ b/.github/workflows/issue_bot.yml
@@ -1,0 +1,344 @@
+name: Issue Bot (opencode)
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    paths:
+      - '.github/workflows/issue_bot.yml'
+
+env:
+  BEDROCK_MODEL: global.anthropic.claude-opus-5
+  COST_TRACKING_ISSUE: 4251
+  # Pin opencode for reproducibility; bump deliberately.
+  OPENCODE_VERSION: 0.15.6
+
+permissions:
+  contents: read
+
+concurrency:
+  group: issue-bot-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  parse:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'issue_comment'
+      && !github.event.issue.pull_request
+      && startsWith(github.event.comment.body, '@torchxpubot fix')
+    permissions:
+      issues: read
+    outputs:
+      issue_number: ${{ steps.parse.outputs.issue_number }}
+      actor: ${{ steps.parse.outputs.actor }}
+      authorized: ${{ steps.parse.outputs.authorized }}
+    steps:
+      - name: Acknowledge Command
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '+1'
+            });
+
+      - name: Parse Command
+        id: parse
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const actor = context.payload.comment.user.login;
+            const assoc = context.payload.comment.author_association;
+            const issueNumber = context.payload.issue.number;
+
+            const privileged = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            const authorized = privileged.includes(assoc);
+
+            core.setOutput('issue_number', String(issueNumber));
+            core.setOutput('actor', actor);
+            core.setOutput('authorized', String(authorized));
+
+      - name: Post permission denied message
+        if: steps.parse.outputs.authorized == 'false'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.parse.outputs.issue_number }},
+              body: 'You do not have permission to use `@torchxpubot fix`. This command requires OWNER, MEMBER, or COLLABORATOR association.'
+            });
+
+      - name: Post starting message
+        if: steps.parse.outputs.authorized == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.parse.outputs.issue_number }},
+              body: `Starting automated fix on this issue. Follow progress in the [workflow run](${runUrl}).`
+            });
+
+  fix:
+    needs: parse
+    if: needs.parse.outputs.authorized == 'true'
+    runs-on: xpu-agent
+    timeout-minutes: 180
+    container:
+      image: intelgpu/ubuntu-24.04-lts2:2523.40
+      volumes:
+        - ${{ github.workspace }}:${{ github.workspace }}
+      options: --device=/dev/mem --device=/dev/dri
+              --security-opt seccomp=unconfined --cap-add=SYS_ADMIN --shm-size=8g --privileged
+              -e ZE_AFFINITY_MASK
+    env:
+      ISSUE_NUMBER: ${{ needs.parse.outputs.issue_number }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+      GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
+      HF_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+      OPENCODE_DISABLE_AUTOUPDATE: '1'
+    steps:
+      - name: Checkout torch-xpu-ops
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.MERGE_TOKEN }}
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config --global --add safe.directory "${{ github.workspace }}"
+          git config --global user.name "torchxpubot"
+          git config --global user.email "torchxpubot@intel.com"
+
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
+        with:
+          python: '3.10'
+
+      - name: Install latest nightly PyTorch-XPU
+        run: |
+          # Reproduction/verify environment: latest nightly XPU build.
+          uv pip install --prerelease=allow torch torchvision torchaudio \
+            --index-url https://download.pytorch.org/whl/nightly/xpu
+          python -c "import torch; print('torch', torch.__version__); print('xpu available:', torch.xpu.is_available())"
+
+      - name: Setup opencode
+        uses: ./.github/actions/setup-opencode
+        with:
+          version: ${{ env.OPENCODE_VERSION }}
+          aws_region: ${{ secrets.AWS_REGION }}
+          config_path: opencode.json
+
+      - name: Run opencode issue-handler
+        id: opencode
+        run: |
+          PROMPT="Use the issue-handler skill in pipeline mode to fix issue #${ISSUE_NUMBER} in ${GITHUB_REPOSITORY}. Reproduce and verify locally on this XPU host, implement the fix, re-verify, then hand off to the xpu-ops-pr-creation skill to open a pull request. Post your status back to the issue as the skill dictates."
+          set +e
+          # stdout: JSON event stream; stderr: human-readable logs.
+          opencode run --auto --format json --print-logs \
+            --model "amazon-bedrock/${BEDROCK_MODEL}" \
+            "${PROMPT}" >/tmp/opencode.json 2>/tmp/opencode.log
+          rc=$?
+          set -e
+          echo "exit_code=${rc}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Parse opencode output
+        id: parse_out
+        if: always()
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const out = process.env.GITHUB_OUTPUT;
+
+          function readEvents(path) {
+            let raw = '';
+            try { raw = fs.readFileSync(path, 'utf8'); } catch (e) { return []; }
+            const events = [];
+            // Try a single JSON document (array or object) first.
+            try {
+              const doc = JSON.parse(raw);
+              return Array.isArray(doc) ? doc : [doc];
+            } catch (e) { /* fall through to NDJSON */ }
+            for (const line of raw.split('\n')) {
+              const s = line.trim();
+              if (!s) continue;
+              try { events.push(JSON.parse(s)); } catch (e) { /* skip */ }
+            }
+            return events;
+          }
+
+          // Recursively collect assistant text parts and usage/cost fields.
+          let cost = 0, inTok = 0, outTok = 0;
+          const texts = [];
+          function walk(node) {
+            if (!node || typeof node !== 'object') return;
+            if (Array.isArray(node)) { node.forEach(walk); return; }
+            if (typeof node.cost === 'number') cost += node.cost;
+            const tk = node.tokens;
+            if (tk && typeof tk === 'object') {
+              const cache = tk.cache || {};
+              inTok = (tk.input || 0) + (cache.read || 0) + (cache.write || 0);
+              outTok = (tk.output || 0) + (tk.reasoning || 0);
+            }
+            if (node.type === 'text' && typeof node.text === 'string') texts.push(node.text);
+            for (const k of Object.keys(node)) walk(node[k]);
+          }
+          readEvents('/tmp/opencode.json').forEach(walk);
+
+          let message = texts.join('\n').trim();
+          if (!message) {
+            try {
+              const log = fs.readFileSync('/tmp/opencode.log', 'utf8');
+              message = log.split('\n').slice(-100).join('\n');
+            } catch (e) { message = '(no output captured)'; }
+          }
+          message = message.slice(-60000);
+
+          fs.writeFileSync('/tmp/opencode_message.txt', message);
+          fs.appendFileSync(out, `cost=${cost.toFixed(4)}\n`);
+          fs.appendFileSync(out, `in_tokens=${inTok}\n`);
+          fs.appendFileSync(out, `out_tokens=${outTok}\n`);
+          fs.appendFileSync(out, `has_output=${message && message !== '(no output captured)' ? 'true' : 'false'}\n`);
+          NODE
+
+      - name: Post result comment
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const rc = '${{ steps.opencode.outputs.exit_code }}';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            let message = '(no output captured)';
+            try { message = fs.readFileSync('/tmp/opencode_message.txt', 'utf8'); } catch (e) {}
+            const status = rc === '0' ? 'completed' : `exited with code ${rc}`;
+            const body = [
+              `Automated fix run ${status}. See the [workflow run](${runUrl}).`,
+              '',
+              '<details><summary>opencode output</summary>',
+              '',
+              '```',
+              message,
+              '```',
+              '</details>'
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.ISSUE_NUMBER),
+              body
+            });
+
+      - name: Report usage to cost tracking issue
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const rc = '${{ steps.opencode.outputs.exit_code }}';
+            const cost = '${{ steps.parse_out.outputs.cost }}' || '0.0000';
+            const inTok = Number('${{ steps.parse_out.outputs.in_tokens }}' || 0).toLocaleString();
+            const outTok = Number('${{ steps.parse_out.outputs.out_tokens }}' || 0).toLocaleString();
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const date = new Date().toISOString().split('T')[0];
+            const status = rc === '0' ? 'ok' : 'error';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.COST_TRACKING_ISSUE),
+              body: `\`${date}\` [\`fix\`](${runUrl}) on #${process.env.ISSUE_NUMBER} — **$${cost}** (${inTok} in / ${outTok} out) [${status}]`
+            });
+
+      - name: Verify opencode succeeded
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const rc = '${{ steps.opencode.outputs.exit_code }}';
+            const hasOutput = '${{ steps.parse_out.outputs.has_output }}' === 'true';
+            if (rc !== '0' || !hasOutput) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: Number(process.env.ISSUE_NUMBER),
+                body: '@chuanqi129 `@torchxpubot fix` failed: opencode returned an error or no output. Please check AWS token validity and the workflow run.'
+              });
+              core.setFailed('opencode run failed.');
+            }
+
+  token-permission-test:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: "Test: MERGE_TOKEN can read issues and comment"
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const comment = await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: 'issue_bot token permission test -- this comment will be deleted.'
+            });
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              comment_id: comment.data.id, content: '+1'
+            });
+            await github.rest.issues.deleteComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              comment_id: comment.data.id
+            });
+            console.log('MERGE_TOKEN issue read/comment OK');
+
+      - name: "Test: AWS Bedrock connectivity via Claude Code Action"
+        id: bedrock-test
+        uses: anthropics/claude-code-action@v1
+        with:
+          use_bedrock: "true"
+          github_token: ${{ secrets.MERGE_TOKEN }}
+          claude_args: "--model ${{ env.BEDROCK_MODEL }} --max-turns 1"
+          use_sticky_comment: "true"
+          show_full_output: "true"
+          prompt: |
+            Reply with exactly: "Bedrock connectivity test passed."
+            Do not do anything else.
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+
+      - name: "Verify: Bedrock test actually succeeded"
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const file = '${{ steps.bedrock-test.outputs.execution_file }}';
+            let ok = false;
+            if (file && fs.existsSync(file)) {
+              const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+              const result = data.filter(e => e.type === 'result').pop();
+              ok = result && !result.is_error && result.total_cost_usd > 0;
+            }
+            if (!ok) {
+              core.setFailed('Bedrock connectivity test failed.');
+            }


### PR DESCRIPTION
## Summary

Adds a comment-triggered CI workflow that runs the opencode CLI on an XPU
self-hosted runner to fix a GitHub issue end-to-end.

- **`.github/workflows/issue_bot.yml`** — on `@torchxpubot fix` in an issue
  comment: acknowledges (+1), authorizes by `author_association`
  (OWNER/MEMBER/COLLABORATOR), then on `xpu-agent` inside a GPU container it
  sets up a uv-based nightly PyTorch-XPU env, runs opencode with the
  `issue-handler` skill (triage -> reproduce/verify locally on XPU -> fix ->
  re-verify -> open PR), posts the result back to the issue, and reports
  token/cost usage (parsed from opencode `--format json`) to the
  cost-tracking issue (#4251). A PR-path `token-permission-test` job
  self-tests `MERGE_TOKEN` permissions and Bedrock connectivity.
- **`.github/actions/setup-opencode/action.yml`** — reusable composite action
  that installs opencode (pinned + cached), adds it to PATH, and writes the
  `amazon-bedrock` provider config. Modeled on the official opencode action
  but setup-only (no `opencode github run`).
- Reuses the repo's `./.github/actions/setup-python` action for the uv venv.

Draft: this needs a real end-to-end run to confirm runtime unknowns (opencode
install path/JSON event schema, nightly XPU index availability inside the
container, self-hosted runner cache reachability).

Authored with the help of an AI assistant.

Test: none (CI workflow addition; validated locally via `python -c "import yaml; yaml.safe_load(...)"` and the in-PR `token-permission-test` self-test job)