### PR TITLE
skills: add issue-triage — shallow text-only issue classification

### DIFF
--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -29,8 +29,15 @@ this skill).
 ## Inputs
 
 - A GitHub issue: URL, number, or raw title+body+labels. If given a
-  number or URL, fetch with `gh issue view --json title,body,labels`.
-- Read-only. This skill never runs tests or edits files.
+  number or URL, fetch it:
+
+  ```bash
+  gh issue view "$N" --repo "$OWNER/$REPO" --json title,body,labels
+  ```
+
+- Read-only with respect to the repository: this skill never reads
+  source, runs tests, or edits files. Its only writes are the issue
+  comment and the labels in Step 6.
 
 ## Shell helpers
 
@@ -89,9 +96,8 @@ Report `yes` when the issue lacks all of:
 
 Report `no` when at least one of the above is present.
 
-Skip-list issues are exempt — they list already-skipped test node ids
-in their body, which counts as "test node id reference" per the second
-bullet.
+Skip-list issues list already-skipped test node ids in their body, so
+they satisfy the second bullet and report `no`.
 
 ## Step 3: Estimate `scope`
 
@@ -160,11 +166,15 @@ human-readable output:
 ```markdown
 | Field | Value |
 |-------|-------|
-| Reproduction missing | <yes | no> |
-| Scope | <pytorch | torch-xpu-ops | both | unclear> |
-| Dependencies | <comma-separated list, or "(none)"> |
-| Handling | <agent-fixable | needs-human> |
+| Reproduction missing | yes / no |
+| Scope | pytorch / torch-xpu-ops / both / unclear |
+| Dependencies | comma-separated list, or (none) |
+| Handling | agent-fixable / needs-human |
 ```
+
+Each `Value` cell above lists the allowed choices; emit exactly one of
+them. Never leave a literal `|` inside a cell — it splits the cell and
+breaks the rendered table.
 
 When `Handling == needs-human`, append a `**Reason:** <one-line>` line
 below the table.
@@ -195,39 +205,34 @@ OWNER=<owner> REPO=<repo> N=<issue_number>
 triage_body_file=$(mktemp)
 # Write the marker + heading + table + reason to $triage_body_file.
 
