### PR TITLE
Align test_fused_inputs_dim_3 with upstream SDPA 3D-input support (fixes #4915)

### DIFF
--- a/test/xpu/test_transformers_xpu.py
+++ b/test/xpu/test_transformers_xpu.py
@@ -2110,7 +2110,7 @@ class TestSDPAFailureModes(NNTestCase):
         attn_mask = (
             None
             if kernel == SDPBackend.FLASH_ATTENTION
-            else torch.randn(3, 3, device=device, dtype=dtype)
+            else torch.tril(torch.ones(3, 3, device=device, dtype=torch.bool))
         )
 
         with sdpa_kernel(backends=[kernel]):

--- a/test/xpu/test_transformers_xpu.py
+++ b/test/xpu/test_transformers_xpu.py
@@ -2101,24 +2101,30 @@ class TestSDPAFailureModes(NNTestCase):
         "kernel",
         PLATFORM_SPECIFIC_SDPA,
     )
-    def test_invalid_fused_inputs_dim_3(self, device, kernel: SDPBackend):
+    def test_fused_inputs_dim_3(self, device, kernel: SDPBackend):
+        size = (2, 3, 8)
+        dtype = torch.float16
+        q = torch.randn(size, device=device, dtype=dtype)
+        k = torch.randn(size, device=device, dtype=dtype)
+        v = torch.randn(size, device=device, dtype=dtype)
+        attn_mask = (
+            None
+            if kernel == SDPBackend.FLASH_ATTENTION
+            else torch.randn(3, 3, device=device, dtype=dtype)
+        )
+
         with sdpa_kernel(backends=[kernel]):
-            # Dim is not 4
-            size = (2, 3, 8)
-            dtype = torch.float16
-            q = torch.randn(size, device=device, dtype=dtype)
-            k = torch.randn(size, device=device, dtype=dtype)
-            v = torch.randn(size, device=device, dtype=dtype)
-            with self.assertWarnsRegex(
-                UserWarning,
-                "All fused kernels requires query, key and value to be 4 dimensional",
-            ):
-                self.assertRaises(
-                    RuntimeError,
-                    lambda: torch.nn.functional.scaled_dot_product_attention(
-                        q, k, v, None, 0.0, False
-                    ),
-                )
+            # XPU does not implement the mem-efficient backend and falls back to
+            # math, so _fused_sdp_choice is not asserted here; verify instead that
+            # 3D inputs are handled the same as explicitly unsqueezed 4D inputs.
+            expected = torch.nn.functional.scaled_dot_product_attention(
+                q.unsqueeze(0), k.unsqueeze(0), v.unsqueeze(0), attn_mask
+            ).squeeze(0)
+            actual = torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, attn_mask
+            )
+
+        self.assertEqual(actual, expected)
 
     @onlyAccelerator
     @unittest.skipIf(


### PR DESCRIPTION
### Summary
Fixes #4915. `TestSDPAFailureModesXPU::test_invalid_fused_inputs_dim_3` failed on XPU with `AssertionError: RuntimeError not raised by <lambda>` for both `kernel0` and `kernel1`.

### Root cause
This is test parity drift. Upstream `test/test_transformers.py` renamed `test_invalid_fused_inputs_dim_3` to `test_fused_inputs_dim_3` and changed its semantics: scaled_dot_product_attention now **supports** 3D inputs (internally unsqueezing/squeezing to 4D) instead of raising `RuntimeError`. The XPU copy still asserted the old "must raise `RuntimeError` + emit 4-dimensional UserWarning" behavior, so it fails now that 3D inputs succeed.

### Fix
Port the upstream test into `test_transformers_xpu.py`:
- Rename `test_invalid_fused_inputs_dim_3` → `test_fused_inputs_dim_3`.
- Replace the `assertRaises`/`assertWarnsRegex` body with the upstream check that 3D inputs produce the same result as explicitly unsqueezed 4D inputs.
- Omit the upstream `torch._fused_sdp_choice(...) == kernel.value` assertion:  XPU does not implement the memory-efficient backend and falls back to math (`_fused_sdp_choice` returns `MATH` for `EFFICIENT_ATTENTION`), which is a CUDA-specific check. The retained numeric equality check is backend-agnostic.