### PR TITLE
Deal nan case for topk

### DIFF
--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernelImpl.h
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernelImpl.h
@@ -60,10 +60,34 @@ template <
     bool Largest,
     typename IndexT = int>
 struct SubgroupTopKFunctor {
-  // Insert val into a K-sorted buffer. For Largest=true the buffer is sorted
-  // descending (top_vals[0] is max); for Largest=false it is sorted ascending
-  // (top_vals[0] is min).
-  //
+  // Returns true if a is "better" than b — i.e. a should rank higher.
+  // NaN is treated as better than any non-NaN (matching CPU/CUDA behavior).
+  // A sentinel (idx == -1) is always worse than a real entry.
+  static inline bool better(
+      scalar_t a,
+      IndexT a_idx,
+      scalar_t b,
+      IndexT b_idx) {
+    // Sentinel is always worse
+    if (a_idx == -1)
+      return false;
+    if (b_idx == -1)
+      return true;
+    // NaN beats non-NaN
+    bool a_nan = at::_isnan(a);
+    bool b_nan = at::_isnan(b);
+    if (a_nan != b_nan)
+      return a_nan;
+    if (a_nan)
+      return a_idx < b_idx; // both NaN: smaller index ranks higher
+    if constexpr (Largest) {
+      return a > b;
+    } else {
+      return a < b;
+    }
+  }
+
+  // Insert val into a K-sorted buffer.
   // Fully unrolled, no early break — SIMD-friendly.
   inline void insert(
       scalar_t* top_vals,
@@ -71,32 +95,13 @@ struct SubgroupTopKFunctor {
       int count,
       scalar_t val,
       IndexT idx) const {
-    // Threshold is at the bottom of the buffer (top_vals[K-1]).
-    if constexpr (Largest) {
-      if (count >= K && !(val > top_vals[K - 1]) && top_idx[K - 1] != -1)
-        return;
-    } else {
-      if (count >= K && !(val < top_vals[K - 1]) && top_idx[K - 1] != -1)
-        return;
-    }
+    if (count >= K && !better(val, idx, top_vals[K - 1], top_idx[K - 1]))
+      return;
     bool inserted = false;
 #pragma unroll
     for (int i = K - 1; i >= 0; --i) {
-      // When count < K the buffer is partially filled: positions [0, count)
-      // hold real values while [count, K) still contain sentinels.
-      // Guard "i <= count" ensures we only stop at position i when
-      // top_vals[i-1] is a real entry.  Without this guard, an input
-      // value equal to the sentinel (e.g. all -inf for largest=true)
-      // would always stop at position K-1, overwriting it repeatedly
-      // instead of filling lower positions.
-      bool stop;
-      if constexpr (Largest) {
-        stop = (i == 0) ||
-            (i <= count && !(val > top_vals[i - 1]) && top_idx[i - 1] != -1);
-      } else {
-        stop = (i == 0) ||
-            (i <= count && !(val < top_vals[i - 1]) && top_idx[i - 1] != -1);
-      }
+      bool stop = (i == 0) ||
+          (i <= count && !better(val, idx, top_vals[i - 1], top_idx[i - 1]));
       if (!inserted && stop) {
         top_vals[i] = val;
         top_idx[i] = idx;
@@ -109,8 +114,6 @@ struct SubgroupTopKFunctor {
   }
 
   // Bitonic merge: A[K] and B[K] are both sorted in the same direction.
-  // Step 1: A[i] = max/min(A[i], B[K-1-i]) — produces bitonic sequence.
-  // Step 2: bitonic sort restores sorted order on A.
   // When A[i] holds a sentinel (A_idx[i]==-1), any real entry replaces it.
   inline void bitonic_merge(
       scalar_t* A,
@@ -122,13 +125,7 @@ struct SubgroupTopKFunctor {
     for (int i = 0; i < K; ++i) {
       scalar_t bv = B[K - 1 - i];
       IndexT bi = B_idx[K - 1 - i];
-      bool take;
-      if constexpr (Largest) {
-        take = bv > A[i] || A_idx[i] == -1;
-      } else {
-        take = bv < A[i] || A_idx[i] == -1;
-      }
-      if (take && bi != -1) {
+      if (better(bv, bi, A[i], A_idx[i])) {
         A[i] = bv;
         A_idx[i] = bi;
       }
@@ -159,12 +156,7 @@ struct SubgroupTopKFunctor {
 #pragma unroll
       for (int i = 0; i < K; ++i) {
         int j = i ^ stride;
-        bool swap;
-        if constexpr (Largest) {
-          swap = (j > i) && (A[j] > A[i] || A_idx[i] == -1) && A_idx[j] != -1;
-        } else {
-          swap = (j > i) && (A[j] < A[i] || A_idx[i] == -1) && A_idx[j] != -1;
-        }
+        bool swap = (j > i) && better(A[j], A_idx[j], A[i], A_idx[i]);
         if (swap) {
           scalar_t tv = A[i];
           A[i] = A[j];

--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernelImpl.h
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernelImpl.h
@@ -65,8 +65,10 @@ struct SubgroupTopKFunctor {
   inline bool better(scalar_t a, scalar_t b) const {
     bool a_nan = at::_isnan(a);
     bool b_nan = at::_isnan(b);
-    if (a_nan != b_nan) return a_nan;
-    if (a_nan) return false; // both NaN
+    if (a_nan != b_nan)
+      return a_nan;
+    if (a_nan)
+      return false; // both NaN
     if constexpr (Largest) {
       return a > b;
     } else {
@@ -79,8 +81,10 @@ struct SubgroupTopKFunctor {
   inline bool better(scalar_t a, IndexT a_idx, scalar_t b, IndexT b_idx) const {
     bool a_nan = at::_isnan(a);
     bool b_nan = at::_isnan(b);
-    if (a_nan != b_nan) return a_nan;
-    if (a_nan) return a_idx > b_idx;
+    if (a_nan != b_nan)
+      return a_nan;
+    if (a_nan)
+      return a_idx > b_idx;
     if constexpr (Largest) {
       return a > b || (a == b && a_idx > b_idx);
     } else {

--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernelImpl.h
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernelImpl.h
@@ -60,43 +60,9 @@ template <
     bool Largest,
     typename IndexT = int>
 struct SubgroupTopKFunctor {
-  // NaN-propagating "better" comparison: NaN is treated as better than
-  // any non-NaN value
-  inline bool better(scalar_t a, scalar_t b) const {
-    bool a_nan = at::_isnan(a);
-    bool b_nan = at::_isnan(b);
-    if (a_nan != b_nan)
-      return a_nan;
-    if (a_nan)
-      return false; // both NaN
-    if constexpr (Largest) {
-      return a > b;
-    } else {
-      return a < b;
-    }
-  }
-
-  // Tie-breaking variant: when values are equal, prefer larger index
-  // (real entries with idx>=0 beat sentinels with idx=-1).
-  inline bool better(scalar_t a, IndexT a_idx, scalar_t b, IndexT b_idx) const {
-    bool a_nan = at::_isnan(a);
-    bool b_nan = at::_isnan(b);
-    if (a_nan != b_nan)
-      return a_nan;
-    if (a_nan)
-      return a_idx > b_idx;
-    if constexpr (Largest) {
-      return a > b || (a == b && a_idx > b_idx);
-    } else {
-      return a < b || (a == b && a_idx > b_idx);
-    }
-  }
-
   // Insert val into a K-sorted buffer. For Largest=true the buffer is sorted
   // descending (top_vals[0] is max); for Largest=false it is sorted ascending
-  // (top_vals[0] is min). The comparator `better(a, b)` means "a should sit
-  // above b in the buffer" — i.e. strictly greater for largest, strictly less
-  // for smallest.
+  // (top_vals[0] is min).
   //
   // Fully unrolled, no early break — SIMD-friendly.
   inline void insert(
@@ -105,8 +71,14 @@ struct SubgroupTopKFunctor {
       int count,
       scalar_t val,
       IndexT idx) const {
-    if (count >= K && !better(val, top_vals[K - 1]))
-      return;
+    // Threshold is at the bottom of the buffer (top_vals[K-1]).
+    if constexpr (Largest) {
+      if (count >= K && !(val > top_vals[K - 1]) && top_idx[K - 1] != -1)
+        return;
+    } else {
+      if (count >= K && !(val < top_vals[K - 1]) && top_idx[K - 1] != -1)
+        return;
+    }
     bool inserted = false;
 #pragma unroll
     for (int i = K - 1; i >= 0; --i) {
@@ -117,7 +89,12 @@ struct SubgroupTopKFunctor {
       // value equal to the sentinel (e.g. all -inf for largest=true)
       // would always stop at position K-1, overwriting it repeatedly
       // instead of filling lower positions.
-      bool stop = (i == 0) || (i <= count && !better(val, top_vals[i - 1]));
+      bool stop;
+      if constexpr (Largest) {
+        stop = (i == 0) || (i <= count && !(val > top_vals[i - 1]) && top_idx[i - 1] != -1);
+      } else {
+        stop = (i == 0) || (i <= count && !(val < top_vals[i - 1]) && top_idx[i - 1] != -1);
+      }
       if (!inserted && stop) {
         top_vals[i] = val;
         top_idx[i] = idx;
@@ -129,9 +106,10 @@ struct SubgroupTopKFunctor {
     }
   }
 
-  // Bitonic merge: A[K] and B[K] are both sorted in the "better" direction.
-  // Step 1: A[i] = better(A[i], B[K-1-i]) — produces bitonic sequence.
-  // Step 2: bitonic sort restores the sorted-by-better order on A.
+  // Bitonic merge: A[K] and B[K] are both sorted in the same direction.
+  // Step 1: A[i] = max/min(A[i], B[K-1-i]) — produces bitonic sequence.
+  // Step 2: bitonic sort restores sorted order on A.
+  // When A[i] holds a sentinel (A_idx[i]==-1), any real entry replaces it.
   inline void bitonic_merge(
       scalar_t* A,
       IndexT* A_idx,
@@ -142,7 +120,13 @@ struct SubgroupTopKFunctor {
     for (int i = 0; i < K; ++i) {
       scalar_t bv = B[K - 1 - i];
       IndexT bi = B_idx[K - 1 - i];
-      if (better(bv, bi, A[i], A_idx[i])) {
+      bool take;
+      if constexpr (Largest) {
+        take = bv > A[i] || A_idx[i] == -1;
+      } else {
+        take = bv < A[i] || A_idx[i] == -1;
+      }
+      if (take && bi != -1) {
         A[i] = bv;
         A_idx[i] = bi;
       }
@@ -173,8 +157,12 @@ struct SubgroupTopKFunctor {
 #pragma unroll
       for (int i = 0; i < K; ++i) {
         int j = i ^ stride;
-        // Swap if j is the higher-index partner and A[j] is better than A[i]
-        bool swap = (j > i) && better(A[j], A_idx[j], A[i], A_idx[i]);
+        bool swap;
+        if constexpr (Largest) {
+          swap = (j > i) && (A[j] > A[i] || A_idx[i] == -1) && A_idx[j] != -1;
+        } else {
+          swap = (j > i) && (A[j] < A[i] || A_idx[i] == -1) && A_idx[j] != -1;
+        }
         if (swap) {
           scalar_t tv = A[i];
           A[i] = A[j];

--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernelImpl.h
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernelImpl.h
@@ -20,6 +20,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
+#include <ATen/NumericUtils.h>
 #include <ATen/ceil_div.h>
 #include <ATen/native/xpu/sycl/MemoryAccessUtils.h>
 #include <ATen/native/xpu/sycl/TensorTopKSbtopkKernel.h>
@@ -59,6 +60,34 @@ template <
     bool Largest,
     typename IndexT = int>
 struct SubgroupTopKFunctor {
+  // NaN-propagating "better" comparison: NaN is treated as better than
+  // any non-NaN value
+  inline bool better(scalar_t a, scalar_t b) const {
+    bool a_nan = at::_isnan(a);
+    bool b_nan = at::_isnan(b);
+    if (a_nan != b_nan) return a_nan;
+    if (a_nan) return false; // both NaN
+    if constexpr (Largest) {
+      return a > b;
+    } else {
+      return a < b;
+    }
+  }
+
+  // Tie-breaking variant: when values are equal, prefer larger index
+  // (real entries with idx>=0 beat sentinels with idx=-1).
+  inline bool better(scalar_t a, IndexT a_idx, scalar_t b, IndexT b_idx) const {
+    bool a_nan = at::_isnan(a);
+    bool b_nan = at::_isnan(b);
+    if (a_nan != b_nan) return a_nan;
+    if (a_nan) return a_idx > b_idx;
+    if constexpr (Largest) {
+      return a > b || (a == b && a_idx > b_idx);
+    } else {
+      return a < b || (a == b && a_idx > b_idx);
+    }
+  }
+
   // Insert val into a K-sorted buffer. For Largest=true the buffer is sorted
   // descending (top_vals[0] is max); for Largest=false it is sorted ascending
   // (top_vals[0] is min). The comparator `better(a, b)` means "a should sit
@@ -72,14 +101,8 @@ struct SubgroupTopKFunctor {
       int count,
       scalar_t val,
       IndexT idx) const {
-    // Threshold is at the bottom of the buffer (top_vals[K-1]).
-    if constexpr (Largest) {
-      if (count >= K && !(val > top_vals[K - 1]))
-        return;
-    } else {
-      if (count >= K && !(val < top_vals[K - 1]))
-        return;
-    }
+    if (count >= K && !better(val, top_vals[K - 1]))
+      return;
     bool inserted = false;
 #pragma unroll
     for (int i = K - 1; i >= 0; --i) {
@@ -90,12 +113,7 @@ struct SubgroupTopKFunctor {
       // value equal to the sentinel (e.g. all -inf for largest=true)
       // would always stop at position K-1, overwriting it repeatedly
       // instead of filling lower positions.
-      bool stop;
-      if constexpr (Largest) {
-        stop = (i == 0) || (i <= count && !(val > top_vals[i - 1]));
-      } else {
-        stop = (i == 0) || (i <= count && !(val < top_vals[i - 1]));
-      }
+      bool stop = (i == 0) || (i <= count && !better(val, top_vals[i - 1]));
       if (!inserted && stop) {
         top_vals[i] = val;
         top_idx[i] = idx;
@@ -120,13 +138,7 @@ struct SubgroupTopKFunctor {
     for (int i = 0; i < K; ++i) {
       scalar_t bv = B[K - 1 - i];
       IndexT bi = B_idx[K - 1 - i];
-      bool take;
-      if constexpr (Largest) {
-        take = bv > A[i];
-      } else {
-        take = bv < A[i];
-      }
-      if (take) {
+      if (better(bv, bi, A[i], A_idx[i])) {
         A[i] = bv;
         A_idx[i] = bi;
       }
@@ -157,12 +169,8 @@ struct SubgroupTopKFunctor {
 #pragma unroll
       for (int i = 0; i < K; ++i) {
         int j = i ^ stride;
-        bool swap;
-        if constexpr (Largest) {
-          swap = (j > i) && (A[i] < A[j]);
-        } else {
-          swap = (j > i) && (A[i] > A[j]);
-        }
+        // Swap if j is the higher-index partner and A[j] is better than A[i]
+        bool swap = (j > i) && better(A[j], A_idx[j], A[i], A_idx[i]);
         if (swap) {
           scalar_t tv = A[i];
           A[i] = A[j];

--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernelImpl.h
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernelImpl.h
@@ -91,9 +91,11 @@ struct SubgroupTopKFunctor {
       // instead of filling lower positions.
       bool stop;
       if constexpr (Largest) {
-        stop = (i == 0) || (i <= count && !(val > top_vals[i - 1]) && top_idx[i - 1] != -1);
+        stop = (i == 0) ||
+            (i <= count && !(val > top_vals[i - 1]) && top_idx[i - 1] != -1);
       } else {
-        stop = (i == 0) || (i <= count && !(val < top_vals[i - 1]) && top_idx[i - 1] != -1);
+        stop = (i == 0) ||
+            (i <= count && !(val < top_vals[i - 1]) && top_idx[i - 1] != -1);
       }
       if (!inserted && stop) {
         top_vals[i] = val;

--- a/test/regressions/test_sort.py
+++ b/test/regressions/test_sort.py
@@ -54,3 +54,74 @@ class TestNNMethod(TestCase):
         self.assertTrue((values == 0.0).all())
         # Indices must be valid positions within the input dimension.
         self.assertTrue((indices >= 0).all() and (indices < n).all())
+
+    def test_topk_nan_input(self):
+        num_cols = 128
+        k = 6
+        for dtype in (torch.float32, torch.bfloat16):
+            for num_rows in (16, 1024, 4096, 8192):
+                x = torch.randn(num_rows, num_cols, device="cpu", dtype=dtype)
+                n_nan = max(1, num_rows // 16)
+                x[-n_nan:, :] = float("nan")
+                cpu_vals, cpu_ids = torch.topk(x, k=k, dim=-1, sorted=True)
+                xpu_vals, xpu_ids = torch.topk(x.xpu(), k=k, dim=-1, sorted=True)
+                torch.xpu.synchronize()
+                self.assertEqual(cpu_vals.isnan(), xpu_vals.cpu().isnan())
+                self.assertEqual(cpu_vals.nan_to_num(), xpu_vals.cpu().nan_to_num())
+                self.assertTrue(
+                    (xpu_ids >= 0).all() and (xpu_ids < num_cols).all(),
+                    f"Out-of-range indices for dtype={dtype}, N={num_rows}",
+                )
+
+    def test_topk_neginf_input(self):
+        num_cols = 128
+        k = 6
+        for dtype in (torch.float32, torch.bfloat16):
+            x = torch.full((2048, num_cols), float("-inf"), device="cpu", dtype=dtype)
+            cpu_vals, cpu_ids = torch.topk(x, k=k, dim=-1, sorted=True)
+            xpu_vals, xpu_ids = torch.topk(x.xpu(), k=k, dim=-1, sorted=True)
+            torch.xpu.synchronize()
+            self.assertEqual(cpu_vals, xpu_vals.cpu())
+            self.assertTrue(
+                (xpu_ids >= 0).all() and (xpu_ids < num_cols).all(),
+                f"Out-of-range indices for all -inf input, dtype={dtype}",
+            )
+            # indices must be unique per row
+            for r in range(x.shape[0]):
+                ids_list = xpu_ids[r].cpu().tolist()
+                self.assertEqual(
+                    len(set(ids_list)), k,
+                    f"Duplicate indices in row {r} for dtype={dtype}: {ids_list}",
+                )
+
+    def test_topk_equal_values(self):
+        num_cols = 128
+        for k in (1, 6, 8):
+            for dtype in (torch.float32, torch.bfloat16):
+                x = torch.ones(2048, num_cols, device="cpu", dtype=dtype)
+                cpu_vals, _ = torch.topk(x, k=k, dim=-1, sorted=True)
+                xpu_vals, xpu_ids = torch.topk(x.xpu(), k=k, dim=-1, sorted=True)
+                torch.xpu.synchronize()
+                self.assertEqual(cpu_vals, xpu_vals.cpu())
+                self.assertTrue(
+                    (xpu_ids >= 0).all() and (xpu_ids < num_cols).all(),
+                    f"Out-of-range indices for k={k}, dtype={dtype}",
+                )
+                for r in range(x.shape[0]):
+                    ids_list = xpu_ids[r].cpu().tolist()
+                    self.assertEqual(
+                        len(set(ids_list)), k,
+                        f"Duplicate indices in row {r} for k={k}, dtype={dtype}: {ids_list}",
+                    )
+
+    def test_topk_random_values(self):
+        num_cols = 128
+        for k in (1, 6, 8):
+            for largest in (True, False):
+                torch.manual_seed(0)
+                x = torch.randn(2048, num_cols, dtype=torch.float32)
+                cpu_vals, cpu_ids = torch.topk(x, k=k, dim=-1, sorted=True, largest=largest)
+                xpu_vals, xpu_ids = torch.topk(x.xpu(), k=k, dim=-1, sorted=True, largest=largest)
+                torch.xpu.synchronize()
+                self.assertEqual(cpu_vals, xpu_vals.cpu())
+                self.assertEqual(cpu_ids, xpu_ids.cpu())

--- a/test/regressions/test_sort.py
+++ b/test/regressions/test_sort.py
@@ -58,36 +58,29 @@ class TestNNMethod(TestCase):
     def test_topk_nan_input(self):
         num_cols = 128
         k = 6
-        n_nan_cols = 10
+        n_nan_cols = 3
         for dtype in (torch.float32, torch.bfloat16):
             for num_rows in (1024, 4096, 8192):
                 torch.manual_seed(0)
                 x = torch.randn(num_rows, num_cols, device="cpu", dtype=dtype)
                 x[:, -n_nan_cols:] = float("nan")
-                cpu_vals, cpu_ids = torch.topk(x, k=k, dim=-1, sorted=True)
+                cpu_vals, _ = torch.topk(x, k=k, dim=-1, sorted=True)
                 xpu_vals, xpu_ids = torch.topk(x.xpu(), k=k, dim=-1, sorted=True)
                 torch.xpu.synchronize()
-                self.assertTrue(
-                    (xpu_ids >= 0).all() and (xpu_ids < num_cols).all(),
-                    f"Out-of-range indices for dtype={dtype}, N={num_rows}",
-                )
+                # Values must match CPU
                 self.assertEqual(cpu_vals.isnan(), xpu_vals.cpu().isnan())
                 self.assertEqual(cpu_vals.nan_to_num(), xpu_vals.cpu().nan_to_num())
-                # Non-NaN positions: indices must match CPU exactly
-                non_nan_mask = ~cpu_vals.isnan()
-                self.assertEqual(cpu_ids[non_nan_mask], xpu_ids.cpu()[non_nan_mask])
-                # NaN positions: indices must be valid, unique per row, and
-                # point to NaN values
-                nan_mask = cpu_vals.isnan()
-                nan_ids = xpu_ids[nan_mask.xpu()]
-                self.assertTrue((nan_ids >= 0).all() and (nan_ids < num_cols).all())
+                # Indices: valid, unique, and point to correct values
+                gathered = x.xpu().gather(1, xpu_ids)
+                nan_mask = xpu_vals.isnan()
+                self.assertTrue(gathered[nan_mask].isnan().all())
+                self.assertEqual(
+                    gathered[~nan_mask],
+                    xpu_vals[~nan_mask],
+                )
                 for r in range(num_rows):
                     row_ids = xpu_ids[r].cpu().tolist()
-                    self.assertEqual(
-                        len(set(row_ids)),
-                        k,
-                        f"Duplicate indices for dtype={dtype}, N={num_rows}, row={r}",
-                    )
+                    self.assertEqual(len(set(row_ids)), k)
 
     def test_topk_neginf_input(self):
         num_cols = 128

--- a/test/regressions/test_sort.py
+++ b/test/regressions/test_sort.py
@@ -58,20 +58,35 @@ class TestNNMethod(TestCase):
     def test_topk_nan_input(self):
         num_cols = 128
         k = 6
+        n_nan_cols = 10
         for dtype in (torch.float32, torch.bfloat16):
-            for num_rows in (16, 1024, 4096, 8192):
+            for num_rows in (1024, 4096, 8192):
+                torch.manual_seed(0)
                 x = torch.randn(num_rows, num_cols, device="cpu", dtype=dtype)
-                n_nan = max(1, num_rows // 16)
-                x[-n_nan:, :] = float("nan")
+                x[:, -n_nan_cols:] = float("nan")
                 cpu_vals, cpu_ids = torch.topk(x, k=k, dim=-1, sorted=True)
                 xpu_vals, xpu_ids = torch.topk(x.xpu(), k=k, dim=-1, sorted=True)
                 torch.xpu.synchronize()
-                self.assertEqual(cpu_vals.isnan(), xpu_vals.cpu().isnan())
-                self.assertEqual(cpu_vals.nan_to_num(), xpu_vals.cpu().nan_to_num())
                 self.assertTrue(
                     (xpu_ids >= 0).all() and (xpu_ids < num_cols).all(),
                     f"Out-of-range indices for dtype={dtype}, N={num_rows}",
                 )
+                self.assertEqual(cpu_vals.isnan(), xpu_vals.cpu().isnan())
+                self.assertEqual(cpu_vals.nan_to_num(), xpu_vals.cpu().nan_to_num())
+                # Non-NaN positions: indices must match CPU exactly
+                non_nan_mask = ~cpu_vals.isnan()
+                self.assertEqual(cpu_ids[non_nan_mask], xpu_ids.cpu()[non_nan_mask])
+                # NaN positions: indices must be valid, unique per row, and
+                # point to NaN values
+                nan_mask = cpu_vals.isnan()
+                nan_ids = xpu_ids[nan_mask.xpu()]
+                self.assertTrue((nan_ids >= 0).all() and (nan_ids < num_cols).all())
+                for r in range(num_rows):
+                    row_ids = xpu_ids[r].cpu().tolist()
+                    self.assertEqual(
+                        len(set(row_ids)), k,
+                        f"Duplicate indices for dtype={dtype}, N={num_rows}, row={r}",
+                    )
 
     def test_topk_neginf_input(self):
         num_cols = 128

--- a/test/regressions/test_sort.py
+++ b/test/regressions/test_sort.py
@@ -90,7 +90,8 @@ class TestNNMethod(TestCase):
             for r in range(x.shape[0]):
                 ids_list = xpu_ids[r].cpu().tolist()
                 self.assertEqual(
-                    len(set(ids_list)), k,
+                    len(set(ids_list)),
+                    k,
                     f"Duplicate indices in row {r} for dtype={dtype}: {ids_list}",
                 )
 
@@ -110,7 +111,8 @@ class TestNNMethod(TestCase):
                 for r in range(x.shape[0]):
                     ids_list = xpu_ids[r].cpu().tolist()
                     self.assertEqual(
-                        len(set(ids_list)), k,
+                        len(set(ids_list)),
+                        k,
                         f"Duplicate indices in row {r} for k={k}, dtype={dtype}: {ids_list}",
                     )
 
@@ -120,8 +122,12 @@ class TestNNMethod(TestCase):
             for largest in (True, False):
                 torch.manual_seed(0)
                 x = torch.randn(2048, num_cols, dtype=torch.float32)
-                cpu_vals, cpu_ids = torch.topk(x, k=k, dim=-1, sorted=True, largest=largest)
-                xpu_vals, xpu_ids = torch.topk(x.xpu(), k=k, dim=-1, sorted=True, largest=largest)
+                cpu_vals, cpu_ids = torch.topk(
+                    x, k=k, dim=-1, sorted=True, largest=largest
+                )
+                xpu_vals, xpu_ids = torch.topk(
+                    x.xpu(), k=k, dim=-1, sorted=True, largest=largest
+                )
                 torch.xpu.synchronize()
                 self.assertEqual(cpu_vals, xpu_vals.cpu())
                 self.assertEqual(cpu_ids, xpu_ids.cpu())

--- a/test/regressions/test_sort.py
+++ b/test/regressions/test_sort.py
@@ -84,7 +84,8 @@ class TestNNMethod(TestCase):
                 for r in range(num_rows):
                     row_ids = xpu_ids[r].cpu().tolist()
                     self.assertEqual(
-                        len(set(row_ids)), k,
+                        len(set(row_ids)),
+                        k,
                         f"Duplicate indices for dtype={dtype}, N={num_rows}, row={r}",
                     )
 


### PR DESCRIPTION
The behavior of topk when input is nan is not defined. Return the index of nan values instead of return -1