-# Find the oldest existing triage comment (if any).
-comment_id=$(gh issue view "$N" --repo "$OWNER/$REPO" \
-  --json comments \
-  --jq '.comments
-        | map(select(.body | startswith("<!-- agent:triage -->")))
-        | sort_by(.createdAt)
-        | .[0].id')
+# List existing triage comments, oldest first. Use the REST endpoint: it
+# returns numeric comment ids, which the PATCH/DELETE comment endpoints
+# require. `gh issue view --json comments` returns GraphQL node ids
+# instead, and those endpoints reject them.
+mapfile -t triage_ids < <(gh api "/repos/$OWNER/$REPO/issues/$N/comments" \
+    --paginate \
+    --jq '.[] | select(.body | startswith("<!-- agent:triage -->")) | .id')
 
-if [ -z "$comment_id" ] || [ "$comment_id" = "null" ]; then
+if [ "${#triage_ids[@]}" -eq 0 ]; then
     gh issue comment "$N" --repo "$OWNER/$REPO" \
         --body-file "$triage_body_file" \
         || abort "gh issue comment failed"
 else
     # `--field body="$(cat file)"` — do NOT use `-f body=@file`; gh
     # does not expand @path for POST/PATCH fields the way curl does.
-    gh api "/repos/$OWNER/$REPO/issues/comments/$comment_id" \
+    gh api "/repos/$OWNER/$REPO/issues/comments/${triage_ids[0]}" \
         --method PATCH \
         --field body="$(cat "$triage_body_file")" \
         || abort "gh api PATCH failed"
-fi
 
-# Best-effort dedup: if more than one triage comment exists, delete
-# the newer duplicates. Failure here is a warning, not a hard abort.
-gh issue view "$N" --repo "$OWNER/$REPO" --json comments \
-  --jq '.comments
-        | map(select(.body | startswith("<!-- agent:triage -->")))
-        | sort_by(.createdAt)
-        | .[1:][] | .id' \
-  | while read dup_id; do
-      gh api "/repos/$OWNER/$REPO/issues/comments/$dup_id" \
-        --method DELETE \
-        || log_warn "could not delete duplicate triage comment $dup_id"
+    # Best-effort dedup: delete the newer duplicates. Failure here is a
+    # warning, not a hard abort.
+    for dup_id in "${triage_ids[@]:1}"; do
+        gh api "/repos/$OWNER/$REPO/issues/comments/$dup_id" \
+            --method DELETE \
+            || log_warn "could not delete duplicate triage comment $dup_id"
     done
+fi
 ```
 
 ### 6c. Apply GitHub labels
@@ -275,6 +280,8 @@ no explanation:
 
 Field notes:
 
+- `reproduction_missing` is a JSON boolean: `true` for the `yes` shown
+  in the table, `false` for `no`.
 - `runtime_dependencies` is an array from the closed set in Step 4;
   empty `[]` when none named.
 - `reason` is required non-empty when `handling == needs-human`, empty
@@ -292,5 +299,9 @@ Field notes:
 - **`gh api ... -f body=@file` is wrong** for editing comments. `gh`
   does not expand `@path` for POST/PATCH fields the way curl does.
   Use `--field body="$(cat file)"`.
+- **Comment ids must come from the REST list endpoint.** PATCH/DELETE
+  on `/repos/.../issues/comments/<id>` need the numeric id returned by
+  `gh api /repos/.../issues/<n>/comments`, not the GraphQL node id
+  returned by `gh issue view --json comments`.
 - **Labels are advisory** — repeated `add-label` calls for a label
   already on the issue are no-ops, not failures.

--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: issue-triage
+description: >
+  Shallow (text-only) triage of a GitHub issue on pytorch or torch-xpu-ops.
+  Classify as bug/skip-list/nonbug, detect whether a reproducer is present,
+  estimate scope (pytorch/torch-xpu-ops/both/unclear), identify runtime
+  dependencies (triton/onednn/onemkl/driver/sycl/xccl), and emit a handling
+  decision (agent-fixable / needs-human) based on those signals. Posts the
+  result to the issue as a comment, applies matching GitHub labels, and
+  returns a JSON summary. Use as a standalone triage entry point, or as
+  the shallow first stage of a larger fix pipeline.
+---
+
+# Issue Triage — Shallow Classification & Handling Decision
+
+Text-only triage. Reads the issue title, body, and labels. Does NOT read
+source code, does NOT run tests, does NOT open PRs. Produces three
+outputs:
+
+1. A markdown table posted as a comment on the issue.
+2. GitHub labels applied to the issue.
+3. A JSON summary returned to the caller.
+
+`Handling` (agent-fixable vs needs-human) is derived from the other
+signals — see "Step 5" below. Deep root-cause analysis and any override
+of this decision happens later in a downstream skill (out of scope for
+this skill).
+
+## Inputs
+
+- A GitHub issue: URL, number, or raw title+body+labels. If given a
+  number or URL, fetch with `gh issue view --json title,body,labels`.
+- Read-only. This skill never runs tests or edits files.
+
+## Shell helpers
+
+Recipes below assume two helpers are in scope. Define them once at the
+top of your shell (or source a shared file):
+
+```bash
+abort()    { echo "ABORT: $*" >&2; exit 1; }
+log_warn() { echo "WARN: $*"  >&2; }
+```
+
+## Preflight
+
+`gh` must be authenticated with `repo` or `write:issues` scope (this
+skill writes a comment and applies labels):
+
+```bash
+gh auth status 2>&1 | grep -q "Logged in to github.com" \
+  || abort "gh not authenticated; run: gh auth login"
+
+scopes=$(gh auth status -t 2>&1 | grep -oE "'[a-z:_-]+'" | tr -d "'")
+echo "$scopes" | grep -qE '^(repo|write:issues)$' \
+  || abort "issue-triage requires 'repo' or 'write:issues' scope; got: $scopes"
+```
+
+## Step 1: Classify issue_type
+
+- **bug** — test failures, runtime errors, assertion errors, incorrect
+  output, crashes.
+  Indicators: error tracebacks, failing test names, `RuntimeError`,
+  `AssertionError`, "fails with", `### 🐛 Describe the bug`, test logs.
+
+- **skip-list** — a "Bug Skip" tracking issue asking whether a list of
+  already-skipped tests should still be skipped.
+  Indicators: `Bug Skip` in the title/template, `agent_test: skip-list`
+  label, body is a checklist of test node ids (often with
+  `~~strike-through~~` for entries already resolved), no fresh
+  traceback.
+
+- **nonbug** — feature requests, tasks, performance issues, questions,
+  discussions, tracking issues, enhancement proposals, feature gaps.
+  Indicators: "Enable", "[Task]", "Consider", "Align", "feature gap",
+  "clarification", checklists of work items, `enhancement` label,
+  `performance` label, no failing tests.
+
+**Labels are authoritative** — if labels say `agent_test: skip-list`,
+`issue_type = skip-list` regardless of body content.
+
+## Step 2: Detect `reproduction_missing`
+
+Report `yes` when the issue lacks all of:
+
+- A reproducer command (pytest node id, `python -c ...`, shell command).
+- A test node id reference (e.g. `test_foo.py::TestBar::test_baz`).
+- A minimal code snippet that triggers the failure.
+
+Report `no` when at least one of the above is present.
+
+Skip-list issues are exempt — they list already-skipped test node ids
+in their body, which counts as "test node id reference" per the second
+bullet.
+
+## Step 3: Estimate `scope`
+
+Based on issue text alone (no source reading):
+
+- **`pytorch`** — issue explicitly points at pytorch code (`torch/`,
+  `aten/`, `torch/_inductor/`, `torch/_dynamo/`), a pytorch PR, or a
+  framework-level regression.
+- **`torch-xpu-ops`** — issue explicitly points at torch-xpu-ops code
+  (`src/ATen/native/xpu/`, XPU kernels, SYCL implementations), or a
+  ported CUDA test failing on XPU due to a kernel gap.
+- **`both`** — issue text names changes needed in BOTH repos (e.g.
+  pytorch API addition + XPU implementation of that API).
+- **`unclear`** — issue text does not specify. This is the common case
+  for most bug reports; a downstream deep-triage skill will decide
+  after reading source.
+
+## Step 4: Detect `runtime_dependencies`
+
+Scan the issue body, error log, environment section, and labels for
+explicit mentions of external runtime dependencies. Closed set:
+
+| Value | What it means |
+|---|---|
+| `triton` | Inductor / torch.compile GPU codegen backend. |
+| `onednn` | Intel oneDNN library (matmul, conv, etc.). |
+| `onemkl` | Intel oneMKL library (BLAS, LAPACK, sparse). |
+| `driver` | GPU driver, level-zero, compute-runtime, `libze_intel_gpu.so`. |
+| `sycl` | SYCL runtime / DPC++ compiler. |
+| `xccl` | XCCL communication library. |
+
+Only report dependencies **explicitly named** in the issue. Do NOT infer
+from a stack-trace path alone (e.g. a traceback through
+`torch._inductor` does not by itself imply `triton` — the issue must
+say so or show a triton-side error).
+
+Empty array `[]` when none are named.
+
+## Step 5: Derive `Handling`
+
+Evaluate in order; first match wins:
+
+1. `issue_type` is `nonbug` or an umbrella tracking task (a "parent"
+   issue tracking multiple skip-listed/child test issues, not a single
+   bug itself) → **needs-human**
+   (reason: `"not a bug / task issue"`).
+2. `reproduction_missing == yes` → **needs-human**
+   (reason: `"no reproducer or test-name reference"`).
+3. `runtime_dependencies` is non-empty → **needs-human**
+   (reason: `"runtime dependency requires human triage: <list>"`).
+4. Issue explicitly requires hardware or a non-public model/dataset the
+   agent cannot access → **needs-human**
+   (reason: names the missing resource).
+5. Otherwise → **agent-fixable**.
+
+`scope=both` and `scope=unclear` do NOT force needs-human — a
+downstream deep-triage skill decides the final target repo.
+
+## Step 6: Output
+
+### 6a. Markdown table
+
+Assemble this table (values from Steps 1–5). This is the primary
+human-readable output:
+
+```markdown
+| Field | Value |
+|-------|-------|
+| Reproduction missing | <yes | no> |
+| Scope | <pytorch | torch-xpu-ops | both | unclear> |
+| Dependencies | <comma-separated list, or "(none)"> |
+| Handling | <agent-fixable | needs-human> |
+```
+
+When `Handling == needs-human`, append a `**Reason:** <one-line>` line
+below the table.
+
+### 6b. Post / update the issue comment
+
+Post the table as a GitHub comment on the issue, wrapped with a marker
+so re-runs can find and update it in place:
+
+```
+<!-- agent:triage -->
+
+## Issue Triage
+
+<table from 6a>
+
+<optional reason line>
+
+*Automated by issue-triage.*
+```
+
+Look up the existing triage comment (if any) by the marker and edit
+it in place; otherwise post new. Concrete recipe:
+
+```bash
+OWNER=<owner> REPO=<repo> N=<issue_number>
+
+triage_body_file=$(mktemp)
+# Write the marker + heading + table + reason to $triage_body_file.
+
+# Find the oldest existing triage comment (if any).
+comment_id=$(gh issue view "$N" --repo "$OWNER/$REPO" \
+  --json comments \
+  --jq '.comments
+        | map(select(.body | startswith("<!-- agent:triage -->")))
+        | sort_by(.createdAt)
+        | .[0].id')
+
+if [ -z "$comment_id" ] || [ "$comment_id" = "null" ]; then
+    gh issue comment "$N" --repo "$OWNER/$REPO" \
+        --body-file "$triage_body_file" \
+        || abort "gh issue comment failed"
+else
+    # `--field body="$(cat file)"` — do NOT use `-f body=@file`; gh
+    # does not expand @path for POST/PATCH fields the way curl does.
+    gh api "/repos/$OWNER/$REPO/issues/comments/$comment_id" \
+        --method PATCH \
+        --field body="$(cat "$triage_body_file")" \
+        || abort "gh api PATCH failed"
+fi
+
+# Best-effort dedup: if more than one triage comment exists, delete
+# the newer duplicates. Failure here is a warning, not a hard abort.
+gh issue view "$N" --repo "$OWNER/$REPO" --json comments \
+  --jq '.comments
+        | map(select(.body | startswith("<!-- agent:triage -->")))
+        | sort_by(.createdAt)
+        | .[1:][] | .id' \
+  | while read dup_id; do
+      gh api "/repos/$OWNER/$REPO/issues/comments/$dup_id" \
+        --method DELETE \
+        || log_warn "could not delete duplicate triage comment $dup_id"
+    done
+```
+
+### 6c. Apply GitHub labels
+
+Only apply "needs human attention"-class labels; scope and dependency
+values live in the JSON output, not as labels:
+
+- If `reproduction_missing == yes` → add `agent:reproduction-needed`.
+- If `Handling == needs-human` → add `agent:needs-human`.
+
+```bash
+if [ "$reproduction_missing" = "yes" ]; then
+    gh issue edit "$N" --repo "$OWNER/$REPO" \
+        --add-label "agent:reproduction-needed" \
+        || log_warn "add-label agent:reproduction-needed failed"
+fi
+
+if [ "$handling" = "needs-human" ]; then
+    gh issue edit "$N" --repo "$OWNER/$REPO" \
+        --add-label "agent:needs-human" \
+        || log_warn "add-label agent:needs-human failed"
+fi
+```
+
+`gh` returns non-zero if a label is already applied. That is a no-op,
+not a failure. `log_warn` here is intentional: label state on the
+issue is still correct even when the API call reports the label was
+already there.
+
+### 6d. Return JSON to the caller
+
+Return this JSON as the LAST thing in your response, no markdown fences,
+no explanation:
+
+```json
+{
+  "issue_type": "bug | skip-list | nonbug",
+  "reproduction_missing": true | false,
+  "scope": "pytorch | torch-xpu-ops | both | unclear",
+  "runtime_dependencies": [],
+  "handling": "agent-fixable | needs-human",
+  "reason": ""
+}
+```
+
+Field notes:
+
+- `runtime_dependencies` is an array from the closed set in Step 4;
+  empty `[]` when none named.
+- `reason` is required non-empty when `handling == needs-human`, empty
+  string when `handling == agent-fixable`.
+- Do NOT invent values not derived from the issue text.
+
+## HARD RULES
+
+- **Never modify the issue body.** The body is user-owned. All
+  agent-side state on the issue lives in comments (single
+  `<!-- agent:triage -->` comment) and labels.
+- **Never read source or run tests.** This skill's contract is
+  text-only shallow triage. Deep source-reading analysis belongs to a
+  separate downstream skill.
+- **`gh api ... -f body=@file` is wrong** for editing comments. `gh`
+  does not expand `@path` for POST/PATCH fields the way curl does.
+  Use `--field body="$(cat file)"`.
+- **Labels are advisory** — repeated `add-label` calls for a label
+  already on the issue are no-ops, not failures.

--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -1,25 +1,26 @@
 ---
 name: issue-triage
 description: >
-  Shallow (text-only) triage of a GitHub issue on pytorch or torch-xpu-ops.
-  Classify as bug/skip-list/nonbug, detect whether a reproducer is present,
-  estimate scope (pytorch/torch-xpu-ops/both/unclear), identify runtime
-  dependencies (triton/onednn/onemkl/driver/sycl/xccl), and emit a handling
-  decision (agent-fixable / needs-human) based on those signals. Posts the
-  result to the issue as a comment, applies matching GitHub labels, and
-  returns a JSON summary. Use as a standalone triage entry point, or as
-  the shallow first stage of a larger fix pipeline.
+  Shallow, text-only triage of a GitHub issue on pytorch or torch-xpu-ops.
+  Classifies the issue and returns a report (markdown table + JSON) for
+  the caller to act on. Read-only; the skill itself does not comment on
+  or label the issue.
 ---
 
 # Issue Triage — Shallow Classification & Handling Decision
 
 Text-only triage. Reads the issue title, body, and labels. Does NOT read
-source code, does NOT run tests, does NOT open PRs. Produces three
-outputs:
+source code, does NOT run tests, does NOT open PRs, does NOT modify the
+issue in any way (no comments, no labels, no body edits).
 
-1. A markdown table posted as a comment on the issue.
-2. GitHub labels applied to the issue.
-3. A JSON summary returned to the caller.
+Produces a single **report** returned to the caller, containing:
+
+1. A markdown table with the classification fields.
+2. A JSON summary with the same fields as structured data.
+
+The caller (a bot job, an orchestrator skill, or a human) decides what to
+do with the report: post it as a comment, apply labels, feed it into a
+larger pipeline, or just read it.
 
 `Handling` (agent-fixable vs needs-human) is derived from the other
 signals — see "Step 5" below. Deep root-cause analysis and any override
@@ -35,33 +36,28 @@ this skill).
   gh issue view "$N" --repo "$OWNER/$REPO" --json title,body,labels
   ```
 
-- Read-only with respect to the repository: this skill never reads
-  source, runs tests, or edits files. Its only writes are the issue
-  comment and the labels in Step 6.
+- Read-only. This skill never writes to the repository — no comments,
+  no labels, no file edits. The only side effects are the `gh issue
+  view` read above and printing the report to stdout.
 
 ## Shell helpers
 
-Recipes below assume two helpers are in scope. Define them once at the
-top of your shell (or source a shared file):
+Recipes below assume one helper is in scope:
 
 ```bash
