### PR TITLE
[SYCL free func] migrate UpSampleBicubic2dKernels kernels 

### DIFF
--- a/src/ATen/native/xpu/sycl/UpSampleBicubic2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleBicubic2dKernels.cpp
@@ -19,6 +19,7 @@ DISABLE_RETURN_TYPE_WARNING_BEGIN
 #include <ATen/ceil_div.h>
 #include <ATen/native/xpu/UpSample.h>
 #include <comm/SYCLContext.h>
+#include <comm/SYCLHelpers.h>
 #include <comm/xpu_aten.h>
 
 #include <ATen/native/xpu/sycl/UpSampleBicubic2dKernels.h>
@@ -26,130 +27,122 @@ DISABLE_RETURN_TYPE_WARNING_BEGIN
 namespace at::native::xpu {
 
 template <typename scalar_t, typename accscalar_t>
-struct UpsampleBicubic2dKernelFunctor {
-  void operator()(sycl::nd_item<1> item) const {
-    auto idata = in_data_;
-    auto odata = out_data_;
-    int global_id = item.get_global_linear_id();
-    const int nbatch = idata.size(0);
-    const int channels = idata.size(1);
-    const int input_height = idata.size(2);
-    const int input_width = idata.size(3);
-    const int output_height = odata.size(2);
-    const int output_width = odata.size(3);
-    if (global_id < output_height * output_width) {
-      const int output_x = global_id % output_width;
-      const int output_y = global_id / output_width;
-      if (input_height == output_height && input_width == output_width) {
-        for (int n = 0; n < nbatch; n++) {
-          for (int c = 0; c < channels; c++) {
-            auto val = idata[n][c][output_y][output_x];
-            odata[n][c][output_y][output_x] = val;
-          }
-        }
-        return;
-      }
-
-      // Interpolation kernel
-      accscalar_t real_x = area_pixel_compute_source_index(
-          width_scale_, output_x, align_corners_, /*cubic=*/true);
-      int in_x = sycl::floor(real_x);
-      accscalar_t t_x = real_x - in_x;
-
-      accscalar_t real_y = area_pixel_compute_source_index(
-          height_scale_, output_y, align_corners_, /*cubic=*/true);
-      int in_y = sycl::floor(real_y);
-      accscalar_t t_y = real_y - in_y;
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(
+    (sycl::ext::oneapi::experimental::nd_range_kernel<1>))
+void upsample_bicubic2d_kernel(
+    PackedTensorAccessor64<scalar_t, 4> out_data,
+    const PackedTensorAccessor64<const scalar_t, 4> in_data,
+    int64_t onum,
+    bool align_corners,
+    accscalar_t height_scale,
+    accscalar_t width_scale) {
+  sycl::nd_item<1> item = sycl::ext::oneapi::this_work_item::get_nd_item<1>();
+  int global_id = item.get_global_linear_id();
+  const int nbatch = in_data.size(0);
+  const int channels = in_data.size(1);
+  const int input_height = in_data.size(2);
+  const int input_width = in_data.size(3);
+  const int output_height = out_data.size(2);
+  const int output_width = out_data.size(3);
+  if (global_id < output_height * output_width) {
+    const int output_x = global_id % output_width;
+    const int output_y = global_id / output_width;
+    if (input_height == output_height && input_width == output_width) {
       for (int n = 0; n < nbatch; n++) {
         for (int c = 0; c < channels; c++) {
-          accscalar_t coefficients[4];
-          for (int k = 0; k < 4; k++) {
-            coefficients[k] = cubic_interp1d<scalar_t, accscalar_t>(
-                upsample_get_value_bounded<scalar_t>(
-                    idata,
-                    n,
-                    c,
-                    input_width,
-                    input_height,
-                    in_x - 1,
-                    in_y - 1 + k),
-                upsample_get_value_bounded<scalar_t>(
-                    idata,
-                    n,
-                    c,
-                    input_width,
-                    input_height,
-                    in_x + 0,
-                    in_y - 1 + k),
-                upsample_get_value_bounded<scalar_t>(
-                    idata,
-                    n,
-                    c,
-                    input_width,
-                    input_height,
-                    in_x + 1,
-                    in_y - 1 + k),
-                upsample_get_value_bounded<scalar_t>(
-                    idata,
-                    n,
-                    c,
-                    input_width,
-                    input_height,
-                    in_x + 2,
-                    in_y - 1 + k),
-                t_x);
-          }
-
-          odata[n][c][output_y][output_x] =
-              static_cast<scalar_t>(cubic_interp1d<scalar_t, accscalar_t>(
-                  coefficients[0],
-                  coefficients[1],
-                  coefficients[2],
-                  coefficients[3],
-                  t_y));
+          auto val = in_data[n][c][output_y][output_x];
+          out_data[n][c][output_y][output_x] = val;
         }
+      }
+      return;
+    }
+
+    // Interpolation kernel
+    accscalar_t real_x = area_pixel_compute_source_index(
+        width_scale, output_x, align_corners, /*cubic=*/true);
+    int in_x = floorf(real_x);
+    accscalar_t t_x = real_x - in_x;
+
+    accscalar_t real_y = area_pixel_compute_source_index(
+        height_scale, output_y, align_corners, /*cubic=*/true);
+    int in_y = floorf(real_y);
+    accscalar_t t_y = real_y - in_y;
+    for (int n = 0; n < nbatch; n++) {
+      for (int c = 0; c < channels; c++) {
+        accscalar_t coefficients[4];
+        for (int k = 0; k < 4; k++) {
+          coefficients[k] = cubic_interp1d<scalar_t, accscalar_t>(
+              upsample_get_value_bounded<scalar_t>(
+                  in_data,
+                  n,
+                  c,
+                  input_width,
+                  input_height,
+                  in_x - 1,
+                  in_y - 1 + k),
+              upsample_get_value_bounded<scalar_t>(
+                  in_data,
+                  n,
+                  c,
+                  input_width,
+                  input_height,
+                  in_x + 0,
+                  in_y - 1 + k),
+              upsample_get_value_bounded<scalar_t>(
+                  in_data,
+                  n,
+                  c,
+                  input_width,
+                  input_height,
+                  in_x + 1,
+                  in_y - 1 + k),
+              upsample_get_value_bounded<scalar_t>(
+                  in_data,
+                  n,
+                  c,
+                  input_width,
+                  input_height,
+                  in_x + 2,
+                  in_y - 1 + k),
+              t_x);
+        }
+
+        out_data[n][c][output_y][output_x] =
+            static_cast<scalar_t>(cubic_interp1d<scalar_t, accscalar_t>(
+                coefficients[0],
+                coefficients[1],
+                coefficients[2],
+                coefficients[3],
+                t_y));
       }
     }
   }
-  UpsampleBicubic2dKernelFunctor(
-      PackedTensorAccessor64<scalar_t, 4> out_data,
-      const PackedTensorAccessor64<const scalar_t, 4> in_data,
-      int64_t onum,
-      bool align_corners,
-      const accscalar_t height_scale,
-      const accscalar_t width_scale)
-      : out_data_(out_data),
-        in_data_(in_data),
-        onum_(onum),
-        align_corners_(align_corners),
-        height_scale_(height_scale),
-        width_scale_(width_scale) {}
-
- private:
-  PackedTensorAccessor64<scalar_t, 4> out_data_;
-  const PackedTensorAccessor64<const scalar_t, 4> in_data_;
-  int64_t onum_;
-  bool align_corners_;
-  const accscalar_t height_scale_;
-  const accscalar_t width_scale_;
-};
+}
 
 template <typename scalar_t, typename accscalar_t>
-static void upsample_bicubic2d_out_template(
+static void launch_upsample_bicubic2d_out_kernel(
     PackedTensorAccessor64<scalar_t, 4> odata,
     const PackedTensorAccessor64<const scalar_t, 4> idata,
     int64_t onum,
     bool align_corners,
     const accscalar_t height_scale,
     const accscalar_t width_scale) {
-  UpsampleBicubic2dKernelFunctor<scalar_t, accscalar_t> kfn(
-      odata, idata, onum, align_corners, height_scale, width_scale);
-
-  int64_t wg_size = syclMaxWorkGroupSize(kfn);
+  int64_t wg_size =
+      syclMaxWorkGroupSize<upsample_bicubic2d_kernel<scalar_t, accscalar_t>>();
   int64_t num_wg = at::ceil_div(onum, wg_size);
   auto queue = getCurrentSYCLQueue();
 
-  sycl_kernel_submit(num_wg * wg_size, wg_size, queue, kfn);
+  sycl_kernel_submit<upsample_bicubic2d_kernel<scalar_t, accscalar_t>>(
+      num_wg * wg_size,
+      wg_size,
+      queue,
+      0,
+      odata,
+      idata,
+      onum,
+      align_corners,
+      height_scale,
+      width_scale);
 }
 
 void upsample_bicubic2d_kernel(
@@ -188,113 +181,105 @@ void upsample_bicubic2d_kernel(
         const accscalar_t rwidth = area_pixel_compute_scale<accscalar_t>(
             input_width, output_width, align_corners, scales_w);
 
-        upsample_bicubic2d_out_template<scalar_t, accscalar_t>(
+        launch_upsample_bicubic2d_out_kernel<scalar_t, accscalar_t>(
             odata, idata, num_output_elements, align_corners, rheight, rwidth);
       });
 }
 
 template <typename scalar_t, typename accscalar_t>
-struct UpsampleBicubic2dBackwardKernelFunctor {
-  void operator()(sycl::nd_item<1> item) const {
-    auto idata = in_data_;
-    auto odata = out_data_;
-    int index = item.get_global_linear_id();
-    const int batchsize = idata.size(0);
-    const int channels = idata.size(1);
-    const int input_height = idata.size(2);
-    const int input_width = idata.size(3);
-    const int output_height = odata.size(2);
-    const int output_width = odata.size(3);
-    if (index >= num_elements_) {
-      return;
-    }
-    const int output_x = index % output_width;
-    const int output_y = index / output_width;
-    // special case: output_xust copy
-    if (input_height == output_height && input_width == output_width) {
-      for (int n = 0; n < batchsize; n++) {
-        for (int c = 0; c < channels; ++c) {
-          const scalar_t val = odata[n][c][output_y][output_x];
-          idata[n][c][output_y][output_x] = val;
-        }
-      }
-      return;
-    }
-
-    accscalar_t real_x = area_pixel_compute_source_index(
-        width_scale_, output_x, align_corners_, /*cubic=*/true);
-    int input_x = sycl::floor(real_x);
-    accscalar_t t_x = real_x - input_x;
-
-    accscalar_t real_y = area_pixel_compute_source_index(
-        height_scale_, output_y, align_corners_, /*cubic=*/true);
-    int input_y = sycl::floor(real_y);
-    accscalar_t t_y = real_y - input_y;
-
-    accscalar_t x_coeffs[4];
-    accscalar_t y_coeffs[4];
-
-    get_cubic_upsampling_coefficients(x_coeffs, t_x);
-    get_cubic_upsampling_coefficients(y_coeffs, t_y);
-
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(
+    (sycl::ext::oneapi::experimental::nd_range_kernel<1>))
+void upsample_bicubic2d_backward_kernel(
+    int num_elements,
+    accscalar_t height_scale,
+    accscalar_t width_scale,
+    bool align_corners,
+    PackedTensorAccessor64<scalar_t, 4> in_data,
+    const PackedTensorAccessor64<const scalar_t, 4> out_data) {
+  sycl::nd_item<1> item = sycl::ext::oneapi::this_work_item::get_nd_item<1>();
+  int index = item.get_global_linear_id();
+  const int batchsize = in_data.size(0);
+  const int channels = in_data.size(1);
+  const int input_height = in_data.size(2);
+  const int input_width = in_data.size(3);
+  const int output_height = out_data.size(2);
+  const int output_width = out_data.size(3);
+  if (index >= num_elements) {
+    return;
+  }
+  const int output_x = index % output_width;
+  const int output_y = index / output_width;
+  // special case: output_xust copy
+  if (input_height == output_height && input_width == output_width) {
     for (int n = 0; n < batchsize; n++) {
       for (int c = 0; c < channels; ++c) {
-        scalar_t out_value = odata[n][c][output_y][output_x];
-        for (int i = 0; i < 4; i++) {
-          for (int j = 0; j < 4; j++) {
-            upsample_increment_value_bounded<scalar_t, accscalar_t>(
-                idata,
-                n,
-                c,
-                input_height,
-                input_width,
-                input_y - 1 + i,
-                input_x - 1 + j,
-                out_value * y_coeffs[i] * x_coeffs[j]);
-          }
+        const scalar_t val = out_data[n][c][output_y][output_x];
+        in_data[n][c][output_y][output_x] = val;
+      }
+    }
+    return;
+  }
+
+  accscalar_t real_x = area_pixel_compute_source_index(
+      width_scale, output_x, align_corners, /*cubic=*/true);
+  int input_x = floorf(real_x);
+  accscalar_t t_x = real_x - input_x;
+
+  accscalar_t real_y = area_pixel_compute_source_index(
+      height_scale, output_y, align_corners, /*cubic=*/true);
+  int input_y = floorf(real_y);
+  accscalar_t t_y = real_y - input_y;
+
+  accscalar_t x_coeffs[4];
+  accscalar_t y_coeffs[4];
+
+  get_cubic_upsampling_coefficients(x_coeffs, t_x);
+  get_cubic_upsampling_coefficients(y_coeffs, t_y);
+
+  for (int n = 0; n < batchsize; n++) {
+    for (int c = 0; c < channels; ++c) {
+      scalar_t out_value = out_data[n][c][output_y][output_x];
+      for (int i = 0; i < 4; i++) {
+        for (int j = 0; j < 4; j++) {
+          upsample_increment_value_bounded<scalar_t, accscalar_t>(
+              in_data,
+              n,
+              c,
+              input_height,
+              input_width,
+              input_y - 1 + i,
+              input_x - 1 + j,
+              out_value * y_coeffs[i] * x_coeffs[j]);
         }
       }
     }
   }
-  UpsampleBicubic2dBackwardKernelFunctor(
-      const int num_elements,
-      const accscalar_t height_scale,
-      const accscalar_t width_scale,
-      const bool align_corners,
-      PackedTensorAccessor64<scalar_t, 4> in_data,
-      const PackedTensorAccessor64<const scalar_t, 4> out_data)
-      : num_elements_(num_elements),
-        height_scale_(height_scale),
-        width_scale_(width_scale),
-        align_corners_(align_corners),
-        in_data_(in_data),
-        out_data_(out_data) {}
-
- private:
-  const int num_elements_;
-  const accscalar_t height_scale_;
-  const accscalar_t width_scale_;
-  const bool align_corners_;
-  PackedTensorAccessor64<scalar_t, 4> in_data_;
-  const PackedTensorAccessor64<const scalar_t, 4> out_data_;
-};
+}
 
 template <typename scalar_t, typename accscalar_t>
-static void upsample_bicubic2d_backward_out_template(
+static void launch_upsample_bicubic2d_backward_out_kernel(
     int64_t num_elements,
     const accscalar_t height_scale,
     const accscalar_t width_scale,
     const bool align_corners,
     PackedTensorAccessor64<scalar_t, 4> idata,
     const PackedTensorAccessor64<const scalar_t, 4> odata) {
-  UpsampleBicubic2dBackwardKernelFunctor<scalar_t, accscalar_t> kfn(
-      num_elements, height_scale, width_scale, align_corners, idata, odata);
-
-  int64_t wg_size = syclMaxWorkGroupSize(kfn);
+  int64_t wg_size = syclMaxWorkGroupSize<
+      upsample_bicubic2d_backward_kernel<scalar_t, accscalar_t>>();
   int64_t num_wg = at::ceil_div(num_elements, wg_size);
   auto queue = getCurrentSYCLQueue();
 
-  sycl_kernel_submit(num_wg * wg_size, wg_size, queue, kfn);
+  sycl_kernel_submit<upsample_bicubic2d_backward_kernel<scalar_t, accscalar_t>>(
+      num_wg * wg_size,
+      wg_size,
+      queue,
+      0,
+      (int)num_elements,
+      height_scale,
+      width_scale,
+      align_corners,
+      idata,
+      odata);
 }
 
 void upsample_bicubic2d_backward_kernel(
@@ -335,7 +320,7 @@ void upsample_bicubic2d_backward_kernel(
         const accscalar_t rwidth = area_pixel_compute_scale<accscalar_t>(
             input_width, output_width, align_corners, scales_w);
 
-        upsample_bicubic2d_backward_out_template<scalar_t, accscalar_t>(
+        launch_upsample_bicubic2d_backward_out_kernel<scalar_t, accscalar_t>(
             num_elements, rheight, rwidth, align_corners, idata, odata);
       });
 }


### PR DESCRIPTION
# UpSampleBicubic2dKernels.cpp — Kernel UT Report

- SYCL kernel conversion check: In [UpSampleBicubic2dKernels.cpp](vscode-file://vscode-app/c:/Users/minmingz/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html), two kernels are implemented as free functions via SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((sycl::ext::oneapi::experimental::nd_range_kernel<1>)) and launched with sycl_kernel_submit<...>() function pointer:
    - upsample_bicubic2d_out_fn (line 28) — forward interpolation kernel
    - upsample_bicubic2d_backward_out_fn (line 133) — backward gradient kernel
- No legacy functor-based SYCL kernel launch patterns remain in this file.
- Changed-kernel related UTs run:

1. In PyTorch ([pytorch-public](vscode-file://vscode-app/c:/Users/minmingz/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html)):
    - pytest test_nn_xpu.py -v -k "upsamplingBicubic2d"
    - Result: 6 passed, 3498 deselected.
2. Functional verification (bicubic2d forward/backward on XPU):
    - Forward upsampling (scale_factor=2, align_corners=False): input [1,3,4,4] → output [1,3,8,8] ✓
    - Backward: grad_input shape correct, non-zero gradients ✓
    - Forward (align_corners=True): output [1,3,8,8] ✓
    - Downsampling (size=(2,2)): output [1,3,2,2] ✓
    - Half (float16) precision forward: correct dtype and shape ✓
    - BFloat16 precision forward: correct dtype and shape ✓