### PR TITLE
[Workflow] Add the daily XPU alignment scan, review and filing pipeline

### DIFF
--- a/.github/scripts/alignment_triage.py
+++ b/.github/scripts/alignment_triage.py
@@ -19,7 +19,9 @@ import sys
 import tempfile
 
 UNIT_MARKER = "<!-- alignment-unit: {unit_id} -->"
-RUN_MARKER = "<!-- alignment-run: {run_id} {scan_date} -->"
+# Provenance is visible text, not an HTML comment: a triager reading a draft
+# needs the run that produced it in order to re-read the underlying evidence.
+PROVENANCE_LINE = "<sub>alignment scan `{scan_date}`, run `{run_id}`</sub>"
 FILED_MARKER = "<!-- alignment-unit-filed: #{number} -->"
 FILED_MARKER_RE = re.compile(r"<!-- alignment-unit-filed: #(\d+) -->")
 TITLE_LINE_RE = re.compile(r"^### (.+)$", re.MULTILINE)
@@ -61,7 +63,7 @@ def list_comments(repo: str, issue: int) -> list[dict]:
 def render_draft(unit_id: str, title: str, body: str, run_id: str, scan_date: str) -> str:
     return (
         f"{UNIT_MARKER.format(unit_id=unit_id)}\n"
-        f"{RUN_MARKER.format(run_id=run_id, scan_date=scan_date)}\n"
+        f"{PROVENANCE_LINE.format(run_id=run_id, scan_date=scan_date)}\n"
         f"### {title}\n\n{body}\n"
     )
 
@@ -71,8 +73,8 @@ def render_filed_note(unit_id: str, issue_url: str, run_id: str, scan_date: str)
     return (
         f"{UNIT_MARKER.format(unit_id=unit_id)}\n"
         f"{FILED_MARKER.format(number=issue_number(issue_url))}\n"
-        f"{RUN_MARKER.format(run_id=run_id, scan_date=scan_date)}\n"
-        f"`{scan_date}` automatically filed `{unit_id}` as {issue_url}\n"
+        f"`{scan_date}` automatically filed `{unit_id}` as {issue_url} "
+        f"in run `{run_id}`\n"
     )
 
 