-abort()    { echo "ABORT: $*" >&2; exit 1; }
-log_warn() { echo "WARN: $*"  >&2; }
+abort() { echo "ABORT: $*" >&2; exit 1; }
 ```
 
 ## Preflight
 
-`gh` must be authenticated with `repo` or `write:issues` scope (this
-skill writes a comment and applies labels):
+`gh` must be authenticated with read access to the target repo:
 
 ```bash
 gh auth status 2>&1 | grep -q "Logged in to github.com" \
   || abort "gh not authenticated; run: gh auth login"
-
-scopes=$(gh auth status -t 2>&1 | grep -oE "'[a-z:_-]+'" | tr -d "'")
-echo "$scopes" | grep -qE '^(repo|write:issues)$' \
-  || abort "issue-triage requires 'repo' or 'write:issues' scope; got: $scopes"
 ```
+
+No write scope is required — this skill only reads.
 
 ## Step 1: Classify issue_type
 
@@ -156,116 +152,48 @@ Evaluate in order; first match wins:
 `scope=both` and `scope=unclear` do NOT force needs-human — a
 downstream deep-triage skill decides the final target repo.
 
-## Step 6: Output
+## Step 6: Return the report
 
-### 6a. Markdown table
+Emit both a markdown block and a JSON block to stdout, in that order,
+separated by a blank line. The caller reads one, both, or neither.
 
-Assemble this table (values from Steps 1–5). This is the primary
-human-readable output:
+### 6a. Markdown block
+
+Assemble this exact structure (values from Steps 1–5). This is what a
+caller would paste as a comment:
 
 ```markdown
