### PR TITLE
[SYCL free func] migrate WeightNormKernels kernels

### DIFF
--- a/src/ATen/native/xpu/sycl/BatchKernel.h
+++ b/src/ATen/native/xpu/sycl/BatchKernel.h
@@ -78,6 +78,28 @@ class BatchKernelConfig {
     return cfg;
   }
 
+  template <auto* kptr>
+  static BatchKernelConfig make_config(
+      int64_t batch,
+      int64_t problem,
+      int64_t stride,
+      int64_t problem_batch,
+      bool problem_along_x,
+      std::vector<Policy> policies,
+      int64_t prefer_wg_size = 0) {
+    BatchKernelConfig cfg = {
+        batch,
+        problem,
+        stride,
+        problem_batch,
+        problem_along_x,
+        policies,
+        prefer_wg_size};
+    cfg.template build<kptr>();
+
+    return cfg;
+  }
+
   sycl::range<2> global_size() const {
     return {glb_range_y_, glb_range_x_};
   }
@@ -209,6 +231,107 @@ class BatchKernelConfig {
       wg_size = prefer_wg_size_;
     } else {
       wg_size = syclMaxWorkGroupSize<KernelClass>();
+    }
+    wg_range_x_ = sg_size;
+    wg_range_y_ = wg_size / wg_range_x_;
+
+    size_t limit_x =
+        (uint8_t)policy_ & (uint8_t)Policy::pAggressiveSplit ? 1 : sg_size;
+
+    if (problem_batch_ == 0)
+      problem_batch_ = batch_ * stride_;
+
+    // ensure assigning successive work items along contiguous (small stride)
+    // dimension
+    auto range_bound_x = problem_along_x_ ? problem_ : problem_batch_;
+    auto range_bound_y = problem_along_x_ ? problem_batch_ : problem_;
+
+    // Implications,
+    // 1. assign proper x/y to accommodate workload exactly.
+    // 2. prefer enough x (at least limit_x) to access memory coalecsingly.
+    // Spare y for x if workload is not large along y.
+    wg_range_y_ =
+        std::min<size_t>(wg_range_y_, std::bit_ceil((uint64_t)range_bound_y));
+    // Subscribe appropriate x at least limit_x.
+    wg_range_x_ = std::max<size_t>(
+        std::min<size_t>(
+            wg_size / wg_range_y_, std::bit_ceil((uint64_t)range_bound_x)),
+        limit_x);
+    // Retieve y if necessary, if x is not large.
+    wg_range_y_ = std::min<size_t>(
+        wg_size / wg_range_x_, std::bit_ceil((uint64_t)range_bound_y));
+
+    if ((uint8_t)policy_ & (uint8_t)Policy::pAdaptive) {
+      size_t target_glb_range = syclMaxWorkItemsPerTile() /
+          (wg_range_x_ * wg_range_y_) * (wg_range_x_ * wg_range_y_);
+      if (problem_along_x_) {
+        glb_range_y_ = wg_range_y_;
+
+        glb_range_x_ = target_glb_range / glb_range_y_;
+        if (glb_range_x_ > range_bound_x) {
+          auto wg_num_x = std::max<size_t>(range_bound_x / wg_range_x_, 1);
+          glb_range_x_ = wg_range_x_ * wg_num_x;
+        }
+
+        glb_range_y_ = target_glb_range / glb_range_x_;
+        if (glb_range_y_ > range_bound_y) {
+          auto wg_num_y = std::max<size_t>(range_bound_y / wg_range_y_, 1);
+          glb_range_y_ = wg_range_y_ * wg_num_y;
+        }
+      } else {
+        glb_range_x_ = wg_range_x_;
+
+        glb_range_y_ = target_glb_range / glb_range_x_;
+        if (glb_range_y_ > range_bound_y) {
+          auto wg_num_y = std::max<size_t>(range_bound_y / wg_range_y_, 1);
+          glb_range_y_ = wg_range_y_ * wg_num_y;
+        }
+
+        glb_range_x_ = target_glb_range / glb_range_y_;
+        if (glb_range_x_ > range_bound_x) {
+          auto wg_num_x = std::max<size_t>(range_bound_x / wg_range_x_, 1);
+          glb_range_x_ = wg_range_x_ * wg_num_x;
+        }
+      }
+    } else {
+      if (problem_along_x_) {
+        glb_range_x_ = (uint8_t)policy_ & (uint8_t)Policy::pLoop
+            ? wg_range_x_
+            : size_t((problem_ + wg_range_x_ - 1) / wg_range_x_) * wg_range_x_;
+        glb_range_y_ =
+            size_t((problem_batch_ + wg_range_y_ - 1) / wg_range_y_) *
+            wg_range_y_;
+      } else {
+        glb_range_x_ =
+            size_t((problem_batch_ + wg_range_x_ - 1) / wg_range_x_) *
+            wg_range_x_;
+        glb_range_y_ = (uint8_t)policy_ & (uint8_t)Policy::pLoop
+            ? wg_range_y_
+            : size_t((problem_ + wg_range_y_ - 1) / wg_range_y_) * wg_range_y_;
+      }
+    }
+
+    problem_wg_range_ = problem_along_x_ ? wg_range_x_ : wg_range_y_;
+    problem_glb_range_ = problem_along_x_ ? glb_range_x_ : glb_range_y_;
+    batch_glb_range_ = problem_along_x_ ? glb_range_y_ : glb_range_x_;
+    problem_range_ = problem_along_x_
+        ? (problem_ + glb_range_x_ - 1) / glb_range_x_ * glb_range_x_
+        : (problem_ + glb_range_y_ - 1) / glb_range_y_ * glb_range_y_;
+    batch_range_ = problem_along_x_
+        ? (problem_batch_ + glb_range_y_ - 1) / glb_range_y_ * glb_range_y_
+        : (problem_batch_ + glb_range_x_ - 1) / glb_range_x_ * glb_range_x_;
+  }
+
+  template <auto* kptr>
+  void build() {
+    size_t wg_size;
+    size_t sg_size = syclMaxSubGroupSize();
+    // Caller takes responsibility of if work group size is valid or compatible.
+    if (prefer_wg_size_ != 0 && prefer_wg_size_ % sg_size == 0 &&
+        prefer_wg_size_ <= syclDeviceMaxWorkGroupSize()) {
+      wg_size = prefer_wg_size_;
+    } else {
+      wg_size = syclMaxWorkGroupSize<kptr>();
     }
     wg_range_x_ = sg_size;
     wg_range_y_ = wg_size / wg_range_x_;

--- a/src/ATen/native/xpu/sycl/WeightNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/WeightNormKernels.cpp
@@ -44,8 +44,8 @@ void weight_norm_reduce_kernel(
     bool need_squre,
     bool is_final) {
   auto item = syclext::this_work_item::get_nd_item<2>();
-  char* shared_ptr = (char*)syclexp::get_work_group_scratch_memory();
-
+  char* shared_ptr = static_cast<char*>(syclexp::get_work_group_scratch_memory());
+  
   auto id = cfg.get_item_desc(item);
   int64_t si = id.glb_batch % cfg.stride_;
   int64_t bi = id.glb_batch / cfg.stride_;

--- a/src/ATen/native/xpu/sycl/WeightNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/WeightNormKernels.cpp
@@ -44,7 +44,8 @@ void weight_norm_reduce_kernel(
     bool need_squre,
     bool is_final) {
   auto item = syclext::this_work_item::get_nd_item<2>();
-  char* shared_ptr = static_cast<char*>(syclexp::get_work_group_scratch_memory());
+  char* shared_ptr =
+      static_cast<char*>(syclexp::get_work_group_scratch_memory());
   
   auto id = cfg.get_item_desc(item);
   int64_t si = id.glb_batch % cfg.stride_;

--- a/src/ATen/native/xpu/sycl/WeightNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/WeightNormKernels.cpp
@@ -827,9 +827,9 @@ std::tuple<Tensor, Tensor> weight_norm_backward_kernel(
   auto grad_v = at::empty_like(saved_v, c10::get_contiguous_memory_format());
   auto grad_g = at::empty_like(saved_g, c10::get_contiguous_memory_format());
 
-  // Empty saved_v: grad_v is empty, grad_g = 0/0 = NaN (matches CPU/CUDA).
+  // Empty saved_v: grad_v is empty, grad_g = 0 (matches CPU/CUDA).
   if (saved_v.numel() == 0) {
-    grad_g.fill_(std::numeric_limits<double>::quiet_NaN());
+    grad_g.zero_();
     return {grad_v, grad_g};
   }
 

--- a/src/ATen/native/xpu/sycl/WeightNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/WeightNormKernels.cpp
@@ -36,93 +36,49 @@ template <
     typename scalar_t,
     typename accscalar_t,
     typename vec_t>
-struct WeightNormReduceKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
-  void operator()(sycl::nd_item<2> item) const {
-    auto id = cfg_.get_item_desc(item);
-    int64_t si = id.glb_batch % cfg_.stride_;
-    int64_t bi = id.glb_batch / cfg_.stride_;
-    int64_t ldr_pi = id.chunk * id.chunk_size + id.chunk_off;
-    int64_t str_pi = id.chunk;
-    int64_t ldr_lid =
-        si + ldr_pi * cfg_.stride_ + bi * cfg_.problem_ * cfg_.stride_;
-    int64_t ldr_off =
-        at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-            ldr_lid, iinfo_);
-    int64_t str_lid =
-        si + str_pi * cfg_.stride_ + bi * id.chunk_num * cfg_.stride_;
-    int64_t str_off =
-        at::xpu::detail::IndexToOffset<accscalar_t, int64_t, -1>::get(
-            str_lid, oinfo_);
-
-    accscalar_t value = 0;
-    if (id.glb_problem < cfg_.problem_ && id.glb_batch < cfg_.problem_batch_) {
-      value = (accscalar_t)iinfo_.data[ldr_off];
-      if (need_squre_)
-        value *= value;
-    }
-
-    if (cfg_.problem_along_x_) {
-      value = group_x_reduce(
-          item, shared_, vec_t(value), ReduceAdd<accscalar_t>())[0];
-    } else {
-      value = group_y_reduce(
-          item, shared_, vec_t(value), ReduceAdd<accscalar_t>())[0];
-    }
-
-    if (id.glb_problem < cfg_.problem_ && id.glb_batch < cfg_.problem_batch_) {
-      if (id.chunk_off == 0) {
-        oinfo_.data[str_off] = is_final_ ? sycl::sqrt(value) : value;
-      }
-    }
-  }
-
-  void sycl_ker_config_convention(sycl::handler& cgh) {
-    shared_ = sycl_local_acc_t<accscalar_t>(shared_memeory_size_, cgh);
-  }
-  WeightNormReduceKernelFunctor(
-      ScalarTypeInfo iinfo,
-      AccTypeInfo oinfo,
-      BatchKernelConfig cfg,
-      bool need_squre,
-      bool is_final,
-      int64_t shared_memeory_size)
-      : iinfo_(iinfo),
-        oinfo_(oinfo),
-        cfg_(cfg),
-        need_squre_(need_squre),
-        is_final_(is_final),
-        shared_memeory_size_(shared_memeory_size) {}
-
- private:
-  ScalarTypeInfo iinfo_;
-  AccTypeInfo oinfo_;
-  BatchKernelConfig cfg_;
-  bool need_squre_;
-  bool is_final_;
-  int64_t shared_memeory_size_;
-  sycl_local_acc_t<accscalar_t> shared_;
-};
-
-template <class ScalarTypeInfo, class AccTypeInfo>
-static inline void launch_weight_norm_reduce_kernel(
-    ScalarTypeInfo& iinfo,
-    AccTypeInfo& oinfo,
-    BatchKernelConfig& cfg,
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<2>))
+void weight_norm_reduce_kernel(
+    ScalarTypeInfo iinfo,
+    AccTypeInfo oinfo,
+    BatchKernelConfig cfg,
     bool need_squre,
     bool is_final) {
-  using scalar_t = typename ScalarTypeInfo::scalar_t;
-  using accscalar_t = typename AccTypeInfo::scalar_t;
-  using vec_t = at::detail::Array<accscalar_t, 1>;
+  auto item = syclext::this_work_item::get_nd_item<2>();
+  char* shared_ptr = (char*)syclexp::get_work_group_scratch_memory();
 
-  WeightNormReduceKernelFunctor<
-      ScalarTypeInfo,
-      AccTypeInfo,
-      scalar_t,
-      accscalar_t,
-      vec_t>
-      kfn(iinfo, oinfo, cfg, need_squre, is_final, cfg.group_size().size());
-  sycl_kernel_submit(
-      cfg.global_size(), cfg.group_size(), getCurrentSYCLQueue(), kfn);
+  auto id = cfg.get_item_desc(item);
+  int64_t si = id.glb_batch % cfg.stride_;
+  int64_t bi = id.glb_batch / cfg.stride_;
+  int64_t ldr_pi = id.chunk * id.chunk_size + id.chunk_off;
+  int64_t str_pi = id.chunk;
+  int64_t ldr_lid = si + ldr_pi * cfg.stride_ + bi * cfg.problem_ * cfg.stride_;
+  int64_t ldr_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
+      ldr_lid, iinfo);
+  int64_t str_lid = si + str_pi * cfg.stride_ + bi * id.chunk_num * cfg.stride_;
+  int64_t str_off =
+      at::xpu::detail::IndexToOffset<accscalar_t, int64_t, -1>::get(
+          str_lid, oinfo);
+
+  accscalar_t value = 0;
+  if (id.glb_problem < cfg.problem_ && id.glb_batch < cfg.problem_batch_) {
+    value = (accscalar_t)iinfo.data[ldr_off];
+    if (need_squre)
+      value *= value;
+  }
+
+  if (cfg.problem_along_x_) {
+    value = group_x_reduce(
+        item, shared_ptr, vec_t(value), ReduceAdd<accscalar_t>())[0];
+  } else {
+    value = group_y_reduce(
+        item, shared_ptr, vec_t(value), ReduceAdd<accscalar_t>())[0];
+  }
+
+  if (id.glb_problem < cfg.problem_ && id.glb_batch < cfg.problem_batch_) {
+    if (id.chunk_off == 0) {
+      oinfo.data[str_off] = is_final ? std::sqrt(value) : value;
+    }
+  }
 }
 
 template <class ScalarTypeInfo, class AccTypeInfo>
