### PR TITLE
Fix batchnorm accuracy by sycl::rsqrt

### DIFF
--- a/.ci/benchmarks/torchbench.yaml
+++ b/.ci/benchmarks/torchbench.yaml
@@ -72,8 +72,10 @@ tolerance:
     - sam
     - sam_fast
     - vision_maskrcnn
+    - detectron2_maskrcnn
     - detectron2_maskrcnn_r_101_fpn
     - detectron2_maskrcnn_r_50_c4
+    - detectron2_maskrcnn_r_50_fpn
 
   # Custom IoU thresholds per model (default is 0.99)
   iou_thresholds:

--- a/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
@@ -138,7 +138,7 @@ struct InvStd {
   inline T operator()(T var, double epsilon) const {
     T invstd = 0.0f;
     if (var != static_cast<T>(0.0f) || epsilon != static_cast<T>(0.0f)) {
-      invstd = static_cast<T>(1.0f) / sycl::sqrt(var + static_cast<T>(epsilon));
+      invstd = sycl::rsqrt(var + static_cast<T>(epsilon));
     }
     return invstd;
   }
@@ -1048,9 +1048,7 @@ struct BatchNormTransformInputKernelFunctor {
     if constexpr (train) {
       invstd = var_or_invstd_[plane];
     } else {
-      invstd =
-          static_cast<stat_accscalar_t>(1) /
-          sycl::sqrt(
+      invstd = sycl::rsqrt(
               static_cast<stat_accscalar_t>(var_or_invstd_[plane]) + epsilon_);
     }
 
@@ -1168,9 +1166,7 @@ struct BatchNormTransformInputVectorizedKernelFunctor {
     if constexpr (train) {
       invstd = var_or_invstd_[plane];
     } else {
-      invstd =
-          static_cast<stat_accscalar_t>(1) /
-          sycl::sqrt(
+      invstd = sycl::rsqrt(
               static_cast<stat_accscalar_t>(var_or_invstd_[plane]) + epsilon_);
     }
 
@@ -3972,7 +3968,7 @@ template <typename scalar_t, typename acc_t>
 struct BatchNormCalcInvstdFunctor {
   acc_t operator()(scalar_t var) const {
     volatile acc_t v = var + eps_;
-    return c10::xpu::compat::rsqrt(v);
+    return sycl::rsqrt(v);
   }
 
   BatchNormCalcInvstdFunctor(acc_t eps) : eps_(eps) {}
@@ -4177,9 +4173,7 @@ struct BatchNormBackwardKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
       invstd = save_invstd_[plane];
     } else {
       mean = static_cast<stat_accscalar_t>(running_mean_[plane]);
-      invstd =
-          static_cast<stat_accscalar_t>(1) /
-          sycl::sqrt(
+      invstd = sycl::rsqrt(
               static_cast<stat_accscalar_t>(running_var_[plane]) + epsilon_);
     }
 
@@ -4384,9 +4378,7 @@ struct BatchNormBackwardVectorizedKernelFunctor
       invstd = save_invstd_[plane];
     } else {
       mean = static_cast<stat_accscalar_t>(running_mean_[plane]);
-      invstd =
-          static_cast<stat_accscalar_t>(1) /
-          sycl::sqrt(
+      invstd = sycl::rsqrt(
               static_cast<stat_accscalar_t>(running_var_[plane]) + epsilon_);
     }
 
@@ -5099,8 +5091,7 @@ struct BatchNormReduceStatisticsKernelFunctor {
         n += count;
       }
       mean[i] = avg;
-      invstd[i] =
-          static_cast<accscalar_t>(1) / sycl::sqrt(var_n / n + epsilon_);
+      invstd[i] = sycl::rsqrt(var_n / n + epsilon_);
       if (running_mean.data() != NULL) {
         running_mean[i] = static_cast<scalar_t>(
             (1 - momentum_) * running_mean[i] + momentum_ * avg);

--- a/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
@@ -1049,7 +1049,7 @@ struct BatchNormTransformInputKernelFunctor {
       invstd = var_or_invstd_[plane];
     } else {
       invstd = sycl::rsqrt(
-              static_cast<stat_accscalar_t>(var_or_invstd_[plane]) + epsilon_);
+          static_cast<stat_accscalar_t>(var_or_invstd_[plane]) + epsilon_);
     }
 
     index_t bs = input_.size(0);
@@ -1167,7 +1167,7 @@ struct BatchNormTransformInputVectorizedKernelFunctor {
       invstd = var_or_invstd_[plane];
     } else {
       invstd = sycl::rsqrt(
-              static_cast<stat_accscalar_t>(var_or_invstd_[plane]) + epsilon_);
+          static_cast<stat_accscalar_t>(var_or_invstd_[plane]) + epsilon_);
     }
 
     index_t bs = input_.size(0);
@@ -3856,8 +3856,8 @@ void batch_norm_mean_var(
           save_var,
           save_mean,
           self,
-          /*dims=*/reduce_dims,
-          /*unbiased=*/false,
+          /*dim=*/reduce_dims,
+          /*correction=*/false,
           /*keepdim=*/false);
       return;
     }
@@ -4174,7 +4174,7 @@ struct BatchNormBackwardKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
     } else {
       mean = static_cast<stat_accscalar_t>(running_mean_[plane]);
       invstd = sycl::rsqrt(
-              static_cast<stat_accscalar_t>(running_var_[plane]) + epsilon_);
+          static_cast<stat_accscalar_t>(running_var_[plane]) + epsilon_);
     }
 
     stat_accscalar_t weight_val = weight_.size(0) > 0
@@ -4379,7 +4379,7 @@ struct BatchNormBackwardVectorizedKernelFunctor
     } else {
       mean = static_cast<stat_accscalar_t>(running_mean_[plane]);
       invstd = sycl::rsqrt(
-              static_cast<stat_accscalar_t>(running_var_[plane]) + epsilon_);
+          static_cast<stat_accscalar_t>(running_var_[plane]) + epsilon_);
     }
 
     stat_accscalar_t weight_val = weight_.size(0) > 0


### PR DESCRIPTION
Align  rsqrt with inductor. Should fix timm_efficientnet accuracy issue in https://github.com/intel/torch-xpu-ops/issues/4905. For detectron2_maskrcnn and detectron2_maskrcnn_r_50_fpn, add them to use_iou_for_bool_masks
After https://github.com/pytorch/pytorch/pull/190206, inductor use rsqrt instead of 1/sqrt
Currently, the compute order of eager and inductor is still different, but changing them will cause UT accuracy fail