+<!-- agent:triage -->
+
+## Issue Triage
+
 | Field | Value |
 |-------|-------|
 | Reproduction missing | yes / no |
 | Scope | pytorch / torch-xpu-ops / both / unclear |
 | Dependencies | comma-separated list, or (none) |
 | Handling | agent-fixable / needs-human |
+
+**Reason:** <one-line, only when handling=needs-human>
+
+*Automated by issue-triage.*
 ```
 
 Each `Value` cell above lists the allowed choices; emit exactly one of
 them. Never leave a literal `|` inside a cell — it splits the cell and
 breaks the rendered table.
 
-When `Handling == needs-human`, append a `**Reason:** <one-line>` line
-below the table.
+Include the `<!-- agent:triage -->` marker on the first line so a
+downstream caller can locate its own previous comment (if any) and
+update it in place. The marker is part of the report; the skill does
+not consume it.
 
-### 6b. Post / update the issue comment
+Omit the `**Reason:**` line entirely when `handling == agent-fixable`.
 
-Post the table as a GitHub comment on the issue, wrapped with a marker
-so re-runs can find and update it in place:
+### 6b. JSON block
 
-```
-<!-- agent:triage -->
-
-## Issue Triage
-
-<table from 6a>
-
-<optional reason line>
-
-*Automated by issue-triage.*
-```
-
-Look up the existing triage comment (if any) by the marker and edit
-it in place; otherwise post new. Concrete recipe:
-
-```bash
-OWNER=<owner> REPO=<repo> N=<issue_number>
-
-triage_body_file=$(mktemp)
-# Write the marker + heading + table + reason to $triage_body_file.
-
-# List existing triage comments, oldest first. Use the REST endpoint: it
-# returns numeric comment ids, which the PATCH/DELETE comment endpoints
-# require. `gh issue view --json comments` returns GraphQL node ids
-# instead, and those endpoints reject them.
-mapfile -t triage_ids < <(gh api "/repos/$OWNER/$REPO/issues/$N/comments" \
-    --paginate \
-    --jq '.[] | select(.body | startswith("<!-- agent:triage -->")) | .id')
-
-if [ "${#triage_ids[@]}" -eq 0 ]; then
-    gh issue comment "$N" --repo "$OWNER/$REPO" \
-        --body-file "$triage_body_file" \
-        || abort "gh issue comment failed"
-else
-    # `--field body="$(cat file)"` — do NOT use `-f body=@file`; gh
-    # does not expand @path for POST/PATCH fields the way curl does.
-    gh api "/repos/$OWNER/$REPO/issues/comments/${triage_ids[0]}" \
-        --method PATCH \
-        --field body="$(cat "$triage_body_file")" \
-        || abort "gh api PATCH failed"
-
-    # Best-effort dedup: delete the newer duplicates. Failure here is a
-    # warning, not a hard abort.
-    for dup_id in "${triage_ids[@]:1}"; do
-        gh api "/repos/$OWNER/$REPO/issues/comments/$dup_id" \
-            --method DELETE \
-            || log_warn "could not delete duplicate triage comment $dup_id"
-    done
-fi
-```
-
-### 6c. Apply GitHub labels
-
-Only apply "needs human attention"-class labels; scope and dependency
-values live in the JSON output, not as labels:
-
-- If `reproduction_missing == yes` → add `agent:reproduction-needed`.
-- If `Handling == needs-human` → add `agent:needs-human`.
-
-```bash
-if [ "$reproduction_missing" = "yes" ]; then
-    gh issue edit "$N" --repo "$OWNER/$REPO" \
-        --add-label "agent:reproduction-needed" \
-        || log_warn "add-label agent:reproduction-needed failed"
-fi
-
-if [ "$handling" = "needs-human" ]; then
-    gh issue edit "$N" --repo "$OWNER/$REPO" \
-        --add-label "agent:needs-human" \
-        || log_warn "add-label agent:needs-human failed"
-fi
-```
-
-`gh` returns non-zero if a label is already applied. That is a no-op,
-not a failure. `log_warn` here is intentional: label state on the
-issue is still correct even when the API call reports the label was
-already there.
-
-### 6d. Return JSON to the caller
-
-Return this JSON as the LAST thing in your response, no markdown fences,
-no explanation:
+Immediately after the markdown block (with one blank line between),
+emit:
 
 ```json
 {
@@ -274,7 +202,8 @@ no explanation:
   "scope": "pytorch | torch-xpu-ops | both | unclear",
   "runtime_dependencies": [],
   "handling": "agent-fixable | needs-human",
-  "reason": ""
+  "reason": "",
+  "suggested_labels": []
 }
 ```
 
@@ -286,22 +215,29 @@ Field notes:
   empty `[]` when none named.
 - `reason` is required non-empty when `handling == needs-human`, empty
   string when `handling == agent-fixable`.
+- `suggested_labels` lists the labels a caller might apply to the
+  issue. Advisory only — the skill does not apply them. Populate per
+  the rules below.
 - Do NOT invent values not derived from the issue text.
+
+### 6c. Suggested labels
+
+`suggested_labels` is populated as follows:
+
+- If `reproduction_missing == true` → include `agent:reproduction-needed`.
+- If `handling == "needs-human"` → include `agent:needs-human`.
+- Empty array when neither applies (i.e. agent-fixable with a
+  reproducer).
+
+Scope and dependency values live in the JSON structure, not as labels.
 
 ## HARD RULES
 
-- **Never modify the issue body.** The body is user-owned. All
-  agent-side state on the issue lives in comments (single
-  `<!-- agent:triage -->` comment) and labels.
+- **Never modify the issue.** No comments, no labels, no body edits.
+  The caller applies changes based on the report.
 - **Never read source or run tests.** This skill's contract is
   text-only shallow triage. Deep source-reading analysis belongs to a
   separate downstream skill.
-- **`gh api ... -f body=@file` is wrong** for editing comments. `gh`
-  does not expand `@path` for POST/PATCH fields the way curl does.
-  Use `--field body="$(cat file)"`.
-- **Comment ids must come from the REST list endpoint.** PATCH/DELETE
-  on `/repos/.../issues/comments/<id>` need the numeric id returned by
-  `gh api /repos/.../issues/<n>/comments`, not the GraphQL node id
-  returned by `gh issue view --json comments`.
-- **Labels are advisory** — repeated `add-label` calls for a label
-  already on the issue are no-ops, not failures.
+- **Emit exactly one markdown block and one JSON block to stdout,** in
+  that order. Nothing else. No prose intro, no closing summary. The
+  caller parses stdout; extra text corrupts the parse.

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -87,7 +87,7 @@ jobs:
 
             const command = match[1].toLowerCase();
             const args = (match[2] || '').trim();
-            const validCommands = ['merge', 'revert', 'rebase', 'lint', 'rerun', 'review', 'pr-review', 'ut-check', 'check-ut', 'ut', 'fix', 'help'];
+            const validCommands = ['merge', 'revert', 'rebase', 'lint', 'rerun', 'review', 'pr-review', 'ut-check', 'check-ut', 'ut', 'fix', 'triage', 'help'];
 
             if (!validCommands.includes(command)) {
               reject('Unknown command. Use `@torchxpubot help` to see available commands.');
@@ -99,14 +99,15 @@ jobs:
               : (command === 'check-ut' || command === 'ut') ? 'ut-check'
               : command;
 
-            // Context check: fix is issue-only, help works on both, the rest are PR-only
-            if (normalizedCommand === 'fix') {
+            // Context check: fix and triage are issue-only, help works on
+            // both, the rest are PR-only.
+            if (normalizedCommand === 'fix' || normalizedCommand === 'triage') {
               if (isPR) {
-                reject('`@torchxpubot fix` can only be used on issue comments, not on pull requests.');
+                reject(`\`@torchxpubot ${normalizedCommand}\` can only be used on issue comments, not on pull requests.`);
                 return;
               }
               if (context.payload.issue.state !== 'open') {
-                reject('`@torchxpubot fix` can only be used on open issues.');
+                reject(`\`@torchxpubot ${normalizedCommand}\` can only be used on open issues.`);
                 return;
               }
             } else if (normalizedCommand !== 'help' && !isPR) {
@@ -255,6 +256,7 @@ jobs:
             | Command | Description |
             |---------|-------------|
             | \`@torchxpubot fix\` | Reproduce this issue on an XPU host and attempt a fix (OWNER/MEMBER only) |
+            | \`@torchxpubot triage\` | Shallow text-only triage: classify, detect reproducer, apply agent labels |
             | \`@torchxpubot help\` | Show this help message |
 
             \`fix\` reproduces the issue on a runner that has a prebuilt nightly
@@ -1261,6 +1263,122 @@ jobs:
         if: ${{ always() }}
         run: |
           chown 1000:1000 /__w /github ./ -R
+
+  triage:
+    needs: parse-command
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: >-
+      needs.parse-command.outputs.command == 'triage'
+      && needs.parse-command.outputs.authorized == 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Run AI triage
+        id: ai-triage
+        uses: anthropics/claude-code-action@v1
+        with:
+          use_bedrock: "true"
+          github_token: ${{ secrets.MERGE_TOKEN }}
+          settings: '{"alwaysThinkingEnabled": true}'
+          claude_args: "--model ${{ env.BEDROCK_MODEL }} --max-turns 20 --allowedTools Bash,Read,Glob,Grep"
+          prompt: |
+            Use the /issue-triage skill to triage issue
+            #${{ needs.parse-command.outputs.issue_number }} in ${{ github.repository }}.
+            The skill posts its result as a `<!-- agent:triage -->` comment on
+            the issue and applies matching labels; do not post any additional
+            comment yourself.
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+
+      - name: "Verify: AI triage succeeded"
+        if: always()
+        uses: actions/github-script@v9
+        env:
+          AI_TRIAGE_OUTCOME: ${{ steps.ai-triage.outcome }}
+          BOT_ESCALATION_USERS: ${{ secrets.BOT_ESCALATION_USERS }}
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const outcome = process.env.AI_TRIAGE_OUTCOME || 'skipped';
+            const file = '${{ steps.ai-triage.outputs.execution_file }}';
+
+            let result = null;
+            if (file && fs.existsSync(file)) {
+              const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+              result = data.filter(e => e.type === 'result').pop();
+              console.log('Result:', JSON.stringify(result, null, 2));
+            }
+            if (outcome === 'success' && result && !result.is_error && result.total_cost_usd > 0) {
+              return;
+            }
+
+            // Distinguish "the agent never ran" from "the agent failed", so
+            // the comment does not blame Bedrock for a setup or cancellation.
+            let reason;
+            if (outcome === 'cancelled') {
+              reason = 'the run was cancelled.';
+            } else if (outcome === 'skipped') {
+              reason = 'the environment setup failed before the agent started -- checkout or claude-code-action itself.';
+            } else if (result && result.is_error) {
+              reason = 'the agent returned an error. This is usually a Bedrock or model failure; check AWS token validity.';
+            } else if (!result) {
+              reason = 'the agent produced no output. This is usually a Bedrock connectivity or credential failure; check AWS token validity.';
+            } else {
+              reason = 'the agent exited without a usable result.';
+            }
+
+            const jobs = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner, repo: context.repo.repo, run_id: context.runId
+            });
+            const job = jobs.data.jobs.find(j => j.name === 'triage');
+            const jobUrl = job?.html_url || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.parse-command.outputs.issue_number }},
+              body: `${process.env.BOT_ESCALATION_USERS} \`@torchxpubot triage\` failed: ${reason}\n\nSee the [\`triage\` job](${jobUrl}) for details.`
+            });
+            if (outcome !== 'cancelled') {
+              core.setFailed(`AI triage failed: ${reason}`);
+            }
+
+      - name: Report usage cost
+        if: always()
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const file = '${{ steps.ai-triage.outputs.execution_file }}';
+            if (!file || !fs.existsSync(file)) return;
+            const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+            const result = data.filter(e => e.type === 'result').pop();
+            if (!result) return;
+
+            const jobs = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner, repo: context.repo.repo,
+              run_id: context.runId
+            });
+            const job = jobs.data.jobs.find(j => j.name === 'triage');
+            const jobUrl = job?.html_url || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const date = new Date().toISOString().split('T')[0];
+            const cost = (result.total_cost_usd || 0).toFixed(4);
+            const usage = Object.values(result.modelUsage || {})[0] || {};
+            const inTok = ((usage.inputTokens || 0) + (usage.cacheReadInputTokens || 0) + (usage.cacheCreationInputTokens || 0)).toLocaleString();
+            const outTok = (usage.outputTokens || 0).toLocaleString();
+            const status = result.is_error ? 'error' : 'ok';
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: ${{ env.COST_TRACKING_ISSUE }},
+              body: `\`${date}\` [\`triage\`](${jobUrl}) on #${{ needs.parse-command.outputs.issue_number }} — **$${cost}** (${inTok} in / ${outTok} out) [${status}]`
+            });
 
   token-permission-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1286,12 +1286,107 @@ jobs:
           prompt: |
             Use the /issue-triage skill to triage issue
             #${{ needs.parse-command.outputs.issue_number }} in ${{ github.repository }}.