@@ -138,17 +94,39 @@ static inline void weight_norm_reduce(
   using scalar_t = typename ScalarTypeInfo::scalar_t;
   using accscalar_t = typename AccTypeInfo::scalar_t;
   using vec_t = at::detail::Array<accscalar_t, 1>;
-  using KernelClass = WeightNormReduceKernelFunctor<
+  // static constexpr: MSVC loses a plain constexpr local when it is used as
+  // a non-type template argument from inside the launch lambda below
+  // (C2065/C2326)
+  static constexpr auto kptr = weight_norm_reduce_kernel<
       ScalarTypeInfo,
       AccTypeInfo,
       scalar_t,
       accscalar_t,
       vec_t>;
-  BatchKernelConfig cfg = BatchKernelConfig::make_config<KernelClass>(
-      batch, problem, stride, batch * stride, problem_along_x);
+  BatchKernelConfig cfg = BatchKernelConfig::make_config<kptr>(
+      batch,
+      problem,
+      stride,
+      batch * stride,
+      problem_along_x,
+      {BatchKernelConfig::Policy::pSegment});
+
+  int slm_sz = cfg.group_size().size() * sizeof(accscalar_t);
+  auto launch = [&](auto& iinfo, auto& oinfo, bool is_final) {
+    sycl_kernel_submit<kptr, 2>(
+        cfg.global_size(),
+        cfg.group_size(),
+        getCurrentSYCLQueue(),
+        slm_sz,
+        iinfo,
+        oinfo,
+        cfg,
+        need_square,
+        is_final);
+  };
 
   if (cfg.problem_ <= cfg.problem_wg_range_) {
-    launch_weight_norm_reduce_kernel(vinfo, ninfo, cfg, need_square, true);
+    launch(vinfo, ninfo, true);
     return;
   }
 
@@ -158,7 +136,7 @@ static inline void weight_norm_reduce(
   auto cinfo =
       at::xpu::detail::getTensorInfo<typename AccTypeInfo::scalar_t, int64_t>(
           carrier);
-  launch_weight_norm_reduce_kernel(vinfo, cinfo, cfg, need_square, false);
+  launch(vinfo, cinfo, false);
 
   weight_norm_reduce(cinfo, ninfo, 1, false);
   return;
@@ -169,45 +147,35 @@ template <
     class AccTypeInfo,
     typename scalar_t,
     typename accscalar_t>
-struct SegmentWeightNormKernelFunctor {
-  void operator()(sycl::nd_item<2> item) const {
-    auto id = cfg_.get_item_desc(item);
-    int64_t si = id.glb_batch % cfg_.stride_;
-    int64_t bi = id.glb_batch / cfg_.stride_;
-    int64_t pi = id.chunk * id.chunk_size + id.chunk_off;
-    int64_t w_lid = si + pi * cfg_.stride_ + bi * cfg_.problem_ * cfg_.stride_;
-    int64_t n_lid = id.glb_batch;
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<2>))
+void segment_weight_norm_kernel(
+    ScalarTypeInfo vinfo,
+    ScalarTypeInfo ginfo,
+    ScalarTypeInfo winfo,
+    AccTypeInfo ninfo,
+    BatchKernelConfig cfg) {
+  auto item = syclext::this_work_item::get_nd_item<2>();
+  auto id = cfg.get_item_desc(item);
+  int64_t si = id.glb_batch % cfg.stride_;
+  int64_t bi = id.glb_batch / cfg.stride_;
+  int64_t pi = id.chunk * id.chunk_size + id.chunk_off;
+  int64_t w_lid = si + pi * cfg.stride_ + bi * cfg.problem_ * cfg.stride_;
+  int64_t n_lid = id.glb_batch;
 
-    int64_t v_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-        w_lid, vinfo_);
-    int64_t w_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-        w_lid, winfo_);
-    int64_t g_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-        n_lid, ginfo_);
-    int64_t n_off =
-        at::xpu::detail::IndexToOffset<accscalar_t, int64_t, -1>::get(
-            n_lid, ninfo_);
+  int64_t v_off =
+      at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(w_lid, vinfo);
+  int64_t w_off =
+      at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(w_lid, winfo);
+  int64_t g_off =
+      at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(n_lid, ginfo);
+  int64_t n_off = at::xpu::detail::IndexToOffset<accscalar_t, int64_t, -1>::get(
+      n_lid, ninfo);
 
