### PR TITLE
copilot-instructions: mark review mode read-only

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,3 +10,17 @@ memory. The contents of these files are authoritative.
 |--------------------------|---------------------|
 | All agent instructions | `CLAUDE.md` |
 | Review a pull request | `.claude/skills/pr-review/SKILL.md` |
+
+## Review mode is read-only
+
+When invoked to review a PR — the comment contains "review", "/pr-review",
+"/skill-writer", or any similar analysis request — the response is a
+**single markdown comment on the PR**. No file edits, no commits, no
+new branches. Findings that could be fixed directly must be described in
+the comment for the author to apply.
+
+The user can request code changes in a separate follow-up comment with an
+explicit action verb ("fix", "apply", "commit"). Do not preemptively
+combine review with modification, even when the fix looks trivial —
+splitting the two keeps the review reproducible and lets the author
+audit diffs before they land.


### PR DESCRIPTION
### Summary

Adds a `## Review mode is read-only` section to `.github/copilot-instructions.md` so `@copilot` review requests return a comment instead of pushing commits.

### Motivation

On #4983, `@copilot+claude-opus-5 review it with /skill-writer` produced [commit `b57bb0fe`](https://github.com/intel/torch-xpu-ops/pull/4983/commits/b57bb0fe) that rewrote the SKILL.md the author was asking to have reviewed. This is inconsistent with the two other review paths in the repo:

- **`@torchxpubot review`** cannot modify code — its `claude-code-action` invocation has no `Write` / `Edit` in `--allowedTools`.
- **pytorch/pytorch `@claude review`** allows those tools but the `/pr-review` skill and prompt convention keep the output to a markdown comment.


This PR was authored with AI assistance.