### PR TITLE
skills: add fix-implement + fix-verify — staged patch + source-build verification

### DIFF
--- a/.claude/skills/fix-implement/SKILL.md
+++ b/.claude/skills/fix-implement/SKILL.md
@@ -12,8 +12,7 @@ description: >
 # Implement — Apply the Fix
 
 Takes triage output and makes the code change. Does not run tests (that
-is `fix-verify`'s job) and does not open PRs or commit (that is the
-orchestrator's job).
+is `fix-verify`'s job); staging-only, see HARD RULES.
 
 ## Contents
 
@@ -83,8 +82,6 @@ If the issue is not yet triaged, run `fix-root-cause` first.
 
 - **Minimal changes** — fix only what's broken; every changed line must
   trace to the triage output.
-- **Never cherry-pick** upstream fixes. If a fix already landed on trunk,
-  rebase (`git rebase origin/main`) instead.
 - **Stay in your repo** — see the domain reference file loaded during
   triage (`../domain-knowledge/domain-<name>.md`, per the domain
   registry) for path conventions.
@@ -366,7 +363,8 @@ reviewer confidence in a claim that was never verified.
 - NEVER stage `third_party/xpu.txt`. It is a submodule pin managed by
   build tooling; staging it is never part of a bug fix, regardless of
   domain (xpu-kernel / inductor / upstream-pytorch).
-- NEVER cherry-pick upstream commits. Rebase instead.
+- NEVER cherry-pick upstream commits. If a fix already landed on trunk,
+  rebase (`git rebase origin/main`) instead.
 - NEVER commit, push, tag, or open a PR. This skill only stages the
   diff (`git add`); the workflow that invoked it takes over after
   `fix-verify` passes and drives its own PR-creation path.

--- a/.claude/skills/fix-implement/SKILL.md
+++ b/.claude/skills/fix-implement/SKILL.md
@@ -30,17 +30,17 @@ orchestrator's job).
 
 - `triage_result` — JSON output from `fix-root-cause` (`root_cause`,
   `fix_strategy`, `target_repo`, `domain`, `analyzed_sha`).
-- `pytorch_dir` — path to local PyTorch checkout.
+- `PYTORCH_DIR` — path to local PyTorch checkout.
 - `target_repo_dir` — path to the checkout that will be edited. Derived
-  from `pytorch_dir` and `triage_result.target_repo`:
-  - `target_repo == "pytorch"` → `target_repo_dir = pytorch_dir`.
+  from `PYTORCH_DIR` and `triage_result.target_repo`:
+  - `target_repo == "pytorch"` → `target_repo_dir = PYTORCH_DIR`.
   - `target_repo == "torch-xpu-ops"` →
-    `target_repo_dir = <pytorch_dir>/third_party/torch-xpu-ops`
+    `target_repo_dir = <PYTORCH_DIR>/third_party/torch-xpu-ops`
     (per AGENTS.md "Commit Pin & Development Override"; the caller
     is expected to have cloned the working branch there ahead of
     time).
   All git and edit operations in this skill run against
-  `target_repo_dir`, never against `pytorch_dir` when the two differ.
+  `target_repo_dir`, never against `PYTORCH_DIR` when the two differ.
 - `allow_skip` — controls skip decorator strategy:
   - `false` (**issue-handler**): never add skip decorators; must unskip
     and really fix.

--- a/.claude/skills/fix-implement/SKILL.md
+++ b/.claude/skills/fix-implement/SKILL.md
@@ -1,0 +1,372 @@
+---
+name: fix-implement
+description: >
+  Use when asked to implement a fix for a root-caused failure, apply a
+  proposed patch, or produce a staged code change from triage output.
+  Takes fix-root-cause's output and edits code; leaves the change staged
+  (uncommitted) for fix-verify to check. Does NOT run tests, does NOT
+  commit, does NOT open PRs. Called by both issue-handler
+  (`allow_skip=false`) and xpu-nightly-ci-fix (`allow_skip=true`).
+---
+
+# Implement — Apply the Fix
+
+Takes triage output and makes the code change. Does not run tests (that
+is `fix-verify`'s job) and does not open PRs or commit (that is the
+orchestrator's job).
+
+## Contents
+
+- [Inputs](#inputs)
+- Step 0: [Verify environment](#step-0-verify-environment)
+- Step 1: [Read the triage output](#step-1-read-the-triage-output)
+- Step 2: [Implement the fix](#step-2-implement-the-fix)
+- Step 3: [Stage changes](#step-3-stage-changes)
+- Step 3.5: [Skip-guard review (allow_skip=false)](#step-35-skip-guard-review-only-when-allow_skipfalse)
+- [Output](#output)
+- [HARD RULES](#hard-rules)
+
+## Inputs
+
+- `triage_result` — JSON output from `fix-root-cause` (`root_cause`,
+  `fix_strategy`, `target_repo`, `domain`, `analyzed_sha`).
+- `pytorch_dir` — path to local PyTorch checkout.
+- `target_repo_dir` — path to the checkout that will be edited. Derived
+  from `pytorch_dir` and `triage_result.target_repo`:
+  - `target_repo == "pytorch"` → `target_repo_dir = pytorch_dir`.
+  - `target_repo == "torch-xpu-ops"` →
+    `target_repo_dir = <pytorch_dir>/third_party/torch-xpu-ops`
+    (per AGENTS.md "Commit Pin & Development Override"; the caller
+    is expected to have cloned the working branch there ahead of
+    time).
+  All git and edit operations in this skill run against
+  `target_repo_dir`, never against `pytorch_dir` when the two differ.
+- `allow_skip` — controls skip decorator strategy:
+  - `false` (**issue-handler**): never add skip decorators; must unskip
+    and really fix.
+  - `true` (**xpu-nightly-ci-fix**): may add a skip with tracking issue
+    when the fix requires significant implementation work beyond the
+    current scope. Stale skips must still be removed.
+
+## Step 0: Verify environment
+
+```bash
+basename $(git -C $target_repo_dir rev-parse --show-toplevel)  # confirm which repo
+git -C $target_repo_dir status                                 # inspect current state
+```
+
+**On the first attempt** (fresh branch just created by the
+orchestrator), the worktree is clean.
+
+**On a loop-back attempt** (orchestrator returned here after
+`fix-verify` FAILED or the reviewer requested changes), staged
+changes from the previous attempt are still present by design. Do
+NOT abort. Refine those changes on top; do not `git reset` or
+`git clean` — the orchestrator would have done it if a fresh start
+were intended.
+
+## Step 1: Read the triage output
+
+Read `triage_result` carefully before touching any file. Understand:
+
+- Which files/functions need to change
+- Why the failure occurs (if applicable, why CUDA works but XPU fails)
+- Whether the fix is in pytorch or the backend repo
+- Which `analyzed_sha` the triage was against — your edits go on top
+  of that base
+
+If the issue is not yet triaged, run `fix-root-cause` first.
+
+## Step 2: Implement the fix
+
+### Key rules
+
+- **Minimal changes** — fix only what's broken; every changed line must
+  trace to the triage output.
+- **Never cherry-pick** upstream fixes. If a fix already landed on trunk,
+  rebase (`git rebase origin/main`) instead.
+- **Stay in your repo** — see the domain reference file loaded during
+  triage (`../fix-root-cause/domain-<name>.md`, per the domain registry)
+  for path conventions.
+- **Never modify unrelated files.**
+
+### Fix strategies by category
+
+See `fix-root-cause` Step 1 for domain routing. Common strategies:
+
+- **Tolerance:** match upstream `atol`/`rtol` values exactly.
+- **Regression:** find the guilty commit (`git log --oneline -20 -- <file>`),
+  apply a fix aligned with upstream intent; document any divergence in
+  comments.
+- **Newly added test:** enable backend support. If `allow_skip=false`
+  and support is genuinely missing, report `NEEDS_HUMAN` — do not add
+  a skip. If `allow_skip=true`, follow the "Add a new skip" recipe in
+  "Skip operations" below.
+- **Unknown root cause:** compare with upstream backend behavior.
+
+### Skip operations
+
+Skip decorators for a failing test live wherever that test lives: the
+pytorch test tree for upstream tests, `test/xpu/` inside torch-xpu-ops
+for its own tests.
+
+**The skip must live inside `target_repo_dir`.** This skill only ever
+produces a single-repo diff, and the orchestrator commits (or reads)
+only `target_repo_dir`. If the skip would have to be added to a file
+outside `target_repo_dir` — e.g. `target_repo == "torch-xpu-ops"` but
+the failing test is in pytorch's `test/` tree — do NOT edit it: that
+change would be left uncommitted and then wiped by the orchestrator's
+reset between failures. Return `NEEDS_HUMAN(reason=skip_outside_target_repo)`
+naming the file that would need the skip.
+
+**Removing a stale skip** (a `@skipIfXpu` / `xfail` decorator whose
+underlying failure this run is fixing): `read` the test file, delete
+the decorator lines, save. Nothing else to do — the change goes
+through the normal `git add` in Step 3.
+
+**Adding a new skip** (`allow_skip=true` only). File a tracking issue
+first so the skip has a follow-up owner, then edit:
+
+```bash
+# 1. Create the tracking issue and capture the URL.
+issue_url=$(gh issue create \
+  --repo intel/torch-xpu-ops \
+  --title "[skip-added] <test_id> on XPU" \
+  --body "Auto-added by fix-implement (allow_skip=true).
+
+  Test: <test_id>
+  Original failure: <one-line failure summary from triage_result>
+  Root cause: <root_cause from triage_result>
+  Reason for skip: <why the actual fix requires human follow-up>
+  Base analyzed: <target_repo>@<short_sha from analyzed_sha>
+  " \
+  --label "agent-added,module: xpu" \
+  | tail -1)
+
+# 2. Add the decorator with a comment citing $issue_url so a human
+#    can find the tracking issue by grepping the skip in place.
+#    Example additions (choose the one matching the test's shape):
+#
+#      @skipIfXpu(f"see {issue_url}")
+#      def test_foo(self): ...
+#
+#      # or in an OpInfo skips tuple:
+#      DecorateInfo(unittest.skip(f"see {issue_url}"), 'TestFoo', 'test_bar', ...)
+```
+
+Emit the resulting `issue_url` as `tracking_issue` in the JSON output
+(see Output section). `skip_added` becomes `true`. The issue label
+`agent-added` lets a human filter for automated-triage tracking issues.
+
+## Step 3: Stage changes
+
+```bash
+git -C $target_repo_dir add <your_files>
+git -C $target_repo_dir diff --cached --stat   # verify only intended files are staged
+```
+
+Never stage unrelated files. In particular, **never stage
+`third_party/xpu.txt`** — it is a submodule pin managed by build
+tooling, not part of any bug fix (see HARD RULES).
+
+## Step 3.5: Skip-guard review (only when `allow_skip=false`)
+
+Skip this step entirely when `allow_skip=true` (xpu-nightly-ci-fix flow).
+
+When `allow_skip=false`, spawn a fresh-context subagent via the `Task`
+tool (`subagent_type=general-purpose`) to inspect the staged diff for
+skip-shaped workarounds before returning to the orchestrator. The
+implementer must not review its own diff for this specific bias — the
+gatekeeper here is a separate agent with no memory of the reasoning
+that produced the diff.
+
+Pass the reviewer:
+
+- The full staged diff: `git -C $target_repo_dir diff --cached`.
+- The `triage_result` (so the reviewer knows what the root cause is
+  supposed to be).
+- The value of `allow_skip` (always `false` when this step runs).
+
+Instruct the reviewer to reject the diff (return `REQUEST_CHANGES`) if
+any of the following appears anywhere in added lines:
+
+- A new `@skipIfXpu` / `@skipXPU` / `@skipCUDAIf` / `@skipMPS` /
+  `@unittest.skip` / `@unittest.skipIf` / `@pytest.mark.skip` /
+  `@pytest.mark.skipif` / `@pytest.mark.xfail` /
+  `@expectedFailureXPU` / `@expectedFailureCUDA` / `@expectedFailureMPS`
+  / `@expectedFailure` decorator on a test.
+- A new `DecorateInfo(unittest.skip, ...)` / `DecorateInfo(skipIfXpu, ...)`
+  / `DecorateInfo(unittest.expectedFailure, ...)` entry in an
+  `OpInfo` / `ModuleInfo` skips/decorators list.
+- A new `xfail(...)` / `skip(...)` entry in an
+  `instantiate_device_type_tests` skip dict for XPU.
+- Bare `raise unittest.SkipTest(...)` / `self.skipTest(...)` inserted
+  into a previously-running test to short-circuit it on XPU.
+- Loosening `atol` / `rtol` on `assertEqual` (or any tolerance-carrying
+  assertion) by more than an order of magnitude, when the diff has no
+  quantitative justification for the new value in a comment.
+- Hardcoded `set_rng_seed(...)` / `torch.manual_seed(...)` /
+  `random.seed(...)` inserted into a previously-random test purely to
+  dodge a failure region.
+- Deleting or commenting out the failing assertion / the failing test
+  function.
+- A broad `try / except Exception: pass` (or equivalent) wrapping the
+  call that used to fail.
+
+Existing skips being **removed** by the diff are fine — that is a
+legitimate root-cause fix in the "stale test expectation" category. The
+rule only fires on *added* skip-shaped constructs.
+
+The reviewer returns one of:
+
+- `APPROVE` — no skip-shaped workaround found. Continue to Step 4
+  (output).
+- `REQUEST_CHANGES` — cite each offending hunk (file + line + which
+  rule it matched). The implementer MUST address every citation
+  (either replace the workaround with a real root-cause fix or, if no
+  root-cause fix is possible within this run's scope, unstage the
+  offending change and return `NEEDS_HUMAN(reason=skip_guard_rejected)`
+  to the orchestrator with the reviewer's citations attached).
+
+**Do not loop this step more than once.** If a second run of Step 3.5
+still returns `REQUEST_CHANGES`, unstage the offending change and
+return `NEEDS_HUMAN(reason=skip_guard_rejected)` — that is a signal the
+fix cannot be produced without a workaround and a human should take it.
+
+This step is intentionally narrower than the orchestrator's Stage 5.5
+review. Stage 5.5 checks the entire diff for correctness, minimalism,
+and root-cause alignment; Step 3.5 checks only for the specific class of
+"hide the failure instead of fixing it" workarounds that
+`allow_skip=false` is meant to forbid. Both run; they do not replace
+each other.
+
+## Output
+
+Return to the orchestrator a report (markdown block plus JSON block).
+The skill does not commit, push, or open PRs — the caller consumes
+stdout and decides what to do, per the pattern established by
+`issue-triage`, `fix-reproduce`, and `fix-root-cause`.
+
+Include the `<!-- agent:implement -->` marker on the first line of the
+markdown block so a downstream caller can locate its own previous
+implement comment (if any) and update it in place. Comment location and
+update is the **caller's** responsibility.
+
+```
+<!-- agent:implement -->
+
+## Implement Result
+
+- **Target repo:** <pytorch | torch-xpu-ops>
+- **Analyzed at:** <target_repo>@<short_sha>
+- **What I changed:** <bullet list of files and what changed in each>
+- **Why:** <one sentence connecting each change to the triage root cause; must cite file:line for every upstream/CUDA comparison — see the hard rule below>
+- **Skip added:** <yes (tracking: intel/torch-xpu-ops#N, url: <url>) | no>
+- **Ready for verify:** <yes | no>
+
+*Automated by fix-implement.*
+```
+
+```json
+{
+  "target_repo": "pytorch or torch-xpu-ops",
+  "analyzed_sha": "<full 40-char sha inherited from triage_result>",
+  "changed_files": ["path/to/file1.py", "src/ATen/native/xpu/Foo.cpp"],
+  "skip_added": false,
+  "tracking_issue": null,
+  "allow_skip": false,
+  "ready_for_verify": true,
+  "verdict": "READY or NEEDS_HUMAN",
+  "reason": "<enumerated reason code, see below>",
+  "reason_detail": "one-line human-readable detail"
+}
+```
+
+### Field contract
+
+- `target_repo` / `analyzed_sha` — echo from `triage_result` so
+  downstream stages have a self-contained record without re-reading
+  triage output.
+- `changed_files` — list of paths (relative to `target_repo_dir`) that
+  are staged. `fix-verify` reads this to decide whether a C++/SYCL
+  rebuild is required. Must equal `git -C $target_repo_dir diff --cached
+  --name-only` **at output time**. Re-run that command immediately
+  before emitting the JSON block; do not cache a pre-Step-3.5 file list,
+  because Step 3.5's reviewer may have unstaged offending files.
+- `skip_added` — `true` only when this run added a new skip decorator
+  under `allow_skip=true`. Removing a stale skip is NOT `skip_added`.
+- `tracking_issue` — issue URL from the "Add a new skip" recipe in
+  Step 2 when `skip_added=true`; `null` otherwise. `xpu-nightly-ci-fix`
+  reads this to populate the "Needs Human (skip added)" section of
+  its summary.
+- `allow_skip` — echo the input flag verbatim, so a reviewer can tell
+  by looking at the output alone whether Step 3.5 ran.
+- `ready_for_verify` — `true` when Step 3.5 (if it ran) returned
+  `APPROVE` and staged changes exist; `false` if the implementer
+  decided to bail out with `NEEDS_HUMAN` (in which case the
+  orchestrator should not call `fix-verify`).
+- `verdict` — `READY` (staged diff exists, fix-verify may run) or
+  `NEEDS_HUMAN` (see reason).
+
+### `reason` values
+
+On `verdict=READY`: `ok`.
+
+On `verdict=NEEDS_HUMAN`:
+
+- `skip_outside_target_repo` — the skip decorator that would need to be
+  added lives outside `target_repo_dir`; see Step 2's "Skip operations".
+- `skip_guard_rejected` — Step 3.5's subagent reviewer returned
+  `REQUEST_CHANGES` twice, or the implementer chose to bail out rather
+  than fight the reviewer.
+- `no_fix_possible` — the fix strategy in `triage_result` is not
+  implementable without either widening the diff outside `target_repo`
+  or adding a skip when `allow_skip=false`.
+- `other` — fallback; put full explanation in `reason_detail`.
+
+**Contract:** changes are left staged (`git add`) but NOT committed.
+The orchestrator commits only after `fix-verify` returns `PASSED`.
+`fix-verify` relies on `git stash` to record a before-state, which
+requires uncommitted changes to be present when verify is called.
+
+### HARD RULE: every upstream/CUDA claim in "Why" must cite a source
+
+The "Why" line written here will be read by reviewers as factual
+statements. Before writing any of the following phrases, you MUST
+look up the specific file and line number that backs it up:
+
+- "consistent with upstream"
+- "upstream does X" / "upstream already handles this"
+- "same as CUDA/MPS/ROCm"
+- "mirrors upstream behavior"
+- "aligned with upstream"
+
+If you cannot find a specific `file:line` to cite, **do not write the
+phrase**. Replace it with a direct statement of the observable fact,
+e.g.:
+
+| Instead of... | Write... |
+|---|---|
+| "consistent with upstream's bcomplex32 handling" | "BComplex32 comparison (`isclose`/`mul`) raises `NotImplementedError` in the nightly wheel (pytorch warns 'BComplex32 support is experimental')" |
+| "upstream already skips this" | "upstream `test_ops.py:595` skips `{bfloat16, bcomplex32}` inputs in `_ref_test_helper`" |
+
+A "Why" that contains an unsubstantiated upstream comparison is worse
+than one that only cites what you directly observed — it inflates
+reviewer confidence in a claim that was never verified.
+
+## HARD RULES
+
+- NEVER add skip decorators when `allow_skip=false`.
+- NEVER edit a file outside `target_repo_dir` — including when the skip
+  or fix "belongs" in the other repo. That diff cannot be committed or
+  read back by the orchestrator; return `NEEDS_HUMAN` instead.
+- When `allow_skip=false`, Step 3.5 (skip-guard reviewer subagent) is
+  MANDATORY before returning to the orchestrator. Do not skip it, do
+  not run it inline in your own context.
+- NEVER stage `third_party/xpu.txt`. It is a submodule pin managed by
+  build tooling; staging it is never part of a bug fix, regardless of
+  domain (xpu-kernel / inductor / upstream-pytorch).
+- NEVER cherry-pick upstream commits. Rebase instead.
+- NEVER commit, push, tag, or open a PR. This skill only stages the
+  diff (`git add`); the workflow that invoked it takes over after
+  `fix-verify` passes and drives its own PR-creation path.

--- a/.claude/skills/fix-implement/SKILL.md
+++ b/.claude/skills/fix-implement/SKILL.md
@@ -86,8 +86,8 @@ If the issue is not yet triaged, run `fix-root-cause` first.
 - **Never cherry-pick** upstream fixes. If a fix already landed on trunk,
   rebase (`git rebase origin/main`) instead.
 - **Stay in your repo** — see the domain reference file loaded during
-  triage (`../fix-root-cause/domain-<name>.md`, per the domain registry)
-  for path conventions.
+  triage (`../domain-knowledge/domain-<name>.md`, per the domain
+  registry) for path conventions.
 - **Never modify unrelated files.**
 
 ### Fix strategies by category

--- a/.claude/skills/fix-verify/SKILL.md
+++ b/.claude/skills/fix-verify/SKILL.md
@@ -21,9 +21,9 @@ see.
 - [Shell helpers](#shell-helpers)
 - Step 1: [Confirm source build environment](#step-1-confirm-source-build-environment)
 - Step 2: [Rebuild if needed](#step-2-rebuild-if-needed)
-- Step 3: [Before/after comparison](#step-3-beforeafter-comparison-if-run_before_after_difftrue)
+- Step 3: [Before/after comparison](#step-3-beforeafter-comparison)
 - Step 4: [Run test](#step-4-run-test)
-- Step 5: [Lint](#step-5-lint-if-run_linttrue)
+- Step 5: [Lint](#step-5-lint)
 - [Output](#output)
 
 ## Inputs
@@ -41,11 +41,9 @@ see.
 - `changed_files` — list of changed files from `fix-implement`'s
   output; if any are C++/SYCL (`.cpp`, `.h`, `.cu`, `.sycl`), a rebuild
   is required before running.
-- `run_before_after_diff` (bool, default `false`) — if `true`, runs the
-  test before and after the fix to produce a comparison table. Set to
-  `true` by `xpu-nightly-ci-fix`.
-- `run_lint` (bool, default `false`) — if `true`, runs `spin fixlint`
-  after a passing result. Set to `true` by `xpu-nightly-ci-fix`.
+
+This skill always runs the before/after comparison (Step 3) and lints
+a passing result (Step 5); there are no flags to toggle either off.
 
 ## Shell helpers
 
@@ -100,26 +98,22 @@ Override" procedure from AGENTS.md **before** loading `xpu-build-pytorch`:
 git -C $target_repo_dir rev-parse HEAD > $pytorch_dir/third_party/xpu.txt
 ```
 
-**When `run_before_after_diff=true` and the changed files include
-C++/SYCL sources**, DO NOT rebuild first. A rebuild with the fix
-staged compiles the fix into `torch/lib/*.so`, and the later "before"
-run (Step 3, after `git stash -u`) would still load the fix's `.so`
-even with sources removed — producing a false-negative "before" that
-already passes. Instead, defer the rebuild into Step 3's before/after
-loop where it is done at each phase.
+**When the changed files include C++/SYCL sources**, DO NOT rebuild
+first. A rebuild with the fix staged compiles the fix into
+`torch/lib/*.so`, and the later "before" run (Step 3, after
+`git stash -u`) would still load the fix's `.so` even with sources
+removed — producing a false-negative "before" that already passes.
+Instead, defer the rebuild into Step 3's before/after loop where it is
+done at each phase.
 
-Otherwise (i.e. `run_before_after_diff=false`, or all changes are
-python-only regardless of the flag):
+If all changed files are python-only, no rebuild is needed here (the
+before/after loop in Step 3 re-imports without a build step).
 
-- If any changed file is C++/SYCL: load `xpu-build-pytorch` and rebuild
-  now.
-- If all changed files are python-only: no rebuild needed.
-
-## Step 3: Before/after comparison (if `run_before_after_diff=true`)
+## Step 3: Before/after comparison
 
 **Contract:** this step requires that `fix-implement` left changes
 staged but uncommitted. `git stash -u` temporarily removes them to
-obtain a before-state. If `run_before_after_diff=true` and the stash
+obtain a before-state. If the stash
 finds nothing (orchestrator committed the changes early), the contract
 is violated — return
 `CANNOT_VERIFY(reason=no_staged_changes)` (see below), do NOT silently
@@ -209,9 +203,9 @@ Result interpretation:
 - `FAILED` → `FAILED` with `reason=test_still_failing`.
 - `PASSED` → `PASSED` with `reason=ok`.
 
-## Step 5: Lint (if `run_lint=true`)
+## Step 5: Lint
 
-Only run after a passing test result. Run it in `target_repo_dir` —
+Always run after a passing test result. Run it in `target_repo_dir` —
 the repo that owns the changed files — not in `pytorch_dir`:
 
 ```bash
@@ -253,9 +247,8 @@ update is the **caller's** responsibility.
 - **Target repo:** <pytorch | torch-xpu-ops>
 - **Refined command:** <refined_command>
 - **Verdict:** <PASSED | FAILED | CANNOT_VERIFY> — <one-line reason>
-- **Lint:** <clean | not run | errors: <summary>>
+- **Lint:** <clean | errors: <summary>>
 
-<if run_before_after_diff=true, include:>
 ### Before / after
 
 | Test case | Before | After |
@@ -270,8 +263,6 @@ update is the **caller's** responsibility.
   "target_repo": "pytorch or torch-xpu-ops",
   "refined_command": "<echo of input>",
   "changed_files": ["path/to/file1.py"],
-  "run_before_after_diff": false,
-  "run_lint": false,
   "verdict": "PASSED or FAILED or CANNOT_VERIFY",
   "reason": "<enumerated reason code, see below>",
   "reason_detail": "one-line human-readable detail",
@@ -286,11 +277,9 @@ update is the **caller's** responsibility.
 - `refined_command` — echo the exact command that was run.
 - `changed_files` — echo from `fix-implement`; downstream orchestrator
   uses this to build the commit's file list.
-- `run_before_after_diff` / `run_lint` — echo the input flags verbatim,
-  so a reviewer can tell from the JSON alone which paths this run
-  exercised.
-- `before_after_table` — non-null only when `run_before_after_diff=true`
-  and the phases ran successfully; otherwise `null`.
+- `before_after_table` — the markdown table from Step 3 when both
+  phases ran successfully; `null` only when Step 3 could not produce it
+  (e.g. a `CANNOT_VERIFY` before reaching the after phase).
 - `failure_output` — non-null on `FAILED`; excerpt of the test or lint
   output (bounded — do not dump multi-MB logs, ~40 lines is enough for
   a human to see the failure).
@@ -299,7 +288,7 @@ update is the **caller's** responsibility.
 
 On `verdict=PASSED`:
 
-- `ok` — test passed with the fix applied; lint clean (or `run_lint=false`).
+- `ok` — test passed with the fix applied; lint clean.
 
 On `verdict=FAILED`:
 

--- a/.claude/skills/fix-verify/SKILL.md
+++ b/.claude/skills/fix-verify/SKILL.md
@@ -118,8 +118,9 @@ staged but uncommitted. `git stash -u` temporarily removes them to
 obtain a before-state. If the stash
 finds nothing (orchestrator committed the changes early), the contract
 is violated — return
-`CANNOT_VERIFY(reason=no_staged_changes)` (see below), do NOT silently
-produce an after-only table.
+`CANNOT_VERIFY(reason=no_staged_changes)` with `blocker="no staged
+changes; fix-implement contract requires uncommitted changes"`, do NOT
+silently produce an after-only table.
 
 All git commands here run against `target_repo_dir` (not `PYTORCH_DIR`);
 these can differ when `target_repo == "torch-xpu-ops"`.
@@ -173,10 +174,6 @@ fi
 
 The before/after outputs are folded into the markdown report (see
 Output section) as a comparison table.
-
-If `git stash -u` reports "No local changes to save", return
-`CANNOT_VERIFY(reason=no_staged_changes)` with `blocker="no staged
-changes; fix-implement contract requires uncommitted changes"`.
 
 ## Step 4: Run test
 

--- a/.claude/skills/fix-verify/SKILL.md
+++ b/.claude/skills/fix-verify/SKILL.md
@@ -39,8 +39,8 @@ see.
   runs from `PYTORCH_DIR` because `pip install -e .` builds pytorch and
   pulls its submodule pin.
 - `changed_files` — list of changed files from `fix-implement`'s
-  output; if any are C++/SYCL (`.cpp`, `.h`, `.cu`, `.sycl`), a rebuild
-  is required before running.
+  output; if any are C++/SYCL (`.cpp`, `.h`, `.cu`, `.sycl`) or CMake
+  (`CMakeLists.txt`, `*.cmake`), a rebuild is required before running.
 
 This skill always runs the before/after comparison (Step 3) and lints
 a passing result (Step 5); there are no flags to toggle either off.
@@ -82,8 +82,10 @@ reproduced at `stage=nightly`).
 
 ## Step 2: Rebuild if needed
 
-If any of `changed_files` are C++/SYCL (`.cpp`, `.h`, `.cu`, `.sycl`),
-a rebuild is required.
+If any of `changed_files` are C++/SYCL (`.cpp`, `.h`, `.cu`, `.sycl`)
+or CMake (`CMakeLists.txt`, `*.cmake`), a rebuild is required. On the
+first rebuild, clean the build cache and retry once if
+`xpu-build-pytorch` reports a cache-related failure.
 
 **When `target_repo_dir != PYTORCH_DIR`** (i.e. the fix is inside
 `third_party/torch-xpu-ops`), the pytorch build reads
@@ -98,9 +100,9 @@ Override" procedure from AGENTS.md **before** loading `xpu-build-pytorch`:
 git -C $target_repo_dir rev-parse HEAD > $PYTORCH_DIR/third_party/xpu.txt
 ```
 
-**When the changed files include C++/SYCL sources**, DO NOT rebuild
-first. A rebuild with the fix staged compiles the fix into
-`torch/lib/*.so`, and the later "before" run (Step 3, after
+**When the changed files require a rebuild** (C++/SYCL or CMake, per
+Step 2), DO NOT rebuild first. A rebuild with the fix staged compiles
+the fix into `torch/lib/*.so`, and the later "before" run (Step 3, after
 `git stash -u`) would still load the fix's `.so` even with sources
 removed — producing a false-negative "before" that already passes.
 Instead, defer the rebuild into Step 3's before/after loop where it is

--- a/.claude/skills/fix-verify/SKILL.md
+++ b/.claude/skills/fix-verify/SKILL.md
@@ -30,13 +30,13 @@ see.
 
 - `refined_command` — the exact test command from `fix-reproduce`'s
   output.
-- `pytorch_dir` — path to local PyTorch checkout.
+- `PYTORCH_DIR` — path to local PyTorch checkout.
 - `target_repo_dir` — path to the checkout that holds the staged fix
-  (same derivation rule as in `fix-implement`: equals `pytorch_dir` for
-  `target_repo=pytorch`, `<pytorch_dir>/third_party/torch-xpu-ops` for
+  (same derivation rule as in `fix-implement`: equals `PYTORCH_DIR` for
+  `target_repo=pytorch`, `<PYTORCH_DIR>/third_party/torch-xpu-ops` for
   `target_repo=torch-xpu-ops`). All `git stash`/`git diff --cached`
   operations run against `target_repo_dir`. The rebuild (Step 2) still
-  runs from `pytorch_dir` because `pip install -e .` builds pytorch and
+  runs from `PYTORCH_DIR` because `pip install -e .` builds pytorch and
   pulls its submodule pin.
 - `changed_files` — list of changed files from `fix-implement`'s
   output; if any are C++/SYCL (`.cpp`, `.h`, `.cu`, `.sycl`), a rebuild
@@ -61,7 +61,7 @@ silently".
 
 ## Step 1: Confirm source build environment
 
-The installed `torch` must be the one built from `pytorch_dir`, not a
+The installed `torch` must be the one built from `PYTORCH_DIR`, not a
 wheel. Checking `torch.version.git_version` is NOT sufficient —
 released and nightly wheels also carry a real commit hash there.
 Check where `torch` is imported from instead:
@@ -70,7 +70,7 @@ Check where `torch` is imported from instead:
 python -c "import torch, os; print(os.path.realpath(torch.__file__))"
 ```
 
-The printed path must be under `$(realpath $pytorch_dir)/torch/`. If it
+The printed path must be under `$(realpath $PYTORCH_DIR)/torch/`. If it
 resolves into `site-packages` of an unrelated prefix, the environment
 is a wheel install: return
 `CANNOT_VERIFY(reason=wheel_install_not_source)` with `blocker="torch
@@ -85,7 +85,7 @@ reproduced at `stage=nightly`).
 If any of `changed_files` are C++/SYCL (`.cpp`, `.h`, `.cu`, `.sycl`),
 a rebuild is required.
 
-**When `target_repo_dir != pytorch_dir`** (i.e. the fix is inside
+**When `target_repo_dir != PYTORCH_DIR`** (i.e. the fix is inside
 `third_party/torch-xpu-ops`), the pytorch build reads
 `third_party/xpu.txt` and would clobber the staged fix by resetting
 the submodule to the pinned commit. Apply the "Commit Pin & Development
@@ -95,7 +95,7 @@ Override" procedure from AGENTS.md **before** loading `xpu-build-pytorch`:
 # Rewrite the pin to the working branch's HEAD so CMake's checkout
 # becomes a no-op. Do NOT stage or commit this file (never staging
 # third_party/xpu.txt is a HARD RULE in fix-implement).
-git -C $target_repo_dir rev-parse HEAD > $pytorch_dir/third_party/xpu.txt
+git -C $target_repo_dir rev-parse HEAD > $PYTORCH_DIR/third_party/xpu.txt
 ```
 
 **When the changed files include C++/SYCL sources**, DO NOT rebuild
@@ -119,7 +119,7 @@ is violated — return
 `CANNOT_VERIFY(reason=no_staged_changes)` (see below), do NOT silently
 produce an after-only table.
 
-All git commands here run against `target_repo_dir` (not `pytorch_dir`);
+All git commands here run against `target_repo_dir` (not `PYTORCH_DIR`);
 these can differ when `target_repo == "torch-xpu-ops"`.
 
 **When any `changed_files` are C++/SYCL, the before/after phases each
@@ -136,8 +136,8 @@ staged_before=$(git -C $target_repo_dir diff --cached)
 git -C $target_repo_dir stash -u   # stash staged, unstaged, untracked
 # For torch-xpu-ops fixes, also restore xpu.txt to the base commit's pin
 # so the rebuild sees the ORIGINAL submodule state.
-if [ "$target_repo_dir" != "$pytorch_dir" ]; then
-    git -C $pytorch_dir checkout -- third_party/xpu.txt
+if [ "$target_repo_dir" != "$PYTORCH_DIR" ]; then
+    git -C $PYTORCH_DIR checkout -- third_party/xpu.txt
 fi
 # Rebuild WITHOUT the fix (only if C++/SYCL changed):
 #   invoke xpu-build-pytorch skill here
@@ -160,8 +160,8 @@ if [ "$before_sha" != "$after_sha" ]; then
 fi
 
 # Re-apply the xpu.txt override so the rebuild sees the working branch.
-if [ "$target_repo_dir" != "$pytorch_dir" ]; then
-    git -C $target_repo_dir rev-parse HEAD > $pytorch_dir/third_party/xpu.txt
+if [ "$target_repo_dir" != "$PYTORCH_DIR" ]; then
+    git -C $target_repo_dir rev-parse HEAD > $PYTORCH_DIR/third_party/xpu.txt
 fi
 # Rebuild WITH the fix (only if C++/SYCL changed):
 #   invoke xpu-build-pytorch skill here
@@ -206,7 +206,7 @@ Result interpretation:
 ## Step 5: Lint
 
 Always run after a passing test result. Run it in `target_repo_dir` —
-the repo that owns the changed files — not in `pytorch_dir`:
+the repo that owns the changed files — not in `PYTORCH_DIR`:
 
 ```bash
 cd $target_repo_dir

--- a/.claude/skills/fix-verify/SKILL.md
+++ b/.claude/skills/fix-verify/SKILL.md
@@ -1,0 +1,337 @@
+---
+name: fix-verify
+description: >
+  Use when asked to verify a fix works, confirm a staged patch resolves a
+  failure, or produce a before/after comparison of a fix. Runs the test
+  command against a source build with the fix applied and reports
+  PASSED / FAILED / CANNOT_VERIFY. Called by both issue-handler and
+  xpu-nightly-ci-fix orchestrators after fix-implement.
+---
+
+# Verify — Confirm the Fix Works
+
+Runs the test against a source build (with the fix applied) and reports
+whether the fix is effective. Always uses source build — never nightly
+wheel — since the fix lives in local code that a wheel install cannot
+see.
+
+## Contents
+
+- [Inputs](#inputs)
+- [Shell helpers](#shell-helpers)
+- Step 1: [Confirm source build environment](#step-1-confirm-source-build-environment)
+- Step 2: [Rebuild if needed](#step-2-rebuild-if-needed)
+- Step 3: [Before/after comparison](#step-3-beforeafter-comparison-if-run_before_after_difftrue)
+- Step 4: [Run test](#step-4-run-test)
+- Step 5: [Lint](#step-5-lint-if-run_linttrue)
+- [Output](#output)
+
+## Inputs
+
+- `refined_command` — the exact test command from `fix-reproduce`'s
+  output.
+- `pytorch_dir` — path to local PyTorch checkout.
+- `target_repo_dir` — path to the checkout that holds the staged fix
+  (same derivation rule as in `fix-implement`: equals `pytorch_dir` for
+  `target_repo=pytorch`, `<pytorch_dir>/third_party/torch-xpu-ops` for
+  `target_repo=torch-xpu-ops`). All `git stash`/`git diff --cached`
+  operations run against `target_repo_dir`. The rebuild (Step 2) still
+  runs from `pytorch_dir` because `pip install -e .` builds pytorch and
+  pulls its submodule pin.
+- `changed_files` — list of changed files from `fix-implement`'s
+  output; if any are C++/SYCL (`.cpp`, `.h`, `.cu`, `.sycl`), a rebuild
+  is required before running.
+- `run_before_after_diff` (bool, default `false`) — if `true`, runs the
+  test before and after the fix to produce a comparison table. Set to
+  `true` by `xpu-nightly-ci-fix`.
+- `run_lint` (bool, default `false`) — if `true`, runs `spin fixlint`
+  after a passing result. Set to `true` by `xpu-nightly-ci-fix`.
+
+## Shell helpers
+
+The recipes below call `abort` (exit non-zero with a diagnostic). It is
+not a shell builtin — define it once at the top of your shell, same as
+the orchestrators do:
+
+```bash
+abort() { echo "ABORT: $*" >&2; exit 1; }
+```
+
+An `abort` in this skill means "return `CANNOT_VERIFY` to the
+orchestrator with that message as the `blocker`", never "continue
+silently".
+
+## Step 1: Confirm source build environment
+
+The installed `torch` must be the one built from `pytorch_dir`, not a
+wheel. Checking `torch.version.git_version` is NOT sufficient —
+released and nightly wheels also carry a real commit hash there.
+Check where `torch` is imported from instead:
+
+```bash
+python -c "import torch, os; print(os.path.realpath(torch.__file__))"
+```
+
+The printed path must be under `$(realpath $pytorch_dir)/torch/`. If it
+resolves into `site-packages` of an unrelated prefix, the environment
+is a wheel install: return
+`CANNOT_VERIFY(reason=wheel_install_not_source)` with `blocker="torch
+imported from <path>; verify requires a source build"` — a fix staged
+in the local tree has no effect on an installed wheel. Producing the
+source build is the orchestrator's job (both orchestrators load
+`xpu-build-pytorch` before calling this skill when `fix-reproduce`
+reproduced at `stage=nightly`).
+
+## Step 2: Rebuild if needed
+
+If any of `changed_files` are C++/SYCL (`.cpp`, `.h`, `.cu`, `.sycl`),
+a rebuild is required.
+
+**When `target_repo_dir != pytorch_dir`** (i.e. the fix is inside
+`third_party/torch-xpu-ops`), the pytorch build reads
+`third_party/xpu.txt` and would clobber the staged fix by resetting
+the submodule to the pinned commit. Apply the "Commit Pin & Development
+Override" procedure from AGENTS.md **before** loading `xpu-build-pytorch`:
+
+```bash
+# Rewrite the pin to the working branch's HEAD so CMake's checkout
+# becomes a no-op. Do NOT stage or commit this file (never staging
+# third_party/xpu.txt is a HARD RULE in fix-implement).
+git -C $target_repo_dir rev-parse HEAD > $pytorch_dir/third_party/xpu.txt
+```
+
+**When `run_before_after_diff=true` and the changed files include
+C++/SYCL sources**, DO NOT rebuild first. A rebuild with the fix
+staged compiles the fix into `torch/lib/*.so`, and the later "before"
+run (Step 3, after `git stash -u`) would still load the fix's `.so`
+even with sources removed — producing a false-negative "before" that
+already passes. Instead, defer the rebuild into Step 3's before/after
+loop where it is done at each phase.
+
+Otherwise (i.e. `run_before_after_diff=false`, or all changes are
+python-only regardless of the flag):
+
+- If any changed file is C++/SYCL: load `xpu-build-pytorch` and rebuild
+  now.
+- If all changed files are python-only: no rebuild needed.
+
+## Step 3: Before/after comparison (if `run_before_after_diff=true`)
+
+**Contract:** this step requires that `fix-implement` left changes
+staged but uncommitted. `git stash -u` temporarily removes them to
+obtain a before-state. If `run_before_after_diff=true` and the stash
+finds nothing (orchestrator committed the changes early), the contract
+is violated — return
+`CANNOT_VERIFY(reason=no_staged_changes)` (see below), do NOT silently
+produce an after-only table.
+
+All git commands here run against `target_repo_dir` (not `pytorch_dir`);
+these can differ when `target_repo == "torch-xpu-ops"`.
+
+**When any `changed_files` are C++/SYCL, the before/after phases each
+run their own rebuild** (see Step 2 rationale). For python-only changes
+the rebuild lines below are no-ops.
+
+```bash
+# Capture the staged diff BEFORE stashing so we can compare after pop.
+staged_before=$(git -C $target_repo_dir diff --cached)
+[ -z "$staged_before" ] && \
+  abort "no staged changes; fix-implement contract requires uncommitted staged changes"
+
+# Record BEFORE (without the fix)
+git -C $target_repo_dir stash -u   # stash staged, unstaged, untracked
+# For torch-xpu-ops fixes, also restore xpu.txt to the base commit's pin
+# so the rebuild sees the ORIGINAL submodule state.
+if [ "$target_repo_dir" != "$pytorch_dir" ]; then
+    git -C $pytorch_dir checkout -- third_party/xpu.txt
+fi
+# Rebuild WITHOUT the fix (only if C++/SYCL changed):
+#   invoke xpu-build-pytorch skill here
+# run test, capture output as before_output
+
+# Restore the fix. `--index` restores the staged state the orchestrator
+# commits from — but git will silently fall back to a non-index pop
+# if the working tree conflicts with the popped state (e.g. a rebuild
+# artifact appearing at a path that clashes with a stashed file).
+git -C $target_repo_dir stash pop --index || \
+  abort "git stash pop failed; staged fix state cannot be restored"
+
+# Verify the staged diff matches what we captured before stashing.
+# Compare via hash to handle diffs that exceed ARG_MAX.
+before_sha=$(printf %s "$staged_before" | sha256sum | cut -d' ' -f1)
+after_sha=$(printf %s "$(git -C $target_repo_dir diff --cached)" \
+            | sha256sum | cut -d' ' -f1)
+if [ "$before_sha" != "$after_sha" ]; then
+    abort "git stash pop --index did not restore staged state"
+fi
+
+# Re-apply the xpu.txt override so the rebuild sees the working branch.
+if [ "$target_repo_dir" != "$pytorch_dir" ]; then
+    git -C $target_repo_dir rev-parse HEAD > $pytorch_dir/third_party/xpu.txt
+fi
+# Rebuild WITH the fix (only if C++/SYCL changed):
+#   invoke xpu-build-pytorch skill here
+# Record AFTER (with the fix)
+# run test, capture output as after_output
+```
+
+The before/after outputs are folded into the markdown report (see
+Output section) as a comparison table.
+
+If `git stash -u` reports "No local changes to save", return
+`CANNOT_VERIFY(reason=no_staged_changes)` with `blocker="no staged
+changes; fix-implement contract requires uncommitted changes"`.
+
+## Step 4: Run test
+
+Run ALL failing test cases from the original report individually.
+
+Result interpretation:
+
+- `all skipped` → read pytest's `SKIPPED [N] <file:line>: <reason>`
+  line to classify:
+  - Reason matches an XPU marker (`skipIfXpu`, `xfailIfXPU`,
+    `expectedFailureXPU`, `skipXPU`, or a message containing "xpu")
+    → `FAILED` with `reason=stale_skip_after_fix`. Rationale: a fix
+    that leaves the failing test skipped is an incomplete fix. This
+    is intentionally different from `fix-reproduce`'s handling —
+    reproduce temporarily unskips to confirm the bug, but verify's
+    job is to confirm the fix; if the XPU-marker skip is still in
+    place, the fix did not touch what it should have. Suggest in
+    `reason_detail`: "test still skipped after fix — the stale skip
+    decorator should have been removed as part of the fix (see the
+    Skip operations section of `fix-implement`)."
+  - Reason is environmental (missing dep, no GPU, tool not found,
+    "no accelerator", etc.) →
+    `CANNOT_VERIFY(reason=environmental_skip)` with
+    `blocker="test skipped for environmental reason: <marker>"`.
+- `xfailed` → `FAILED` with `reason=xfail_after_fix`.
+- `FAILED` → `FAILED` with `reason=test_still_failing`.
+- `PASSED` → `PASSED` with `reason=ok`.
+
+## Step 5: Lint (if `run_lint=true`)
+
+Only run after a passing test result. Run it in `target_repo_dir` —
+the repo that owns the changed files — not in `pytorch_dir`:
+
+```bash
+cd $target_repo_dir
+spin fixlint
+# fixlint rewrites files in the working tree, which UNSTAGES those
+# hunks. The orchestrator commits what is staged, so re-stage the
+# same files or the lint fixes are silently dropped from the commit.
+git -C $target_repo_dir add -- <changed_files>
+# Nothing outside changed_files may become staged; if `git status`
+# shows fixlint touched other files, return FAILED rather than
+# widening the diff.
+spin lint 2>&1 | tail -40
+```
+
+- If **clean**: include `lint: clean` in the `PASSED` output.
+- If **errors remain after fixlint**: return
+  `FAILED(reason=lint_errors_after_autofix)` with the lint errors as
+  `failure_output` and suggest that the remaining errors need a
+  human touch.
+
+## Output
+
+Return to the orchestrator a report (markdown block plus JSON block).
+The skill does not commit or push — the caller consumes stdout and
+decides what to do, per the pattern established by `issue-triage`,
+`fix-reproduce`, `fix-root-cause`, and `fix-implement`.
+
+Include the `<!-- agent:verify -->` marker on the first line of the
+markdown block so a downstream caller can locate its own previous
+verify comment (if any) and update it in place. Comment location and
+update is the **caller's** responsibility.
+
+```
+<!-- agent:verify -->
+
+## Verify Result
+
+- **Target repo:** <pytorch | torch-xpu-ops>
+- **Refined command:** <refined_command>
+- **Verdict:** <PASSED | FAILED | CANNOT_VERIFY> — <one-line reason>
+- **Lint:** <clean | not run | errors: <summary>>
+
+<if run_before_after_diff=true, include:>
+### Before / after
+
+| Test case | Before | After |
+|-----------|--------|-------|
+| TestFooXPU::test_bar | FAILED (AssertionError: ...) | PASSED |
+
+*Automated by fix-verify.*
+```
+
+```json
+{
+  "target_repo": "pytorch or torch-xpu-ops",
+  "refined_command": "<echo of input>",
+  "changed_files": ["path/to/file1.py"],
+  "run_before_after_diff": false,
+  "run_lint": false,
+  "verdict": "PASSED or FAILED or CANNOT_VERIFY",
+  "reason": "<enumerated reason code, see below>",
+  "reason_detail": "one-line human-readable detail",
+  "before_after_table": "<markdown table string, or null>",
+  "failure_output": "<test/lint output excerpt on FAILED, or null>"
+}
+```
+
+### Field contract
+
+- `target_repo` — echo from `fix-implement`'s output.
+- `refined_command` — echo the exact command that was run.
+- `changed_files` — echo from `fix-implement`; downstream orchestrator
+  uses this to build the commit's file list.
+- `run_before_after_diff` / `run_lint` — echo the input flags verbatim,
+  so a reviewer can tell from the JSON alone which paths this run
+  exercised.
+- `before_after_table` — non-null only when `run_before_after_diff=true`
+  and the phases ran successfully; otherwise `null`.
+- `failure_output` — non-null on `FAILED`; excerpt of the test or lint
+  output (bounded — do not dump multi-MB logs, ~40 lines is enough for
+  a human to see the failure).
+
+### `reason` values
+
+On `verdict=PASSED`:
+
+- `ok` — test passed with the fix applied; lint clean (or `run_lint=false`).
+
+On `verdict=FAILED`:
+
+- `test_still_failing` — Step 4 reported `FAILED`; fix is incomplete.
+- `stale_skip_after_fix` — Step 4 reported `all skipped` with an XPU
+  marker still in place.
+- `xfail_after_fix` — Step 4 reported `xfailed`; fix did not turn the
+  test green.
+- `lint_errors_after_autofix` — Step 5 could not clean the lint after
+  `spin fixlint`; a human touch is needed.
+- `unrelated_files_touched_by_lint` — Step 5's `spin fixlint` modified
+  files outside `changed_files`.
+
+On `verdict=CANNOT_VERIFY`:
+
+- `wheel_install_not_source` — Step 1 saw `torch` imported from
+  `site-packages`; can't verify a source-tree fix through a wheel.
+- `rebuild_failed` — `xpu-build-pytorch` returned failure in Step 2 or
+  Step 3.
+- `no_staged_changes` — Step 3 found nothing to stash; the contract
+  from `fix-implement` (staged, uncommitted) is violated.
+- `stash_pop_failed` — `git stash pop --index` failed or did not
+  restore the staged state in Step 3.
+- `environmental_skip` — Step 4's `all skipped` had an environmental
+  reason (missing dep, no accelerator).
+- `test_collect_zero` — Step 4's `refined_command` resolves to zero
+  collected tests; the fix cannot be validated against the reported
+  reproducer.
+- `test_timeout` — the test process exceeded its timeout and was
+  killed.
+- `other` — fallback; put full explanation in `reason_detail`.
+
+The orchestrator decides whether to loop back to `fix-implement` on
+`FAILED`, or proceed to commit/PR on `PASSED`, based on `verdict` and
+`reason`.


### PR DESCRIPTION
**Merge order:** issue-triage (#4983) → fix-reproduce (#4997) → fix-root-cause (#5011) → **fix-implement/fix-verify (#5012)** → issue-handler (#5014). PR 4/5.

### Summary

Adds the two leaves that complete the fix pipeline:

- **`fix-implement`** — takes `fix-root-cause`'s output, edits code, leaves the change **staged** (uncommitted). No tests, no commit, no PR.
- **`fix-verify`** — runs the refined command against a source build with the staged fix, always producing a stash-based before/after comparison and running `spin fixlint` on a pass.

Leaf skills called by orchestrators; no bot command.

### Contract

**`fix-implement`** — in: `triage_result`, `pytorch_dir`, `target_repo_dir`, `allow_skip` (false for issue-handler, true for xpu-nightly-ci-fix). Out:
- `READY(ok)` — staged diff exists.
- `NEEDS_HUMAN` — `skip_outside_target_repo` / `skip_guard_rejected` / `no_fix_possible` / `other`.

Stages via `git add` only; the workflow commits after `fix-verify` PASSES. Never commits/pushes/opens a PR.

**`fix-verify`** — in: `refined_command`, `pytorch_dir`, `target_repo_dir`, `changed_files`. No behavior flags. Out:
- `PASSED(ok)`
- `FAILED` — `test_still_failing` / `stale_skip_after_fix` / `xfail_after_fix` / `lint_errors_after_autofix` / `unrelated_files_touched_by_lint`
- `CANNOT_VERIFY` — `wheel_install_not_source` / `rebuild_failed` / `no_staged_changes` / `test_collect_zero` / `test_timeout` / etc.

### before/after + lint are unconditional

The source branch gated these behind `run_before_after_diff` / `run_lint` (default off). Both orchestrators want both — the before/after table is the FAIL→PASS evidence, `fixlint` keeps the diff landable — so they were dead configurability. Commit `99c67dbb` removes both inputs and their conditions; Step 2's C++/SYCL rebuild-deferral is now unconditional. The matching orchestrator-side removal lands on #5014.

### Behavior from #4918 review

- **Skip-guard subagent** (`fix-implement` Step 3.5, `allow_skip=false`): a fresh-context `Task` — not the implementer — vetoes skip-shaped diffs (skip decorators, `DecorateInfo`, `xfail` dicts, seed hardcoding, tolerance loosening, deletions, broad `try/except`). Removing existing skips is fine.
- **Before/after stash** (`fix-verify`): stash → rebuild-without-fix (before) → `stash pop --index` → rebuild-with-fix (after); sha256-compare staged diffs to catch stash-pop degradation.
- **`third_party/xpu.txt` pin**: `fix-verify` rewrites it to the branch HEAD before rebuild and restores base for the "before" phase; `fix-implement` never stages it.
- **Source-import check**: `os.path.realpath(torch.__file__)` must resolve under `pytorch_dir`, else `CANNOT_VERIFY(wheel_install_not_source)`.
- **`fixlint` re-stage**: fixlint unstages files; re-stage the same list, fail rather than widen the diff if it touched files outside `changed_files`.

Also dropped `patch_proposal_mode` (every diff is a proposal — staging is uniform) and inlined skip add/remove recipes (~10 lines each) instead of a separate `fix-skip-management` skill, matching pytorch upstream convention.

### Not in this PR

- No bot integration.
- `fix-skip-list` (loop-over-entries) belongs in the orchestrator rewrites (#5014), not a leaf skill — it's orchestration, not reusable knowledge.

### Test Plan

Docs-only.
```bash
lintrunner .claude/skills/fix-implement/ .claude/skills/fix-verify/
```
Live behavior verifiable once an orchestrator calls these skills.

_Authored with the assistance of an AI coding agent._
