### PR TITLE
skills: allow forward slashes in skill-writer naming rule

### DIFF
--- a/.claude/skills/skill-writer/SKILL.md
+++ b/.claude/skills/skill-writer/SKILL.md
@@ -84,10 +84,12 @@ description: Brief description of what this does and when to use it
 **Field requirements**:
 
 - **name**:
-  - Lowercase letters, numbers, hyphens only
+  - Lowercase letters, numbers, hyphens only; forward slashes (`/`) are
+    allowed as hierarchy separators for nested skills
   - Max 64 characters
-  - Must match directory name
-  - Good: `pdf-processor`, `git-commit-helper`
+  - Must match the skill's directory path relative to `.claude/skills/`
+    (e.g. skill at `.claude/skills/fix/reproduce/` → `name: fix/reproduce`)
+  - Good: `pdf-processor`, `git-commit-helper`, `fix/reproduce`, `fix/domains/xpu-kernel`
   - Bad: `PDF_Processor`, `Git Commits!`
 
 - **description**:
@@ -334,7 +336,7 @@ Detailed reference: See [reference.md](reference.md)
 
 Before finalizing a Skill, verify:
 
-- [ ] Name is lowercase, hyphens only, max 64 chars
+- [ ] Name is lowercase, hyphens and forward slashes only, max 64 chars; matches directory path relative to `.claude/skills/`
 - [ ] Description is specific and < 1024 chars
 - [ ] Description includes "what" and "when"
 - [ ] YAML frontmatter is valid

--- a/.claude/skills/skill-writer/SKILL.md
+++ b/.claude/skills/skill-writer/SKILL.md
@@ -87,8 +87,10 @@ description: Brief description of what this does and when to use it
   - Lowercase letters, numbers, hyphens only; forward slashes (`/`) are
     allowed as hierarchy separators for nested skills
   - Max 64 characters
-  - Must match the skill's directory path relative to `.claude/skills/`
-    (e.g. skill at `.claude/skills/fix/reproduce/` → `name: fix/reproduce`)
+  - Must be unique across all Skills, and must match either the skill's
+    directory name or its directory path relative to `.claude/skills/`
+    (a skill at `.claude/skills/fix/reproduce/` may be named `reproduce`
+    or `fix/reproduce`)
   - Good: `pdf-processor`, `git-commit-helper`, `fix/reproduce`, `fix/domains/xpu-kernel`
   - Bad: `PDF_Processor`, `Git Commits!`
 
@@ -206,7 +208,7 @@ Check these requirements:
 
 ✅ **File structure**:
 - [ ] SKILL.md exists in correct location
-- [ ] Directory name matches frontmatter `name`
+- [ ] Frontmatter `name` matches the directory name or the directory path relative to `.claude/skills/`
 
 ✅ **YAML frontmatter**:
 - [ ] Opening `---` on line 1
@@ -336,7 +338,7 @@ Detailed reference: See [reference.md](reference.md)
 
 Before finalizing a Skill, verify:
 
-- [ ] Name is lowercase, hyphens and forward slashes only, max 64 chars; matches directory path relative to `.claude/skills/`
+- [ ] Name is lowercase, hyphens and forward slashes only, max 64 chars; unique and matches the directory name or path
 - [ ] Description is specific and < 1024 chars
 - [ ] Description includes "what" and "when"
 - [ ] YAML frontmatter is valid


### PR DESCRIPTION
## Summary

Split out from #4918. This is a standalone rule change to the `skill-writer` spec — independent of the `issue-handler` / `fix/` refactor.

The `skill-writer` spec said "lowercase letters, numbers, hyphens only" and "Must match directory name", which rules out slash-hierarchy names entirely. That's too strict:

- **Nested skills already exist on `main`** and use the *basename* form (`action/sycl/source-oneapi` → `name: source-oneapi`, `action/unitrace/setup` → `name: setup`, `issue-handler/issue-fix` → `name: issue-fix`). The strict rule as written would have required either renaming these or their directories.
- **#4918** proposes further nesting (`fix/reproduce`, `fix/domains/xpu-kernel`, etc.) where the *slash-path* form is a clearer fit than the basename.
- The skill tool accepts both forms as-is from the `available_skills` list.

Updated the field requirements and the pre-submit checklist to:

- Allow forward slashes as hierarchy separators (previously hyphens only)
- Accept either the directory basename or the directory path relative to `.claude/skills/` as the `name:` value
- Require uniqueness across all skills — this is the only hard rule
- Add nested examples alongside the flat ones

Author's choice for each new skill: basename or slash-path. Existing skills stay as they are.

## Testing

Docs only. `lintrunner` clean on the changed file.

Cherry-picked from #4918 (commit 850e5a9) at the request of a reviewer to keep the naming-rule change reviewable independently of the larger orchestrator refactor. #4918 will revert this commit so the two PRs don't overlap. Includes a follow-up refinement (commit cfad535, co-authored with Copilot) that relaxed the rule from "must match path" to "basename or path" after review confirmed no existing nested skill uses the strict path form.

This PR was authored with AI assistance.