-    if (id.glb_problem < cfg_.problem_ && id.glb_batch < cfg_.problem_batch_) {
-      winfo_.data[w_off] =
-          (1.f / ninfo_.data[n_off]) * vinfo_.data[v_off] * ginfo_.data[g_off];
-    }
+  if (id.glb_problem < cfg.problem_ && id.glb_batch < cfg.problem_batch_) {
+    winfo.data[w_off] = (accscalar_t(1) / ninfo.data[n_off]) *
+        vinfo.data[v_off] * ginfo.data[g_off];
   }
-  SegmentWeightNormKernelFunctor(
-      ScalarTypeInfo vinfo,
-      ScalarTypeInfo ginfo,
-      ScalarTypeInfo winfo,
-      AccTypeInfo ninfo,
-      BatchKernelConfig cfg)
-      : vinfo_(vinfo), ginfo_(ginfo), winfo_(winfo), ninfo_(ninfo), cfg_(cfg) {}
-
- private:
-  ScalarTypeInfo vinfo_;
-  ScalarTypeInfo ginfo_;
-  ScalarTypeInfo winfo_;
-  AccTypeInfo ninfo_;
-  BatchKernelConfig cfg_;
-};
+}
 
 template <class ScalarTypeInfo, class AccTypeInfo>
 static inline void segment_weight_norm(
@@ -227,17 +195,29 @@ static inline void segment_weight_norm(
   using scalar_t = typename ScalarTypeInfo::scalar_t;
   using accscalar_t = typename AccTypeInfo::scalar_t;
 
-  using KernelClass = SegmentWeightNormKernelFunctor<
+  constexpr auto kptr = segment_weight_norm_kernel<
       ScalarTypeInfo,
       AccTypeInfo,
       scalar_t,
       accscalar_t>;
-  BatchKernelConfig cfg = BatchKernelConfig::make_config<KernelClass>(
-      batch, problem, stride, batch * stride, problem_along_x);
+  BatchKernelConfig cfg = BatchKernelConfig::make_config<kptr>(
+      batch,
+      problem,
+      stride,
+      batch * stride,
+      problem_along_x,
+      {BatchKernelConfig::Policy::pSegment});
 
-  KernelClass kfn(vinfo, ginfo, winfo, ninfo, cfg);
-  sycl_kernel_submit(
-      cfg.global_size(), cfg.group_size(), getCurrentSYCLQueue(), kfn);
+  sycl_kernel_submit<kptr, 2>(
+      cfg.global_size(),
+      cfg.group_size(),
+      getCurrentSYCLQueue(),
+      0,
+      vinfo,
+      ginfo,
+      winfo,
+      ninfo,
+      cfg);
 }
 
 template <
@@ -246,100 +226,77 @@ template <
     typename scalar_t,
     typename accscalar_t,
     typename vec_t>
-struct WeightNormKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
-  void operator()(sycl::nd_item<2> item) const {
-    auto id = cfg_.get_item_desc(item);
-    int64_t n_lid = id.glb_batch;
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<2>))
+void weight_norm_combine_kernel(
+    ScalarTypeInfo vinfo,
+    ScalarTypeInfo ginfo,
+    ScalarTypeInfo winfo,
+    AccTypeInfo ninfo,
+    BatchKernelConfig cfg,
+    int batch_wg_range) {
+  auto item = syclext::this_work_item::get_nd_item<2>();
+  accscalar_t* shared_ = (accscalar_t*)syclexp::get_work_group_scratch_memory();
 
-    int64_t g_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-        n_lid, ginfo_);
+  auto id = cfg.get_item_desc(item);
+  int64_t n_lid = id.glb_batch;
 
-    int64_t n_off =
-        at::xpu::detail::IndexToOffset<accscalar_t, int64_t, -1>::get(
-            n_lid, ninfo_);
+  int64_t g_off =
+      at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(n_lid, ginfo);
 
-    int64_t si = id.glb_batch % cfg_.stride_;
-    int64_t bi = id.glb_batch / cfg_.stride_;
-    int64_t pi = id.chunk_off;
-    bi = si + bi * cfg_.problem_ * cfg_.stride_;
+  int64_t n_off = at::xpu::detail::IndexToOffset<accscalar_t, int64_t, -1>::get(
+      n_lid, ninfo);
 