-            The skill posts its result as a `<!-- agent:triage -->` comment on
-            the issue and applies matching labels; do not post any additional
-            comment yourself.
+            The skill returns a report (a markdown block plus a JSON
+            block) to stdout. Do NOT post any comment yourself, do NOT
+            apply labels, do NOT modify the issue in any way — the
+            workflow that invoked you will consume your stdout and
+            handle those side effects.
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+
+      - name: Post triage report
+        if: steps.ai-triage.outcome == 'success'
+        uses: actions/github-script@v9
+        env:
+          ISSUE_NUMBER: ${{ needs.parse-command.outputs.issue_number }}
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const file = '${{ steps.ai-triage.outputs.execution_file }}';
+            if (!file || !fs.existsSync(file)) return;
+            const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+            const resultEvent = data.filter(e => e.type === 'result').pop();
+            if (!resultEvent || resultEvent.is_error || !resultEvent.result) {
+              core.setFailed('AI triage produced no usable result');
+              return;
+            }
+            const output = resultEvent.result;
+
+            // The skill emits a markdown block, a blank line, then a
+            // JSON block fenced by ```json ... ```. Extract each.
+            const jsonMatch = output.match(/```json\s*\n([\s\S]*?)\n```/);
+            if (!jsonMatch) {
+              core.setFailed('AI triage output did not include a JSON block');
+              return;
+            }
+            let summary;
+            try {
+              summary = JSON.parse(jsonMatch[1]);
+            } catch (e) {
+              core.setFailed(`AI triage JSON parse failed: ${e.message}`);
+              return;
+            }
+
+            // Markdown block is everything up to the ```json fence,
+            // trimmed of trailing whitespace and any stray fence.
+            const markdown = output.slice(0, jsonMatch.index)
+              .replace(/```(markdown)?\s*\n?/g, '')
+              .replace(/\n```\s*$/g, '')
+              .trim();
+            if (!markdown.startsWith('<!-- agent:triage -->')) {
+              core.setFailed('AI triage markdown did not start with the <!-- agent:triage --> marker');
+              return;
+            }
+
+            const N = Number(process.env.ISSUE_NUMBER);
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Locate the previous triage comment via the REST list
+            // endpoint — its ids are numeric and accepted by the
+            // PATCH/DELETE endpoints below.
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: N, per_page: 100 }
+            );
+            const triageIds = comments
+              .filter(c => c.body && c.body.startsWith('<!-- agent:triage -->'))
+              .map(c => c.id);
+
+            if (triageIds.length === 0) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: N, body: markdown
+              });
+            } else {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: triageIds[0], body: markdown
+              });
+              // Best-effort dedup of any older duplicates.
+              for (const dup of triageIds.slice(1)) {
+                try {
+                  await github.rest.issues.deleteComment({
+                    owner, repo, comment_id: dup
+                  });
+                } catch (e) {
+                  console.log(`Could not delete duplicate ${dup}: ${e.message}`);
+                }
+              }
+            }
+
+            // Apply suggested labels. Repeated add-label calls for an
+            // already-applied label are no-ops.
+            const labels = Array.isArray(summary.suggested_labels) ? summary.suggested_labels : [];
+            if (labels.length > 0) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: N, labels
+                });
+              } catch (e) {
+                console.log(`addLabels warning: ${e.message}`);
+              }
+            }
 
       - name: "Verify: AI triage succeeded"
         if: always()


