### PR TITLE
Update guard for empty tensor in weight_norm_backward_kernel

### DIFF
--- a/src/ATen/native/xpu/sycl/WeightNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/WeightNormKernels.cpp
@@ -899,9 +899,9 @@ std::tuple<Tensor, Tensor> weight_norm_backward_kernel(
   auto grad_v = at::empty_like(saved_v, c10::get_contiguous_memory_format());
   auto grad_g = at::empty_like(saved_g, c10::get_contiguous_memory_format());
 
-  // Empty saved_v: grad_v is empty, grad_g = 0/0 = NaN (matches CPU/CUDA).
+  // Empty saved_v: grad_v is empty, grad_g = 0 (matches CPU/CUDA).
   if (saved_v.numel() == 0) {
-    grad_g.fill_(std::numeric_limits<double>::quiet_NaN());
+    grad_g.zero_();
     return {grad_v, grad_g};
   }
 


### PR DESCRIPTION
Fix for issue reported in https://github.com/intel/torch-xpu-ops/issues/4978

Test case fixed:
`op_regression,third_party.torch-xpu-ops.test.regressions.test_index_and_index_put.TestTorchMethod,test_weight_norm_empty`

Updates the guard for empty input in `weight_norm_backward_kernel` added in https://github.com/intel/torch-xpu-ops/pull/3938 to match the CPU behaviour after it has changed in upstream in https://github.com/pytorch/pytorch/pull/192179