-    accscalar_t value = 0;
-    if (id.glb_batch < cfg_.problem_batch_) {
-      for (int pi_ = pi; pi_ < cfg_.problem_; pi_ += cfg_.problem_wg_range_) {
-        int64_t v_lid = bi + pi_ * cfg_.stride_;
-        int64_t v_off =
-            at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-                v_lid, vinfo_);
+  int64_t si = id.glb_batch % cfg.stride_;
+  int64_t bi = id.glb_batch / cfg.stride_;
+  int64_t pi = id.chunk_off;
+  bi = si + bi * cfg.problem_ * cfg.stride_;
 
-        accscalar_t v = (accscalar_t)vinfo_.data[v_off];
-        value += v * v;
-      }
-    }
-
-    if (cfg_.problem_along_x_) {
-      value = group_x_reduce(
-          item, shared_, vec_t(value), ReduceAdd<accscalar_t>())[0];
-    } else {
-      value = group_y_reduce(
-          item, shared_, vec_t(value), ReduceAdd<accscalar_t>())[0];
-    }
-
-    int n_slid = (int)id.glb_batch % batch_wg_range_;
-    if (id.glb_batch < cfg_.problem_batch_ && id.chunk_off == 0) {
-      value = sycl::sqrt(value);
-      ninfo_.data[n_off] = value;
-      shared_[n_slid] = value;
-    }
-    // Here using slm instead. If using ugm, need fence w/
-    // order:acq_rel & scope:workgroup & space:global_mem.
-    sycl::group_barrier(item.get_group());
-
-    if (id.glb_batch < cfg_.problem_batch_) {
-      for (int pi_ = pi; pi_ < cfg_.problem_; pi_ += cfg_.problem_wg_range_) {
-        int64_t v_lid = bi + pi_ * cfg_.stride_;
-        int64_t v_off =
-            at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-                v_lid, vinfo_);
-        int64_t w_off =
-            at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-                v_lid, winfo_);
-
-        winfo_.data[w_off] =
-            (1.f / shared_[n_slid]) * vinfo_.data[v_off] * ginfo_.data[g_off];
-      }
+  accscalar_t value = 0;
+  if (id.glb_batch < cfg.problem_batch_) {
+    for (int pi_ = pi; pi_ < cfg.problem_; pi_ += cfg.problem_wg_range_) {
+      int64_t v_lid = bi + pi_ * cfg.stride_;
+      int64_t v_off =
+          at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
+              v_lid, vinfo);
+      accscalar_t v = (accscalar_t)vinfo.data[v_off];
+      value += v * v;
     }
   }
 
