### PR TITLE
[follow-up to #5005 Load/StoreWithCastFP ]Add comments and tests for mixed fp cast fast path 

### DIFF
--- a/src/ATen/native/xpu/sycl/Loops.h
+++ b/src/ATen/native/xpu/sycl/Loops.h
@@ -573,6 +573,13 @@ void gpu_kernel_impl(TensorIteratorBase& iter, const func_t& f) {
 
   int64_t numel = iter.numel();
 
+  // Fast path for mixed fp32/bf16/fp16 elementwise ops using a compact
+  // 3-case switch (LoadWithCastFP/StoreWithCastFP) to avoid register
+  // spilling from the generic large ScalarType switch (see #4904).
+  // fp_result (compile-time) ensures the functor output type is exactly
+  // float32 (excluding double, bool, etc);
+  // dtype(0)==Float (runtime) guarantees the output pointer is float*
+  // as StoreWithCastFP expects.
   constexpr bool fp_result = std::is_same_v<arg0_t, float>;
   bool use_fp_cast = fp_result && (iter.dtype(0) == at::ScalarType::Float);
   if (use_fp_cast) {

--- a/test/xpu/test_binary_ufuncs_xpu.py
+++ b/test/xpu/test_binary_ufuncs_xpu.py
@@ -68,5 +68,43 @@ instantiate_device_type_tests(
 )
 
 
+from torch.testing._internal.common_utils import TestCase
+
+
+class TestMixedDtypeElementwise(TestCase):
+    """Test mixed-precision elementwise ops (bf16/fp16 + fp32) correctness.
+
+    These exercise the LoadWithCastFP/StoreWithCastFP fast path in
+    gpu_kernel_impl when inputs have mixed floating-point dtypes.
+    """
+
+    def _test_mixed_dtype_binary(self, op, shape, low_dtype, device):
+        a_fp32 = torch.randn(shape, device=device, dtype=torch.float32)
+        b_fp32 = torch.randn(shape, device=device, dtype=torch.float32)
+        a_low = a_fp32.to(low_dtype)
+        expected = op(a_low.float(), b_fp32)
+        result = op(a_low, b_fp32)
+        self.assertEqual(result.dtype, torch.float32)
+        self.assertEqual(result, expected)
+        result_rev = op(b_fp32, a_low)
+        expected_rev = op(b_fp32, a_low.float())
+        self.assertEqual(result_rev, expected_rev)
+
+    def test_mixed_fp_small(self):
+        """GPT2 residual shapes: [4, 1024, 768]"""
+        ops = [torch.add, torch.sub, torch.mul, torch.div]
+        for op in ops:
+            for dt in [torch.bfloat16, torch.float16]:
+                self._test_mixed_dtype_binary(op, [4, 1024, 768], dt, "xpu")
+
+    def test_mixed_fp_large(self):
+        """GPT2 MLP / Albert MLP shapes: [4, 1024, 3072], [16, 512, 3072]"""
+        ops = [torch.add, torch.mul]
+        for op in ops:
+            for dt in [torch.bfloat16, torch.float16]:
+                for shape in [[4, 1024, 3072], [16, 512, 3072]]:
+                    self._test_mixed_dtype_binary(op, shape, dt, "xpu")
+
+
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

Follow-up to #5005. Adds:

- Explanatory comments for the `fp_result` and `use_fp_cast` conditions in `gpu_kernel_impl`, clarifying why both compile-time and runtime checks are needed.
- Unit tests for mixed-precision elementwise ops (add/mul/sub/div with bf16+fp32 and fp16+fp32) using model-realistic shapes (GPT2, Albert).

Co-authored-by: OpenCode (AI assistant)