### PR TITLE
[Cherry-pick release/2.14] Fix group_reduce assert on XPU

### DIFF
--- a/src/ATen/native/xpu/sycl/Reduce.h
+++ b/src/ATen/native/xpu/sycl/Reduce.h
@@ -100,8 +100,7 @@ inline at::detail::Array<arg_t, out_vec_sz> group_reduce(
   int sg_gid = sg.get_group_linear_id();
   int sg_range = sg.get_group_range()[0];
   // group reduce requests workgroup size is multiple of subgroup size
-  SYCL_KERNEL_ASSERT(
-      wg_size % sg_size == 0 && "unsupported workgroup size for group reduce");
+  SYCL_KERNEL_ASSERT(wg_size % sg_size == 0);
 
   // tree reduce in subgroup
   subgroup_tree_reduce<arg_t, CombineFunc, NativeOp, out_vec_sz>(

--- a/test/regressions/test_reduce.py
+++ b/test/regressions/test_reduce.py
@@ -1,0 +1,32 @@
+# Copyright 2020-2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Owner(s): ["module: intel"]
+
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestSimpleReduce(TestCase):
+    def test_aminmax_int64_large(self):
+        # Regression for intel/torch-xpu-ops#4435: the int64 aminmax reduction
+        # over a large input reaches the combined group-x/group-y group_reduce
+        # path and used to abort the process.
+        cpu_input = torch.randint(0, 1000, (16384,), dtype=torch.int64)
+        cpu_min, cpu_max = torch.aminmax(cpu_input)
+
+        xpu_input = cpu_input.xpu()
+        xpu_min, xpu_max = torch.aminmax(xpu_input)
+        torch.xpu.synchronize()
+
+        self.assertEqual(xpu_min.cpu(), cpu_min)
+        self.assertEqual(xpu_max.cpu(), cpu_max)
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
The `&& "msg"` string literal in the `SYCL_KERNEL_ASSERT` condition inside group_reduce is lowered to false in device code, so the assert fires even when `wg_size % sg_size == 0`. Drop the message from the condition.
To solve #4435

Cherry-pick of #5019 to `release/2.14`.
Cherry-picked from commit 7775fe9eb7883a7233ddcc2838fb0552c1a8cb41.