--- a/.github/scripts/alignment_triage.py
+++ b/.github/scripts/alignment_triage.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# Copyright 2026 Intel Corporation
+# Licensed under the Apache License, Version 2.0
+
+"""The comment protocol of the standing XPU alignment triage issue.
+
+Drafts live as bot comments carrying a unit marker. Publishing a draft copies
+its bytes verbatim into a new issue, so a human reads exactly what gets filed
+and no agent runs between approval and filing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+UNIT_MARKER = "<!-- alignment-unit: {unit_id} -->"
+RUN_MARKER = "<!-- alignment-run: {run_id} {scan_date} -->"
+FILED_MARKER = "<!-- alignment-unit-filed: #{number} -->"
+FILED_MARKER_RE = re.compile(r"<!-- alignment-unit-filed: #(\d+) -->")
+TITLE_LINE_RE = re.compile(r"^### (.+)$", re.MULTILINE)
+
+ISSUE_TITLE_PREFIX = "[xpu-alignment]"
+ISSUE_LABELS = ["ai_generated"]
+# Unit ids become comment markers, file names and glob fragments, so they are
+# restricted to one plain token with no separator or metacharacter.
+UNIT_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}")
+
+
+def fail(message: str) -> None:
+    print(f"::error::{message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def gh(args: list[str], stdin: str | None = None) -> str:
+    result = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, input=stdin, check=False
+    )
+    if result.returncode != 0:
+        fail(f"gh {' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def list_comments(repo: str, issue: int) -> list[dict]:
+    comments: list[dict] = []
+    page = 1
+    while True:
+        payload = json.loads(
+            gh(["api", f"repos/{repo}/issues/{issue}/comments?per_page=100&page={page}"])
+        )
+        comments.extend(payload)
+        if len(payload) < 100:
+            return comments
+        page += 1
+
+
+def render_draft(unit_id: str, title: str, body: str, run_id: str, scan_date: str) -> str:
+    return (
+        f"{UNIT_MARKER.format(unit_id=unit_id)}\n"
+        f"{RUN_MARKER.format(run_id=run_id, scan_date=scan_date)}\n"
+        f"### {title}\n\n{body}\n"
+    )
+
+
+def render_filed_note(unit_id: str, issue_url: str, run_id: str, scan_date: str) -> str:
+    """The audit line for a unit the workflow filed without human approval."""
+    return (
+        f"{UNIT_MARKER.format(unit_id=unit_id)}\n"
+        f"{FILED_MARKER.format(number=issue_number(issue_url))}\n"
+        f"{RUN_MARKER.format(run_id=run_id, scan_date=scan_date)}\n"
+        f"`{scan_date}` automatically filed `{unit_id}` as {issue_url}\n"
+    )
+
+
+def has_unit(comments: list[dict], unit_id: str) -> bool:
+    marker = UNIT_MARKER.format(unit_id=unit_id)
+    return any(marker in (comment.get("body") or "") for comment in comments)
+
+
+def find_draft(comments: list[dict], unit_id: str) -> dict:
+    marker = UNIT_MARKER.format(unit_id=unit_id)
+    matches = [comment for comment in comments if marker in (comment.get("body") or "")]
+    if not matches:
+        fail(f"No draft comment carries the marker for `{unit_id}`.")
+    if len(matches) > 1:
+        fail(f"{len(matches)} draft comments carry the marker for `{unit_id}`.")
+    return matches[0]
+
+
+def parse_draft(body: str, unit_id: str) -> tuple[str, str]:
+    already = FILED_MARKER_RE.search(body)
+    if already:
+        fail(f"`{unit_id}` was already filed as #{already.group(1)}.")
+    title_match = TITLE_LINE_RE.search(body)
+    if not title_match:
+        fail(f"The draft for `{unit_id}` has no `### <title>` line.")
+    title = title_match.group(1).strip()
+    if not title.startswith(ISSUE_TITLE_PREFIX):
+        fail(f"The draft title for `{unit_id}` does not start with `{ISSUE_TITLE_PREFIX}`.")
+    issue_body = body[title_match.end() :].strip()
+    if not issue_body:
+        fail(f"The draft for `{unit_id}` has an empty body.")
+    return title, issue_body
+
+
+def issue_number(issue_url: str) -> str:
+    return issue_url.rstrip("/").rsplit("/", 1)[-1]
+
+
+def filed_body(body: str, unit_id: str, issue_url: str) -> str:
+    marker = UNIT_MARKER.format(unit_id=unit_id)
+    return body.replace(
+        marker,
+        f"{marker}\n{FILED_MARKER.format(number=issue_number(issue_url))}\n\n"
+        f"**Filed as {issue_url}**",
+        1,
+    )
+
+
+def create_issue(repo: str, title: str, body: str) -> str:
+    if not title.startswith(ISSUE_TITLE_PREFIX):
+        fail(f"Refusing to file `{title}`: the title must start with `{ISSUE_TITLE_PREFIX}`.")
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as handle:
+        handle.write(body.rstrip() + "\n")
+        body_file = handle.name
+    try:
+        command = ["issue", "create", "--repo", repo, "--title", title, "--body-file", body_file]
+        for label in ISSUE_LABELS:
+            command += ["--label", label]
+        return gh(command).strip().splitlines()[-1].strip()
+    finally:
+        os.unlink(body_file)
+
+
+def post_comment(repo: str, issue: int, body: str) -> None:
+    gh(
+        ["api", "-X", "POST", f"repos/{repo}/issues/{issue}/comments", "--input", "-"],
+        stdin=json.dumps({"body": body}),
+    )
+
+
+def update_comment(repo: str, comment_id: int, body: str) -> None:
+    gh(
+        ["api", "-X", "PATCH", f"repos/{repo}/issues/comments/{comment_id}", "--input", "-"],
+        stdin=json.dumps({"body": body}),
+    )

--- a/.github/scripts/bot_alignment_file.py
+++ b/.github/scripts/bot_alignment_file.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Copyright 2026 Intel Corporation
+# Licensed under the Apache License, Version 2.0
+
+"""File one reviewed alignment candidate from the standing triage issue.
+
+Usage:
+    python bot_alignment_file.py --repo owner/repo --triage-issue 5018 \
+        --requested-on 5018 --unit-id candidate-1
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from alignment_triage import (
+    UNIT_ID_RE,
+    create_issue,
+    fail,
+    filed_body,
+    find_draft,
+    list_comments,
+    parse_draft,
+    update_comment,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="File one reviewed alignment candidate")
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--triage-issue", type=int, required=True)
+    parser.add_argument("--requested-on", type=int, required=True)
+    parser.add_argument("--unit-id", required=True)
+    args = parser.parse_args()
+
+    # The drafts only exist on the standing triage issue, so refuse anywhere else.
+    if args.requested_on != args.triage_issue:
+        fail(f"`file` only works on the alignment triage issue #{args.triage_issue}.")
+    if not UNIT_ID_RE.fullmatch(args.unit_id):
+        fail(f"`{args.unit_id}` is not a valid unit id.")
+
+    comment = find_draft(list_comments(args.repo, args.triage_issue), args.unit_id)
+    title, body = parse_draft(comment["body"], args.unit_id)
+    issue_url = create_issue(args.repo, title, body)
+    update_comment(args.repo, comment["id"], filed_body(comment["body"], args.unit_id, issue_url))
+
+    print(f"Filed {args.unit_id} as {issue_url}")
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with Path(github_output).open("a", encoding="utf-8") as handle:
+            handle.write(f"issue_url={issue_url}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_alignment_triage.py
+++ b/.github/scripts/test_alignment_triage.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+import unittest
+
+from alignment_triage import (
+    UNIT_MARKER,
+    filed_body,
+    find_draft,
+    has_unit,
+    parse_draft,
+    render_draft,
+    render_filed_note,
+)
+
+TITLE = "[xpu-alignment] Fix GELU erf-tail catastrophic cancellation"
+
+
+def draft(unit_id: str, title: str = TITLE, body: str = "Details.") -> str:
+    return render_draft(unit_id, title, body, "12345", "2026-08-18")
+
+
+def comment(unit_id: str, **kwargs: str) -> dict:
+    return {"id": 1, "body": draft(unit_id, **kwargs)}
+
+
+class DraftLookupTests(unittest.TestCase):
+    def test_finds_the_comment_carrying_the_marker(self) -> None:
+        comments = [{"id": 7, "body": "chatter"}, comment("candidate-1")]
+        self.assertEqual(find_draft(comments, "candidate-1")["id"], 1)
+
+    def test_unknown_unit_id_fails(self) -> None:
+        with self.assertRaises(SystemExit):
+            find_draft([comment("candidate-1")], "candidate-2")
+
+    def test_duplicate_markers_fail(self) -> None:
+        with self.assertRaises(SystemExit):
+            find_draft([comment("candidate-1"), comment("candidate-1")], "candidate-1")
+
+    def test_marker_is_not_matched_by_a_longer_id(self) -> None:
+        with self.assertRaises(SystemExit):
+            find_draft([comment("candidate-10")], "candidate-1")
+
+    def test_has_unit_detects_an_already_queued_draft(self) -> None:
+        self.assertTrue(has_unit([comment("candidate-1")], "candidate-1"))
+        self.assertFalse(has_unit([comment("candidate-1")], "candidate-2"))
+
+    def test_has_unit_detects_an_automatically_filed_unit(self) -> None:
+        note = render_filed_note(
+            "candidate-1", "https://github.com/intel/torch-xpu-ops/issues/42", "1", "2026-08-18"
+        )
+        self.assertTrue(has_unit([{"id": 3, "body": note}], "candidate-1"))
+
+
+class DraftParsingTests(unittest.TestCase):
+    def test_splits_title_and_body(self) -> None:
+        title, body = parse_draft(draft("candidate-1"), "candidate-1")
+        self.assertEqual(title, TITLE)
+        self.assertEqual(body, "Details.")
+
+    def test_preserves_a_multiline_body_verbatim(self) -> None:
+        body_text = "## Repro\n\n```python\nimport torch\n```\n\n### Notes\nmore"
+        title, body = parse_draft(draft("candidate-1", body=body_text), "candidate-1")
+        self.assertEqual(title, TITLE)
+        self.assertEqual(body, body_text)
+
+    def test_foreign_title_prefix_fails(self) -> None:
+        with self.assertRaises(SystemExit):
+            parse_draft(draft("candidate-1", title="Fix everything"), "candidate-1")
+
+    def test_missing_title_line_fails(self) -> None:
+        with self.assertRaises(SystemExit):
+            parse_draft(f"{UNIT_MARKER.format(unit_id='candidate-1')}\nno heading\n", "candidate-1")
+
+    def test_empty_body_fails(self) -> None:
+        with self.assertRaises(SystemExit):
+            parse_draft(draft("candidate-1", body=""), "candidate-1")
+
+    def test_an_already_filed_draft_cannot_be_filed_twice(self) -> None:
+        filed = filed_body(
+            draft("candidate-1"), "candidate-1", "https://github.com/intel/torch-xpu-ops/issues/42"
+        )
+        with self.assertRaises(SystemExit):
+            parse_draft(filed, "candidate-1")
+
+    def test_an_automatically_filed_note_cannot_be_filed_again(self) -> None:
+        note = render_filed_note(
+            "candidate-1", "https://github.com/intel/torch-xpu-ops/issues/42", "1", "2026-08-18"
+        )
+        with self.assertRaises(SystemExit):
+            parse_draft(note, "candidate-1")
+
+
+class FiledMarkerTests(unittest.TestCase):
+    def test_records_the_issue_number_and_keeps_the_draft(self) -> None:
+        updated = filed_body(
+            draft("candidate-1"), "candidate-1", "https://github.com/intel/torch-xpu-ops/issues/42"
+        )
+        self.assertIn("<!-- alignment-unit-filed: #42 -->", updated)
+        self.assertIn(UNIT_MARKER.format(unit_id="candidate-1"), updated)
+        self.assertIn(f"### {TITLE}", updated)
+
+    def test_marks_only_the_first_occurrence(self) -> None:
+        body = draft("candidate-1") + draft("candidate-1")
+        updated = filed_body(body, "candidate-1", "https://github.com/x/y/issues/9")
+        self.assertEqual(updated.count("<!-- alignment-unit-filed: #9 -->"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/scripts/test_xpu_alignment_gate.py
+++ b/.github/scripts/test_xpu_alignment_gate.py
@@ -179,10 +179,43 @@ class AlignmentGateTests(unittest.TestCase):
                     "local_status": "pending",
                 },
             ]
-            decision = self.decide(root) if write_run(root, ledger=ledger) else None
-            assert decision is not None
+            write_run(root, ledger=ledger)
+            decision = self.decide(root)
             self.assertEqual(decision["decision"], "file-one")
             self.assertEqual(decision["pending_units"], [])
+
+    def test_unknown_local_status_blocks_instead_of_vanishing(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            ledger = [
+                done("candidate-1"),
+                {
+                    "id": "candidate-7",
+                    "title_status": "pass",
+                    "deep_status": "pass",
+                    "local_status": "error",
+                },
+            ]
+            write_run(root, ledger=ledger)
+            decision = self.decide(root)
+            # Without the allowlist this row would join neither the pending nor
+            # the mandatory set, and the day would report itself as finished.
+            self.assertEqual(decision["decision"], "blocked")
+            self.assertIn("ledger-invalid-status:candidate-7", decision["blockers"])
+
+    def test_conflicting_ledger_rows_across_runs_block(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(root)
+            write_run(
+                root,
+                scope="restored-copy",
+                ledger=[pending("candidate-1")],
+                payloads=[],
+            )
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "blocked")
+            self.assertIn("ledger-conflicting-row:candidate-1", decision["blockers"])
 
     def test_missing_ledger_blocks(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -302,6 +335,45 @@ class AlignmentGateTests(unittest.TestCase):
             decision = self.decide(root)
             self.assertEqual(decision["decision"], "blocked")
             self.assertIn("payload-not-unique:candidate-1:0", decision["blockers"])
+
+    def test_one_unusable_payload_still_publishes_the_others(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(
+                root,
+                ledger=[done("candidate-a"), done("candidate-b")],
+                units=[
+                    {"id": "candidate-a", "verdict": "needs-xpu-fix"},
+                    {"id": "candidate-b", "verdict": "needs-xpu-fix"},
+                ],
+                payloads=["candidate-a"],
+            )
+            decision = self.decide(root)
+            # The GPU time already spent on candidate-a still reaches a human.
+            self.assertEqual(decision["decision"], "triage")
+            self.assertEqual(
+                [payload["unit_id"] for payload in decision["payloads"]], ["candidate-a"]
+            )
+            self.assertEqual(decision["blockers"], [])
+            self.assertIn("payload-not-unique:candidate-b:0", decision["unpublishable_units"])
+            self.assertTrue(decision["needs_attention"])
+
+    def test_an_unusable_payload_closes_the_automatic_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(
+                root,
+                ledger=[done("candidate-a"), done("candidate-b")],
+                units=[
+                    {"id": "candidate-a", "verdict": "needs-xpu-fix"},
+                    {"id": "candidate-b", "verdict": "non-issue"},
+                ],
+                payloads=[],
+            )
+            write_payload(root / SCAN / "reports", "candidate-a", body="   ")
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "blocked")
+            self.assertIn("payload-empty-body:candidate-a", decision["blockers"])
 
     def test_payload_with_a_foreign_title_prefix_blocks(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/.github/scripts/test_xpu_alignment_gate.py
+++ b/.github/scripts/test_xpu_alignment_gate.py
@@ -284,6 +284,18 @@ class AlignmentGateTests(unittest.TestCase):
                 any(b.startswith("manifest-missing-conclusions") for b in decision["blockers"])
             )
 
+    def test_a_blocked_review_cannot_unlock_filing_through_the_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            run = write_run(root)
+            (run / "reports" / "review_conclusions.md").write_text(
+                "# conclusions\n\n**Review status:** blocked\n\nNo higher-tier reviewer.\n",
+                encoding="utf-8",
+            )
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "blocked")
+            self.assertTrue(any(b.startswith("review-blocked") for b in decision["blockers"]))
+
     def test_unknown_verdict_blocks(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/.github/scripts/test_xpu_alignment_gate.py
+++ b/.github/scripts/test_xpu_alignment_gate.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from xpu_alignment_gate import build_decision
+
+SCAN = "2026-08-18"
+
+
+def write_run(
+    root: Path,
+    *,
+    ledger: list[dict[str, str]] | None = None,
+    units: list[dict[str, str]] | None = None,
+    payloads: list[str] | None = None,
+    conclusions: bool = True,
+    manifest: object | None = None,
+    scope: str = SCAN,
+) -> Path:
+    """Lay out one restored run directory following the official skill layout."""
+    run = root / scope
+    artifacts = run / "artifacts"
+    reports = run / "reports"
+    artifacts.mkdir(parents=True, exist_ok=True)
+    reports.mkdir(parents=True, exist_ok=True)
+
+    if ledger is None:
+        ledger = [done("candidate-1")]
+    (artifacts / "candidate_ledger.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in ledger), encoding="utf-8"
+    )
+
+    if conclusions:
+        (reports / "review_conclusions.md").write_text("# conclusions\n", encoding="utf-8")
+
+    if manifest is None:
+        manifest = {
+            "units": units
+            if units is not None
+            else [{"id": "candidate-1", "verdict": "needs-xpu-fix"}]
+        }
+    (reports / "reviewer_manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    if payloads is None:
+        payloads = [
+            unit["id"]
+            for unit in (units or [{"id": "candidate-1", "verdict": "needs-xpu-fix"}])
+            if unit.get("verdict") == "needs-xpu-fix"
+        ]
+    for unit_id in payloads:
+        write_payload(reports, unit_id)
+    return run
+
+
+def write_payload(reports: Path, unit_id: str, **overrides: object) -> Path:
+    payload: dict[str, object] = {
+        "unit_id": unit_id,
+        "title": f"[xpu-alignment] {unit_id} diverges from CPU reference",
+        "body": "## Summary\nDetails.\n",
+        "labels": ["ai_generated"],
+    }
+    payload.update(overrides)
+    path = reports / f"final_issue_{unit_id}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+def done(unit_id: str) -> dict[str, str]:
+    return {
+        "id": unit_id,
+        "title_status": "pass",
+        "deep_status": "pass",
+        "local_status": "done",
+    }
+
+
+def pending(unit_id: str) -> dict[str, str]:
+    return {
+        "id": unit_id,
+        "title_status": "pass",
+        "deep_status": "pending",
+        "local_status": "pending",
+    }
+
+
+def rejected(unit_id: str) -> dict[str, str]:
+    return {
+        "id": unit_id,
+        "title_status": "pass",
+        "deep_status": "reject",
+        "local_status": "pending",
+    }
+
+
+class AlignmentGateTests(unittest.TestCase):
+    def decide(self, root: Path, **kwargs: object) -> dict[str, object]:
+        options: dict[str, object] = {"auto_file": True, "scan_date": SCAN}
+        options.update(kwargs)
+        return build_decision(root, **options)  # type: ignore[arg-type]
+
+    # --- the four normal outcomes -------------------------------------------------
+
+    def test_single_actionable_unit_files_automatically(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(root)
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "file-one")
+            self.assertEqual(decision["actionable_units"], ["candidate-1"])
+            self.assertFalse(decision["needs_attention"])
+            self.assertEqual(len(decision["payloads"]), 1)
+
+    def test_no_actionable_unit_is_a_quiet_green_day(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(root, units=[{"id": "candidate-1", "verdict": "non-issue"}])
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "none")
+            self.assertFalse(decision["needs_attention"])
+            self.assertEqual(decision["payloads"], [])
+
+    def test_two_actionable_units_go_to_triage_and_stay_green(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(
+                root,
+                ledger=[done("candidate-a"), done("candidate-b")],
+                units=[
+                    {"id": "candidate-a", "verdict": "needs-xpu-fix"},
+                    {"id": "candidate-b", "verdict": "needs-xpu-fix"},
+                ],
+            )
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "triage")
+            self.assertEqual(decision["actionable_units"], ["candidate-a", "candidate-b"])
+            # A busy day is normal, not a fault.
+            self.assertFalse(decision["needs_attention"])
+            self.assertEqual(len(decision["payloads"]), 2)
+
+    def test_auto_file_disabled_sends_a_single_unit_to_triage(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(root)
+            decision = self.decide(root, auto_file=False)
+            self.assertEqual(decision["decision"], "triage")
+            self.assertFalse(decision["needs_attention"])
+
+    # --- completeness comes from the ledger ---------------------------------------
+
+    def test_pending_row_closes_the_automatic_path_and_turns_red(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(root, ledger=[done("candidate-1"), pending("candidate-2")])
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "triage")
+            self.assertFalse(decision["scan_complete"])
+            self.assertTrue(decision["needs_attention"])
+            self.assertEqual(decision["pending_units"], ["candidate-2"])
+
+    def test_deep_rejected_row_is_not_pending_work(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(root, ledger=[done("candidate-1"), rejected("candidate-9")])
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "file-one")
+            self.assertTrue(decision["scan_complete"])
+            self.assertEqual(decision["pending_units"], [])
+
+    def test_title_rejected_row_is_not_pending_work(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            ledger = [
+                done("candidate-1"),
+                {
+                    "id": "candidate-8",
+                    "title_status": "reject",
+                    "deep_status": "pending",
+                    "local_status": "pending",
+                },
+            ]
+            decision = self.decide(root) if write_run(root, ledger=ledger) else None
+            assert decision is not None
+            self.assertEqual(decision["decision"], "file-one")
+            self.assertEqual(decision["pending_units"], [])
+
+    def test_missing_ledger_blocks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(root)
+            next(root.glob("**/candidate_ledger.jsonl")).unlink()
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "blocked")
+            self.assertIn("ledger-missing", decision["blockers"])
+
+    def test_unparsable_ledger_line_blocks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(root)
+            path = next(root.glob("**/candidate_ledger.jsonl"))
+            path.write_text(path.read_text(encoding="utf-8") + "{oops\n", encoding="utf-8")
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "blocked")
+            self.assertTrue(any(b.startswith("ledger-unparsable") for b in decision["blockers"]))
+
+    # --- review coverage ----------------------------------------------------------
+
+    def test_review_that_skipped_a_done_row_blocks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(
+                root,
+                ledger=[done("candidate-1"), done("candidate-2")],
+                units=[{"id": "candidate-1", "verdict": "needs-xpu-fix"}],
+            )
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "blocked")
+            self.assertIn("coverage-gap:candidate-2", decision["blockers"])
+
+    def test_verdict_for_a_unit_absent_from_the_ledger_blocks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(
+                root,
+                ledger=[done("candidate-1")],
+                units=[
+                    {"id": "candidate-1", "verdict": "needs-xpu-fix"},
+                    {"id": "invented-1", "verdict": "needs-xpu-fix"},
+                ],
+            )
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "blocked")
+            self.assertIn("unknown-unit:invented-1", decision["blockers"])
+
+    def test_missing_manifest_blocks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(root)
+            next(root.glob("**/reviewer_manifest.json")).unlink()
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "blocked")
+            self.assertIn("reviewer-manifest-missing", decision["blockers"])
+
+    def test_manifest_without_review_conclusions_blocks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(root, conclusions=False)
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "blocked")
+            self.assertTrue(
+                any(b.startswith("manifest-missing-conclusions") for b in decision["blockers"])
+            )
+
+    def test_unknown_verdict_blocks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(
+                root,
+                units=[{"id": "candidate-1", "verdict": "looks-bad"}],
+                payloads=["candidate-1"],
+            )
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "blocked")
+            self.assertIn("manifest-invalid-unit:candidate-1", decision["blockers"])
+
+    def test_conflicting_verdicts_across_manifests_block(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(root)
+            write_run(
+                root,
+                scope="restored-copy",
+                units=[{"id": "candidate-1", "verdict": "non-issue"}],
+                payloads=[],
+            )
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "blocked")
+            self.assertIn("conflicting-verdict:candidate-1", decision["blockers"])
+
+    def test_unit_id_with_a_path_separator_blocks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(
+                root,
+                ledger=[done("candidate-1")],
+                units=[
+                    {"id": "candidate-1", "verdict": "needs-xpu-fix"},
+                    {"id": "../../escape", "verdict": "needs-xpu-fix"},
+                ],
+                payloads=["candidate-1"],
+            )
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "blocked")
+            self.assertIn("manifest-invalid-unit:../../escape", decision["blockers"])
+
+    # --- pre-generated payloads ---------------------------------------------------
+
+    def test_missing_payload_blocks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(root, payloads=[])
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "blocked")
+            self.assertIn("payload-not-unique:candidate-1:0", decision["blockers"])
+
+    def test_payload_with_a_foreign_title_prefix_blocks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            run = write_run(root, payloads=[])
+            write_payload(run / "reports", "candidate-1", title="Fix everything")
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "blocked")
+            self.assertIn("payload-invalid-title:candidate-1", decision["blockers"])
+
+    def test_payload_with_extra_labels_blocks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            run = write_run(root, payloads=[])
+            write_payload(run / "reports", "candidate-1", labels=["ai_generated", "bug"])
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "blocked")
+            self.assertIn("payload-invalid-labels:candidate-1", decision["blockers"])
+
+    def test_payload_claiming_another_unit_blocks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            run = write_run(root, payloads=[])
+            path = run / "reports" / "final_issue_candidate-1.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "unit_id": "candidate-2",
+                        "title": "[xpu-alignment] something",
+                        "body": "body",
+                        "labels": ["ai_generated"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "blocked")
+            self.assertIn("payload-unit-mismatch:candidate-1", decision["blockers"])
+
+    def test_second_payload_for_the_same_unit_blocks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(root)
+            duplicate = root / "restored-copy" / "reports"
+            duplicate.mkdir(parents=True)
+            write_payload(duplicate, "candidate-1")
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "blocked")
+            self.assertIn("payload-not-unique:candidate-1:2", decision["blockers"])
+
+    def test_a_blocked_run_publishes_nothing(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_run(root, payloads=[])
+            decision = self.decide(root)
+            self.assertEqual(decision["decision"], "blocked")
+            self.assertEqual(decision["payloads"], [])
+            self.assertTrue(decision["needs_attention"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/scripts/xpu_alignment_gate.py
+++ b/.github/scripts/xpu_alignment_gate.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Decide what one alignment run may publish, from the scan ledger and reviewer verdicts.
+
+Completeness is computed from ``artifacts/candidate_ledger.jsonl`` rather than
+taken from a self-reported status field, so a truncated scan or a truncated
+review cannot present itself as a finished day.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from pathlib import Path
+
+from alignment_triage import ISSUE_LABELS, ISSUE_TITLE_PREFIX, UNIT_ID_RE
+
+# Mirrors the verdict table in the official review reference.
+ALLOWED_VERDICTS = frozenset(
+    {
+        "needs-xpu-fix",
+        "track-upstream",
+        "fixed",
+        "non-issue",
+        "duplicate",
+        "verification-gap",
+    }
+)
+ACTIONABLE_VERDICT = "needs-xpu-fix"
+
+LEDGER_GLOB = "**/artifacts/candidate_ledger.jsonl"
+MANIFEST_GLOB = "**/reports/reviewer_manifest.json"
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip().lower()
+
+
+def load_ledger(root: Path) -> tuple[dict[str, dict[str, str]], list[str]]:
+    """Merge every restored ledger by candidate id."""
+    rows: dict[str, dict[str, str]] = {}
+    errors: list[str] = []
+    paths = sorted(root.glob(LEDGER_GLOB))
+    if not paths:
+        return rows, ["ledger-missing"]
+
+    for path in paths:
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            errors.append(f"ledger-unreadable:{path}:{exc}")
+            continue
+        for number, line in enumerate(lines, start=1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                errors.append(f"ledger-unparsable:{path}:{number}")
+                continue
+            if not isinstance(row, dict):
+                errors.append(f"ledger-not-an-object:{path}:{number}")
+                continue
+            unit_id = str(row.get("id", "")).strip()
+            if not UNIT_ID_RE.fullmatch(unit_id):
+                errors.append(f"ledger-invalid-id:{path}:{number}")
+                continue
+            normalized = {
+                "title_status": _text(row.get("title_status")),
+                "deep_status": _text(row.get("deep_status")),
+                "local_status": _text(row.get("local_status")),
+            }
+            if rows.setdefault(unit_id, normalized) != normalized:
+                errors.append(f"ledger-conflicting-row:{unit_id}")
+    return rows, errors
+
+
+def load_verdicts(root: Path) -> tuple[dict[str, str], list[str], list[str]]:
+    """Merge reviewer verdicts across every restored manifest."""
+    verdicts: dict[str, str] = {}
+    errors: list[str] = []
+    paths = sorted(root.glob(MANIFEST_GLOB))
+    if not paths:
+        return verdicts, ["reviewer-manifest-missing"], []
+
+    for path in paths:
+        try:
+            manifest = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(f"manifest-unreadable:{path}:{exc}")
+            continue
+        if not isinstance(manifest, dict):
+            errors.append(f"manifest-not-an-object:{path}")
+            continue
+        # The official skill owns the human-auditable Markdown; a JSON-only
+        # reviewer must not be able to unlock filing without it.
+        if not (path.parent / "review_conclusions.md").is_file():
+            errors.append(f"manifest-missing-conclusions:{path}")
+            continue
+        units = manifest.get("units")
+        if not isinstance(units, list) or not units:
+            errors.append(f"manifest-missing-units:{path}")
+            continue
+        for entry in units:
+            if not isinstance(entry, dict):
+                errors.append(f"manifest-malformed-unit:{path}")
+                continue
+            unit_id = str(entry.get("id", "")).strip()
+            verdict = _text(entry.get("verdict"))
+            if not UNIT_ID_RE.fullmatch(unit_id) or verdict not in ALLOWED_VERDICTS:
+                errors.append(f"manifest-invalid-unit:{unit_id or '<unnamed>'}")
+                continue
+            if verdicts.setdefault(unit_id, verdict) != verdict:
+                errors.append(f"conflicting-verdict:{unit_id}")
+    return verdicts, errors, [str(path) for path in paths]
+
+
+def load_payload(root: Path, unit_id: str) -> tuple[dict[str, object] | None, str | None]:
+    """Read the issue payload the scan/review phase pre-generated for one unit."""
+    paths = sorted(root.glob(f"**/reports/final_issue_{unit_id}.json"))
+    if len(paths) != 1:
+        return None, f"payload-not-unique:{unit_id}:{len(paths)}"
+    try:
+        payload = json.loads(paths[0].read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, f"payload-unreadable:{unit_id}:{exc}"
+    if not isinstance(payload, dict):
+        return None, f"payload-not-an-object:{unit_id}"
+    if str(payload.get("unit_id", "")).strip() != unit_id:
+        return None, f"payload-unit-mismatch:{unit_id}"
+    title = str(payload.get("title", ""))
+    if not title.startswith(ISSUE_TITLE_PREFIX):
+        return None, f"payload-invalid-title:{unit_id}"
+    if not str(payload.get("body", "")).strip():
+        return None, f"payload-empty-body:{unit_id}"
+    if payload.get("labels") != ISSUE_LABELS:
+        return None, f"payload-invalid-labels:{unit_id}"
+    return {
+        "unit_id": unit_id,
+        "title": title,
+        "body": str(payload["body"]),
+        "labels": ISSUE_LABELS,
+    }, None
+
+
+def build_decision(
+    root: Path,
+    *,
+    auto_file: bool,
+    run_id: str = "",
+    scan_date: str = "",
+) -> dict[str, object]:
+    ledger, ledger_errors = load_ledger(root)
+    verdicts, review_errors, manifest_paths = load_verdicts(root)
+
+    def survives_filtering(row: dict[str, str]) -> bool:
+        return row["title_status"] == "pass" and row["deep_status"] != "reject"
+
+    pending = sorted(
+        unit
+        for unit, row in ledger.items()
+        if survives_filtering(row) and row["local_status"] == "pending"
+    )
+    mandatory = sorted(
+        unit
+        for unit, row in ledger.items()
+        if survives_filtering(row) and row["local_status"] == "done"
+    )
+
+    # A verdict the ledger never mentions means the reviewer invented a unit;
+    # a mandatory row with no verdict means the review stopped early.
+    coverage_gaps = [unit for unit in mandatory if unit not in verdicts]
+    unknown_units = sorted(unit for unit in verdicts if unit not in ledger)
+
+    actionable = sorted(
+        unit for unit, verdict in verdicts.items() if verdict == ACTIONABLE_VERDICT
+    )
+
+    payloads: list[dict[str, object]] = []
+    payload_errors: list[str] = []
+    for unit in actionable:
+        payload, error = load_payload(root, unit)
+        if error:
+            payload_errors.append(error)
+        else:
+            payloads.append(payload)  # type: ignore[arg-type]
+
+    blockers = (
+        ledger_errors
+        + review_errors
+        + payload_errors
+        + [f"coverage-gap:{unit}" for unit in coverage_gaps]
+        + [f"unknown-unit:{unit}" for unit in unknown_units]
+    )
+
+    complete = not pending
+    if blockers:
+        decision = "blocked"
+    elif not actionable:
+        decision = "none"
+    elif complete and auto_file and len(actionable) == 1:
+        decision = "file-one"
+    else:
+        decision = "triage"
+
+    return {
+        "run_id": run_id,
+        "scan_date": scan_date,
+        "decision": decision,
+        # `blocked` and an unfinished scan are the only conditions that should
+        # turn the run red; a busy day is normal.
+        "needs_attention": bool(blockers) or not complete,
+        "scan_complete": complete,
+        "pending_units": pending,
+        "mandatory_units": mandatory,
+        "unit_verdicts": dict(sorted(verdicts.items())),
+        "actionable_units": actionable,
+        "auto_file_requested": auto_file,
+        "blockers": blockers,
+        "reviewer_manifests": manifest_paths,
+        "payloads": payloads if decision in {"file-one", "triage"} else [],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--run-id", default="")
+    parser.add_argument("--scan-date", default="")
+    parser.add_argument("--auto-file", action="store_true")
+    args = parser.parse_args()
+
+    decision = build_decision(
+        args.root,
+        auto_file=args.auto_file,
+        run_id=args.run_id,
+        scan_date=args.scan_date,
+    )
+    output = args.root / "filing_decision.json"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(decision, indent=2) + "\n", encoding="utf-8")
+
+    summary = dict(decision)
+    summary["payloads"] = [payload["unit_id"] for payload in decision["payloads"]]  # type: ignore[index]
+    print(json.dumps(summary, indent=2))
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with Path(github_output).open("a", encoding="utf-8") as handle:
+            handle.write(f"decision={decision['decision']}\n")
+            handle.write(
+                f"needs_attention={'true' if decision['needs_attention'] else 'false'}\n"
+            )
+            handle.write(f"actionable_count={len(decision['actionable_units'])}\n")  # type: ignore[arg-type]
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/xpu_alignment_gate.py
+++ b/.github/scripts/xpu_alignment_gate.py
@@ -29,6 +29,10 @@ ALLOWED_VERDICTS = frozenset(
 )
 ACTIONABLE_VERDICT = "needs-xpu-fix"
 
+# A row that survives filtering has either run or not; any other value would
+# fall through both the pending and the mandatory set and vanish from the day.
+ALLOWED_LOCAL_STATUSES = frozenset({"done", "pending"})
+
 LEDGER_GLOB = "**/artifacts/candidate_ledger.jsonl"
 MANIFEST_GLOB = "**/reports/reviewer_manifest.json"
 
@@ -167,6 +171,11 @@ def build_decision(
         for unit, row in ledger.items()
         if survives_filtering(row) and row["local_status"] == "done"
     )
+    invalid_statuses = sorted(
+        unit
+        for unit, row in ledger.items()
+        if survives_filtering(row) and row["local_status"] not in ALLOWED_LOCAL_STATUSES
+    )
 
     # A verdict the ledger never mentions means the reviewer invented a unit;
     # a mandatory row with no verdict means the review stopped early.
@@ -189,17 +198,22 @@ def build_decision(
     blockers = (
         ledger_errors
         + review_errors
-        + payload_errors
+        + [f"ledger-invalid-status:{unit}" for unit in invalid_statuses]
         + [f"coverage-gap:{unit}" for unit in coverage_gaps]
         + [f"unknown-unit:{unit}" for unit in unknown_units]
     )
+    # One unusable payload must not discard the units that are fine, so it only
+    # blocks the day when nothing is left to publish. It always closes the
+    # unattended path, which assumes every reviewed unit reached the gate.
+    if actionable and not payloads:
+        blockers = blockers + payload_errors
 
     complete = not pending
     if blockers:
         decision = "blocked"
     elif not actionable:
         decision = "none"
-    elif complete and auto_file and len(actionable) == 1:
+    elif complete and auto_file and not payload_errors and len(payloads) == 1:
         decision = "file-one"
     else:
         decision = "triage"
@@ -208,12 +222,13 @@ def build_decision(
         "run_id": run_id,
         "scan_date": scan_date,
         "decision": decision,
-        # `blocked` and an unfinished scan are the only conditions that should
-        # turn the run red; a busy day is normal.
-        "needs_attention": bool(blockers) or not complete,
+        # `blocked`, an unfinished scan and a unit that cannot be published are
+        # the only conditions that should turn the run red; a busy day is normal.
+        "needs_attention": bool(blockers) or not complete or bool(payload_errors),
         "scan_complete": complete,
         "pending_units": pending,
         "mandatory_units": mandatory,
+        "unpublishable_units": payload_errors,
         "unit_verdicts": dict(sorted(verdicts.items())),
         "actionable_units": actionable,
         "auto_file_requested": auto_file,

--- a/.github/scripts/xpu_alignment_gate.py
+++ b/.github/scripts/xpu_alignment_gate.py
@@ -36,6 +36,10 @@ ALLOWED_LOCAL_STATUSES = frozenset({"done", "pending"})
 LEDGER_GLOB = "**/artifacts/candidate_ledger.jsonl"
 MANIFEST_GLOB = "**/reports/reviewer_manifest.json"
 
+# The official review reference writes this line when it cannot reach a verdict,
+# and says blocked outputs never unlock filing.
+BLOCKED_REVIEW_RE = re.compile(r"review\s+status\s*\**\s*:\s*\**\s*blocked", re.IGNORECASE)
+
 
 def _text(value: object) -> str:
     return str(value or "").strip().lower()
@@ -99,8 +103,14 @@ def load_verdicts(root: Path) -> tuple[dict[str, str], list[str], list[str]]:
             continue
         # The official skill owns the human-auditable Markdown; a JSON-only
         # reviewer must not be able to unlock filing without it.
-        if not (path.parent / "review_conclusions.md").is_file():
+        conclusions = path.parent / "review_conclusions.md"
+        try:
+            verdict_prose = conclusions.read_text(encoding="utf-8")
+        except OSError:
             errors.append(f"manifest-missing-conclusions:{path}")
+            continue
+        if BLOCKED_REVIEW_RE.search(verdict_prose):
+            errors.append(f"review-blocked:{conclusions}")
             continue
         units = manifest.get("units")
         if not isinstance(units, list) or not units:

--- a/.github/scripts/xpu_alignment_publish.py
+++ b/.github/scripts/xpu_alignment_publish.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# Copyright 2026 Intel Corporation
+# Licensed under the Apache License, Version 2.0
+
+"""Publish the alignment gate's decision to the standing triage issue.
+
+`file-one` files one issue and records it; `triage` posts one draft comment per
+reviewed candidate for a human to approve with `@torchxpubot file <unit-id>`.
+
+Usage:
+    python xpu_alignment_publish.py --repo owner/repo --triage-issue 5018 \
+        --decision alignment-artifacts/filing_decision.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from alignment_triage import (
+    create_issue,
+    fail,
+    has_unit,
+    list_comments,
+    post_comment,
+    render_draft,
+    render_filed_note,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Publish the alignment gate decision")
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--triage-issue", type=int, required=True)
+    parser.add_argument("--decision", type=Path, required=True)
+    args = parser.parse_args()
+
+    decision = json.loads(args.decision.read_text(encoding="utf-8"))
+    verdict = decision["decision"]
+    if verdict in {"blocked", "none"}:
+        print(f"Nothing to publish (decision: {verdict}).")
+        return 0
+
+    run_id = str(decision.get("run_id", ""))
+    scan_date = str(decision.get("scan_date", ""))
+    payloads = decision["payloads"]
+    if verdict == "file-one" and len(payloads) != 1:
+        fail(f"decision file-one carries {len(payloads)} payloads")
+
+    # Re-running a day must not repost drafts or file a second copy.
+    existing = list_comments(args.repo, args.triage_issue)
+
+    for payload in payloads:
+        unit_id = payload["unit_id"]
+        if has_unit(existing, unit_id):
+            print(f"Skipping {unit_id}: already present on #{args.triage_issue}.")
+            continue
+        if verdict == "file-one":
+            issue_url = create_issue(args.repo, payload["title"], payload["body"])
+            post_comment(
+                args.repo,
+                args.triage_issue,
+                render_filed_note(unit_id, issue_url, run_id, scan_date),
+            )
+            print(f"Filed {unit_id} as {issue_url}")
+        else:
+            post_comment(
+                args.repo,
+                args.triage_issue,
+                render_draft(unit_id, payload["title"], payload["body"], run_id, scan_date),
+            )
+            print(f"Queued {unit_id} for triage on #{args.triage_issue}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -14,7 +14,7 @@ env:
   COST_TRACKING_ISSUE: 4251
   # The standing issue that carries the daily XPU alignment drafts. `file`
   # refuses to run anywhere else, so this number is the command's whole scope.
-  ALIGNMENT_TRIAGE_ISSUE: 5018
+  ALIGNMENT_TRIAGE_ISSUE: '5018'
 
 permissions:
   contents: read
@@ -1321,11 +1321,14 @@ jobs:
       - name: Report the outcome
         if: ${{ always() }}
         uses: actions/github-script@v9
+        env:
+          UNIT_ID: ${{ needs.parse-command.outputs.unit_id }}
+          ISSUE_URL: ${{ steps.file.outputs.issue_url }}
         with:
           github-token: ${{ secrets.MERGE_TOKEN }}
           script: |
-            const unit = '${{ needs.parse-command.outputs.unit_id }}';
-            const url = '${{ steps.file.outputs.issue_url }}';
+            const unit = process.env.UNIT_ID;
+            const url = process.env.ISSUE_URL;
             const body = url
               ? `Filed \`${unit}\` as ${url}.`
               : `Could not file \`${unit}\`. See the [job log](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}) for the reason.`;

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -12,6 +12,9 @@ env:
   BEDROCK_MODEL: global.anthropic.claude-opus-5
   CLAUDE_ALLOWED_TOOLS: Bash,Read,Glob,Grep,WebFetch,Skill,Task
   COST_TRACKING_ISSUE: 4251
+  # The standing issue that carries the daily XPU alignment drafts. `file`
+  # refuses to run anywhere else, so this number is the command's whole scope.
+  ALIGNMENT_TRIAGE_ISSUE: 5018
 
 permissions:
   contents: read
@@ -35,6 +38,7 @@ jobs:
       rerun_mode: ${{ steps.parse.outputs.rerun_mode }}
       pytorch_ref: ${{ steps.parse.outputs.pytorch_ref }}
       revert_reason: ${{ steps.parse.outputs.revert_reason }}
+      unit_id: ${{ steps.parse.outputs.unit_id }}
       pr_number: ${{ steps.parse.outputs.pr_number }}
       issue_number: ${{ steps.parse.outputs.issue_number }}
       is_pr: ${{ steps.parse.outputs.is_pr }}
@@ -87,7 +91,7 @@ jobs:
 
             const command = match[1].toLowerCase();
             const args = (match[2] || '').trim();
-            const validCommands = ['merge', 'revert', 'rebase', 'lint', 'rerun', 'review', 'pr-review', 'ut-check', 'check-ut', 'ut', 'fix', 'triage', 'help'];
+            const validCommands = ['merge', 'revert', 'rebase', 'lint', 'rerun', 'review', 'pr-review', 'ut-check', 'check-ut', 'ut', 'fix', 'triage', 'file', 'help'];
 
             if (!validCommands.includes(command)) {
               reject('Unknown command. Use `@torchxpubot help` to see available commands.');
@@ -99,9 +103,9 @@ jobs:
               : (command === 'check-ut' || command === 'ut') ? 'ut-check'
               : command;
 
-            // Context check: fix and triage are issue-only, help works on
-            // both, the rest are PR-only.
-            if (normalizedCommand === 'fix' || normalizedCommand === 'triage') {
+            // Context check: fix, triage and file are issue-only, help works
+            // on both, the rest are PR-only.
+            if (normalizedCommand === 'fix' || normalizedCommand === 'triage' || normalizedCommand === 'file') {
               if (isPR) {
                 reject(`\`@torchxpubot ${normalizedCommand}\` can only be used on issue comments, not on pull requests.`);
                 return;
@@ -122,9 +126,10 @@ jobs:
 
             if (command === 'help') {
               authorized = true; // anyone
-            } else if (command === 'fix') {
-              // fix drives an autonomous agent with write access, so it is
-              // gated like `merge -f` rather than like the read-only commands.
+            } else if (command === 'fix' || command === 'file') {
+              // fix drives an autonomous agent with write access, and file
+              // publishes a public issue, so both are gated like `merge -f`
+              // rather than like the read-only commands.
               authorized = maintainerOnly.includes(assoc);
             } else if (!privileged.includes(assoc)) {
               authorized = false;
@@ -135,6 +140,7 @@ jobs:
             let rerunMode = 'all';
             let pytorchRef = '';
             let revertReason = '';
+            let unitId = '';
 
             if (command === 'merge') {
               if (args.includes('-f')) {
@@ -161,6 +167,15 @@ jobs:
               if (branchMatch) {
                 pytorchRef = branchMatch[1];
               }
+            } else if (command === 'file') {
+              // The unit id reaches a shell argument and a comment marker, so
+              // it is validated here rather than downstream.
+              const unitMatch = args.match(/^([A-Za-z0-9][A-Za-z0-9._-]{0,63})$/);
+              if (!unitMatch) {
+                reject('`file` needs exactly one unit id, as in `@torchxpubot file candidate-1`.');
+                return;
+              }
+              unitId = unitMatch[1];
             }
 
             core.setOutput('command', normalizedCommand);
@@ -168,6 +183,7 @@ jobs:
             core.setOutput('rerun_mode', rerunMode);
             core.setOutput('pytorch_ref', pytorchRef);
             core.setOutput('revert_reason', revertReason);
+            core.setOutput('unit_id', unitId);
             core.setOutput('authorized', String(authorized));
 
   invalid-command:
@@ -214,6 +230,8 @@ jobs:
               msg = 'Only OWNER or MEMBER can use `@torchxpubot merge -f` (force merge).';
             } else if (cmd === 'fix') {
               msg = 'Only OWNER or MEMBER can use `@torchxpubot fix`.';
+            } else if (cmd === 'file') {
+              msg = 'Only OWNER or MEMBER can use `@torchxpubot file`, because it opens a public issue.';
             }
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -257,6 +275,7 @@ jobs:
             |---------|-------------|
             | \`@torchxpubot fix\` | Reproduce this issue on an XPU host and attempt a fix (OWNER/MEMBER only) |
             | \`@torchxpubot triage\` | Shallow text-only triage: classify, detect reproducer, apply agent labels |
+            | \`@torchxpubot file <unit-id>\` | On the alignment triage issue, file one reviewed draft as its own issue (OWNER/MEMBER only) |
             | \`@torchxpubot help\` | Show this help message |
 
             \`fix\` reproduces the issue on a runner that has a prebuilt nightly
@@ -268,6 +287,13 @@ jobs:
 
             \`fix\` also updates this issue's body with agent status markers and
             applies stage labels while it runs.
+
+            \`file\` only works on the standing XPU alignment triage issue. The
+            daily alignment workflow posts one draft comment per reviewed
+            candidate there; \`file <unit-id>\` copies that comment's text into a
+            new issue verbatim. No agent runs in between, so what you read in the
+            draft is exactly what gets published. You can only file a unit the
+            review already produced, and each unit can be filed once.
 
             All other commands (merge, revert, rebase, lint, rerun, review, ut-check)
             are only available on pull request comments.`;
@@ -1263,6 +1289,52 @@ jobs:
         if: ${{ always() }}
         run: |
           chown 1000:1000 /__w /github ./ -R
+
+  file:
+    needs: parse-command
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: >-
+      needs.parse-command.outputs.command == 'file'
+      && needs.parse-command.outputs.authorized == 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      # No agent runs here. The draft comment was written by the reviewed daily
+      # alignment run and is copied into the new issue byte for byte, so the
+      # maintainer who approves it has already read exactly what gets published.
+      - name: File the approved alignment draft
+        id: file
+        env:
+          GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
+          UNIT_ID: ${{ needs.parse-command.outputs.unit_id }}
+          REQUESTED_ON: ${{ needs.parse-command.outputs.issue_number }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/bot_alignment_file.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --triage-issue "$ALIGNMENT_TRIAGE_ISSUE" \
+            --requested-on "$REQUESTED_ON" \
+            --unit-id "$UNIT_ID"
+
+      - name: Report the outcome
+        if: ${{ always() }}
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const unit = '${{ needs.parse-command.outputs.unit_id }}';
+            const url = '${{ steps.file.outputs.issue_url }}';
+            const body = url
+              ? `Filed \`${unit}\` as ${url}.`
+              : `Could not file \`${unit}\`. See the [job log](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}) for the reason.`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.parse-command.outputs.issue_number }},
+              body
+            });
 
   triage:
     needs: parse-command

--- a/.github/workflows/xpu_alignment.yml
+++ b/.github/workflows/xpu_alignment.yml
@@ -1,0 +1,322 @@
+name: XPU Alignment
+
+# Deliberate deviation from `.claude/skills/xpu-alignment/SKILL.md` rule 2, which
+# tells a human operator to ask before filing a review-approved draft. The agents
+# here still never file: the scan stops before Step 4 and the reviewer only writes
+# reports. Filing is done by this workflow, and only when every one of these holds:
+# an independent review covered every finished ledger row, the scan finished the
+# day, and exactly one candidate came back `needs-xpu-fix`. Anything else goes to
+# the standing triage issue for a human to approve one unit at a time.
+
+on:
+  schedule:
+    # Run at 02:00 UTC and inspect the preceding UTC calendar day.
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      scan_date:
+        description: 'UTC date to scan (YYYY-MM-DD); defaults to yesterday.'
+        required: false
+        type: string
+      runner:
+        description: 'XPU runner label.'
+        required: false
+        type: string
+        default: pvc
+      auto_file:
+        description: 'Allow filing one reviewed needs-xpu-fix issue without approval.'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  # A scheduled run cannot know its date before a step runs, so serialise the
+  # whole workflow instead: two runs must never publish for the same day at once.
+  group: xpu-alignment
+  cancel-in-progress: false
+
+env:
+  BEDROCK_MODEL: global.anthropic.claude-opus-5
+  CLAUDE_ALIGNMENT_TOOLS: Bash,Read,Write,Edit,Glob,Grep,WebFetch,Skill
+  # The official skill writes everything below this root, so artifacts are
+  # restored here too and a skill-compliant reviewer lands inside the upload.
+  ALIGNMENT_RUN_ROOT: agent_space_xpu/runs
+  # One artifact name per attempt, so a re-run does not collide with the
+  # artifacts of the previous attempt.
+  ALIGNMENT_ARTIFACT: xpu-alignment-${{ github.run_id }}-${{ github.run_attempt }}
+  ALIGNMENT_TRIAGE_ISSUE: '5018'
+
+defaults:
+  run:
+    shell: bash {0}
+
+jobs:
+  scan-and-validate:
+    name: Scan and validate on XPU
+    runs-on: ${{ inputs.runner || 'pvc' }}
+    # Wall-clock budget advertised to the scan agent.
+    timeout-minutes: 240
+    outputs:
+      scan_date: ${{ steps.context.outputs.scan_date }}
+    container:
+      image: intelgpu/ubuntu-24.04-lts2:2523.40
+      volumes:
+        - ${{ github.workspace }}:${{ github.workspace }}
+      options: >-
+        --device=/dev/mem --device=/dev/dri
+        --security-opt seccomp=unconfined --cap-add=SYS_PTRACE --shm-size=8g
+        -e ZE_AFFINITY_MASK
+      env:
+        AGENT_TOOLSDIRECTORY: /tmp/xpu-tool
+        PYTORCH_DEBUG_XPU_FALLBACK: '1'
+    steps:
+      - name: Checkout torch-xpu-ops
+        uses: actions/checkout@v4
+
+      - name: Resolve scan date
+        id: context
+        env:
+          INPUT_SCAN_DATE: ${{ inputs.scan_date }}
+        run: |
+          set -euo pipefail
+          scan_date="${INPUT_SCAN_DATE:-$(date -u -d 'yesterday' +%F)}"
+          [[ "$scan_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || { echo 'scan_date must be YYYY-MM-DD' >&2; exit 1; }
+          echo "scan_date=$scan_date" >> "$GITHUB_OUTPUT"
+
+      - name: Install nightly XPU runtime
+        run: |
+          set -euo pipefail
+          python3 -m pip install --upgrade pip wheel setuptools
+          python3 -m pip install --pre torch torchvision torchaudio \
+            --index-url https://download.pytorch.org/whl/nightly/xpu
+          python3 - <<'PY'
+          import torch
+          print(torch.__version__)
+          if not torch.xpu.is_available():
+              raise SystemExit("XPU is not available on the runner")
+          print(torch.xpu.device_count())
+          PY
+          xpu-smi discovery -y --json --dump -1 || true
+
+      - name: Run xpu-alignment scan agent
+        id: scan-agent
+        uses: anthropics/claude-code-action@v1
+        with:
+          use_bedrock: "true"
+          github_token: ${{ github.token }}
+          settings: '{"alwaysThinkingEnabled": true}'
+          claude_args: "--model ${{ env.BEDROCK_MODEL }} --max-turns 80 --allowedTools ${{ env.CLAUDE_ALIGNMENT_TOOLS }}"
+          prompt: |
+            Run the official .claude/skills/xpu-alignment/SKILL.md against pytorch/pytorch
+            for the single UTC day ${{ steps.context.outputs.scan_date }}.
+
+            Follow the official skill through candidate collection, deep filtering,
+            reproducer construction, independent repro precheck, XPU execution, and the
+            Step 3 audit. Write provisional drafts and stop before Step 4; the separate
+            independent-review job owns every review artifact. Do not file issues, post
+            comments, or modify GitHub objects in this job.
+
+            Keep every output under ${{ env.ALIGNMENT_RUN_ROOT }}/${{ steps.context.outputs.scan_date }}/
+            exactly as the skill requires. `artifacts/candidate_ledger.jsonl` is the record
+            the downstream gate reads: it decides from that file whether the day finished,
+            so keep it accurate row by row. Never mark a row done that was not executed and
+            never invent a reject to empty the queue. If the budget expires with rows still
+            pending, leave them pending and write the progress checkpoint; the gate reports
+            an unfinished day and routes the finished units to humans.
+
+            Every ledger `id` must match ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$, because ids are
+            used downstream as file names and comment markers.
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+
+      - name: Upload scan artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ALIGNMENT_ARTIFACT }}
+          path: ${{ env.ALIGNMENT_RUN_ROOT }}/
+          if-no-files-found: warn
+          retention-days: 30
+
+  independent-review:
+    name: Independent alignment review
+    needs: scan-and-validate
+    # Review whatever evidence the scan uploaded, even if the scan job failed.
+    # always() would also survive a cancelled run, which must stop the chain.
+    if: ${{ !cancelled() }}
+    runs-on: ${{ inputs.runner || 'pvc' }}
+    timeout-minutes: 240
+    container:
+      image: intelgpu/ubuntu-24.04-lts2:2523.40
+      volumes:
+        - ${{ github.workspace }}:${{ github.workspace }}
+      options: >-
+        --device=/dev/mem --device=/dev/dri
+        --security-opt seccomp=unconfined --cap-add=SYS_PTRACE --shm-size=8g
+        -e ZE_AFFINITY_MASK
+      env:
+        AGENT_TOOLSDIRECTORY: /tmp/xpu-tool
+        PYTORCH_DEBUG_XPU_FALLBACK: '1'
+    steps:
+      - name: Checkout torch-xpu-ops
+        uses: actions/checkout@v4
+
+      - name: Restore the scan into the official run layout
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.ALIGNMENT_ARTIFACT }}
+          path: ${{ env.ALIGNMENT_RUN_ROOT }}
+
+      - name: Check restored scan evidence
+        run: |
+          set -euo pipefail
+          ledgers="$(find "$ALIGNMENT_RUN_ROOT" -type f -name candidate_ledger.jsonl | wc -l)"
+          (( ledgers > 0 )) || { echo 'No candidate ledger was restored' >&2; exit 1; }
+          echo "Restored $ledgers candidate ledger(s) under $ALIGNMENT_RUN_ROOT"
+
+      - name: Run independent reviewer
+        id: reviewer
+        uses: anthropics/claude-code-action@v1
+        with:
+          use_bedrock: "true"
+          github_token: ${{ github.token }}
+          settings: '{"alwaysThinkingEnabled": true}'
+          claude_args: "--model ${{ env.BEDROCK_MODEL }} --max-turns 60 --allowedTools ${{ env.CLAUDE_ALIGNMENT_TOOLS }}"
+          prompt: |
+            Act as the independent reviewer required by the official
+            .claude/skills/xpu-alignment/references/xpu-alignment-review.md.
+            You did not produce the scan. It is restored in the official layout under
+            `${{ env.ALIGNMENT_RUN_ROOT }}/`; review every scope beneath it and write your
+            outputs into the same run directory, next to the scan's own reports.
+
+            Your review scope is every row of `artifacts/candidate_ledger.jsonl` with
+            title_status pass, deep_status not reject, and local_status done. The gate
+            blocks the whole run if any such row has no verdict, and blocks it again if you
+            emit a verdict for an id the ledger does not contain, so review exactly that
+            set. Rows still pending were never executed; leave them alone.
+
+            Refresh GitHub live state with read-only queries and write the required
+            review_conclusions.md, review_dashboard.md, and review_comment_drafts.md.
+            Do not file issues, post comments, or modify GitHub objects.
+
+            Also write two machine-readable files the gate consumes.
+
+            1. `reports/reviewer_manifest.json`:
+                 {"units": [{"id": "<ledger id>", "verdict": "<allowed verdict>"}]}
+               One entry per reviewed unit, using the verdict vocabulary of the official
+               reference. If the evidence cannot support a verdict, stop and leave the unit
+               out: an incomplete manifest blocks filing, which is the safe outcome.
+
+            2. For every unit you judge `needs-xpu-fix`, one payload named
+               `reports/final_issue_<id>.json`:
+                 {"unit_id": "<id>", "title": "[xpu-alignment] ...", "body": "<markdown>",
+                  "labels": ["ai_generated"]}
+               The title must start with `[xpu-alignment]` and labels must be exactly
+               ["ai_generated"]. Write the body as the issue a maintainer should read:
+               upstream source, local XPU result, your verdict and its evidence, the
+               reproducer path, and the tracking repository intel/torch-xpu-ops. These
+               bytes are published verbatim, either automatically or after a human
+               approves them, so nothing downstream will rewrite or improve them.
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+
+      - name: Upload review artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ALIGNMENT_ARTIFACT }}-review
+          path: ${{ env.ALIGNMENT_RUN_ROOT }}/
+          if-no-files-found: warn
+          retention-days: 30
+
+  gate-and-publish:
+    name: Gate and publish
+    needs: [scan-and-validate, independent-review]
+    # A cancelled run must never reach the publishing step.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      issues: read
+    timeout-minutes: 20
+    steps:
+      - name: Checkout torch-xpu-ops
+        uses: actions/checkout@v4
+
+      - name: Restore the reviewed run
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.ALIGNMENT_ARTIFACT }}-review
+          path: ${{ env.ALIGNMENT_RUN_ROOT }}
+
+      - name: Validate gate and triage protocol
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/test_xpu_alignment_gate.py
+          python3 .github/scripts/test_alignment_triage.py
+
+      - name: Build publishing decision
+        id: decision
+        env:
+          # A scheduled run has no inputs context, so the dispatch default would
+          # otherwise evaluate to empty and never file.
+          AUTO_FILE: ${{ github.event_name == 'schedule' || inputs.auto_file }}
+          SCAN_DATE: ${{ needs.scan-and-validate.outputs.scan_date }}
+        run: |
+          set -euo pipefail
+          args=(--root "$ALIGNMENT_RUN_ROOT" --run-id "$GITHUB_RUN_ID" --scan-date "$SCAN_DATE")
+          if [[ "$AUTO_FILE" == true ]]; then
+            args+=(--auto-file)
+          fi
+          python3 .github/scripts/xpu_alignment_gate.py "${args[@]}"
+
+      - name: Publish to the triage issue
+        if: steps.decision.outputs.decision == 'file-one' || steps.decision.outputs.decision == 'triage'
+        env:
+          GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
+        run: |
+          set -euo pipefail
+          test -n "$GH_TOKEN" || { echo 'MERGE_TOKEN is required to publish' >&2; exit 1; }
+          python3 .github/scripts/xpu_alignment_publish.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --triage-issue "$ALIGNMENT_TRIAGE_ISSUE" \
+            --decision "$ALIGNMENT_RUN_ROOT/filing_decision.json"
+
+      - name: Write workflow summary
+        if: always()
+        run: |
+          set -euo pipefail
+          decision_file="$ALIGNMENT_RUN_ROOT/filing_decision.json"
+          echo '## XPU alignment gate' >> "$GITHUB_STEP_SUMMARY"
+          if [[ -f "$decision_file" ]]; then
+            echo '```json' >> "$GITHUB_STEP_SUMMARY"
+            jq 'del(.payloads[].body)' "$decision_file" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'No publishing decision was produced.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload gate artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ALIGNMENT_ARTIFACT }}-gate
+          path: ${{ env.ALIGNMENT_RUN_ROOT }}/
+          if-no-files-found: warn
+          retention-days: 30
+
+      # Runs last so a blocked or unfinished day still publishes what it can.
+      # A busy day is not a fault and stays green; only these two conditions are.
+      - name: Report a blocked or unfinished run
+        if: steps.decision.outputs.needs_attention == 'true'
+        run: |
+          set -euo pipefail
+          echo "::error::The alignment run was blocked or did not finish the day; see filing_decision.json in the gate artifact."
+          exit 1

--- a/.github/workflows/xpu_alignment.yml
+++ b/.github/workflows/xpu_alignment.yml
@@ -5,8 +5,16 @@ name: XPU Alignment
 # here still never file: the scan stops before Step 4 and the reviewer only writes
 # reports. Filing is done by this workflow, and only when every one of these holds:
 # an independent review covered every finished ledger row, the scan finished the
-# day, and exactly one candidate came back `needs-xpu-fix`. Anything else goes to
-# the standing triage issue for a human to approve one unit at a time.
+# day, both agent jobs ended clean, and exactly one candidate came back
+# `needs-xpu-fix`. Anything else goes to the standing triage issue for a human to
+# approve one unit at a time.
+#
+# Second deliberate deviation, from references/xpu-alignment-review.md, which keeps
+# the authoritative verdict and the permission to file in the review Markdown and
+# forbids a JSON cache from holding either. A workflow gate cannot read prose, so
+# the reviewer also writes `reviewer_manifest.json`. The Markdown stays the record
+# a human audits, and the gate reads its `Review status: blocked` line, so a review
+# that blocked itself cannot unlock filing through the JSON.
 
 on:
   schedule:
@@ -98,6 +106,30 @@ jobs:
           PY
           xpu-smi discovery -y --json --dump -1 || true
 
+      - name: Verify GitHub read access
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # The skill reaches GitHub through the MCP server or `gh`. Only the
+          # fallback exists here, and an absent or unauthenticated CLI would
+          # shrink the day's candidate set instead of failing, so prove it first.
+          if ! command -v gh >/dev/null 2>&1; then
+            apt-get update -qq
+            apt-get install -y -qq curl ca-certificates
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+              -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+            chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+              > /etc/apt/sources.list.d/github-cli.list
+            apt-get update -qq
+            apt-get install -y -qq gh
+          fi
+          gh auth status
+          remaining="$(gh api rate_limit --jq '.resources.core.remaining')"
+          echo "GitHub core quota remaining: $remaining"
+          (( remaining >= 1000 )) || { echo 'Too little GitHub quota to scan a full day' >&2; exit 1; }
+
       - name: Run xpu-alignment scan agent
         id: scan-agent
         uses: anthropics/claude-code-action@v1
@@ -129,6 +161,7 @@ jobs:
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Upload scan artifacts
         if: always()
@@ -175,6 +208,29 @@ jobs:
           (( ledgers > 0 )) || { echo 'No candidate ledger was restored' >&2; exit 1; }
           echo "Restored $ledgers candidate ledger(s) under $ALIGNMENT_RUN_ROOT"
 
+      - name: Verify GitHub read access
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # The reviewer refreshes live upstream state, so it needs the same
+          # proven `gh` channel the scan used.
+          if ! command -v gh >/dev/null 2>&1; then
+            apt-get update -qq
+            apt-get install -y -qq curl ca-certificates
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+              -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+            chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+              > /etc/apt/sources.list.d/github-cli.list
+            apt-get update -qq
+            apt-get install -y -qq gh
+          fi
+          gh auth status
+          remaining="$(gh api rate_limit --jq '.resources.core.remaining')"
+          echo "GitHub core quota remaining: $remaining"
+          (( remaining >= 200 )) || { echo 'Too little GitHub quota to refresh live state' >&2; exit 1; }
+
       - name: Run independent reviewer
         id: reviewer
         uses: anthropics/claude-code-action@v1
@@ -195,6 +251,15 @@ jobs:
             blocks the whole run if any such row has no verdict, and blocks it again if you
             emit a verdict for an id the ledger does not contain, so review exactly that
             set. Rows still pending were never executed; leave them alone.
+
+            That mandatory set is derived from the scan's own ledger, so on its own it can
+            never expose a candidate the scan wrongly rejected. Also sample the negatives as
+            the official reference requires: normalize the title and deep rejects into its
+            categories, then audit the first three ids, sorted lexically, from each
+            normalized category, and all of them where a category holds fewer than three.
+            Record that sample in review_conclusions.md. A sampled reject that turns out to
+            be a real XPU divergence may carry a verdict too; the gate accepts a verdict for
+            any id present in the ledger.
 
             Refresh GitHub live state with read-only queries and write the required
             review_conclusions.md, review_dashboard.md, and review_comment_drafts.md.
@@ -221,6 +286,7 @@ jobs:
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Upload review artifacts
         if: always()
@@ -262,7 +328,13 @@ jobs:
         env:
           # A scheduled run has no inputs context, so the dispatch default would
           # otherwise evaluate to empty and never file.
-          AUTO_FILE: ${{ github.event_name == 'schedule' || inputs.auto_file }}
+          # A crashed scan can leave candidates out of the ledger entirely, which
+          # reads downstream as a finished day, so only a clean run may file
+          # unattended; a failed one still routes its finished units to humans.
+          AUTO_FILE: >-
+            ${{ (github.event_name == 'schedule' || inputs.auto_file)
+            && needs.scan-and-validate.result == 'success'
+            && needs.independent-review.result == 'success' }}
           SCAN_DATE: ${{ needs.scan-and-validate.outputs.scan_date }}
         run: |
           set -euo pipefail

--- a/.github/workflows/xpu_alignment.yml
+++ b/.github/workflows/xpu_alignment.yml
@@ -50,10 +50,6 @@ env:
   ALIGNMENT_ARTIFACT: xpu-alignment-${{ github.run_id }}-${{ github.run_attempt }}
   ALIGNMENT_TRIAGE_ISSUE: '5018'
 
-defaults:
-  run:
-    shell: bash {0}
-
 jobs:
   scan-and-validate:
     name: Scan and validate on XPU
@@ -244,7 +240,6 @@ jobs:
     permissions:
       contents: read
       actions: read
-      issues: read
     timeout-minutes: 20
     steps:
       - name: Checkout torch-xpu-ops
@@ -313,10 +308,11 @@ jobs:
           retention-days: 30
 
       # Runs last so a blocked or unfinished day still publishes what it can.
-      # A busy day is not a fault and stays green; only these two conditions are.
+      # A busy day is not a fault and stays green; only a blocked run, an
+      # unfinished day and a unit that could not be published are.
       - name: Report a blocked or unfinished run
         if: steps.decision.outputs.needs_attention == 'true'
         run: |
           set -euo pipefail
-          echo "::error::The alignment run was blocked or did not finish the day; see filing_decision.json in the gate artifact."
+          echo "::error::The alignment run was blocked, did not finish the day, or held back a unit it could not publish; see filing_decision.json in the gate artifact."
           exit 1


### PR DESCRIPTION
## What this does

Runs the `xpu-alignment` skill against `pytorch/pytorch` once a day, has a second
agent review the result, and then lets a CPU-only gate decide what reaches GitHub.

```
02:00 UTC ──▶ scan (pvc) ──▶ independent review (pvc) ──▶ gate (ubuntu-latest)
                                                             │
                    ┌────────────────────────────────────────┤
                    ▼                    ▼                   ▼
              0 actionable        exactly 1 actionable   2+ actionable
              nothing to do       file it automatically  post drafts to the
                                                         triage issue for a
                                                         maintainer to approve
```

Approval happens with `@torchxpubot file <unit-id>` on the standing triage issue
(#5018).

## Why one automatic issue per day

This is a **risk budget**, not a claim that two candidates would be suspicious.
Two or more is an ordinary busy day — when this process was run by hand it
produced 4 issues on 2026-07-30 and 1 each on 07-09 and 07-29 — so the busy path
keeps the run **green** and simply asks a human to work through the list. Only a
blocked or unfinished run turns the job red.

Capping the unattended path at one per day bounds how much a bad scan can put in
the repository before a person notices, without blocking the days that only need
one issue.

## How the gate decides

The gate reads `artifacts/candidate_ledger.jsonl` — the ledger the skill already
maintains — instead of trusting a status the reviewer reports about itself.

- **Day finished?** No row with `title_status == pass` and `deep_status != reject`
  and `local_status == pending`. This is the skill's own audit rule (SKILL.md
  §Step 3.1).
- **Review complete?** Every finished actionable row carries a reviewer verdict.
  A review that runs out of time now fails hard instead of silently reporting
  fewer candidates than the scan found.

| decision | condition | result |
|---|---|---|
| `none` | nothing actionable | nothing written, green |
| `file-one` | day finished, exactly 1 actionable, auto-file on | 1 issue filed + audit line on #5018, green |
| `triage` | 2+ actionable, or day unfinished | one draft comment per candidate on #5018, green (red if unfinished) |
| `blocked` | evidence does not add up | nothing written, red |

An unfinished day still publishes its finished candidates for human triage — that
GPU time is not thrown away — but the unattended path is switched off, because it
assumes a complete picture of the day.

## No agent runs after the gate

Issue bodies are generated during the scan and review phase as
`reports/final_issue_<unit-id>.json`. Both publishing paths copy a payload that
already existed when the decision was made.

This is deliberate. In an earlier revision the gate wrote its decision to a file
and *then* an agent with `Write` access ran in the same workspace before the
filing step re-read that file. A reproduction showed the agent could change which
candidate was approved and pass every downstream check with exit code 0. Removing
the step removes the window rather than guarding it.

The same property holds for the human path: `@torchxpubot file` copies the draft
comment's bytes into the new issue, so what a maintainer reads is exactly what
gets published.

## Deliberate deviation from the skill

`.claude/skills/xpu-alignment/SKILL.md` rule #2 says:

> Never file issues automatically. Write local drafts, complete independent
> review, then ask the user before filing a review-approved draft on GitHub.

The scan agent still obeys the first sentence — it is told to stop before Step 4
and never writes to GitHub. **This workflow deliberately overrides the second
sentence on one path only**: a day with exactly one reviewed `needs-xpu-fix`
candidate is filed without asking.

Compensating controls for that path:

- a separate reviewer agent must return a verdict for it
- at most one such issue per day
- the day must be complete; an unfinished scan disables the path
- the issue is public, labelled `ai_generated`, and recorded on #5018
- two or more candidates always go to a human

Every other path still asks a person.

## Security

- Both agents run with the read-only `github.token`.
- `MERGE_TOKEN` appears only in the `env` of the two steps that write, never
  inside an agent's tool scope.
- Titles must start with `[xpu-alignment]` and labels must be exactly
  `["ai_generated"]`; a payload that fails either check is refused.
- Unit ids are restricted to `[A-Za-z0-9][A-Za-z0-9._-]{0,63}` because they reach
  shell arguments, glob fragments and comment markers.
- Duplicate detection uses comment markers, not a search query built from an
  LLM-authored title.
- The whole workflow shares one concurrency group: a scheduled run cannot know its
  scan date before a step runs, so grouping by date would not actually serialise
  same-day runs.

## Files

| file | lines | |
|---|---|---|
| `.github/workflows/xpu_alignment.yml` | 322 | scan → review → gate |
| `.github/scripts/xpu_alignment_gate.py` | 260 | ledger + coverage → decision |
| `.github/scripts/alignment_triage.py` | 150 | triage issue comment protocol |
| `.github/scripts/xpu_alignment_publish.py` | 78 | automatic path |
| `.github/scripts/bot_alignment_file.py` | 58 | human path |
| `.github/workflows/bot.yml` | +86 | `file` command |
| tests | 474 | 37 cases |

## Testing

- 37 unit tests across the gate and the comment protocol.
- Structural checks on both workflows: YAML parse, job dependency graph, `bash -n`
  on all 15 `run` blocks, embedded Python compiles, no `secrets.` interpolated
  inside a `run` block.
- End-to-end smoke run against a stub `gh` with a realistic artifact layout,
  covering: automatic filing and its idempotency on re-run, triage plus human
  approval, rejection of a duplicate/unknown/wrong-issue approval, an unfinished
  scan disabling the unattended path, a coverage gap blocking with zero writes,
  and `auto_file=false`.

## Before merging

- #5018 is currently empty. It should carry a short usage note
  (`@torchxpubot file <unit-id>`, OWNER/MEMBER only) so the first person to see a
  draft there knows what to do.
- Worth one `workflow_dispatch` run with `auto_file=false` to confirm both agents
  produce the expected files on real hardware.

## Known limits

- The ledger is written by the scan agent. Checking the reviewer against it
  catches a review that stopped early; it cannot catch a candidate the scan
  dropped before writing the ledger. There is no independent enumeration of
  upstream activity to compare against.
- Whether the pre-generated issue bodies are good enough to file unattended has
  not been observed on real data yet.

## Relationship to #5003

#5003 stays open and untouched. This branch is a rewrite from a different set of
requirements, so it starts fresh from `main` rather than continuing that history.
