### PR TITLE
[xpu][fix] Handle empty-batch FFT in oneMKL _exec_fft

### DIFF
--- a/src/ATen/native/xpu/mkl/SpectralOps.cpp
+++ b/src/ATen/native/xpu/mkl/SpectralOps.cpp
@@ -179,6 +179,14 @@ Tensor& _exec_fft(
     IntArrayRef dim,
     bool onesided,
     bool forward) {
+  // oneMKL DFT rejects zero-element batches (NUMBER_OF_TRANSFORMS = 0). An
+  // empty batch has nothing to transform, so skip planning and execution and
+  // return the output in its expected (empty) shape. Matches CPU MKL and CUDA
+  // (pytorch/pytorch#190483).
+  if (out.numel() == 0) {
+    out.resize_(out_sizes, MemoryFormat::Contiguous);
+    return out;
+  }
   const auto ndim = self.dim();
   const int64_t signal_ndim = dim.size();
   const auto batch_dims = ndim - signal_ndim;


### PR DESCRIPTION
## Motivation

Nightly XPU CI on pytorch/pytorch@[1b5baff2649](https://github.com/pytorch/pytorch/commit/1b5baff2649da3d5c57ad14d72cc2dbc24dbdf72) (xpu.yml) fails 10 FFT test cases with the same oneMKL error:

```
RuntimeError: oneapi::mkl::dft::set_value: invalid argument: invalid
configuration value for the targeted configuration parameter
oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS
```

### Root cause / blocking upstream PR

The failing tests share empty-batch `SampleInput`s introduced by upstream PR pytorch/pytorch#190483 — [pytorch/pytorch@1a955c70e48](https://github.com/pytorch/pytorch/commit/1a955c70e48e5f53c2725e39560733b88397cd15), "Add handling for empty batch dimensions in FFT operations", merged 2026-08-16. It added `SampleInput`s like `Tensor[size=(0, 1, 1), dtype=float64]` to the shared FFT OpInfo.

After collapsing batch dims in `_exec_fft`, an empty batch produces `batch_size = 0`, and oneMKL DFT rejects `NUMBER_OF_TRANSFORMS = 0`.

CPU MKL and CUDA received a matching guard in the same upstream PR, but the XPU oneMKL path was missed:
- CUDA guard: [aten/src/ATen/native/cuda/SpectralOps.cpp#L170-L176](https://github.com/pytorch/pytorch/blob/1a955c70e48e5f53c2725e39560733b88397cd15/aten/src/ATen/native/cuda/SpectralOps.cpp#L170-L176)
- CPU MKL guard: [aten/src/ATen/native/mkl/SpectralOps.cpp#L430-L436](https://github.com/pytorch/pytorch/blob/1a955c70e48e5f53c2725e39560733b88397cd15/aten/src/ATen/native/mkl/SpectralOps.cpp#L430-L436)

## Solution

Short-circuit `_exec_fft` when `out.numel() == 0`: resize the output to its expected empty shape and return. Mirrors the CUDA/CPU MKL fix in pytorch/pytorch#190483.

Fixes #4980.

## Test plan

Reproduced on `torch 2.15.0.dev20260817+xpu` (nightly, contains #190483 OpInfo samples, no XPU guard), then verified against a local editable build with this fix.

|                                            | Before (nightly) | After (fix) |
|--------------------------------------------|:----------------:|:-----------:|
| test_fn_fwgrad_bwgrad_fft_fft2_xpu_float64 | FAILED           | OK          |
| test_comprehensive_fft_fftn_xpu_int32      | FAILED           | OK          |
| test_comprehensive_fft_irfft_xpu_bool      | FAILED           | OK          |
| test_comprehensive_fft_hfft_xpu_float64    | FAILED           | OK          |
| test_comprehensive_fft_fft_xpu_float64     | FAILED           | OK          |
| test_comprehensive_fft_fft2_xpu_float16    | FAILED           | OK          |
| test_comprehensive_fft_fftn_xpu_float16    | FAILED           | OK          |
| test_comprehensive_fft_fft2_xpu_float64    | FAILED           | OK          |
| test_comprehensive_fft_ifft_xpu_bool       | FAILED           | OK          |
| test_comprehensive_fft_fft_xpu_bool        | FAILED           | OK          |
| **Total**                                  | **10/10 FAILED** | **10/10 PASS** |

Before-fix repro on the nightly:

```
Exception: oneapi::mkl::dft::set_value: invalid argument: invalid configuration
value for the targeted configuration parameter oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS

Caused by sample input at index 7: SampleInput(
    input=Tensor[size=(0, 1, 1), device="xpu:0", dtype=torch.float64],
    args=(), kwargs={'dim': '(-2,-1)'}, ...)
```

Non-empty regression check (after-fix): 6/6 non-empty float32 FFT tests still pass — `test_comprehensive_fft_{fft,fft2,fftn,ifft,irfft,rfft}_xpu_float32`.

Lint:

```
$ PYTORCH_ROOT=... lintrunner src/ATen/native/xpu/mkl/SpectralOps.cpp
ok No lint issues.
```

Repro / verify commands:

```bash
# Before-fix
pip install --pre --index-url https://download.pytorch.org/whl/nightly/xpu \
    torch==2.15.0.dev20260817+xpu
python test/test_ops_fwd_gradients.py -v \
    -k test_fn_fwgrad_bwgrad_fft_fft2_xpu_float64
# -> FAILED, sample index 7 = (0,1,1) empty batch

# After-fix (local editable build with this branch pinned in xpu.txt)
for t in test_comprehensive_fft_fftn_xpu_int32 test_comprehensive_fft_irfft_xpu_bool \
         test_comprehensive_fft_hfft_xpu_float64 test_comprehensive_fft_fft_xpu_float64 \
         test_comprehensive_fft_fft2_xpu_float16 test_comprehensive_fft_fftn_xpu_float16 \
         test_comprehensive_fft_fft2_xpu_float64 test_comprehensive_fft_ifft_xpu_bool \
         test_comprehensive_fft_fft_xpu_bool; do
  python test/inductor/test_torchinductor_opinfo.py -v -k "$t"
done
```

---

Note: This PR was authored with AI assistance.