### PR TITLE
Add XPU dispatch for linalg.polar

### DIFF
--- a/src/ATen/native/xpu/XPUFallback.cpp
+++ b/src/ATen/native/xpu/XPUFallback.cpp
@@ -359,7 +359,6 @@ TORCH_LIBRARY_IMPL(aten, XPU, m) {
       "linalg_lu.out",
       "linalg_matrix_exp",
       "linalg_matrix_sqrth",
-      "linalg_polar.out",
       "_linalg_svd.U",
       "lu_unpack.out",
       "ormqr",


### PR DESCRIPTION
This patch removes `linalg.polar.out` from hardcoded CPU-fallback list, so it can be registered in upstream PyTorch `native_functions.yaml`. This op decomposes into other ops e.g. `svd` that will fallback to CPU anyway, but it will be easier to add native implementation in the future

Upstream PR: https://github.com/pytorch/pytorch/pull/188253