-  void sycl_ker_config_convention(sycl::handler& cgh) {
-    shared_ = sycl_local_acc_t<accscalar_t>(wg_size_, cgh);
+  char* shared_ptr = reinterpret_cast<char*>(shared_);
+  if (cfg.problem_along_x_) {
+    value = group_x_reduce(
+        item, shared_ptr, vec_t(value), ReduceAdd<accscalar_t>())[0];
+  } else {
+    value = group_y_reduce(
+        item, shared_ptr, vec_t(value), ReduceAdd<accscalar_t>())[0];
   }
 
-  WeightNormKernelFunctor(
-      ScalarTypeInfo vinfo,
-      ScalarTypeInfo ginfo,
-      ScalarTypeInfo winfo,
-      AccTypeInfo ninfo,
-      BatchKernelConfig cfg,
-      int wg_size,
-      int batch_wg_range)
-      : vinfo_(vinfo),
-        ginfo_(ginfo),
-        winfo_(winfo),
-        ninfo_(ninfo),
-        cfg_(cfg),
-        wg_size_(wg_size),
-        batch_wg_range_(batch_wg_range) {}
+  int n_slid = (int)id.glb_batch % batch_wg_range;
+  if (id.glb_batch < cfg.problem_batch_ && id.chunk_off == 0) {
+    value = std::sqrt(value);
+    ninfo.data[n_off] = value;
+    shared_[n_slid] = value;
+  }
+  // Here using slm instead. If using ugm, need fence w/
+  // order:acq_rel & scope:workgroup & space:global_mem.
+  sycl::group_barrier(item.get_group());
 
- private:
-  ScalarTypeInfo vinfo_;
-  ScalarTypeInfo ginfo_;
-  ScalarTypeInfo winfo_;
-  AccTypeInfo ninfo_;
-  BatchKernelConfig cfg_;
-  int wg_size_;
-  int batch_wg_range_;
-  sycl_local_acc_t<accscalar_t> shared_;
-};
+  if (id.glb_batch < cfg.problem_batch_) {
+    for (int pi_ = pi; pi_ < cfg.problem_; pi_ += cfg.problem_wg_range_) {
+      int64_t v_lid = bi + pi_ * cfg.stride_;
+      int64_t v_off =
+          at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
+              v_lid, vinfo);
+      int64_t w_off =
+          at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
+              v_lid, winfo);
+
+      winfo.data[w_off] = (accscalar_t(1) / shared_[n_slid]) *
+          vinfo.data[v_off] * ginfo.data[g_off];
+    }
+  }
+}
 
 template <class ScalarTypeInfo, class AccTypeInfo>
 static inline void weight_norm(
@@ -356,25 +313,34 @@ static inline void weight_norm(
   using accscalar_t = typename AccTypeInfo::scalar_t;
   using vec_t = at::detail::Array<accscalar_t, 1>;
 
-  using KernelClass = WeightNormKernelFunctor<
+  constexpr auto kptr = weight_norm_combine_kernel<
       ScalarTypeInfo,
       AccTypeInfo,
       scalar_t,
       accscalar_t,
       vec_t>;
-  BatchKernelConfig cfg = BatchKernelConfig::make_config<KernelClass>(
+  BatchKernelConfig cfg = BatchKernelConfig::make_config<kptr>(
       batch,
       problem,
       stride,
       batch * stride,
       problem_along_x,
-      BatchKernelConfig::Policy::pLoop);
+      {BatchKernelConfig::Policy::pLoop});
 
   int wg_size = cfg.group_size().size();
   int batch_wg_range = wg_size / cfg.problem_wg_range_;
-  KernelClass kfn(vinfo, ginfo, winfo, ninfo, cfg, wg_size, batch_wg_range);
-  sycl_kernel_submit(
-      cfg.global_size(), cfg.group_size(), getCurrentSYCLQueue(), kfn);
+  int slm_sz = wg_size * sizeof(accscalar_t);
+  sycl_kernel_submit<kptr, 2>(
+      cfg.global_size(),
+      cfg.group_size(),
+      getCurrentSYCLQueue(),
+      slm_sz,
+      vinfo,
+      ginfo,
+      winfo,
+      ninfo,
+      cfg,
+      batch_wg_range);
 
   return;
 }
@@ -446,107 +412,58 @@ template <
     typename scalar2_t,
     typename accscalar_t,
     typename vec_t>
-struct WeightNormBackwardReduceKernelFunctor
-    : public __SYCL_KER_CONFIG_CONVENTION__ {
-  void operator()(sycl::nd_item<2> item) const {
-    auto id = cfg_.get_item_desc(item);
-    int64_t si = id.glb_batch % cfg_.stride_;
-    int64_t bi = id.glb_batch / cfg_.stride_;
-    int64_t i_pi = id.chunk * id.chunk_size + id.chunk_off;
-    int64_t o_pi = id.chunk;
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<2>))
+void weight_norm_backward_reduce_kernel(
+    ScalarType1Info i1info,
+    ScalarType2Info i2info,
+    AccTypeInfo oinfo,
+    BatchKernelConfig cfg) {
+  auto item = syclext::this_work_item::get_nd_item<2>();
+  char* shared_ptr = (char*)syclexp::get_work_group_scratch_memory();
 
-    int64_t i_lid =
-        si + i_pi * cfg_.stride_ + bi * cfg_.problem_ * cfg_.stride_;
-    int64_t i1_off =
-        at::xpu::detail::IndexToOffset<scalar1_t, int64_t, -1>::get(
-            i_lid, i1info_);
-    int64_t i2_off;
+  auto id = cfg.get_item_desc(item);
+  int64_t si = id.glb_batch % cfg.stride_;
+  int64_t bi = id.glb_batch / cfg.stride_;
+  int64_t i_pi = id.chunk * id.chunk_size + id.chunk_off;
+  int64_t o_pi = id.chunk;
+
+  int64_t i_lid = si + i_pi * cfg.stride_ + bi * cfg.problem_ * cfg.stride_;
+  int64_t i1_off = at::xpu::detail::IndexToOffset<scalar1_t, int64_t, -1>::get(
+      i_lid, i1info);
+  int64_t i2_off;
+  if (is_first) {
+    i2_off = at::xpu::detail::IndexToOffset<scalar2_t, int64_t, -1>::get(
+        i_lid, i2info);
+  }
+
+  int64_t o_lid = si + o_pi * cfg.stride_ + bi * id.chunk_num * cfg.stride_;
+  int64_t o_off = at::xpu::detail::IndexToOffset<accscalar_t, int64_t, -1>::get(
+      o_lid, oinfo);
+
+  accscalar_t value = 0;
+  if (id.glb_problem < cfg.problem_ && id.glb_batch < cfg.problem_batch_) {
     if (is_first) {
-      i2_off = at::xpu::detail::IndexToOffset<scalar2_t, int64_t, -1>::get(
-          i_lid, i2info_);
-    }
-
-    int64_t o_lid = si + o_pi * cfg_.stride_ + bi * id.chunk_num * cfg_.stride_;
-    int64_t o_off =
-        at::xpu::detail::IndexToOffset<accscalar_t, int64_t, -1>::get(
-            o_lid, oinfo_);
-
-    accscalar_t value = 0;
-    if (id.glb_problem < cfg_.problem_ && id.glb_batch < cfg_.problem_batch_) {
-      if (is_first) {
-        auto value1 = (accscalar_t)i1info_.data[i1_off];
-        auto value2 = (accscalar_t)i2info_.data[i2_off];
-        value = value1 * value2;
-      } else {
-        value = (accscalar_t)i1info_.data[i1_off];
-      }
-    }
-
-    if (cfg_.problem_along_x_) {
-      value = group_x_reduce(
-          item, shared_, vec_t(value), ReduceAdd<accscalar_t>())[0];
+      auto value1 = (accscalar_t)i1info.data[i1_off];
+      auto value2 = (accscalar_t)i2info.data[i2_off];
+      value = value1 * value2;
     } else {
-      value = group_y_reduce(
-          item, shared_, vec_t(value), ReduceAdd<accscalar_t>())[0];
-    }
-
-    if (id.glb_problem < cfg_.problem_ && id.glb_batch < cfg_.problem_batch_) {
-      if (id.chunk_off == 0) {
-        oinfo_.data[o_off] = value;
-      }
+      value = (accscalar_t)i1info.data[i1_off];
     }
   }
 
-  void sycl_ker_config_convention(sycl::handler& cgh) {
-    shared_ = sycl_local_acc_t<accscalar_t>(local_size_, cgh);
+  if (cfg.problem_along_x_) {
+    value = group_x_reduce(
+        item, shared_ptr, vec_t(value), ReduceAdd<accscalar_t>())[0];
+  } else {
+    value = group_y_reduce(
+        item, shared_ptr, vec_t(value), ReduceAdd<accscalar_t>())[0];
   }
-  WeightNormBackwardReduceKernelFunctor(
-      ScalarType1Info i1info,
-      ScalarType2Info i2info,
-      AccTypeInfo oinfo,
-      BatchKernelConfig cfg,
-      int64_t local_size)
-      : i1info_(i1info),
-        i2info_(i2info),
-        oinfo_(oinfo),
-        cfg_(cfg),
-        local_size_(local_size) {}
 
- private:
-  ScalarType1Info i1info_;
-  ScalarType2Info i2info_;
-  AccTypeInfo oinfo_;
-  BatchKernelConfig cfg_;
-  int64_t local_size_;
-  sycl_local_acc_t<accscalar_t> shared_;
-};
-
-template <
-    bool is_first,
-    class ScalarType1Info,
-    class ScalarType2Info,
-    class AccTypeInfo>
-static inline void launch_weight_norm_backward_reduce_kernel(
-    ScalarType1Info& i1info,
-    ScalarType2Info& i2info,
-    AccTypeInfo& oinfo,
-    BatchKernelConfig& cfg) {
-  using scalar1_t = typename ScalarType1Info::scalar_t;
-  using scalar2_t = typename ScalarType2Info::scalar_t;
-  using accscalar_t = typename AccTypeInfo::scalar_t;
-  using vec_t = at::detail::Array<accscalar_t, 1>;
-  WeightNormBackwardReduceKernelFunctor<
-      is_first,
-      ScalarType1Info,
-      ScalarType2Info,
-      AccTypeInfo,
-      scalar1_t,
-      scalar2_t,
-      accscalar_t,
-      vec_t>
-      kfn(i1info, i2info, oinfo, cfg, cfg.group_size().size());
-  sycl_kernel_submit(
-      cfg.global_size(), cfg.group_size(), getCurrentSYCLQueue(), kfn);
+  if (id.glb_problem < cfg.problem_ && id.glb_batch < cfg.problem_batch_) {
+    if (id.chunk_off == 0) {
+      oinfo.data[o_off] = value;
+    }
+  }
 }
 
 template <class ScalarType1Info, class ScalarType2Info, class AccTypeInfo>
@@ -565,7 +482,10 @@ static inline void weight_norm_backward_reduce(
   using scalar2_t = typename ScalarType2Info::scalar_t;
   using accscalar_t = typename AccTypeInfo::scalar_t;
   using vec_t = at::detail::Array<accscalar_t, 1>;
-  using KernelClass = WeightNormBackwardReduceKernelFunctor<
+  // static constexpr: MSVC loses a plain constexpr local when it is used as
+  // a non-type template argument from inside the launch lambda below
+  // (C2065/C2326)
+  static constexpr auto kptr_first = weight_norm_backward_reduce_kernel<
       true,
       ScalarType1Info,
       ScalarType2Info,
@@ -574,16 +494,58 @@ static inline void weight_norm_backward_reduce(
       scalar2_t,
       accscalar_t,
       vec_t>;
-  BatchKernelConfig cfg = BatchKernelConfig::make_config<KernelClass>(
-      batch, problem, stride, batch * stride, problem_along_x);
-  if (cfg.problem_ <= cfg.problem_wg_range_) {
+  static constexpr auto kptr_rest = weight_norm_backward_reduce_kernel<
+      false,
+      ScalarType1Info,
+      ScalarType2Info,
+      AccTypeInfo,
+      scalar1_t,
+      scalar2_t,
+      accscalar_t,
+      vec_t>;
+
+  BatchKernelConfig cfg = is_first ? BatchKernelConfig::make_config<kptr_first>(
+                                         batch,
+                                         problem,
+                                         stride,
+                                         batch * stride,
+                                         problem_along_x,
+                                         {BatchKernelConfig::Policy::pSegment})
+                                   : BatchKernelConfig::make_config<kptr_rest>(
+                                         batch,
+                                         problem,
+                                         stride,
+                                         batch * stride,
+                                         problem_along_x,
+                                         {BatchKernelConfig::Policy::pSegment});
+
+  int slm_sz = cfg.group_size().size() * sizeof(accscalar_t);
+  auto launch = [&](auto& iinfo, auto& oinfo) {
     if (is_first) {
-      launch_weight_norm_backward_reduce_kernel<true>(
-          vinfo, gwinfo, rinfo, cfg);
+      sycl_kernel_submit<kptr_first, 2>(
+          cfg.global_size(),
+          cfg.group_size(),
+          getCurrentSYCLQueue(),
+          slm_sz,
+          iinfo,
+          gwinfo,
+          oinfo,
+          cfg);
     } else {
-      launch_weight_norm_backward_reduce_kernel<false>(
-          vinfo, gwinfo, rinfo, cfg);
+      sycl_kernel_submit<kptr_rest, 2>(
+          cfg.global_size(),
+          cfg.group_size(),
+          getCurrentSYCLQueue(),
+          slm_sz,
+          iinfo,
+          gwinfo,
+          oinfo,
+          cfg);
     }
+  };
+
+  if (cfg.problem_ <= cfg.problem_wg_range_) {
+    launch(vinfo, rinfo);
     return;
   }
 
@@ -593,11 +555,7 @@ static inline void weight_norm_backward_reduce(
   auto cinfo =
       at::xpu::detail::getTensorInfo<typename AccTypeInfo::scalar_t, int64_t>(
           carrier);
-  if (is_first) {
-    launch_weight_norm_backward_reduce_kernel<true>(vinfo, gwinfo, cinfo, cfg);
-  } else {
-    launch_weight_norm_backward_reduce_kernel<false>(vinfo, gwinfo, cinfo, cfg);
-  }
+  launch(vinfo, cinfo);
 
   weight_norm_backward_reduce(cinfo, gwinfo, rinfo, 1, false);
   return;
@@ -608,83 +566,62 @@ template <
     class AccTypeInfo,
     typename scalar_t,
     typename accscalar_t>
-struct SegmentWeightNormBackwardKernelFunctor {
-  void operator()(sycl::nd_item<2> item) const {
-    auto id = cfg_.get_item_desc(item);
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<2>))
+void segment_weight_norm_backward_kernel(
+    ScalarTypeInfo vinfo,
+    ScalarTypeInfo ginfo,
+    ScalarTypeInfo gwinfo,
+    AccTypeInfo ninfo,
+    ScalarTypeInfo gvinfo,
+    ScalarTypeInfo gginfo,
+    AccTypeInfo rinfo,
+    BatchKernelConfig cfg) {
+  auto item = syclext::this_work_item::get_nd_item<2>();
+  auto id = cfg.get_item_desc(item);
 
-    int64_t si = id.glb_batch % cfg_.stride_;
-    int64_t bi = id.glb_batch / cfg_.stride_;
-    int64_t pi = id.chunk * id.chunk_size + id.chunk_off;
+  int64_t si = id.glb_batch % cfg.stride_;
+  int64_t bi = id.glb_batch / cfg.stride_;
+  int64_t pi = id.chunk * id.chunk_size + id.chunk_off;
 
-    int64_t gv_lid = si + pi * cfg_.stride_ + bi * cfg_.problem_ * cfg_.stride_;
-    int64_t gg_lid = id.glb_batch;
+  int64_t gv_lid = si + pi * cfg.stride_ + bi * cfg.problem_ * cfg.stride_;
+  int64_t gg_lid = id.glb_batch;
 
-    int64_t v_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-        gv_lid, vinfo_);
+  int64_t v_off =
+      at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(gv_lid, vinfo);
 
-    int64_t gw_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-        gv_lid, gwinfo_);
+  int64_t gw_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
+      gv_lid, gwinfo);
 
-    int64_t gv_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-        gv_lid, gvinfo_);
+  int64_t gv_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
+      gv_lid, gvinfo);
 
-    int64_t g_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-        gg_lid, ginfo_);
+  int64_t g_off =
+      at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(gg_lid, ginfo);
 
-    int64_t n_off =
-        at::xpu::detail::IndexToOffset<accscalar_t, int64_t, -1>::get(
-            gg_lid, ninfo_);
+  int64_t n_off = at::xpu::detail::IndexToOffset<accscalar_t, int64_t, -1>::get(
+      gg_lid, ninfo);
 
-    int64_t r_off =
-        at::xpu::detail::IndexToOffset<accscalar_t, int64_t, -1>::get(
-            gg_lid, rinfo_);
+  int64_t r_off = at::xpu::detail::IndexToOffset<accscalar_t, int64_t, -1>::get(
+      gg_lid, rinfo);
 
-    int64_t gg_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-        gg_lid, gginfo_);
+  int64_t gg_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
+      gg_lid, gginfo);
 
