### PR TITLE
[xccl] Use native onecclAllToAllV for unequal-split all_to_all_single

### DIFF
--- a/cmake/XCCL.cmake
+++ b/cmake/XCCL.cmake
@@ -27,4 +27,21 @@ if(NOT __XCCL_INCLUDED)
   set_property(
     TARGET torch::xccl PROPERTY INTERFACE_LINK_LIBRARIES
     "-Wl,--no-as-needed,${XCCL_LIBRARY},--as-needed")
+
+  # onecclAllToAllV was added during the oneCCL 2022.2 cycle, so the version
+  # macros cannot tell whether a given 2022.2 header provides it. Probe the
+  # header instead. decltype avoids needing the symbol at link time.
+  include(CheckCXXSourceCompiles)
+  set(CMAKE_REQUIRED_INCLUDES ${XCCL_INCLUDE_DIR})
+  check_cxx_source_compiles("
+    #include <oneapi/ccl.h>
+    using alltoallv_t = decltype(&onecclAllToAllV);
+    int main() { return 0; }
+    " XCCL_HAS_ALLTOALLV)
+  unset(CMAKE_REQUIRED_INCLUDES)
+  if(XCCL_HAS_ALLTOALLV)
+    set_property(
+      TARGET torch::xccl APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS
+      XCCL_HAS_ALLTOALLV)
+  endif()
 endif()

--- a/src/xccl/xccl.cpp
+++ b/src/xccl/xccl.cpp
@@ -231,6 +231,23 @@ static std::pair<bool, size_t> checkUniformAllToAll(
   return {uniformCount > 0, uniformCount};
 }
 
+// onecclAllToAllV does not take displacements: it derives them internally as
+// the running prefix sums of the counts. The native path is therefore only
+// valid when the caller's displacements match that layout.
+static bool checkContiguousDispls(
+    const size_t* counts,
+    const size_t* displs,
+    int numranks) {
+  size_t expected = 0;
+  for (int r = 0; r < numranks; ++r) {
+    if (displs[r] != expected) {
+      return false;
+    }
+    expected += counts[r];
+  }
+  return true;
+}
+
 void onecclAllToAll(
     void* sendbuff,
     const size_t* sendcounts,
@@ -255,6 +272,23 @@ void onecclAllToAll(
         sendbuff, recvbuff, uniformCount, xcclDataType, comm, &stream.queue());
     return;
   }
+
+#if defined(XCCL_HAS_ALLTOALLV)
+  // Use native onecclAllToAllV for the non-uniform case when the buffers are
+  // packed contiguously, which is what c10d::computeLengthsAndOffsets produces.
+  if (checkContiguousDispls(sendcounts, senddispls, numranks) &&
+      checkContiguousDispls(recvcounts, recvdispls, numranks)) {
+    onecclAllToAllV(
+        sendbuff,
+        sendcounts,
+        recvbuff,
+        recvcounts,
+        xcclDataType,
+        comm,
+        &stream.queue());
+    return;
+  }
+#endif
 
   // Fallback to send/recv based implementation for non-uniform case
   xccl::oneccl_group_start();


### PR DESCRIPTION
oneCCL 2022.2 (oneccl-v2 PR#652, MLSL-4180) adds onecclAllToAllV. Route the non-uniform all-to-all through it instead of the group send/recv emulation, mirroring how ProcessGroupNCCL prefers ncclAllToAllv when the NCCL build provides it.

onecclAllToAllV takes no displacements: it derives them internally as the running prefix sums of the counts. Guard the native path with a contiguity check so the send/recv fallback still covers any other layout.