### PR TITLE
Use const_data_ptr for read-only tensor arguments in sparse kernels

### DIFF
--- a/src/ATen/native/sparse/xpu/sycl/SparseBinaryOpIntersectionKernels.cpp
+++ b/src/ATen/native/sparse/xpu/sycl/SparseBinaryOpIntersectionKernels.cpp
@@ -555,7 +555,7 @@ void _sparse_binary_op_intersection_kernel_impl(
         ? (*source_indices_hash_opt).contiguous()
         : at::empty({0}, probably_coalesced._indices().options().dtype(kLong));
     const auto* RESTRICT hash_ptr = source_indices_hash_opt.has_value()
-        ? hash.data_ptr<int64_t>()
+        ? hash.const_data_ptr<int64_t>()
         : nullptr;
 
     auto iter = TensorIteratorConfig()

--- a/src/ATen/native/sparse/xpu/sycl/SparseCsrTensorMathKernels.cpp
+++ b/src/ATen/native/sparse/xpu/sycl/SparseCsrTensorMathKernels.cpp
@@ -138,14 +138,15 @@ Tensor reduce_sparse_csr_dim0_xpu_template(
       values.options(), values.scalar_type(), new_nnz);
   Tensor new_values = std::get<0>(acc_buffer);
   Tensor new_values_acc = std::get<1>(acc_buffer);
-  scalar_t* values_ptr = values.data_ptr<scalar_t>();
+  const scalar_t* values_ptr = values.const_data_ptr<scalar_t>();
   acc_t* new_values_acc_ptr = new_values_acc.data_ptr<acc_t>();
   auto queue = getCurrentSYCLQueue();
 
   AT_DISPATCH_INDEX_TYPES(
       col_indices.scalar_type(), "reduce_sparse_csr_dim0_xpu_indices", [&]() {
         const index_t* col_indices_ptr = col_indices.const_data_ptr<index_t>();
-        index_t* new_col_indices_ptr = new_col_indices.data_ptr<index_t>();
+        const index_t* new_col_indices_ptr =
+            new_col_indices.const_data_ptr<index_t>();
         using KernelFn = ReduceSparseCsrDim0KernelFunctor<
             scalar_t,
             index_t,
@@ -300,7 +301,7 @@ Tensor reduce_sparse_csr_dim1_xpu_template(
         new_values.resize_(new_nnz);
         new_values_acc.resize_(new_nnz);
 
-        scalar_t* values_ptr = values.data_ptr<scalar_t>();
+        const scalar_t* values_ptr = values.const_data_ptr<scalar_t>();
         acc_t* new_values_acc_ptr = new_values_acc.data_ptr<acc_t>();
         auto kfn = KernelFn(
             new_values_acc_ptr,

--- a/src/ATen/native/sparse/xpu/sycl/SparseSoftmaxKernels.cpp
+++ b/src/ATen/native/sparse/xpu/sycl/SparseSoftmaxKernels.cpp
@@ -175,10 +175,10 @@ struct ReducePred {
   bool operator()(const T& x, const T& y) const {
     return offsets_ptr[x] == offsets_ptr[y];
   }
-  ReducePred(T* offsets_ptr) : offsets_ptr(offsets_ptr) {}
+  ReducePred(const T* offsets_ptr) : offsets_ptr(offsets_ptr) {}
 
  private:
-  T* offsets_ptr;
+  const T* offsets_ptr;
 };
 
 template <typename scalar_t, bool LogSoftMax>
@@ -199,9 +199,9 @@ struct SparseCooSoftmaxFunctor {
 
     while (index < pool_size) {
       int64_t offset = pool_offsets[index];
-      int64_t* pool_indices = sorted_pool_indices + offset;
+      const int64_t* pool_indices = sorted_pool_indices + offset;
       int64_t pool_indices_size = pool_sizes[index];
-      scalar_t* mx_row = mx_rows + index * nvalues;
+      const scalar_t* mx_row = mx_rows + index * nvalues;
 
       for (int64_t j = 0; j < nvalues; j++) {
         scalar_t exp_sums = 0;
@@ -233,12 +233,12 @@ struct SparseCooSoftmaxFunctor {
   }
 
   SparseCooSoftmaxFunctor(
-      int64_t* sorted_pool_indices,
+      const int64_t* sorted_pool_indices,
       int64_t pool_size,
-      int64_t* pool_sizes,
-      int64_t* pool_offsets,
+      const int64_t* pool_sizes,
+      const int64_t* pool_offsets,
       int64_t nvalues,
-      scalar_t* mx_rows,
+      const scalar_t* mx_rows,
       GenericPackedTensorAccessor<scalar_t, 2> input_values_acc,
       GenericPackedTensorAccessor<scalar_t, 2> output_values_acc)
       : sorted_pool_indices(sorted_pool_indices),
@@ -251,12 +251,12 @@ struct SparseCooSoftmaxFunctor {
         output_values_acc(output_values_acc) {}
 
  private:
-  int64_t* sorted_pool_indices;
+  const int64_t* sorted_pool_indices;
   int64_t pool_size;
-  int64_t* pool_sizes;
-  int64_t* pool_offsets;
+  const int64_t* pool_sizes;
+  const int64_t* pool_offsets;
   int64_t nvalues;
-  scalar_t* mx_rows;
+  const scalar_t* mx_rows;
   GenericPackedTensorAccessor<scalar_t, 2> input_values_acc;
   GenericPackedTensorAccessor<scalar_t, 2> output_values_acc;
 };
@@ -279,7 +279,7 @@ struct SparseCooSoftmaxbBackwardFunctor {
 
     while (index < size) {
       int64_t offset = pool_offsets[index];
-      int64_t* pool_indices = sorted_pool_indices + offset;
+      const int64_t* pool_indices = sorted_pool_indices + offset;
       int64_t pool_indices_size = pool_sizes[index];
 
       for (int64_t k = 0; k < nvalues; k++) {
@@ -332,15 +332,15 @@ struct SparseCooSoftmaxbBackwardFunctor {
   }
 
   SparseCooSoftmaxbBackwardFunctor(
-      int64_t* sorted_pool_indices,
+      const int64_t* sorted_pool_indices,
       int64_t size,
-      int64_t* pool_sizes,
-      int64_t* pool_offsets,
+      const int64_t* pool_sizes,
+      const int64_t* pool_offsets,
       int64_t nvalues,
       int64_t grad_nnz,
-      int64_t* grad_offsets,
-      int64_t* out_offsets,
-      int64_t* lower_bound_values,
+      const int64_t* grad_offsets,
+      const int64_t* out_offsets,
+      const int64_t* lower_bound_values,
       GenericPackedTensorAccessor<scalar_t, 2> values_accessor,
       GenericPackedTensorAccessor<scalar_t, 2> out_values_accessor,
       GenericPackedTensorAccessor<scalar_t, 2> grad_values_accessor)
@@ -358,15 +358,15 @@ struct SparseCooSoftmaxbBackwardFunctor {
         grad_values_accessor(grad_values_accessor) {}
 
  private:
-  int64_t* sorted_pool_indices;
+  const int64_t* sorted_pool_indices;
   int64_t size;
-  int64_t* pool_sizes;
-  int64_t* pool_offsets;
+  const int64_t* pool_sizes;
+  const int64_t* pool_offsets;
   int64_t nvalues;
   int64_t grad_nnz;
-  int64_t* grad_offsets;
-  int64_t* out_offsets;
-  int64_t* lower_bound_values;
+  const int64_t* grad_offsets;
+  const int64_t* out_offsets;
+  const int64_t* lower_bound_values;
   GenericPackedTensorAccessor<scalar_t, 2> values_accessor;
   GenericPackedTensorAccessor<scalar_t, 2> out_values_accessor;
   GenericPackedTensorAccessor<scalar_t, 2> grad_values_accessor;
@@ -417,7 +417,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> compute_pool_max(
   auto nnz = indices.size(1);
 
   auto offsets = get_offsets(indices, sizes, dim);
-  int64_t* offsets_ptr = offsets.data_ptr<int64_t>();
+  const int64_t* offsets_ptr = offsets.const_data_ptr<int64_t>();
   // Same values as offsets, but pstl::sort permutes it in place below.
   auto offsets_sort = offsets.clone();
   int64_t* offsets_sort_ptr = offsets_sort.mutable_data_ptr<int64_t>();
@@ -437,6 +437,8 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> compute_pool_max(
   auto new_end = pstl::reduce_by_key<int64_t>(
       sorted_indices_ptr,
       sorted_indices_ptr + nnz,
+      // Not const: inclusive_scan_if inside reduce_by_key deduces one InputIt
+      // for both this values range and the mutable head-flags mask.
       constant_it.data_ptr<int64_t>(),
       discard_it.mutable_data_ptr<int64_t>(),
       pool_sizes.data_ptr<int64_t>(),
@@ -464,9 +466,9 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> compute_pool_max(
         values.options());
     auto mx_buffer_ptr = mx_buffer.data_ptr<scalar_t>();
 
-    auto pool_sizes_ptr = pool_sizes.data_ptr<int64_t>();
-    auto sorted_indices_ptr = sorted_indices.data_ptr<int64_t>();
-    auto pool_offsets_ptr = pool_offsets.data_ptr<int64_t>();
+    auto pool_sizes_ptr = pool_sizes.const_data_ptr<int64_t>();
+    auto sorted_indices_ptr = sorted_indices.const_data_ptr<int64_t>();
+    auto pool_offsets_ptr = pool_offsets.const_data_ptr<int64_t>();
 
     max_row<scalar_t>(
         pool_sizes_ptr,
@@ -538,12 +540,12 @@ void xpu_sparse_coo_softmax(
   // let's not launch a kernel unless both are non-zero.
   if (nvalues > 0 && pool_size > 0) {
     auto kfn = SparseCooSoftmaxFunctor<scalar_t, LogSoftMax>(
-        sorted_indices.template data_ptr<int64_t>(),
+        sorted_indices.template const_data_ptr<int64_t>(),
         pool_size,
-        pool_sizes.template data_ptr<int64_t>(),
-        pool_offsets.template data_ptr<int64_t>(),
+        pool_sizes.template const_data_ptr<int64_t>(),
+        pool_offsets.template const_data_ptr<int64_t>(),
         nvalues,
-        mx_buffer.template data_ptr<scalar_t>(),
+        mx_buffer.template const_data_ptr<scalar_t>(),
         values_accessor,
         out_values_accessor);
     sycl_kernel_submit(global_range, local_range, getCurrentSYCLQueue(), kfn);
@@ -598,8 +600,8 @@ void xpu_sparse_coo_softmax_backward(
           out_offsets.to(at::Device(kCPU), indices.dtype(), false, true);
       auto host_grad_offsets =
           grad_offsets.to(at::Device(kCPU), indices.dtype(), false, true);
-      auto out_offsets_accessor = host_out_offsets.data_ptr<int64_t>();
-      auto grad_offsets_accessor = host_grad_offsets.data_ptr<int64_t>();
+      auto out_offsets_accessor = host_out_offsets.const_data_ptr<int64_t>();
+      auto grad_offsets_accessor = host_grad_offsets.const_data_ptr<int64_t>();
 
       for (int64_t i = 0; i < out_nnz; i++) {
         auto low = std::lower_bound(
@@ -646,10 +648,10 @@ void xpu_sparse_coo_softmax_backward(
       at::empty({out_offsets.size(0)}, indices.options());
 
   pstl::lower_bound_tensor<int64_t>(
-      grad_offsets.data_ptr<int64_t>(),
-      grad_offsets.data_ptr<int64_t>() + grad_offsets.size(0),
-      out_offsets.data_ptr<int64_t>(),
-      out_offsets.data_ptr<int64_t>() + out_offsets.size(0),
+      grad_offsets.const_data_ptr<int64_t>(),
+      grad_offsets.const_data_ptr<int64_t>() + grad_offsets.size(0),
+      out_offsets.const_data_ptr<int64_t>(),
+      out_offsets.const_data_ptr<int64_t>() + out_offsets.size(0),
       lower_bound_values.data_ptr<int64_t>());
 
   /* Compute independent pools of indices */
@@ -667,15 +669,15 @@ void xpu_sparse_coo_softmax_backward(
 
   if (nvalues > 0 && pool_size > 0) {
     auto kfn = SparseCooSoftmaxbBackwardFunctor<scalar_t, LogSoftMax>(
-        sorted_indices.template data_ptr<int64_t>(),
+        sorted_indices.template const_data_ptr<int64_t>(),
         pool_size,
-        pool_sizes.template data_ptr<int64_t>(),
-        pool_offsets.template data_ptr<int64_t>(),
+        pool_sizes.template const_data_ptr<int64_t>(),
+        pool_offsets.template const_data_ptr<int64_t>(),
         nvalues,
         grad_nnz,
-        grad_offsets.data_ptr<int64_t>(),
-        out_offsets.data_ptr<int64_t>(),
-        lower_bound_values.data_ptr<int64_t>(),
+        grad_offsets.const_data_ptr<int64_t>(),
+        out_offsets.const_data_ptr<int64_t>(),
+        lower_bound_values.const_data_ptr<int64_t>(),
         values_accessor,
         out_values_accessor,
         grad_values_accessor);

--- a/src/ATen/native/sparse/xpu/sycl/SparseTensorKernels.cpp
+++ b/src/ATen/native/sparse/xpu/sycl/SparseTensorKernels.cpp
@@ -89,9 +89,9 @@ struct CoalesceValuesKernelFunctor {
     }
   }
   CoalesceValuesKernelFunctor(
-      int64_t* segment_offsets,
-      int64_t* value_indices,
-      Dtype* values,
+      const int64_t* segment_offsets,
+      const int64_t* value_indices,
+      const Dtype* values,
       Dtype* newValues,
       int64_t nnz,
       int64_t newNnz,
@@ -105,9 +105,9 @@ struct CoalesceValuesKernelFunctor {
         stride_(stride) {}
 
  private:
-  int64_t* segment_offsets_;
-  int64_t* value_indices_;
-  Dtype* values_;
+  const int64_t* segment_offsets_;
+  const int64_t* value_indices_;
+  const Dtype* values_;
   Dtype* newValues_;
   int64_t nnz_;
   int64_t newNnz_;
@@ -175,9 +175,9 @@ SparseTensor coalesce_sparse_kernel(const SparseTensor& self) {
         [&] {
           using accscalar_t = acc_type_device<scalar_t, kXPU>;
           auto caller = CoalesceValuesKernelFunctor<scalar_t, accscalar_t>(
-              uniqueOffsets.data_ptr<int64_t>(),
-              origIndices.data_ptr<int64_t>(),
-              values.data_ptr<scalar_t>(),
+              uniqueOffsets.const_data_ptr<int64_t>(),
+              origIndices.const_data_ptr<int64_t>(),
+              values.const_data_ptr<scalar_t>(),
               newValues.data_ptr<scalar_t>(),
               nnz,
               newNnz,

--- a/src/ATen/native/sparse/xpu/sycl/SparseTensorMathKernels.cpp
+++ b/src/ATen/native/sparse/xpu/sycl/SparseTensorMathKernels.cpp
@@ -666,10 +666,10 @@ Tensor _sparse_sum_backward_kernel(
           at::empty_like(input_indices_1D, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
 
       pstl::lower_bound_tensor<int64_t>(
-          grad_indices_1D.data_ptr<int64_t>(),
-          grad_indices_1D.data_ptr<int64_t>() + grad_nnz,
-          input_indices_1D.data_ptr<int64_t>(),
-          input_indices_1D.data_ptr<int64_t>() + input_nnz,
+          grad_indices_1D.const_data_ptr<int64_t>(),
+          grad_indices_1D.const_data_ptr<int64_t>() + grad_nnz,
+          input_indices_1D.const_data_ptr<int64_t>(),
+          input_indices_1D.const_data_ptr<int64_t>() + input_nnz,
           input_indices_pos.data_ptr<int64_t>());
 
       auto grad_indices_ti = getTensorInfo<int64_t, int64_t>(grad_indices_1D);


### PR DESCRIPTION
`data_ptr<T>()` returns a mutable pointer regardless of use. This converts read-only call sites in the sparse XPU kernels to `const_data_ptr`, const-qualifying the consuming functor members where they were only read. Written buffers are left alone. A wrong conversion is a compile error, not a silent behavior change.

Authored with the assistance of an AI coding agent.