-    if (id.glb_problem < cfg_.problem_ && id.glb_batch < cfg_.problem_batch_) {
-      accscalar_t g = ginfo_.data[g_off];
-      accscalar_t gw = gwinfo_.data[gw_off];
-      accscalar_t v = vinfo_.data[v_off];
-      accscalar_t n = 1.f / ninfo_.data[n_off];
-      accscalar_t r = rinfo_.data[r_off];
-      accscalar_t gg = r * n;
-      accscalar_t n3 = n * n * n;
-      accscalar_t gv = g * (n * gw - n3 * v * r);
+  if (id.glb_problem < cfg.problem_ && id.glb_batch < cfg.problem_batch_) {
+    accscalar_t g = ginfo.data[g_off];
+    accscalar_t gw = gwinfo.data[gw_off];
+    accscalar_t v = vinfo.data[v_off];
+    accscalar_t n = accscalar_t(1) / ninfo.data[n_off];
+    accscalar_t r = rinfo.data[r_off];
+    accscalar_t gg = r * n;
+    accscalar_t n3 = n * n * n;
+    accscalar_t gv = g * (n * gw - n3 * v * r);
 
-      gvinfo_.data[gv_off] = static_cast<scalar_t>(gv);
-      if (id.chunk == 0 && id.chunk_off == 0)
-        gginfo_.data[gg_off] = static_cast<scalar_t>(gg);
-    }
+    gvinfo.data[gv_off] = static_cast<scalar_t>(gv);
+    if (id.chunk == 0 && id.chunk_off == 0)
+      gginfo.data[gg_off] = static_cast<scalar_t>(gg);
   }
