### PR TITLE
Scope ConvNeXt emulate_precision_casts to BF16 training

### DIFF
--- a/.github/actions/linux-e2etest/action.yml
+++ b/.github/actions/linux-e2etest/action.yml
@@ -102,6 +102,12 @@ runs:
                 if ! contains "accuracy,performance" "$scenario"; then
                   continue
                 fi
+                if [[ "${{ inputs.overwrite_model_list }}" == "true" && "$suite" == "timm_models" ]]; then
+                  cp ../.ci/benchmarks/timm_models.yaml benchmarks/dynamo/timm_models.yaml
+                  if [[ "$mode,$dt" != "training,bfloat16" && "$mode,$dt" != "training,amp_bf16" ]]; then
+                    sed -i '/^  - convnextv2_nano\.fcmae_ft_in22k_in1k$/d' benchmarks/dynamo/timm_models.yaml
+                  fi
+                fi
                 run_with_shard
                 # summarize pass rate
                 LOG_DIR="inductor_log/${suite}/${dt}"


### PR DESCRIPTION
## Problem

`convnextv2_nano.fcmae_ft_in22k_in1k` was added to the global `emulate_precision_casts` model list to fix BF16 training accuracy(PR #4291 ). However, the TIMM runner applies this setting regardless of mode and dtype, enabling it during inference as well.

On XPU, enabling `emulate_precision_casts` preserves low-precision downcast/upcast boundaries that Inductor would otherwise eliminate during fusion. For ConvNeXt, this materializes additional intermediates around the repeated NHWC LayerNorm and MLP boundaries.

These intermediates are processed by `maybe_apply_channels_last_stride_order()`, introduced by PyTorch PR [#169260](https://github.com/pytorch/pytorch/pull/169260).
The helper was intended for CPP/MKLDNN convolution layout propagation, but it is not guarded to CPU and therefore also applies its channels-last stride constraint to XPU tensors. For logical NHWC tensors, this can effectively apply a second channels-last interpretation and introduce unnecessary layout
materializations.

This adds 32 scheduler nodes and 21 Triton launches, increasing the generated Triton kernel count from 80 to 101 and regressing BF16 inference latency as shown in issues #4917 .

## Fix

Before each TIMM test, restore the original XPU model configuration and remove ConvNeXt from `emulate_precision_casts` unless the test is:

- BF16 training
- AMP BF16 training

The behavior of other models is unchanged.

