### PR TITLE
build: fix build with dpclang after streamlining device compilation

### DIFF
--- a/cmake/BuildFlags.cmake
+++ b/cmake/BuildFlags.cmake
@@ -153,6 +153,17 @@ macro(set_build_flags)
     endif()
   endif()
 
+  if(WIN32)
+    list(APPEND _sycl_intel_lib_libirc_flag "/Qno-intel-lib:libirc")
+  else()
+    list(APPEND _sycl_intel_lib_libirc_flag "-no-intel-lib=libirc")
+  endif()
+
+  CHECK_SYCL_FLAG("${_sycl_intel_lib_libirc_flag}" SUPPORTS_INTEL_LIB_LIBIRC_FLAG)
+  if(SUPPORTS_INTEL_LIB_LIBIRC_FLAG)
+    list(APPEND SYCL_KERNEL_OPTIONS ${_sycl_intel_lib_libirc_flag})
+  endif()
+
   # -- Device debug flags (aligned with CUDA behavior)
   # XPU_DEVICE_DEBUG=1: full device debug, disables optimization (like CUDA's -g -G)
   #   Orthogonal to build type, always forces device debug.

--- a/cmake/Modules/FindSYCL/run_sycl.cmake
+++ b/cmake/Modules/FindSYCL/run_sycl.cmake
@@ -73,12 +73,6 @@ foreach(flag ${CMAKE_HOST_FLAGS})
   endif()
 endforeach()
 
-if(WIN32)
-  list(APPEND SYCL_compile_flags "/Qno-intel-lib:libirc")
-else()
-  list(APPEND SYCL_compile_flags "-no-intel-lib=libirc")
-endif()
-
 # SYCL_execute_process - Executes a command with optional command echo and status message.
 #
 #   status  - Status message to print if verbose is true


### PR DESCRIPTION
Fixes: https://github.com/intel/torch-xpu-ops/issues/5052
Fixes: 2f80608a (Remove -fsycl-host-compiler, use pure icpx compilation (#2994))

CC: @chunhuanMeng. @mengfei25, @chuanqi129