### PR TITLE
[Cherry-pick release/2.14] Deal nan case for topk

### DIFF
--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernelImpl.h
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernelImpl.h
@@ -20,6 +20,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
+#include <ATen/NumericUtils.h>
 #include <ATen/ceil_div.h>
 #include <ATen/native/xpu/sycl/MemoryAccessUtils.h>
 #include <ATen/native/xpu/sycl/TensorTopKSbtopkKernel.h>
@@ -59,12 +60,34 @@ template <
     bool Largest,
     typename IndexT = int>
 struct SubgroupTopKFunctor {
-  // Insert val into a K-sorted buffer. For Largest=true the buffer is sorted
-  // descending (top_vals[0] is max); for Largest=false it is sorted ascending
-  // (top_vals[0] is min). The comparator `better(a, b)` means "a should sit
-  // above b in the buffer" — i.e. strictly greater for largest, strictly less
-  // for smallest.
-  //
+  // Returns true if a is "better" than b — i.e. a should rank higher.
+  // NaN is treated as better than any non-NaN (matching CPU/CUDA behavior).
+  // A sentinel (idx == -1) is always worse than a real entry.
+  static inline bool better(
+      scalar_t a,
+      IndexT a_idx,
+      scalar_t b,
+      IndexT b_idx) {
+    // Sentinel is always worse
+    if (a_idx == -1)
+      return false;
+    if (b_idx == -1)
+      return true;
+    // NaN beats non-NaN
+    bool a_nan = at::_isnan(a);
+    bool b_nan = at::_isnan(b);
+    if (a_nan != b_nan)
+      return a_nan;
+    if (a_nan)
+      return a_idx < b_idx; // both NaN: smaller index ranks higher
+    if constexpr (Largest) {
+      return a > b;
+    } else {
+      return a < b;
+    }
+  }
+
+  // Insert val into a K-sorted buffer.
   // Fully unrolled, no early break — SIMD-friendly.
   inline void insert(
       scalar_t* top_vals,
@@ -72,30 +95,13 @@ struct SubgroupTopKFunctor {
       int count,
       scalar_t val,
       IndexT idx) const {
-    // Threshold is at the bottom of the buffer (top_vals[K-1]).
-    if constexpr (Largest) {
-      if (count >= K && !(val > top_vals[K - 1]))
-        return;
-    } else {
-      if (count >= K && !(val < top_vals[K - 1]))
-        return;
-    }
+    if (count >= K && !better(val, idx, top_vals[K - 1], top_idx[K - 1]))
+      return;
     bool inserted = false;
 #pragma unroll
     for (int i = K - 1; i >= 0; --i) {
-      // When count < K the buffer is partially filled: positions [0, count)
-      // hold real values while [count, K) still contain sentinels.
-      // Guard "i <= count" ensures we only stop at position i when
-      // top_vals[i-1] is a real entry.  Without this guard, an input
-      // value equal to the sentinel (e.g. all -inf for largest=true)
-      // would always stop at position K-1, overwriting it repeatedly
-      // instead of filling lower positions.
-      bool stop;
-      if constexpr (Largest) {
-        stop = (i == 0) || (i <= count && !(val > top_vals[i - 1]));
-      } else {
-        stop = (i == 0) || (i <= count && !(val < top_vals[i - 1]));
-      }
+      bool stop = (i == 0) ||
+          (i <= count && !better(val, idx, top_vals[i - 1], top_idx[i - 1]));
       if (!inserted && stop) {
         top_vals[i] = val;
         top_idx[i] = idx;
@@ -107,9 +113,8 @@ struct SubgroupTopKFunctor {
     }
   }
 
-  // Bitonic merge: A[K] and B[K] are both sorted in the "better" direction.
-  // Step 1: A[i] = better(A[i], B[K-1-i]) — produces bitonic sequence.
-  // Step 2: bitonic sort restores the sorted-by-better order on A.
+  // Bitonic merge: A[K] and B[K] are both sorted in the same direction.
+  // When A[i] holds a sentinel (A_idx[i]==-1), any real entry replaces it.
   inline void bitonic_merge(
       scalar_t* A,
       IndexT* A_idx,
@@ -120,13 +125,7 @@ struct SubgroupTopKFunctor {
     for (int i = 0; i < K; ++i) {
       scalar_t bv = B[K - 1 - i];
       IndexT bi = B_idx[K - 1 - i];
-      bool take;
-      if constexpr (Largest) {
-        take = bv > A[i];
-      } else {
-        take = bv < A[i];
-      }
-      if (take) {
+      if (better(bv, bi, A[i], A_idx[i])) {
         A[i] = bv;
         A_idx[i] = bi;
       }
@@ -157,12 +156,7 @@ struct SubgroupTopKFunctor {
 #pragma unroll
       for (int i = 0; i < K; ++i) {
         int j = i ^ stride;
-        bool swap;
-        if constexpr (Largest) {
-          swap = (j > i) && (A[i] < A[j]);
-        } else {
-          swap = (j > i) && (A[i] > A[j]);
-        }
+        bool swap = (j > i) && better(A[j], A_idx[j], A[i], A_idx[i]);
         if (swap) {
           scalar_t tv = A[i];
           A[i] = A[j];

--- a/test/regressions/test_sort.py
+++ b/test/regressions/test_sort.py
@@ -54,3 +54,89 @@ class TestNNMethod(TestCase):
         self.assertTrue((values == 0.0).all())
         # Indices must be valid positions within the input dimension.
         self.assertTrue((indices >= 0).all() and (indices < n).all())
+
+    def test_topk_nan_input(self):
+        num_cols = 128
+        k = 6
+        n_nan_cols = 3
+        for dtype in (torch.float32, torch.bfloat16):
+            for num_rows in (1024, 4096, 8192):
+                torch.manual_seed(0)
+                x = torch.randn(num_rows, num_cols, device="cpu", dtype=dtype)
+                x[:, -n_nan_cols:] = float("nan")
+                cpu_vals, _ = torch.topk(x, k=k, dim=-1, sorted=True)
+                xpu_vals, xpu_ids = torch.topk(x.xpu(), k=k, dim=-1, sorted=True)
+                torch.xpu.synchronize()
+                # Values must match CPU
+                self.assertEqual(cpu_vals.isnan(), xpu_vals.cpu().isnan())
+                self.assertEqual(cpu_vals.nan_to_num(), xpu_vals.cpu().nan_to_num())
+                # Indices: valid, unique, and point to correct values
+                gathered = x.xpu().gather(1, xpu_ids)
+                nan_mask = xpu_vals.isnan()
+                self.assertTrue(gathered[nan_mask].isnan().all())
+                self.assertEqual(
+                    gathered[~nan_mask],
+                    xpu_vals[~nan_mask],
+                )
+                for r in range(num_rows):
+                    row_ids = xpu_ids[r].cpu().tolist()
+                    self.assertEqual(len(set(row_ids)), k)
+
+    def test_topk_neginf_input(self):
+        num_cols = 128
+        k = 6
+        for dtype in (torch.float32, torch.bfloat16):
+            x = torch.full((2048, num_cols), float("-inf"), device="cpu", dtype=dtype)
+            cpu_vals, cpu_ids = torch.topk(x, k=k, dim=-1, sorted=True)
+            xpu_vals, xpu_ids = torch.topk(x.xpu(), k=k, dim=-1, sorted=True)
+            torch.xpu.synchronize()
+            self.assertEqual(cpu_vals, xpu_vals.cpu())
+            self.assertTrue(
+                (xpu_ids >= 0).all() and (xpu_ids < num_cols).all(),
+                f"Out-of-range indices for all -inf input, dtype={dtype}",
+            )
+            # indices must be unique per row
+            for r in range(x.shape[0]):
+                ids_list = xpu_ids[r].cpu().tolist()
+                self.assertEqual(
+                    len(set(ids_list)),
+                    k,
+                    f"Duplicate indices in row {r} for dtype={dtype}: {ids_list}",
+                )
+
+    def test_topk_equal_values(self):
+        num_cols = 128
+        for k in (1, 6, 8):
+            for dtype in (torch.float32, torch.bfloat16):
+                x = torch.ones(2048, num_cols, device="cpu", dtype=dtype)
+                cpu_vals, _ = torch.topk(x, k=k, dim=-1, sorted=True)
+                xpu_vals, xpu_ids = torch.topk(x.xpu(), k=k, dim=-1, sorted=True)
+                torch.xpu.synchronize()
+                self.assertEqual(cpu_vals, xpu_vals.cpu())
+                self.assertTrue(
+                    (xpu_ids >= 0).all() and (xpu_ids < num_cols).all(),
+                    f"Out-of-range indices for k={k}, dtype={dtype}",
+                )
+                for r in range(x.shape[0]):
+                    ids_list = xpu_ids[r].cpu().tolist()
+                    self.assertEqual(
+                        len(set(ids_list)),
+                        k,
+                        f"Duplicate indices in row {r} for k={k}, dtype={dtype}: {ids_list}",
+                    )
+
+    def test_topk_random_values(self):
+        num_cols = 128
+        for k in (1, 6, 8):
+            for largest in (True, False):
+                torch.manual_seed(0)
+                x = torch.randn(2048, num_cols, dtype=torch.float32)
+                cpu_vals, cpu_ids = torch.topk(
+                    x, k=k, dim=-1, sorted=True, largest=largest
+                )
+                xpu_vals, xpu_ids = torch.topk(
+                    x.xpu(), k=k, dim=-1, sorted=True, largest=largest
+                )
+                torch.xpu.synchronize()
+                self.assertEqual(cpu_vals, xpu_vals.cpu())
+                self.assertEqual(cpu_ids, xpu_ids.cpu())


### PR DESCRIPTION
The behavior of topk when input is nan is not defined. Return the index of nan values instead of return -1

Cherry-pick of #4986 to `release/2.14`.
Cherry-picked from commit 2c1e18f840ecd3a830b515b069dc0957ab1692d2.