-  SegmentWeightNormBackwardKernelFunctor(
-      ScalarTypeInfo vinfo,
-      ScalarTypeInfo ginfo,
-      ScalarTypeInfo gwinfo,
-      AccTypeInfo ninfo,
-      ScalarTypeInfo gvinfo,
-      ScalarTypeInfo gginfo,
-      AccTypeInfo rinfo,
-      BatchKernelConfig cfg)
-      : vinfo_(vinfo),
-        ginfo_(ginfo),
-        gwinfo_(gwinfo),
-        ninfo_(ninfo),
-        gvinfo_(gvinfo),
-        gginfo_(gginfo),
-        rinfo_(rinfo),
-        cfg_(cfg) {}
-
- private:
-  ScalarTypeInfo vinfo_;
-  ScalarTypeInfo ginfo_;
-  ScalarTypeInfo gwinfo_;
-  AccTypeInfo ninfo_;
-  ScalarTypeInfo gvinfo_;
-  ScalarTypeInfo gginfo_;
-  AccTypeInfo rinfo_;
-  BatchKernelConfig cfg_;
-};
+}
 
 template <class ScalarTypeInfo, class AccTypeInfo>
 static inline void segment_weight_norm_backward(
@@ -707,17 +644,32 @@ static inline void segment_weight_norm_backward(
 
   using scalar_t = typename ScalarTypeInfo::scalar_t;
   using accscalar_t = typename AccTypeInfo::scalar_t;
-  using KernelClass = SegmentWeightNormBackwardKernelFunctor<
+  constexpr auto kptr = segment_weight_norm_backward_kernel<
       ScalarTypeInfo,
       AccTypeInfo,
       scalar_t,
       accscalar_t>;
-  BatchKernelConfig cfg = BatchKernelConfig::make_config<KernelClass>(
-      batch, problem, stride, batch * stride, problem_along_x);
+  BatchKernelConfig cfg = BatchKernelConfig::make_config<kptr>(
+      batch,
+      problem,
+      stride,
+      batch * stride,
+      problem_along_x,
+      {BatchKernelConfig::Policy::pSegment});
 
-  KernelClass kfn(vinfo, ginfo, gwinfo, ninfo, gvinfo, gginfo, rinfo, cfg);
-  sycl_kernel_submit(
-      cfg.global_size(), cfg.group_size(), getCurrentSYCLQueue(), kfn);
+  sycl_kernel_submit<kptr, 2>(
+      cfg.global_size(),
+      cfg.group_size(),
+      getCurrentSYCLQueue(),
+      0,
+      vinfo,
+      ginfo,
+      gwinfo,
+      ninfo,
+      gvinfo,
+      gginfo,
+      rinfo,
+      cfg);
 
   return;
 }
@@ -728,120 +680,94 @@ template <
     typename scalar_t,
     typename accscalar_t,
     typename vec_t>
-struct WeightNormBackwardKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
-  void operator()(sycl::nd_item<2> item) const {
-    auto id = cfg_.get_item_desc(item);
-    int64_t n_lid = id.glb_batch;
-    int64_t g_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-        n_lid, ginfo_);
-    int64_t gg_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-        n_lid, gginfo_);
-    int64_t n_off =
-        at::xpu::detail::IndexToOffset<accscalar_t, int64_t, -1>::get(
-            n_lid, ninfo_);
-    int64_t si = id.glb_batch % cfg_.stride_;
-    int64_t bi = id.glb_batch / cfg_.stride_;
-    int64_t pi = id.chunk_off;
-    bi = si + bi * cfg_.problem_ * cfg_.stride_;
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<2>))
+void weight_norm_backward_combine_kernel(
+    ScalarTypeInfo vinfo,
+    ScalarTypeInfo ginfo,
+    ScalarTypeInfo gwinfo,
+    AccTypeInfo ninfo,
+    ScalarTypeInfo gvinfo,
+    ScalarTypeInfo gginfo,
+    BatchKernelConfig cfg,
+    int batch_wg_range) {
+  auto item = syclext::this_work_item::get_nd_item<2>();
+  accscalar_t* shared_ = (accscalar_t*)syclexp::get_work_group_scratch_memory();
 
-    accscalar_t value = 0;
-    if (id.glb_batch < cfg_.problem_batch_) {
-      for (int pi_ = pi; pi_ < cfg_.problem_; pi_ += cfg_.problem_wg_range_) {
-        int64_t v_lid, v_off, gw_off;
-        v_lid = bi + pi_ * cfg_.stride_;
+  auto id = cfg.get_item_desc(item);
+  int64_t n_lid = id.glb_batch;
+  int64_t g_off =
+      at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(n_lid, ginfo);
+  int64_t gg_off =
+      at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(n_lid, gginfo);
+  int64_t n_off = at::xpu::detail::IndexToOffset<accscalar_t, int64_t, -1>::get(
+      n_lid, ninfo);
+  int64_t si = id.glb_batch % cfg.stride_;
+  int64_t bi = id.glb_batch / cfg.stride_;
+  int64_t pi = id.chunk_off;
+  bi = si + bi * cfg.problem_ * cfg.stride_;
 
-        v_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-            v_lid, vinfo_);
+  accscalar_t value = 0;
+  if (id.glb_batch < cfg.problem_batch_) {
+    for (int pi_ = pi; pi_ < cfg.problem_; pi_ += cfg.problem_wg_range_) {
+      int64_t v_lid, v_off, gw_off;
+      v_lid = bi + pi_ * cfg.stride_;
 
-        gw_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-            v_lid, gwinfo_);
+      v_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
+          v_lid, vinfo);
 
-        accscalar_t v = (accscalar_t)vinfo_.data[v_off];
-        accscalar_t gw = (accscalar_t)gwinfo_.data[gw_off];
-        value += v * gw;
-      }
-    }
+      gw_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
+          v_lid, gwinfo);
 
-    if (cfg_.problem_along_x_) {
-      value = group_x_reduce(
-          item, shared_, vec_t(value), ReduceAdd<accscalar_t>())[0];
-    } else {
-      value = group_y_reduce(
-          item, shared_, vec_t(value), ReduceAdd<accscalar_t>())[0];
-    }
-
-    int n_slid = (int)id.glb_batch % batch_wg_range_;
-    if (id.glb_batch < cfg_.problem_batch_ && id.chunk_off == 0) {
-      shared_[n_slid] = value;
-    }
-    sycl::group_barrier(item.get_group());
-
-    if (id.glb_batch < cfg_.problem_batch_) {
-      for (int pi_ = pi; pi_ < cfg_.problem_; pi_ += cfg_.problem_wg_range_) {
-        int64_t v_lid, v_off, gw_off, gv_off;
-        v_lid = bi + pi_ * cfg_.stride_;
-
-        v_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-            v_lid, vinfo_);
-
-        gw_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-            v_lid, gwinfo_);
-
-        gv_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
-            v_lid, gvinfo_);
-
-        accscalar_t g = ginfo_.data[g_off];
-        accscalar_t gw = gwinfo_.data[gw_off];
-        accscalar_t v = vinfo_.data[v_off];
-        accscalar_t n = 1.f / ninfo_.data[n_off];
-        accscalar_t r = shared_[n_slid];
-        accscalar_t gg = r * n;
-        accscalar_t n3 = n * n * n;
-        accscalar_t gv = g * (n * gw - n3 * v * r);
-
-        gvinfo_.data[gv_off] = static_cast<scalar_t>(gv);
-        if (id.chunk_off == 0)
-          gginfo_.data[gg_off] = static_cast<scalar_t>(gg);
-      }
+      accscalar_t v = (accscalar_t)vinfo.data[v_off];
+      accscalar_t gw = (accscalar_t)gwinfo.data[gw_off];
+      value += v * gw;
     }
   }
 
