### PR TITLE
fix: avoid register spilling in elementwise ops for mixed fp32/bf16/fp16 inputs

### DIFF
--- a/src/ATen/native/xpu/sycl/Loops.h
+++ b/src/ATen/native/xpu/sycl/Loops.h
@@ -579,8 +579,7 @@ void gpu_kernel_impl(TensorIteratorBase& iter, const func_t& f) {
     auto dt = iter.dtype(i);
     if (dt == at::ScalarType::Float) {
       has_float = true;
-    } else if (
-        dt != at::ScalarType::Half && dt != at::ScalarType::BFloat16) {
+    } else if (dt != at::ScalarType::Half && dt != at::ScalarType::BFloat16) {
       use_fp_cast = false;
       break;
     }

--- a/src/ATen/native/xpu/sycl/Loops.h
+++ b/src/ATen/native/xpu/sycl/Loops.h
@@ -573,21 +573,48 @@ void gpu_kernel_impl(TensorIteratorBase& iter, const func_t& f) {
 
   int64_t numel = iter.numel();
 
+  bool use_fp_cast = (iter.dtype(0) == at::ScalarType::Float);
+  if (use_fp_cast) {
+    for (int i = 1; i < ntensors; i++) {
+      auto dt = iter.dtype(i);
+      if (dt != at::ScalarType::Float && dt != at::ScalarType::Half &&
+          dt != at::ScalarType::BFloat16) {
+        use_fp_cast = false;
+        break;
+      }
+    }
+  }
+
   bool contiguous = iter.is_contiguous();
 
   if (contiguous) {
-    auto loader = memory::LoadWithCast<traits::arity>(iter);
-    auto storer = memory::StoreWithCast<1>(iter);
-    auto input_offset_calculator = TrivialOffsetCalculator<traits::arity>();
-    auto output_offset_calculator = TrivialOffsetCalculator<1>();
-    launch_unrolled_kernel(
-        numel,
-        f,
-        data,
-        input_offset_calculator,
-        output_offset_calculator,
-        loader,
-        storer);
+    if (use_fp_cast) {
+      auto loader = memory::LoadWithCastFP<traits::arity>(iter);
+      auto storer = memory::StoreWithCastFP<1>();
+      auto input_offset_calculator = TrivialOffsetCalculator<traits::arity>();
+      auto output_offset_calculator = TrivialOffsetCalculator<1>();
+      launch_unrolled_kernel(
+          numel,
+          f,
+          data,
+          input_offset_calculator,
+          output_offset_calculator,
+          loader,
+          storer);
+    } else {
+      auto loader = memory::LoadWithCast<traits::arity>(iter);
+      auto storer = memory::StoreWithCast<1>(iter);
+      auto input_offset_calculator = TrivialOffsetCalculator<traits::arity>();
+      auto output_offset_calculator = TrivialOffsetCalculator<1>();
+      launch_unrolled_kernel(
+          numel,
+          f,
+          data,
+          input_offset_calculator,
+          output_offset_calculator,
+          loader,
+          storer);
+    }
   } else {
     at::detail::Array<ScalarType, ntensors> dtypes;
     for (int i = 0; i < ntensors; i++) {

--- a/src/ATen/native/xpu/sycl/Loops.h
+++ b/src/ATen/native/xpu/sycl/Loops.h
@@ -573,17 +573,19 @@ void gpu_kernel_impl(TensorIteratorBase& iter, const func_t& f) {
 
   int64_t numel = iter.numel();
 
-  bool use_fp_cast = (iter.dtype(0) == at::ScalarType::Float);
-  if (use_fp_cast) {
-    for (int i = 1; i < ntensors; i++) {
-      auto dt = iter.dtype(i);
-      if (dt != at::ScalarType::Float && dt != at::ScalarType::Half &&
-          dt != at::ScalarType::BFloat16) {
-        use_fp_cast = false;
-        break;
-      }
+  bool use_fp_cast = true;
+  bool has_float = false;
+  for (int i = 0; i < ntensors; i++) {
+    auto dt = iter.dtype(i);
+    if (dt == at::ScalarType::Float) {
+      has_float = true;
+    } else if (
+        dt != at::ScalarType::Half && dt != at::ScalarType::BFloat16) {
+      use_fp_cast = false;
+      break;
     }
   }
+  use_fp_cast = use_fp_cast && has_float;
 
   bool contiguous = iter.is_contiguous();
 

--- a/src/ATen/native/xpu/sycl/Loops.h
+++ b/src/ATen/native/xpu/sycl/Loops.h
@@ -573,7 +573,8 @@ void gpu_kernel_impl(TensorIteratorBase& iter, const func_t& f) {
 
   int64_t numel = iter.numel();
 
-  bool use_fp_cast = (iter.dtype(0) == at::ScalarType::Float);
+  constexpr bool fp_result = std::is_same_v<arg0_t, float>;
+  bool use_fp_cast = fp_result && (iter.dtype(0) == at::ScalarType::Float);
   if (use_fp_cast) {
     for (int i = 1; i < ntensors; i++) {
       auto dt = iter.dtype(i);

--- a/src/ATen/native/xpu/sycl/Loops.h
+++ b/src/ATen/native/xpu/sycl/Loops.h
@@ -573,18 +573,17 @@ void gpu_kernel_impl(TensorIteratorBase& iter, const func_t& f) {
 
   int64_t numel = iter.numel();
 
-  bool use_fp_cast = true;
-  bool has_float = false;
-  for (int i = 0; i < ntensors; i++) {
-    auto dt = iter.dtype(i);
-    if (dt == at::ScalarType::Float) {
-      has_float = true;
-    } else if (dt != at::ScalarType::Half && dt != at::ScalarType::BFloat16) {
-      use_fp_cast = false;
-      break;
+  bool use_fp_cast = (iter.dtype(0) == at::ScalarType::Float);
+  if (use_fp_cast) {
+    for (int i = 1; i < ntensors; i++) {
+      auto dt = iter.dtype(i);
+      if (dt != at::ScalarType::Float && dt != at::ScalarType::Half &&
+          dt != at::ScalarType::BFloat16) {
+        use_fp_cast = false;
+        break;
+      }
     }
   }
-  use_fp_cast = use_fp_cast && has_float;
 
   bool contiguous = iter.is_contiguous();
 

--- a/src/ATen/native/xpu/sycl/MemoryAccessUtils.h
+++ b/src/ATen/native/xpu/sycl/MemoryAccessUtils.h
@@ -135,20 +135,17 @@ struct LoadWithCastFP {
   template <typename scalar_t>
   C10_DEVICE scalar_t load(char* base_ptr, uint32_t offset, int arg) {
     void* ptr = base_ptr + element_sizes[arg] * offset;
-    if constexpr (
-        std::is_same_v<scalar_t, float> ||
-        std::is_same_v<scalar_t, c10::Half> ||
-        std::is_same_v<scalar_t, c10::BFloat16>) {
+    if constexpr (std::is_same_v<scalar_t, float>) {
       switch (dtypes[arg]) {
         case at::ScalarType::Float:
-          return c10::convert<scalar_t>(c10::load<float>(ptr));
+          return c10::load<float>(ptr);
         case at::ScalarType::Half:
-          return c10::convert<scalar_t>(c10::load<c10::Half>(ptr));
+          return c10::convert<float>(c10::load<c10::Half>(ptr));
         case at::ScalarType::BFloat16:
-          return c10::convert<scalar_t>(c10::load<c10::BFloat16>(ptr));
+          return c10::convert<float>(c10::load<c10::BFloat16>(ptr));
       }
     }
-    // Satisfy compiler for non-fp scalar_t instantiations that never run.
+    // Satisfy compiler for non-float scalar_t instantiations that never run.
     return scalar_t{};
   }
 };
@@ -196,12 +193,8 @@ struct StoreWithCastFP {
       char* base_ptr,
       uint32_t offset,
       int arg = 0) {
-    if constexpr (
-        std::is_same_v<scalar_t, float> ||
-        std::is_same_v<scalar_t, c10::Half> ||
-        std::is_same_v<scalar_t, c10::BFloat16>) {
-      *(reinterpret_cast<float*>(base_ptr) + offset) =
-          c10::convert<float>(value);
+    if constexpr (std::is_same_v<scalar_t, float>) {
+      *(reinterpret_cast<float*>(base_ptr) + offset) = value;
     }
   }
 };

--- a/src/ATen/native/xpu/sycl/MemoryAccessUtils.h
+++ b/src/ATen/native/xpu/sycl/MemoryAccessUtils.h
@@ -137,7 +137,6 @@ struct LoadWithCastFP {
     void* ptr = base_ptr + element_sizes[arg] * offset;
     if constexpr (
         std::is_same_v<scalar_t, float> ||
-        std::is_same_v<scalar_t, double> ||
         std::is_same_v<scalar_t, c10::Half> ||
         std::is_same_v<scalar_t, c10::BFloat16>) {
       switch (dtypes[arg]) {
@@ -201,7 +200,6 @@ struct StoreWithCastFP {
       int arg = 0) {
     if constexpr (
         std::is_same_v<scalar_t, float> ||
-        std::is_same_v<scalar_t, double> ||
         std::is_same_v<scalar_t, c10::Half> ||
         std::is_same_v<scalar_t, c10::BFloat16>) {
       *(reinterpret_cast<float*>(base_ptr) + offset) =

--- a/src/ATen/native/xpu/sycl/MemoryAccessUtils.h
+++ b/src/ATen/native/xpu/sycl/MemoryAccessUtils.h
@@ -135,20 +135,13 @@ struct LoadWithCastFP {
   template <typename scalar_t>
   C10_DEVICE scalar_t load(char* base_ptr, uint32_t offset, int arg) {
     void* ptr = base_ptr + element_sizes[arg] * offset;
-    if constexpr (
-        std::is_same_v<scalar_t, float> ||
-        std::is_same_v<scalar_t, c10::Half> ||
-        std::is_same_v<scalar_t, c10::BFloat16>) {
-      switch (dtypes[arg]) {
-        case at::ScalarType::Float:
-          return c10::convert<scalar_t>(c10::load<float>(ptr));
-        case at::ScalarType::Half:
-          return c10::convert<scalar_t>(c10::load<c10::Half>(ptr));
-        case at::ScalarType::BFloat16:
-          return c10::convert<scalar_t>(c10::load<c10::BFloat16>(ptr));
-      }
-    } else {
-      return c10::fetch_and_cast<scalar_t>(dtypes[arg], ptr);
+    switch (dtypes[arg]) {
+      case at::ScalarType::Float:
+        return c10::convert<scalar_t>(c10::load<float>(ptr));
+      case at::ScalarType::Half:
+        return c10::convert<scalar_t>(c10::load<c10::Half>(ptr));
+      case at::ScalarType::BFloat16:
+        return c10::convert<scalar_t>(c10::load<c10::BFloat16>(ptr));
     }
   }
 };
@@ -196,13 +189,8 @@ struct StoreWithCastFP {
       char* base_ptr,
       uint32_t offset,
       int arg = 0) {
-    if constexpr (
-        std::is_same_v<scalar_t, float> ||
-        std::is_same_v<scalar_t, c10::Half> ||
-        std::is_same_v<scalar_t, c10::BFloat16>) {
-      *(reinterpret_cast<float*>(base_ptr) + offset) =
-          c10::convert<float>(value);
-    }
+    *(reinterpret_cast<float*>(base_ptr) + offset) =
+        c10::convert<float>(value);
   }
 };
 

--- a/src/ATen/native/xpu/sycl/MemoryAccessUtils.h
+++ b/src/ATen/native/xpu/sycl/MemoryAccessUtils.h
@@ -189,8 +189,7 @@ struct StoreWithCastFP {
       char* base_ptr,
       uint32_t offset,
       int arg = 0) {
-    *(reinterpret_cast<float*>(base_ptr) + offset) =
-        c10::convert<float>(value);
+    *(reinterpret_cast<float*>(base_ptr) + offset) = c10::convert<float>(value);
   }
 };
 

--- a/src/ATen/native/xpu/sycl/MemoryAccessUtils.h
+++ b/src/ATen/native/xpu/sycl/MemoryAccessUtils.h
@@ -116,6 +116,47 @@ struct LoadWithoutCast {
 };
 
 template <int N>
+struct LoadWithCastFP {
+  using array_t = at::detail::Array<at::ScalarType, std::max<int>(N, 1)>;
+  using size_array_t = at::detail::Array<uint32_t, std::max<int>(N, 1)>;
+
+  array_t dtypes;
+  size_array_t element_sizes;
+
+  LoadWithCastFP(const TensorIteratorBase& iter) {
+    assert(iter.ninputs() == N);
+#pragma unroll
+    for (auto i = 0; i < N; ++i) {
+      this->dtypes[i] = iter.dtype(i + iter.noutputs());
+      element_sizes[i] = c10::elementSize(iter.dtype(i + iter.noutputs()));
+    }
+  }
+
+  template <typename scalar_t>
+  C10_DEVICE scalar_t load(char* base_ptr, uint32_t offset, int arg) {
+    void* ptr = base_ptr + element_sizes[arg] * offset;
+    if constexpr (
+        std::is_same_v<scalar_t, float> ||
+        std::is_same_v<scalar_t, double> ||
+        std::is_same_v<scalar_t, c10::Half> ||
+        std::is_same_v<scalar_t, c10::BFloat16>) {
+      switch (dtypes[arg]) {
+        case at::ScalarType::Float:
+          return c10::convert<scalar_t>(c10::load<float>(ptr));
+        case at::ScalarType::Half:
+          return c10::convert<scalar_t>(c10::load<c10::Half>(ptr));
+        case at::ScalarType::BFloat16:
+          return c10::convert<scalar_t>(c10::load<c10::BFloat16>(ptr));
+        default:
+          return c10::fetch_and_cast<scalar_t>(dtypes[arg], ptr);
+      }
+    } else {
+      return c10::fetch_and_cast<scalar_t>(dtypes[arg], ptr);
+    }
+  }
+};
+
+template <int N>
 struct LoadWithCast {
   using array_t = at::detail::Array<at::ScalarType, std::max<int>(N, 1)>;
   using size_array_t = at::detail::Array<uint32_t, std::max<int>(N, 1)>;
@@ -147,6 +188,25 @@ struct StoreWithoutCast {
       uint32_t offset,
       int arg = 0) {
     *(reinterpret_cast<scalar_t*>(base_ptr) + offset) = value;
+  }
+};
+
+template <int N = 1>
+struct StoreWithCastFP {
+  template <typename scalar_t>
+  C10_DEVICE void store(
+      scalar_t value,
+      char* base_ptr,
+      uint32_t offset,
+      int arg = 0) {
+    if constexpr (
+        std::is_same_v<scalar_t, float> ||
+        std::is_same_v<scalar_t, double> ||
+        std::is_same_v<scalar_t, c10::Half> ||
+        std::is_same_v<scalar_t, c10::BFloat16>) {
+      *(reinterpret_cast<float*>(base_ptr) + offset) =
+          c10::convert<float>(value);
+    }
   }
 };
 

--- a/src/ATen/native/xpu/sycl/MemoryAccessUtils.h
+++ b/src/ATen/native/xpu/sycl/MemoryAccessUtils.h
@@ -135,14 +135,21 @@ struct LoadWithCastFP {
   template <typename scalar_t>
   C10_DEVICE scalar_t load(char* base_ptr, uint32_t offset, int arg) {
     void* ptr = base_ptr + element_sizes[arg] * offset;
-    switch (dtypes[arg]) {
-      case at::ScalarType::Float:
-        return c10::convert<scalar_t>(c10::load<float>(ptr));
-      case at::ScalarType::Half:
-        return c10::convert<scalar_t>(c10::load<c10::Half>(ptr));
-      case at::ScalarType::BFloat16:
-        return c10::convert<scalar_t>(c10::load<c10::BFloat16>(ptr));
+    if constexpr (
+        std::is_same_v<scalar_t, float> ||
+        std::is_same_v<scalar_t, c10::Half> ||
+        std::is_same_v<scalar_t, c10::BFloat16>) {
+      switch (dtypes[arg]) {
+        case at::ScalarType::Float:
+          return c10::convert<scalar_t>(c10::load<float>(ptr));
+        case at::ScalarType::Half:
+          return c10::convert<scalar_t>(c10::load<c10::Half>(ptr));
+        case at::ScalarType::BFloat16:
+          return c10::convert<scalar_t>(c10::load<c10::BFloat16>(ptr));
+      }
     }
+    // Satisfy compiler for non-fp scalar_t instantiations that never run.
+    return scalar_t{};
   }
 };
 
@@ -189,7 +196,13 @@ struct StoreWithCastFP {
       char* base_ptr,
       uint32_t offset,
       int arg = 0) {
-    *(reinterpret_cast<float*>(base_ptr) + offset) = c10::convert<float>(value);
+    if constexpr (
+        std::is_same_v<scalar_t, float> ||
+        std::is_same_v<scalar_t, c10::Half> ||
+        std::is_same_v<scalar_t, c10::BFloat16>) {
+      *(reinterpret_cast<float*>(base_ptr) + offset) =
+          c10::convert<float>(value);
+    }
   }
 };
 

--- a/src/ATen/native/xpu/sycl/MemoryAccessUtils.h
+++ b/src/ATen/native/xpu/sycl/MemoryAccessUtils.h
@@ -146,8 +146,6 @@ struct LoadWithCastFP {
           return c10::convert<scalar_t>(c10::load<c10::Half>(ptr));
         case at::ScalarType::BFloat16:
           return c10::convert<scalar_t>(c10::load<c10::BFloat16>(ptr));
-        default:
-          return c10::fetch_and_cast<scalar_t>(dtypes[arg], ptr);
       }
     } else {
       return c10::fetch_and_cast<scalar_t>(dtypes[arg], ptr);


### PR DESCRIPTION
Fixes #4904 (eager mode regression).

Root cause: commit 35de5ddd3 changed AT_DISPATCH_V2 to include kBComplex32, which expanded the switch inside c10::fetch_and_cast / cast_and_store in LoadWithCast/StoreWithCast. The compiler spills variables to private memory (1024 bytes/thread), causing ~4x slowdown.

Fix: add LoadWithCastFP and StoreWithCastFP with a 3-case switch (Float/Half/BFloat16) for the common mixed-precision path (float output, float/half/bf16 inputs). gpu_kernel_impl detects this pattern and routes to the specialized loader/storer.

Repro:
```python
import torch
a = torch.randn(32, 384, 768, device="xpu", dtype=torch.float32)
b = torch.randn(32, 384, 768, device="xpu", dtype=torch.bfloat16)
for _ in range(100):
    torch.add(a, b, alpha=1.0)
torch.xpu.synchronize()
```

unitrace results:
- main: LoadWithCast, Private Memory = 1024, Avg 799 us
- fix:  LoadWithCastFP, Private Memory = 0,    Avg 82.6 us (9.7x)

Co-authored-by: AI Assistant