### PR TITLE
Use std::min/std::max consistently in device code

### DIFF
--- a/src/ATen/native/xpu/sycl/AveragePool2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/AveragePool2dKernels.cpp
@@ -39,14 +39,14 @@ struct AvgPool2dKernelFunctor {
       int hstart = ph * stride_h_ - pad_h_;
       int wstart = pw * stride_w_ - pad_w_;
       int hend =
-          sycl::min(hstart + kernel_h_, static_cast<int>(height_ + pad_h_));
+          std::min(hstart + kernel_h_, static_cast<int>(height_ + pad_h_));
       int wend =
-          sycl::min(wstart + kernel_w_, static_cast<int>(width_ + pad_w_));
+          std::min(wstart + kernel_w_, static_cast<int>(width_ + pad_w_));
       const int pool_size = (hend - hstart) * (wend - wstart);
-      hstart = sycl::max(hstart, 0);
-      wstart = sycl::max(wstart, 0);
-      hend = sycl::min(hend, static_cast<int>(height_));
-      wend = sycl::min(wend, static_cast<int>(width_));
+      hstart = std::max(hstart, 0);
+      wstart = std::max(wstart, 0);
+      hend = std::min(hend, static_cast<int>(height_));
+      wend = std::min(wend, static_cast<int>(width_));
 
       if (hstart >= hend || wstart >= wend) {
         top_data_[index] = scalar_t(0);
@@ -142,14 +142,14 @@ struct AvgPool2dChannelsLastKernelFunctor {
       int hstart = ph * stride_h_ - pad_h_;
       int wstart = pw * stride_w_ - pad_w_;
       int hend =
-          sycl::min(hstart + kernel_h_, static_cast<int>(height_ + pad_h_));
+          std::min(hstart + kernel_h_, static_cast<int>(height_ + pad_h_));
       int wend =
-          sycl::min(wstart + kernel_w_, static_cast<int>(width_ + pad_w_));
+          std::min(wstart + kernel_w_, static_cast<int>(width_ + pad_w_));
       const int pool_size = (hend - hstart) * (wend - wstart);
-      hstart = sycl::max(hstart, 0);
-      wstart = sycl::max(wstart, 0);
-      hend = sycl::min(hend, static_cast<int>(height_));
-      wend = sycl::min(wend, static_cast<int>(width_));
+      hstart = std::max(hstart, 0);
+      wstart = std::max(wstart, 0);
+      hend = std::min(hend, static_cast<int>(height_));
+      wend = std::min(wend, static_cast<int>(width_));
 
       if (hstart >= hend || wstart >= wend) {
         top_data_[index] = scalar_t(0);
@@ -338,9 +338,9 @@ struct AvgPool2dChannelsLastBackwardKernelFunctor {
       const int h = (index / channels_ / width_) % height_ + pad_h_;
       const int n = index / channels_ / width_ / height_;
       const int phstart = (h < kernel_h_) ? 0 : (h - kernel_h_) / stride_h_ + 1;
-      const int phend = sycl::min(h / stride_h_ + 1, pooled_height_);
+      const int phend = std::min(h / stride_h_ + 1, pooled_height_);
       const int pwstart = (w < kernel_w_) ? 0 : (w - kernel_w_) / stride_w_ + 1;
-      const int pwend = sycl::min(w / stride_w_ + 1, pooled_width_);
+      const int pwend = std::min(w / stride_w_ + 1, pooled_width_);
       accscalar_t gradient = accscalar_t(0);
       const scalar_t* const top_slice =
           top_data_ + n * channels_ * pooled_height_ * pooled_width_ + c;
@@ -350,14 +350,14 @@ struct AvgPool2dChannelsLastBackwardKernelFunctor {
           int hstart = ph * stride_h_ - pad_h_;
           int wstart = pw * stride_w_ - pad_w_;
           int hend =
-              sycl::min(hstart + kernel_h_, static_cast<int>(height_ + pad_h_));
+              std::min(hstart + kernel_h_, static_cast<int>(height_ + pad_h_));
           int wend =
-              sycl::min(wstart + kernel_w_, static_cast<int>(width_ + pad_w_));
+              std::min(wstart + kernel_w_, static_cast<int>(width_ + pad_w_));
           int pool_size = (hend - hstart) * (wend - wstart);
-          hstart = sycl::max(hstart, 0);
-          wstart = sycl::max(wstart, 0);
-          hend = sycl::min(hend, static_cast<int>(height_));
-          wend = sycl::min(wend, static_cast<int>(width_));
+          hstart = std::max(hstart, 0);
+          wstart = std::max(wstart, 0);
+          hend = std::min(hend, static_cast<int>(height_));
+          wend = std::min(wend, static_cast<int>(width_));
           if (hstart >= hend || wstart >= wend) {
             continue;
           }
@@ -445,9 +445,9 @@ struct AvgPool2dBackwarKernelFunctor {
       const int c = (index / width_ / height_) % channels_;
       const int n = index / width_ / height_ / channels_;
       const int phstart = (h < kernel_h_) ? 0 : (h - kernel_h_) / stride_h_ + 1;
-      const int phend = sycl::min(h / stride_h_ + 1, pooled_height_);
+      const int phend = std::min(h / stride_h_ + 1, pooled_height_);
       const int pwstart = (w < kernel_w_) ? 0 : (w - kernel_w_) / stride_w_ + 1;
-      const int pwend = sycl::min(w / stride_w_ + 1, pooled_width_);
+      const int pwend = std::min(w / stride_w_ + 1, pooled_width_);
       accscalar_t gradient = accscalar_t(0);
       const scalar_t* const top_data_slice =
           top_data_ + (n * channels_ + c) * pooled_height_ * pooled_width_;
@@ -457,14 +457,14 @@ struct AvgPool2dBackwarKernelFunctor {
           int hstart = ph * stride_h_ - pad_h_;
           int wstart = pw * stride_w_ - pad_w_;
           int hend =
-              sycl::min(hstart + kernel_h_, static_cast<int>(height_ + pad_h_));
+              std::min(hstart + kernel_h_, static_cast<int>(height_ + pad_h_));
           int wend =
-              sycl::min(wstart + kernel_w_, static_cast<int>(width_ + pad_w_));
+              std::min(wstart + kernel_w_, static_cast<int>(width_ + pad_w_));
           int pool_size = (hend - hstart) * (wend - wstart);
-          hstart = sycl::max(hstart, 0);
-          wstart = sycl::max(wstart, 0);
-          hend = sycl::min(hend, static_cast<int>(height_));
-          wend = sycl::min(wend, static_cast<int>(width_));
+          hstart = std::max(hstart, 0);
+          wstart = std::max(wstart, 0);
+          hend = std::min(hend, static_cast<int>(height_));
+          wend = std::min(wend, static_cast<int>(width_));
           if (hstart >= hend || wstart >= wend) {
             continue;
           }

--- a/src/ATen/native/xpu/sycl/AveragePool3dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/AveragePool3dKernels.cpp
@@ -45,19 +45,19 @@ struct AvgPool3dKernelFunctor {
       index_t hstart = oRow * dH_ - padH_;
       index_t wstart = oCol * dW_ - padW_;
       index_t tend =
-          sycl::min(tstart + kT_, static_cast<index_t>(input_.size(1) + padT_));
+          std::min(tstart + kT_, static_cast<index_t>(input_.size(1) + padT_));
       index_t hend =
-          sycl::min(hstart + kH_, static_cast<index_t>(input_.size(2) + padH_));
+          std::min(hstart + kH_, static_cast<index_t>(input_.size(2) + padH_));
       index_t wend =
-          sycl::min(wstart + kW_, static_cast<index_t>(input_.size(3) + padW_));
+          std::min(wstart + kW_, static_cast<index_t>(input_.size(3) + padW_));
       index_t pool_size = (tend - tstart) * (hend - hstart) * (wend - wstart);
 
-      tstart = sycl::max(tstart, index_t(0));
-      hstart = sycl::max(hstart, index_t(0));
-      wstart = sycl::max(wstart, index_t(0));
-      tend = sycl::min(tend, static_cast<index_t>(input_.size(1)));
-      hend = sycl::min(hend, static_cast<index_t>(input_.size(2)));
-      wend = sycl::min(wend, static_cast<index_t>(input_.size(3)));
+      tstart = std::max(tstart, index_t(0));
+      hstart = std::max(hstart, index_t(0));
+      wstart = std::max(wstart, index_t(0));
+      tend = std::min(tend, static_cast<index_t>(input_.size(1)));
+      hend = std::min(hend, static_cast<index_t>(input_.size(2)));
+      wend = std::min(wend, static_cast<index_t>(input_.size(3)));
 
       if (tstart >= tend || hstart >= hend || wstart >= wend) {
         out_data[slice][oFrame][oRow][oCol] = static_cast<scalar_t>(0.0);
@@ -317,20 +317,20 @@ struct AvgPool3dBackwardStride1KernelFunctor {
     if (iRow < grad_input_.size(2) && iCol < grad_input_.size(3)) {
       accscalar_t sum = 0.0;
       const scalar_t* gOut =
-          &grad_output_[slice][sycl::max(index_t(0), iFrame - kT_ + 1)]
-                       [sycl::max(index_t(0), iRow - kH_ + 1)]
-                       [sycl::max(index_t(0), iCol - kW_ + 1)];
+          &grad_output_[slice][std::max(index_t(0), iFrame - kT_ + 1)]
+                       [std::max(index_t(0), iRow - kH_ + 1)]
+                       [std::max(index_t(0), iCol - kW_ + 1)];
       index_t frameOffset = 0;
-      for (index_t oFrame = sycl::max(index_t(0), iFrame - kT_ + 1); oFrame <
-           sycl::min(iFrame + 1, static_cast<index_t>(grad_output_.size(1)));
+      for (index_t oFrame = std::max(index_t(0), iFrame - kT_ + 1); oFrame <
+           std::min(iFrame + 1, static_cast<index_t>(grad_output_.size(1)));
            ++oFrame) {
         index_t rowOffset = frameOffset;
-        for (index_t oRow = sycl::max(index_t(0), iRow - kH_ + 1); oRow <
-             sycl::min(iRow + 1, static_cast<index_t>(grad_output_.size(2)));
+        for (index_t oRow = std::max(index_t(0), iRow - kH_ + 1); oRow <
+             std::min(iRow + 1, static_cast<index_t>(grad_output_.size(2)));
              ++oRow) {
           index_t colOffset = rowOffset;
-          for (index_t oCol = sycl::max(index_t(0), iCol - kW_ + 1); oCol <
-               sycl::min(iCol + 1, static_cast<index_t>(grad_output_.size(3)));
+          for (index_t oCol = std::max(index_t(0), iCol - kW_ + 1); oCol <
+               std::min(iCol + 1, static_cast<index_t>(grad_output_.size(3)));
                ++oCol) {
             sum += gOut[colOffset];
             ++colOffset;
@@ -419,19 +419,19 @@ struct AvgPool3dBackwardAtomicKernelFunctor {
       index_t tstart = oFrame * dT_ - padT_;
       index_t hstart = oRow * dH_ - padH_;
       index_t wstart = oCol * dW_ - padW_;
-      index_t tend = sycl::min(
+      index_t tend = std::min(
           tstart + kT_, static_cast<index_t>(grad_input_.size(1) + padT_));
-      index_t hend = sycl::min(
+      index_t hend = std::min(
           hstart + kH_, static_cast<index_t>(grad_input_.size(2) + padH_));
-      index_t wend = sycl::min(
+      index_t wend = std::min(
           wstart + kW_, static_cast<index_t>(grad_input_.size(3) + padW_));
       index_t pool_size = (tend - tstart) * (hend - hstart) * (wend - wstart);
-      tstart = sycl::max(tstart, index_t(0));
-      hstart = sycl::max(hstart, index_t(0));
-      wstart = sycl::max(wstart, index_t(0));
-      tend = sycl::min(tend, static_cast<index_t>(grad_input_.size(1)));
-      hend = sycl::min(hend, static_cast<index_t>(grad_input_.size(2)));
-      wend = sycl::min(wend, static_cast<index_t>(grad_input_.size(3)));
+      tstart = std::max(tstart, index_t(0));
+      hstart = std::max(hstart, index_t(0));
+      wstart = std::max(wstart, index_t(0));
+      tend = std::min(tend, static_cast<index_t>(grad_input_.size(1)));
+      hend = std::min(hend, static_cast<index_t>(grad_input_.size(2)));
+      wend = std::min(wend, static_cast<index_t>(grad_input_.size(3)));
 
       accscalar_t divide_factor;
       if (divisor_override_) {
@@ -581,19 +581,19 @@ struct AvgPool3dBackwardKernelFunctor {
       index_t tstart = oFrame * dT_ - padT_;
       index_t hstart = oRow * dH_ - padH_;
       index_t wstart = oCol * dW_ - padW_;
-      index_t tend = sycl::min(
+      index_t tend = std::min(
           tstart + kT_, static_cast<index_t>(grad_input_.size(1) + padT_));
-      index_t hend = sycl::min(
+      index_t hend = std::min(
           hstart + kH_, static_cast<index_t>(grad_input_.size(2) + padH_));
-      index_t wend = sycl::min(
+      index_t wend = std::min(
           wstart + kW_, static_cast<index_t>(grad_input_.size(3) + padW_));
       index_t pool_size = (tend - tstart) * (hend - hstart) * (wend - wstart);
-      tstart = sycl::max(tstart, index_t(0));
-      hstart = sycl::max(hstart, index_t(0));
-      wstart = sycl::max(wstart, index_t(0));
-      tend = sycl::min(tend, static_cast<index_t>(grad_input_.size(1)));
-      hend = sycl::min(hend, static_cast<index_t>(grad_input_.size(2)));
-      wend = sycl::min(wend, static_cast<index_t>(grad_input_.size(3)));
+      tstart = std::max(tstart, index_t(0));
+      hstart = std::max(hstart, index_t(0));
+      wstart = std::max(wstart, index_t(0));
+      tend = std::min(tend, static_cast<index_t>(grad_input_.size(1)));
+      hend = std::min(hend, static_cast<index_t>(grad_input_.size(2)));
+      wend = std::min(wend, static_cast<index_t>(grad_input_.size(3)));
 
       accscalar_t divide_factor;
       if (divisor_override_) {

--- a/src/ATen/native/xpu/sycl/ReplicationPaddingKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ReplicationPaddingKernels.cpp
@@ -32,11 +32,11 @@ struct ParallelReplicationPad1dKernelFunctor {
     auto output_id = item.get_global_id(2);
     if (output_id < output_plane_size_) {
       int64_t output_x = output_id % output_.size(2);
-      int64_t i_start_x = sycl::max(int64_t(0), -pad_left_);
-      int64_t o_start_x = sycl::max(int64_t(0), pad_left_);
+      int64_t i_start_x = std::max(int64_t(0), -pad_left_);
+      int64_t o_start_x = std::max(int64_t(0), pad_left_);
       int64_t input_x =
-          sycl::min(
-              sycl::max(pad_left_, output_x), input_.size(2) + pad_left_ - 1) -
+          std::min(
+              std::max(pad_left_, output_x), input_.size(2) + pad_left_ - 1) -
           o_start_x + i_start_x;
 
       f_(input_,
@@ -156,17 +156,17 @@ struct ParallelReplicationPad2dKernelFunctor {
       const int output_x = output_id / output_.size(3); // height
       const int output_y = output_id % output_.size(3); // width
 
-      const int iStartX = sycl::max(0, static_cast<int>(-padT_));
-      const int iStartY = sycl::max(0, static_cast<int>(-padL_));
-      const int oStartX = sycl::max(0, static_cast<int>(padT_));
-      const int oStartY = sycl::max(0, static_cast<int>(padL_));
+      const int iStartX = std::max(0, static_cast<int>(-padT_));
+      const int iStartY = std::max(0, static_cast<int>(-padL_));
+      const int oStartX = std::max(0, static_cast<int>(padT_));
+      const int oStartY = std::max(0, static_cast<int>(padL_));
 
-      const int input_x = sycl::min(
-                              sycl::max(static_cast<int>(padT_), output_x),
+      const int input_x = std::min(
+                              std::max(static_cast<int>(padT_), output_x),
                               static_cast<int>(input_.size(2) + padT_ - 1)) -
           oStartX + iStartX;
-      const int input_y = sycl::min(
-                              sycl::max(static_cast<int>(padL_), output_y),
+      const int input_y = std::min(
+                              std::max(static_cast<int>(padL_), output_y),
                               static_cast<int>(input_.size(3) + padL_ - 1)) -
           oStartY + iStartY;
 
@@ -277,24 +277,24 @@ struct ParallelReplicationPad3dKernelFunctor {
       int64_t output_y = (output_id / output_.size(4)) % output_.size(3);
       int64_t output_z = output_id / (output_.size(3) * output_.size(4));
 
-      int64_t i_start_x = sycl::max(int64_t(0), -pad_left_);
-      int64_t i_start_y = sycl::max(int64_t(0), -pad_top_);
-      int64_t i_start_z = sycl::max(int64_t(0), -pad_front_);
-      int64_t o_start_x = sycl::max(int64_t(0), pad_left_);
-      int64_t o_start_y = sycl::max(int64_t(0), pad_top_);
-      int64_t o_start_z = sycl::max(int64_t(0), pad_front_);
+      int64_t i_start_x = std::max(int64_t(0), -pad_left_);
+      int64_t i_start_y = std::max(int64_t(0), -pad_top_);
+      int64_t i_start_z = std::max(int64_t(0), -pad_front_);
+      int64_t o_start_x = std::max(int64_t(0), pad_left_);
+      int64_t o_start_y = std::max(int64_t(0), pad_top_);
+      int64_t o_start_z = std::max(int64_t(0), pad_front_);
 
       int64_t input_x =
-          sycl::min(
-              sycl::max(pad_left_, output_x), input_.size(4) + pad_left_ - 1) -
+          std::min(
+              std::max(pad_left_, output_x), input_.size(4) + pad_left_ - 1) -
           o_start_x + i_start_x;
       int64_t input_y =
-          sycl::min(
-              sycl::max(pad_top_, output_y), input_.size(3) + pad_top_ - 1) -
+          std::min(
+              std::max(pad_top_, output_y), input_.size(3) + pad_top_ - 1) -
           o_start_y + i_start_y;
-      int64_t input_z = sycl::min(
-                            sycl::max(pad_front_, output_z),
-                            input_.size(2) + pad_front_ - 1) -
+      int64_t input_z =
+          std::min(
+              std::max(pad_front_, output_z), input_.size(2) + pad_front_ - 1) -
           o_start_z + i_start_z;
 
       f_(input_,


### PR DESCRIPTION
Device code mixed `std::` and `sycl::` min/max. This converges on `std::` across the three files that still used the `sycl::` spelling.

`sycl::min`/`sycl::max` cannot become the single convention: they are constrained to SYCL generic types and reject `c10::Half`/`c10::BFloat16`, and on floating point they follow `fmin`/`fmax`, which discards NaN. `std::` already covers most of the tree and works for every type, so one spelling removes the risk of converting a float site by analogy and silently changing its NaN contract.

All 88 converted sites are `int`/`int64_t`/`index_t` index and bound arithmetic, where the two are equivalent. The one remaining `sycl::max` is in SYCL-TLA flash attention, on a float accumulator where `fmax` semantics is intended.
