### PR TITLE
Skip TestMultiprocessingDeviceType tests that fail on XPU

### DIFF
--- a/test/xpu/test_multiprocessing_xpu.py
+++ b/test/xpu/test_multiprocessing_xpu.py
@@ -82,13 +82,6 @@ if __name__ == "__main__":
     self.assertRegex(stderr, "Cannot re-initialize XPU in forked subprocess.")
 
 
-@unittest.skipIf(IS_WINDOWS, "XPU IPC tensor sharing is not supported on Windows")
-@unittest.skipIf(not torch.xpu.is_available(), "XPU not available")
-def _test_empty_tensor_sharing_xpu(self):
-    self._test_empty_tensor_sharing(torch.float32, torch.device("xpu"))
-    self._test_empty_tensor_sharing(torch.int64, torch.device("xpu"))
-
-
 @unittest.skipIf(
     platform == "darwin", "file descriptor strategy is not supported on macOS"
 )
@@ -100,7 +93,6 @@ def _test_is_shared_xpu(self):
 
 TestMultiprocessing.test_cuda_bad_call = _test_cuda_bad_call
 TestMultiprocessing.test_wrong_cuda_fork = _test_wrong_cuda_fork
-TestMultiprocessing.test_empty_tensor_sharing_cuda = _test_empty_tensor_sharing_xpu
 TestMultiprocessing.test_is_shared_cuda = _test_is_shared_xpu
 
 

--- a/test/xpu/test_multiprocessing_xpu.py
+++ b/test/xpu/test_multiprocessing_xpu.py
@@ -17,7 +17,10 @@ import unittest
 
 import torch
 import torch.multiprocessing as mp
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    skipXPUIf,
+)
 from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase
 
 try:
@@ -85,22 +88,22 @@ if __name__ == "__main__":
 TestMultiprocessing.test_cuda_bad_call = _test_cuda_bad_call
 TestMultiprocessing.test_wrong_cuda_fork = _test_wrong_cuda_fork
 
