### PR TITLE
Fix safe-softmax zeroing rows that contain NaN

### DIFF
--- a/src/ATen/native/xpu/sycl/GroupReduceUtils.h
+++ b/src/ATen/native/xpu/sycl/GroupReduceUtils.h
@@ -82,6 +82,8 @@ inline T& GroupReduceSumWithoutBroadcast(
   return val;
 }
 
+// Keep max_impl below: sycl::maximum under reduce_over_group can drop a NaN,
+// which torch.max/amax must not.
 template <typename T, int SIMD, int DIM>
 inline T& SubgroupReduceMaxWithoutBroadcast(sycl::nd_item<DIM>& item, T& val) {
   auto sg = item.get_sub_group();

--- a/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
+++ b/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
@@ -10,6 +10,7 @@
 
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
+#include <ATen/NumericUtils.h>
 #include <ATen/native/CanUse32BitIndexMath.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/xpu/sycl/Loops.h>
@@ -310,6 +311,9 @@ struct DispatchSoftmaxForwardKernelFunctor
     else if (sum_value != 0)
       sum_value = accscalar_t(1) / sum_value;
 
+      // The max reduce can drop a NaN, so max_value == lowest() alone does not
+      // mean the row was fully masked; sum_value still carries the NaN.
+
       // update result
 #pragma unroll(outer_loop)
     for (int i = 0; i < outer_loop; ++i) {
@@ -326,7 +330,8 @@ struct DispatchSoftmaxForwardKernelFunctor
                 static_cast<outscalar_t>(reg_in[i][j] - max_value - sum_value);
           } else if (
               is_safe_softmax &&
-              max_value == std::numeric_limits<accscalar_t>::lowest()) {
+              max_value == std::numeric_limits<accscalar_t>::lowest() &&
+              !at::_isnan(sum_value)) {
             reg_in[i][j] = static_cast<outscalar_t>(0);
           } else if (sum_value == 0) {
             reg_in[i][j] = nan_;
@@ -340,7 +345,8 @@ struct DispatchSoftmaxForwardKernelFunctor
                 static_cast<outscalar_t>(reg_in[i][j] - max_value - sum_value);
           } else if (
               is_safe_softmax &&
-              max_value == std::numeric_limits<accscalar_t>::lowest()) {
+              max_value == std::numeric_limits<accscalar_t>::lowest() &&
+              !at::_isnan(sum_value)) {
             out_data_point[j] = static_cast<outscalar_t>(0);
           } else if (sum_value == 0) {
             out_data_point[j] = static_cast<outscalar_t>(nan_);
@@ -597,6 +603,9 @@ struct SoftmaxForwardKernelFunctor {
     else
       sum_value = accscalar_t(1) / sum_value;
 
+    // The max reduce can drop a NaN, so max_value == lowest() alone does not
+    // mean the row was fully masked; sum_value still carries the NaN.
+
     // update result
     constexpr int out_vec_size = align_bytes / sizeof(outscalar_t);
     using out_vec_t =
@@ -620,7 +629,8 @@ struct SoftmaxForwardKernelFunctor {
                   in_data_[group_offset + linear_idx] - max_value - sum_value);
             else if (
                 is_safe_softmax &&
-                max_value == std::numeric_limits<accscalar_t>::lowest())
+                max_value == std::numeric_limits<accscalar_t>::lowest() &&
+                !at::_isnan(sum_value))
               out_data_[group_offset + linear_idx] =
                   static_cast<outscalar_t>(0);
             else
@@ -640,7 +650,8 @@ struct SoftmaxForwardKernelFunctor {
                 static_cast<outscalar_t>(in_val[j] - max_value - sum_value);
           else if (
               is_safe_softmax &&
-              max_value == std::numeric_limits<accscalar_t>::lowest())
+              max_value == std::numeric_limits<accscalar_t>::lowest() &&
+              !at::_isnan(sum_value))
             results[j] = static_cast<outscalar_t>(0);
           else
             results[j] = static_cast<outscalar_t>(

--- a/test/regressions/test_safe_softmax.py
+++ b/test/regressions/test_safe_softmax.py
@@ -49,3 +49,17 @@ class TestSafeSoftMax(TestCase):
             r_cpu = torch.ops.aten._safe_softmax(x_cpu, 0)
             r_xpu = torch.ops.aten._safe_softmax(x_xpu, 0)
             self.assertEqual(r_xpu.to(cpu_device), r_cpu)
+
+    def test_sm_nan_in_masked_row(self):
+        # A row holding a NaN is not fully masked, so the row keeps the NaN
+        # rather than being zeroed. The two dim sizes straddle the threshold
+        # that picks between the two forward kernels.
+        for dtype in [torch.float, torch.float16, torch.bfloat16]:
+            for dim_size in [128, 32768]:
+                x_cpu = torch.randn(4, dim_size).to(dtype)
+                x_cpu[0, :] = -float("inf")
+                x_cpu[0, dim_size // 2] = float("nan")
+                x_xpu = x_cpu.to(xpu_device)
+                r_cpu = torch.ops.aten._safe_softmax(x_cpu, -1)
+                r_xpu = torch.ops.aten._safe_softmax(x_xpu, -1)
+                self.assertEqual(r_xpu.to(cpu_device), r_cpu)


### PR DESCRIPTION
The fused kernels infer "fully masked row" from the sentinel `max_value == lowest()`. The group max reduce can drop a NaN, so a masked row still holding one (`NaN + -inf = NaN`) hit that sentinel and was zeroed, where upstream keeps it NaN. Gate the early-out on `sum_value` too: a genuinely masked row sums to 0, never NaN.

Scope: the two `inner_size == 1` kernels (`dim=-1`, the path SDPA uses). `SpatialSoftmaxForwardKernelFunctor` carries the same sentinel and is **not** fixed here -- it seeds its max from an element rather than `lowest()`, so a legitimately masked column already produces a NaN sum and this guard cannot be reused there.

Test: test/regressions/test_safe_softmax.py -- added `test_sm_nan_in_masked_row`, whose two dim sizes hit both kernels in scope.