-  void sycl_ker_config_convention(sycl::handler& cgh) {
-    shared_ = sycl_local_acc_t<accscalar_t>(wg_size_, cgh);
+  char* shared_ptr = reinterpret_cast<char*>(shared_);
+  if (cfg.problem_along_x_) {
+    value = group_x_reduce(
+        item, shared_ptr, vec_t(value), ReduceAdd<accscalar_t>())[0];
+  } else {
+    value = group_y_reduce(
+        item, shared_ptr, vec_t(value), ReduceAdd<accscalar_t>())[0];
   }
 
-  WeightNormBackwardKernelFunctor(
-      ScalarTypeInfo vinfo,
-      ScalarTypeInfo ginfo,
-      ScalarTypeInfo gwinfo,
-      AccTypeInfo ninfo,
-      ScalarTypeInfo gvinfo,
-      ScalarTypeInfo gginfo,
-      BatchKernelConfig cfg,
-      int wg_size,
-      int batch_wg_range)
-      : vinfo_(vinfo),
-        ginfo_(ginfo),
-        gwinfo_(gwinfo),
-        ninfo_(ninfo),
-        gvinfo_(gvinfo),
-        gginfo_(gginfo),
-        cfg_(cfg),
-        wg_size_(wg_size),
-        batch_wg_range_(batch_wg_range) {}
+  int n_slid = (int)id.glb_batch % batch_wg_range;
+  if (id.glb_batch < cfg.problem_batch_ && id.chunk_off == 0) {
+    shared_[n_slid] = value;
+  }
+  sycl::group_barrier(item.get_group());
 
- private:
-  ScalarTypeInfo vinfo_;
-  ScalarTypeInfo ginfo_;
-  ScalarTypeInfo gwinfo_;
-  AccTypeInfo ninfo_;
-  ScalarTypeInfo gvinfo_;
-  ScalarTypeInfo gginfo_;
-  BatchKernelConfig cfg_;
-  int wg_size_;
-  int batch_wg_range_;
-  sycl_local_acc_t<accscalar_t> shared_;
-};
+  if (id.glb_batch < cfg.problem_batch_) {
+    for (int pi_ = pi; pi_ < cfg.problem_; pi_ += cfg.problem_wg_range_) {
+      int64_t v_lid, v_off, gw_off, gv_off;
+      v_lid = bi + pi_ * cfg.stride_;
+
+      v_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
+          v_lid, vinfo);
+
+      gw_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
+          v_lid, gwinfo);
+
+      gv_off = at::xpu::detail::IndexToOffset<scalar_t, int64_t, -1>::get(
+          v_lid, gvinfo);
+
+      accscalar_t g = ginfo.data[g_off];
+      accscalar_t gw = gwinfo.data[gw_off];
+      accscalar_t v = vinfo.data[v_off];
+      accscalar_t n = accscalar_t(1) / ninfo.data[n_off];
+      accscalar_t r = shared_[n_slid];
+      accscalar_t gg = r * n;
+      accscalar_t n3 = n * n * n;
+      accscalar_t gv = g * (n * gw - n3 * v * r);
+
+      gvinfo.data[gv_off] = static_cast<scalar_t>(gv);
+      if (id.chunk_off == 0)
+        gginfo.data[gg_off] = static_cast<scalar_t>(gg);
+    }
+  }
+}
 
 template <class ScalarTypeInfo, class AccTypeInfo>
 static inline void weight_norm_backward(
@@ -860,22 +786,27 @@ static inline void weight_norm_backward(
   using scalar_t = typename ScalarTypeInfo::scalar_t;
   using accscalar_t = typename AccTypeInfo::scalar_t;
   using vec_t = at::detail::Array<accscalar_t, 1>;
-  using KernelClass = WeightNormBackwardKernelFunctor<
+  constexpr auto kptr = weight_norm_backward_combine_kernel<
       ScalarTypeInfo,
       AccTypeInfo,
       scalar_t,
       accscalar_t,
       vec_t>;
-  BatchKernelConfig cfg = BatchKernelConfig::make_config<KernelClass>(
+  BatchKernelConfig cfg = BatchKernelConfig::make_config<kptr>(
       batch,
       problem,
       stride,
       batch * stride,
       problem_along_x,
-      BatchKernelConfig::Policy::pLoop);
+      {BatchKernelConfig::Policy::pLoop});
   int wg_size = cfg.group_size().size();
   int batch_wg_range = wg_size / cfg.problem_wg_range_;
-  KernelClass kfn(
+  int slm_sz = wg_size * sizeof(accscalar_t);
+  sycl_kernel_submit<kptr, 2>(
+      cfg.global_size(),
+      cfg.group_size(),
+      getCurrentSYCLQueue(),
+      slm_sz,
       vinfo,
       ginfo,
       gwinfo,
@@ -883,10 +814,7 @@ static inline void weight_norm_backward(
       gvinfo,
       gginfo,
       cfg,
-      wg_size,
       batch_wg_range);
-  sycl_kernel_submit(
-      cfg.global_size(), cfg.group_size(), getCurrentSYCLQueue(), kfn);
   return;
 }
 
@@ -899,9 +827,9 @@ std::tuple<Tensor, Tensor> weight_norm_backward_kernel(
   auto grad_v = at::empty_like(saved_v, c10::get_contiguous_memory_format());
   auto grad_g = at::empty_like(saved_g, c10::get_contiguous_memory_format());
 
-  // Empty saved_v: grad_v is empty, grad_g = 0 (matches CPU/CUDA).
+  // Empty saved_v: grad_v is empty, grad_g = 0/0 = NaN (matches CPU/CUDA).
   if (saved_v.numel() == 0) {
-    grad_g.zero_();
+    grad_g.fill_(std::numeric_limits<double>::quiet_NaN());
     return {grad_v, grad_g};
   }
 

--- a/src/ATen/native/xpu/sycl/WeightNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/WeightNormKernels.cpp
@@ -46,7 +46,7 @@ void weight_norm_reduce_kernel(
   auto item = syclext::this_work_item::get_nd_item<2>();
   char* shared_ptr =
       static_cast<char*>(syclexp::get_work_group_scratch_memory());
-  
+
   auto id = cfg.get_item_desc(item);
   int64_t si = id.glb_batch % cfg.stride_;
   int64_t bi = id.glb_batch / cfg.stride_;
@@ -236,7 +236,8 @@ void weight_norm_combine_kernel(
     BatchKernelConfig cfg,
     int batch_wg_range) {
   auto item = syclext::this_work_item::get_nd_item<2>();
-  accscalar_t* shared_ = (accscalar_t*)syclexp::get_work_group_scratch_memory();
+  accscalar_t* shared_ =
+      static_cast<accscalar_t*>(syclexp::get_work_group_scratch_memory());
 
   auto id = cfg.get_item_desc(item);
   int64_t n_lid = id.glb_batch;
@@ -420,7 +421,8 @@ void weight_norm_backward_reduce_kernel(
     AccTypeInfo oinfo,
     BatchKernelConfig cfg) {
   auto item = syclext::this_work_item::get_nd_item<2>();
-  char* shared_ptr = (char*)syclexp::get_work_group_scratch_memory();
+  char* shared_ptr =
+      static_cast<char*>(syclexp::get_work_group_scratch_memory());
 
   auto id = cfg.get_item_desc(item);
   int64_t si = id.glb_batch % cfg.stride_;
@@ -692,7 +694,8 @@ void weight_norm_backward_combine_kernel(
     BatchKernelConfig cfg,
     int batch_wg_range) {
   auto item = syclext::this_work_item::get_nd_item<2>();
-  accscalar_t* shared_ = (accscalar_t*)syclexp::get_work_group_scratch_memory();
+  accscalar_t* shared_ =
+      static_cast<accscalar_t*>(syclexp::get_work_group_scratch_memory());
 
   auto id = cfg.get_item_desc(item);
   int64_t n_lid = id.glb_batch;


### PR DESCRIPTION
# WeightNormKernels.cpp — Kernel UT Report

## SYCL Kernel Conversion Check

In `WeightNormKernels.cpp`, five kernels are implemented as free functions via `SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<2>))` and launched with `sycl_kernel_submit<kptr, 2>(...)` function pointer:

- `weight_norm_reduce_kernel` (line 42) — reduction kernel for computing norms
- `segment_weight_norm_kernel` (line 152) — normalization kernel (segment policy)
- `weight_norm_combine_kernel` (line 236) — fused reduce + normalize kernel (loop policy)
- `weight_norm_backward_reduce_kernel` (line 442) — backward reduction kernel
- `segment_weight_norm_backward_kernel` (line 586) — backward gradient kernel (segment policy)
- `weight_norm_backward_combine_kernel` (line 660) — fused backward kernel (loop policy)

No legacy functor-based SYCL kernel launch patterns remain in this file.

**Build fix required:** Added `template <auto* kptr>` overloads for `make_config` and `build` in `BatchKernel.h` to support free function kernel pointers (the class-type template parameter `class KernelClass` does not accept `auto*` non-type function pointers).

## UT Results

1. **PyTorch UT** (`pytorch-public`):
   - `pytest test/torch-xpu-ops-test/xpu/test_nn_xpu.py -v -k "weight_norm"`
   - Result: **3 passed**, 1 skipped (`test_RNN_cudnn_weight_norm` — cuDNN-only), 3500 deselected.

2. **Functional verification** (weight_norm forward/backward on XPU):
   - Linear weight_norm (dim=0): forward + backward, v/g grads non-zero ✓
   - Conv2d weight_norm (dim=0): forward + backward ✓
   - Linear weight_norm (dim=-1): forward + backward ✓
   - Half (float16): forward + backward ✓
   - BFloat16: forward + backward ✓
   - CPU vs XPU numerical correctness: max diff = 1.79e-07 ✓