### PR DESCRIPTION
### Summary

Adds a standalone `issue-triage` skill that classifies a issue based only on its title, body, and labels — no source reading, no test runs. Emits a markdown table as a comment on the issue, applies matching labels, and returns a JSON summary to the caller.

Also wires a `@torchxpubot triage` command in `bot.yml` so the skill can be invoked directly from an issue comment, in the same style as `@torchxpubot review` / `@torchxpubot ut-check`.

This is the first in a planned series of small, focused PRs that split what #4918 tried to do all at once. Each follow-up PR adds one skill or one closely-related set. This PR **only** adds `issue-triage` (and its bot entry point); downstream pieces (reproduce / root-cause / implement / verify / orchestrator) will come in separate PRs.

### What the skill produces

For every issue, three artifacts:

**1. Markdown comment on the issue** (marked `<!-- agent:triage -->`):

```markdown
## Issue Triage

| Field                | Value                                      |
|----------------------|--------------------------------------------|
| Reproduction missing | yes / no                                   |
| Scope                | pytorch / torch-xpu-ops / both / unclear   |
| Dependencies         | triton, onednn / (none)                    |
| Handling             | agent-fixable / needs-human                |

**Reason:** <one-line, only when handling=needs-human>
```

Re-running on the same issue **updates the comment in place** (find by marker, `gh api PATCH` the body).

