### PR TITLE
ci: run pytest with pytest-forked on dpclang testing

### DIFF
--- a/.github/actions/linux-testenv/action.yml
+++ b/.github/actions/linux-testenv/action.yml
@@ -188,7 +188,7 @@ runs:
           # Remove mkl hardcode installation to avoid potential conflicts with torch xpu wheel 
           sed -i '/mkl/d' .ci/docker/requirements-ci.txt
           uv pip install -r .ci/docker/requirements-ci.txt
-          uv pip install pytest pytest-timeout pytest-xdist pytest-rerunfailures
+          uv pip install pytest pytest-timeout pytest-xdist pytest-rerunfailures pytest-forked
         fi
         # install the corresponding torchao
         uv pip uninstall torchao
@@ -222,7 +222,9 @@ runs:
         fi
     - name: Detect devices
       shell: bash -euo pipefail {0}
-      run: ${{ github.workspace }}/.github/scripts/detect-devices.sh --pytest-others-args '-v -rfEsxw --only-rerun crashed.*while.*running --reruns 2'
+      env:
+        FORK_OPT: ${{ inputs.category == 'dpclang' && ' --forked' || '' }}
+      run: ${{ github.workspace }}/.github/scripts/detect-devices.sh --pytest-others-args '-v -rfEsxw --only-rerun crashed.*while.*running --reruns 2 ${FORK_OPT}'
     - name: Torch Config
       shell: bash -xe {0}
       run: |

--- a/.github/workflows/pull_dpclang.yml
+++ b/.github/workflows/pull_dpclang.yml
@@ -113,9 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # 'op_ut' tests take suspiciously too long and sometimes
-        # get cancelled. For now limit the scope to 'basic' tests.
-        ut_name: [basic]
+        ut_name: [basic, op_ut]
     uses: ./.github/workflows/_linux_ut.yml
     with:
       category: dpclang


### PR DESCRIPTION
pytest-forked runs each subtest in a forked subprocess which allows to handle unstable tests crashing in native libraries, for example on asserts.