-TestMultiprocessingDeviceType.test_integer_parameter_serialization = unittest.skip(
-    "XPU storage serialization is not supported"
+TestMultiprocessingDeviceType.test_integer_parameter_serialization = skipXPUIf(
+    True, "XPU storage serialization is not supported"
 )(TestMultiprocessingDeviceType.test_integer_parameter_serialization)
-TestMultiprocessingDeviceType.test_leaf_variable_sharing = unittest.skip(
-    "XPU storage sharing is not supported"
+TestMultiprocessingDeviceType.test_leaf_variable_sharing = skipXPUIf(
+    True, "XPU storage sharing is not supported"
 )(TestMultiprocessingDeviceType.test_leaf_variable_sharing)
-TestMultiprocessingDeviceType.test_parameter_sharing = unittest.skip(
-    "XPU storage sharing is not supported"
+TestMultiprocessingDeviceType.test_parameter_sharing = skipXPUIf(
+    True, "XPU storage sharing is not supported"
 )(TestMultiprocessingDeviceType.test_parameter_sharing)
-TestMultiprocessingDeviceType.test_variable_sharing = unittest.skip(
-    "XPU storage sharing is not supported"
+TestMultiprocessingDeviceType.test_variable_sharing = skipXPUIf(
+    True, "XPU storage sharing is not supported"
 )(TestMultiprocessingDeviceType.test_variable_sharing)
-TestMultiprocessingDeviceType.test_simple_sharing = unittest.skip(
-    "XPU storage sharing is not supported"
+TestMultiprocessingDeviceType.test_simple_sharing = skipXPUIf(
+    True, "XPU storage sharing is not supported"
 )(TestMultiprocessingDeviceType.test_simple_sharing)
-TestMultiprocessingDeviceType.test_empty_tensor_sharing = unittest.skipIf(
+TestMultiprocessingDeviceType.test_empty_tensor_sharing = skipXPUIf(
     IS_WINDOWS, "XPU empty tensor sharing is not supported on Windows"
 )(TestMultiprocessingDeviceType.test_empty_tensor_sharing)
 

--- a/test/xpu/test_multiprocessing_xpu.py
+++ b/test/xpu/test_multiprocessing_xpu.py
@@ -82,6 +82,7 @@ if __name__ == "__main__":
     self.assertRegex(stderr, "Cannot re-initialize XPU in forked subprocess.")
 
 
+@unittest.skipIf(IS_WINDOWS, "XPU IPC tensor sharing is not supported on Windows")
 @unittest.skipIf(not torch.xpu.is_available(), "XPU not available")
 def _test_empty_tensor_sharing_xpu(self):
     self._test_empty_tensor_sharing(torch.float32, torch.device("xpu"))

--- a/test/xpu/test_multiprocessing_xpu.py
+++ b/test/xpu/test_multiprocessing_xpu.py
@@ -14,10 +14,10 @@
 
 import os
 import unittest
-from sys import platform
 
 import torch
 import torch.multiprocessing as mp
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase
 
 try:
@@ -26,7 +26,7 @@ except Exception:
     from .xpu_test_utils import ensure_pytorch_test_path, XPUPatchForImport
 
 with XPUPatchForImport(False) as patcher:
-    from test_multiprocessing import TestMultiprocessing
+    from test_multiprocessing import TestMultiprocessing, TestMultiprocessingDeviceType
 
 
 test_dir = os.path.abspath(patcher.test_package[0])
@@ -82,19 +82,12 @@ if __name__ == "__main__":
     self.assertRegex(stderr, "Cannot re-initialize XPU in forked subprocess.")
 
 
-@unittest.skipIf(
-    platform == "darwin", "file descriptor strategy is not supported on macOS"
-)
-@unittest.skipIf(not torch.xpu.is_available(), "XPU not available")
-def _test_is_shared_xpu(self):
-    t = torch.randn(5, 5).xpu()
-    self.assertTrue(t.is_shared())
-
-
 TestMultiprocessing.test_cuda_bad_call = _test_cuda_bad_call
 TestMultiprocessing.test_wrong_cuda_fork = _test_wrong_cuda_fork
-TestMultiprocessing.test_is_shared_cuda = _test_is_shared_xpu
 
+instantiate_device_type_tests(
+    TestMultiprocessingDeviceType, globals(), only_for="xpu", allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/xpu/test_multiprocessing_xpu.py
+++ b/test/xpu/test_multiprocessing_xpu.py
@@ -85,6 +85,25 @@ if __name__ == "__main__":
 TestMultiprocessing.test_cuda_bad_call = _test_cuda_bad_call
 TestMultiprocessing.test_wrong_cuda_fork = _test_wrong_cuda_fork
 
+TestMultiprocessingDeviceType.test_integer_parameter_serialization = unittest.skip(
+    "XPU storage serialization is not supported"
+)(TestMultiprocessingDeviceType.test_integer_parameter_serialization)
+TestMultiprocessingDeviceType.test_leaf_variable_sharing = unittest.skip(
+    "XPU storage sharing is not supported"
+)(TestMultiprocessingDeviceType.test_leaf_variable_sharing)
+TestMultiprocessingDeviceType.test_parameter_sharing = unittest.skip(
+    "XPU storage sharing is not supported"
+)(TestMultiprocessingDeviceType.test_parameter_sharing)
+TestMultiprocessingDeviceType.test_variable_sharing = unittest.skip(
+    "XPU storage sharing is not supported"
+)(TestMultiprocessingDeviceType.test_variable_sharing)
+TestMultiprocessingDeviceType.test_simple_sharing = unittest.skip(
+    "XPU storage sharing is not supported"
+)(TestMultiprocessingDeviceType.test_simple_sharing)
+TestMultiprocessingDeviceType.test_empty_tensor_sharing = unittest.skipIf(
+    IS_WINDOWS, "XPU empty tensor sharing is not supported on Windows"
+)(TestMultiprocessingDeviceType.test_empty_tensor_sharing)
+
 instantiate_device_type_tests(
     TestMultiprocessingDeviceType, globals(), only_for="xpu", allow_xpu=True
 )


### PR DESCRIPTION
Skip test for Windows as IPC is yet not supported. On Linux, case with empty tensor works correctly so only Windows skip is needed. This change is in place of https://github.com/pytorch/pytorch/pull/189020 according to comment. This can be removed once https://github.com/pytorch/pytorch/pull/191725 is merged. Issue: https://github.com/intel/torch-xpu-ops/issues/4068