**2. GitHub labels:**

- `agent:reproduction-needed` when `reproduction_missing = yes`
- `agent:needs-human` when `handling = needs-human`

Scope and dependency values are metadata (JSON only), not labels.

**3. JSON returned to the caller:**

```json
{
  "issue_type": "bug | skip-list | nonbug",
  "reproduction_missing": true | false,
  "scope": "pytorch | torch-xpu-ops | both | unclear",
  "runtime_dependencies": ["triton", "onednn", "onemkl", "driver", "sycl", "xccl"],
  "handling": "agent-fixable | needs-human",
  "reason": "<one-line reason when needs-human, else empty>"
}
```

### The Handling decision

Derived from the other signals, first match wins:

```
if issue_type in ("nonbug", "umbrella task"):
    handling = needs-human   # not a fixable bug
elif reproduction_missing == yes:
    handling = needs-human   # agent has nothing to run
elif len(runtime_dependencies) > 0:
    handling = needs-human   # any external dep requires human triage
elif hardware-only or non-public dependency:
    handling = needs-human   # agent has no access
else:
    handling = agent-fixable
```

`scope=both` and `scope=unclear` do NOT force needs-human — a downstream deep-triage skill (future PR) decides the final target repo after reading source.

### Runtime dependency enumeration

Closed set of values the skill will emit:

