### PR TITLE
[Cherry-pick release/2.14] fix: avoid register spilling in elementwise ops for mixed fp32/bf16/fp16 inputs

### DIFF
--- a/src/ATen/native/xpu/sycl/Loops.h
+++ b/src/ATen/native/xpu/sycl/Loops.h
@@ -573,21 +573,49 @@ void gpu_kernel_impl(TensorIteratorBase& iter, const func_t& f) {
 
   int64_t numel = iter.numel();
 
+  constexpr bool fp_result = std::is_same_v<arg0_t, float>;
+  bool use_fp_cast = fp_result && (iter.dtype(0) == at::ScalarType::Float);
+  if (use_fp_cast) {
+    for (int i = 1; i < ntensors; i++) {
+      auto dt = iter.dtype(i);
+      if (dt != at::ScalarType::Float && dt != at::ScalarType::Half &&
+          dt != at::ScalarType::BFloat16) {
+        use_fp_cast = false;
+        break;
+      }
+    }
+  }
+
   bool contiguous = iter.is_contiguous();
 
   if (contiguous) {
-    auto loader = memory::LoadWithCast<traits::arity>(iter);
-    auto storer = memory::StoreWithCast<1>(iter);
-    auto input_offset_calculator = TrivialOffsetCalculator<traits::arity>();
-    auto output_offset_calculator = TrivialOffsetCalculator<1>();
-    launch_unrolled_kernel(
-        numel,
-        f,
-        data,
-        input_offset_calculator,
-        output_offset_calculator,
-        loader,
-        storer);
+    if (use_fp_cast) {
+      auto loader = memory::LoadWithCastFP<traits::arity>(iter);
+      auto storer = memory::StoreWithCastFP<1>();
+      auto input_offset_calculator = TrivialOffsetCalculator<traits::arity>();
+      auto output_offset_calculator = TrivialOffsetCalculator<1>();
+      launch_unrolled_kernel(
+          numel,
+          f,
+          data,
+          input_offset_calculator,
+          output_offset_calculator,
+          loader,
+          storer);
+    } else {
+      auto loader = memory::LoadWithCast<traits::arity>(iter);
+      auto storer = memory::StoreWithCast<1>(iter);
+      auto input_offset_calculator = TrivialOffsetCalculator<traits::arity>();
+      auto output_offset_calculator = TrivialOffsetCalculator<1>();
+      launch_unrolled_kernel(
+          numel,
+          f,
+          data,
+          input_offset_calculator,
+          output_offset_calculator,
+          loader,
+          storer);
+    }
   } else {
     at::detail::Array<ScalarType, ntensors> dtypes;
     for (int i = 0; i < ntensors; i++) {

--- a/src/ATen/native/xpu/sycl/MemoryAccessUtils.h
+++ b/src/ATen/native/xpu/sycl/MemoryAccessUtils.h
@@ -116,6 +116,41 @@ struct LoadWithoutCast {
 };
 
 template <int N>
+struct LoadWithCastFP {
+  using array_t = at::detail::Array<at::ScalarType, std::max<int>(N, 1)>;
+  using size_array_t = at::detail::Array<uint32_t, std::max<int>(N, 1)>;
+
+  array_t dtypes;
+  size_array_t element_sizes;
+
+  LoadWithCastFP(const TensorIteratorBase& iter) {
+    assert(iter.ninputs() == N);
+#pragma unroll
+    for (auto i = 0; i < N; ++i) {
+      this->dtypes[i] = iter.dtype(i + iter.noutputs());
+      element_sizes[i] = c10::elementSize(iter.dtype(i + iter.noutputs()));
+    }
+  }
+
+  template <typename scalar_t>
+  C10_DEVICE scalar_t load(char* base_ptr, uint32_t offset, int arg) {
+    void* ptr = base_ptr + element_sizes[arg] * offset;
+    if constexpr (std::is_same_v<scalar_t, float>) {
+      switch (dtypes[arg]) {
+        case at::ScalarType::Float:
+          return c10::load<float>(ptr);
+        case at::ScalarType::Half:
+          return c10::convert<float>(c10::load<c10::Half>(ptr));
+        case at::ScalarType::BFloat16:
+          return c10::convert<float>(c10::load<c10::BFloat16>(ptr));
+      }
+    }
+    // Satisfy compiler for non-float scalar_t instantiations that never run.
+    return scalar_t{};
+  }
+};
+
+template <int N>
 struct LoadWithCast {
   using array_t = at::detail::Array<at::ScalarType, std::max<int>(N, 1)>;
   using size_array_t = at::detail::Array<uint32_t, std::max<int>(N, 1)>;
@@ -147,6 +182,20 @@ struct StoreWithoutCast {
       uint32_t offset,
       int arg = 0) {
     *(reinterpret_cast<scalar_t*>(base_ptr) + offset) = value;
+  }
+};
+
+template <int N = 1>
+struct StoreWithCastFP {
+  template <typename scalar_t>
+  C10_DEVICE void store(
+      scalar_t value,
+      char* base_ptr,
+      uint32_t offset,
+      int arg = 0) {
+    if constexpr (std::is_same_v<scalar_t, float>) {
+      *(reinterpret_cast<float*>(base_ptr) + offset) = value;
+    }
   }
 };
 


### PR DESCRIPTION
Fixes #4904 (eager mode regression).

Root cause: commit 35de5ddd3 changed AT_DISPATCH_V2 to include kBComplex32, which expanded the switch inside c10::fetch_and_cast / cast_and_store in LoadWithCast/StoreWithCast. The compiler spills variables to private memory (1024 bytes/thread), causing ~4x slowdown.

Fix: add LoadWithCastFP and StoreWithCastFP with a 3-case switch (Float/Half/BFloat16) for the common mixed-precision path (float output, float/half/bf16 inputs). gpu_kernel_impl detects this pattern and routes to the specialized loader/storer.

Repro:
```python
import torch
a = torch.randn(32, 384, 768, device="xpu", dtype=torch.float32)
b = torch.randn(32, 384, 768, device="xpu", dtype=torch.bfloat16)
for _ in range(100):
    torch.add(a, b, alpha=1.0)
torch.xpu.synchronize()
```

unitrace results:
- main: LoadWithCast, Private Memory = 1024, Avg 799 us
- fix:  LoadWithCastFP, Private Memory = 0,    Avg 82.6 us (9.7x)

Co-authored-by: AI Assistant

Cherry-pick of #5005 to `release/2.14`.
Cherry-picked from commit 1a3415a46d2486569b0b6da4446e0284cbf3591e.