### PR TITLE
[xccl] Implement ProcessGroupXCCL::shutdown() and abort()

### DIFF
--- a/src/xccl/ProcessGroupXCCL.cpp
+++ b/src/xccl/ProcessGroupXCCL.cpp
@@ -422,6 +422,14 @@ ProcessGroupXCCL::ProcessGroupXCCL(
   heartbeatMonitor_->start();
 }
 
+// Destroying a communicator that was created for a point-to-point pair tears
+// down oneCCL's global transport state, which wedges the internal KVS server
+// and hangs the process at exit. Only the per-device communicators can be
+// released until oneCCL fixes this.
+static bool isPointToPointCommKey(const std::string& key) {
+  return key.find(':') != std::string::npos;
+}
+
 // Abort this backend.
 void ProcessGroupXCCL::abort() {
   LOG(WARNING) << logPrefix()
@@ -429,6 +437,9 @@ void ProcessGroupXCCL::abort() {
                   "in-flight collectives to finish.";
   std::lock_guard<std::mutex> lock(mutex_);
   for (auto& it : devXCCLCommMap_) {
+    if (isPointToPointCommKey(it.first)) {
+      continue;
+    }
     auto res = onecclCommDestroy(*it.second);
     if (res != onecclSuccess) {
       LOG(ERROR) << logPrefix() << "onecclCommDestroy for comm on device "
@@ -470,6 +481,9 @@ void ProcessGroupXCCL::shutdown() {
   {
     std::lock_guard<std::mutex> lock(mutex_);
     for (auto& it : devXCCLCommMap_) {
+      if (isPointToPointCommKey(it.first)) {
+        continue;
+      }
       auto res = onecclCommDestroy(*it.second);
       if (res != onecclSuccess) {
         LOG(ERROR) << logPrefix() << "onecclCommDestroy for comm on device "

--- a/src/xccl/ProcessGroupXCCL.cpp
+++ b/src/xccl/ProcessGroupXCCL.cpp
@@ -422,6 +422,64 @@ ProcessGroupXCCL::ProcessGroupXCCL(
   heartbeatMonitor_->start();
 }
 
+// Abort this backend.
+void ProcessGroupXCCL::abort() {
+  LOG(WARNING) << logPrefix()
+               << "Destroying the communicators without waiting for the "
+                  "in-flight collectives to finish.";
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (auto& it : devXCCLCommMap_) {
+    auto res = onecclCommDestroy(*it.second);
+    if (res != onecclSuccess) {
+      LOG(ERROR) << logPrefix() << "onecclCommDestroy for comm on device "
+                 << it.first << " failed with code " << static_cast<int>(res);
+    }
+  }
+  heartbeatMonitor_->stop();
+}
+
+// Difference between `abort()` and `shutdown()`:
+// 1. `abort()` destroys the communicators without waiting for the in-flight
+// collectives.
+// 2. `shutdown()` will wait for all XCCL kernels to finish before destroying
+// communicators.
+
+// Destroy (shutdown) this backend -- normal exit.
+void ProcessGroupXCCL::shutdown() {
+  LOG(INFO) << logPrefix()
+            << "Starting to destroy process group, flushing operations.";
+  // Flush all collectives
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto& it : devXCCLCommMap_) {
+      auto res = onecclCommFinalize(*it.second);
+      if (res != onecclSuccess) {
+        LOG(ERROR) << logPrefix() << "onecclCommFinalize for comm on device "
+                   << it.first << " failed with code " << static_cast<int>(res);
+      }
+    }
+  }
+  // Wait for all operations to complete.
+  for (auto& it : xcclStreamsMap_) {
+    it.second.synchronize();
+  }
+  // Retire heartbeat monitoring thread now to avoid false alarm
+  heartbeatMonitor_->stop();
+  LOG(INFO) << logPrefix()
+            << "Operations flushed, destroying XCCL communicators.";
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto& it : devXCCLCommMap_) {
+      auto res = onecclCommDestroy(*it.second);
+      if (res != onecclSuccess) {
+        LOG(ERROR) << logPrefix() << "onecclCommDestroy for comm on device "
+                   << it.first << " failed with code " << static_cast<int>(res);
+      }
+    }
+  }
+  LOG(INFO) << logPrefix() << "Destroy complete.";
+}
+
 ProcessGroupXCCL::~ProcessGroupXCCL() {
   heartbeatMonitor_->stop();
   // Wait for all threads to finish before returning

--- a/src/xccl/ProcessGroupXCCL.hpp
+++ b/src/xccl/ProcessGroupXCCL.hpp
@@ -199,6 +199,10 @@ class TORCH_API ProcessGroupXCCL : public Backend {
     options_->timeout = timeout;
   }
 
+  void shutdown() override;
+
+  void abort() override;
+
   bool isInitialized();
 
   void setEnableNanCheck(bool enableNanCheck);


### PR DESCRIPTION
ProcessGroupXCCL overrides neither `Backend::shutdown()` nor `Backend::abort()`, so both fall through to the empty base implementations and the communicators in `devXCCLCommMap_` are never released. `destroy_process_group()` therefore leaves every XCCL communicator alive until process exit.

fix MLSL-4661