| Value | What it means |
|---|---|
| `triton` | Inductor / torch.compile GPU codegen backend |
| `onednn` | Intel oneDNN library (matmul, conv, etc.) |
| `onemkl` | Intel oneMKL library (BLAS, LAPACK, sparse) |
| `driver` | GPU driver, level-zero, compute-runtime, `libze_intel_gpu.so` |
| `sycl` | SYCL runtime / DPC++ compiler |
| `xccl` | XCCL communication library |

Only reported when **explicitly named** in the issue. A stack-trace path through `torch._inductor` alone does not imply `triton` — the issue must say so or show a triton-side error.

### Bot integration (`@torchxpubot triage`)

Adds `triage` as an **issue-only** command wired to this skill.

Usage:

```
User comments on any open issue:  @torchxpubot triage
  → Bot job runs, checks out the repo, loads /issue-triage.
  → Skill fetches the issue, produces the table + labels + JSON.
  → Skill posts a single <!-- agent:triage --> comment on the issue.
  → Repeated invocations update the same comment in place.
```

Parser (`parse-command` job) changes:

- `triage` added to `validCommands`.
- Issue-only rejection: `@torchxpubot triage` on a PR or on a closed issue lands on the existing `invalid-command` path.
- New `issue_number` output — always the issue number (both `issue` and `pull_request` payloads carry it under `issue.number`). Existing `pr_number` semantics are unchanged.

New `triage` job:

- Runs on `ubuntu-latest`, 15-minute timeout.
- Modeled directly on the existing `review` job: same `actions/checkout@v7`, same `claude-code-action@v1` invocation, same verify tail, same cost-reporting to `COST_TRACKING_ISSUE`.
- Differences from `review`: prompts `/issue-triage` instead of `/pr-review`, targets `issue_number` instead of `pr_number`, uses a smaller turn budget (20 vs 60), and does **not** post a separate result comment — `issue-triage` writes its own `<!-- agent:triage -->` comment.

Help table is not updated in this PR — the current help output on `main` is a single PR-only table, and correctly documenting an issue-only command requires the issue/PR help split proposed in #4979. Leaving that to follow up so this diff stays minimal.

### Positioning vs existing skills

| Skill | Depth | Reads source | Overlaps with this PR? |
|---|---|---|---|
| **`issue-triage`** (this PR) | shallow, text-only | no | — |
| `xpu-issues-triaging` (existing) | deep | yes | different depth; no overlap |
| Future `fix/root-cause` (later PR) | deep | yes | different depth; no overlap |

`issue-triage` is the **entry gate** — it decides whether an issue is worth further work. Deep root-cause analysis (existing `xpu-issues-triaging` or a future `fix/root-cause`) runs only after this skill returns `handling = agent-fixable`.

### Repository label

Created the new label in the repo so `add-label` has a real target:

```
agent:reproduction-needed  (F9D0C4)
  Issue needs a reproducer or minimal repro script before agent can proceed
```

The other label the skill uses (`agent:needs-human`) already exists.

### Testing

Docs and workflow YAML only; no build or test surface.

- `lintrunner` clean on both files.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/bot.yml'))"` passes.
- Live bot verification (`@torchxpubot triage` on an open issue) requires the workflow to land on main first, since the bot always runs from the default branch.

### Related

- Supersedes #4918 (closed). The full refactor is being resplit into focused per-skill PRs so each piece can be reviewed independently. Branch `skills_refactor/zzq` is preserved on origin as reference for the follow-up PRs that will build on this one.
- Supersedes #4975 (closed). The flat, hyphen-only `name:` this PR uses (`issue-triage`, single component, no slash) fits within the existing `skill-writer` spec unchanged.
- Rebases cleanly on top of #4979 (`bot fix` command) once one of the two lands — both add new jobs to `bot.yml` in different regions of the file and both add small parallel changes to the `parse-command` output surface (`issue_number` output). The one that merges second only needs to reconcile the two new job blocks and the two new items in `validCommands`.

This PR was authored with AI assistance.