### PR TITLE
Revert "Cap global range for grid-strided loop kernels (#4722)"

### DIFF
--- a/src/ATen/native/xpu/sycl/AveragePool2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/AveragePool2dKernels.cpp
@@ -257,8 +257,8 @@ void launch_avg_pool2d_channels_last_kernel(
 
   auto& queue = at::xpu::getCurrentSYCLQueue();
   const uint32_t group_size = static_cast<int>(syclMaxWorkItemsPerSubSlice());
-  const int64_t global_range =
-      xpuKernelLoopGroupRange(total_elements, group_size) * group_size;
+  const uint32_t global_range =
+      ceil_div<uint32_t>(total_elements, group_size) * group_size;
 
   auto kfn = AvgPool2dChannelsLastKernelFunctor<scalar_t, accscalar_t, index_t>(
       top_data,
@@ -305,8 +305,8 @@ void launch_avg_pool2d_kernel(
 
   auto& queue = at::xpu::getCurrentSYCLQueue();
   const uint32_t group_size = static_cast<int>(syclMaxWorkItemsPerSubSlice());
-  const int64_t global_range =
-      xpuKernelLoopGroupRange(total_elements, group_size) * group_size;
+  const uint32_t global_range =
+      ceil_div<uint32_t>(total_elements, group_size) * group_size;
 
   auto kfn = AvgPool2dKernelFunctor<scalar_t, accscalar_t, index_t>(
       top_data,
@@ -564,8 +564,8 @@ void launch_avg_pool2d_backward_channels_last_kernel(
 
   auto& queue = at::xpu::getCurrentSYCLQueue();
   const uint32_t group_size = static_cast<int>(syclMaxWorkItemsPerSubSlice());
-  const int64_t global_range =
-      xpuKernelLoopGroupRange(total_elements, group_size) * group_size;
+  const uint32_t global_range =
+      ceil_div<uint32_t>(total_elements, group_size) * group_size;
 
   auto kfn = AvgPool2dChannelsLastBackwardKernelFunctor<
       scalar_t,
@@ -615,8 +615,8 @@ void launch_avg_pool2d_backward_kernel(
 
   auto& queue = at::xpu::getCurrentSYCLQueue();
   const uint32_t group_size = static_cast<int>(syclMaxWorkItemsPerSubSlice());
-  const int64_t global_range =
-      xpuKernelLoopGroupRange(total_elements, group_size) * group_size;
+  const uint32_t global_range =
+      ceil_div<uint32_t>(total_elements, group_size) * group_size;
 
   auto kfn = AvgPool2dBackwarKernelFunctor<scalar_t, accscalar_t, index_t>(
       top_data,

--- a/src/ATen/native/xpu/sycl/DepthwiseConv2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/DepthwiseConv2dKernels.cpp
@@ -683,7 +683,7 @@ void conv_depthwise2d_forward_kernel(
               dilationW,
               dilationH);
           int64_t local_range = syclMaxWorkGroupSize(kfn);
-          auto global_range = xpuKernelLoopGroupRange(n, local_range);
+          auto global_range = (n - 1) / local_range + 1;
           sycl_kernel_submit(
               global_range * local_range,
               local_range,
@@ -712,7 +712,7 @@ void conv_depthwise2d_forward_kernel(
               dilationW,
               dilationH);
           int64_t local_range = syclMaxWorkGroupSize(kfn);
-          auto global_range = xpuKernelLoopGroupRange(n, local_range);
+          auto global_range = (n - 1) / local_range + 1;
           sycl_kernel_submit(
               global_range * local_range,
               local_range,
@@ -741,7 +741,7 @@ void conv_depthwise2d_forward_kernel(
               dilationW,
               dilationH);
           int64_t local_range = syclMaxWorkGroupSize(kfn);
-          auto global_range = xpuKernelLoopGroupRange(n, local_range);
+          auto global_range = (n - 1) / local_range + 1;
           sycl_kernel_submit(
               global_range * local_range,
               local_range,
@@ -770,7 +770,7 @@ void conv_depthwise2d_forward_kernel(
               dilationW,
               dilationH);
           int64_t local_range = syclMaxWorkGroupSize(kfn);
-          auto global_range = xpuKernelLoopGroupRange(n, local_range);
+          auto global_range = (n - 1) / local_range + 1;
           sycl_kernel_submit(
               global_range * local_range,
               local_range,
@@ -862,7 +862,7 @@ void conv_depthwise2d_backward_kernel(
                 dilationW,
                 dilationH);
             int64_t local_range = syclMaxWorkGroupSize(kfn);
-            auto global_range = xpuKernelLoopGroupRange(n, local_range);
+            auto global_range = (n - 1) / local_range + 1;
             sycl_kernel_submit(
                 global_range * local_range,
                 local_range,
@@ -890,7 +890,7 @@ void conv_depthwise2d_backward_kernel(
                 dilationW,
                 dilationH);
             int64_t local_range = syclMaxWorkGroupSize(kfn);
-            auto global_range = xpuKernelLoopGroupRange(n, local_range);
+            auto global_range = (n - 1) / local_range + 1;
             sycl_kernel_submit(
                 global_range * local_range,
                 local_range,
@@ -918,7 +918,7 @@ void conv_depthwise2d_backward_kernel(
                 dilationW,
                 dilationH);
             int64_t local_range = syclMaxWorkGroupSize(kfn);
-            auto global_range = xpuKernelLoopGroupRange(n, local_range);
+            auto global_range = (n - 1) / local_range + 1;
             sycl_kernel_submit(
                 global_range * local_range,
                 local_range,
@@ -948,7 +948,7 @@ void conv_depthwise2d_backward_kernel(
                 dilationW,
                 dilationH);
             int64_t local_range = syclMaxWorkGroupSize(kfn);
-            auto global_range = xpuKernelLoopGroupRange(n, local_range);
+            auto global_range = (n - 1) / local_range + 1;
             sycl_kernel_submit(
                 global_range * local_range,
                 local_range,
@@ -976,7 +976,7 @@ void conv_depthwise2d_backward_kernel(
                 dilationW,
                 dilationH);
             int64_t local_range = syclMaxWorkGroupSize(kfn);
-            auto global_range = xpuKernelLoopGroupRange(n, local_range);
+            auto global_range = (n - 1) / local_range + 1;
             sycl_kernel_submit(
                 global_range * local_range,
                 local_range,
@@ -1004,7 +1004,7 @@ void conv_depthwise2d_backward_kernel(
                 dilationW,
                 dilationH);
             int64_t local_range = syclMaxWorkGroupSize(kfn);
-            auto global_range = xpuKernelLoopGroupRange(n, local_range);
+            auto global_range = (n - 1) / local_range + 1;
             sycl_kernel_submit(
                 global_range * local_range,
                 local_range,
@@ -1034,7 +1034,7 @@ void conv_depthwise2d_backward_kernel(
                 dilationW,
                 dilationH);
             int64_t local_range = syclMaxWorkGroupSize(kfn);
-            auto global_range = xpuKernelLoopGroupRange(n, local_range);
+            auto global_range = (n - 1) / local_range + 1;
             sycl_kernel_submit(
                 global_range * local_range,
                 local_range,
@@ -1062,7 +1062,7 @@ void conv_depthwise2d_backward_kernel(
                 dilationW,
                 dilationH);
             int64_t local_range = syclMaxWorkGroupSize(kfn);
-            auto global_range = xpuKernelLoopGroupRange(n, local_range);
+            auto global_range = (n - 1) / local_range + 1;
             sycl_kernel_submit(
                 global_range * local_range,
                 local_range,
@@ -1090,7 +1090,7 @@ void conv_depthwise2d_backward_kernel(
                 dilationW,
                 dilationH);
             int64_t local_range = syclMaxWorkGroupSize(kfn);
-            auto global_range = xpuKernelLoopGroupRange(n, local_range);
+            auto global_range = (n - 1) / local_range + 1;
             sycl_kernel_submit(
                 global_range * local_range,
                 local_range,
@@ -1119,7 +1119,7 @@ void conv_depthwise2d_backward_kernel(
               dilationW,
               dilationH);
           int64_t local_range = syclMaxWorkGroupSize(kfn);
-          auto global_range = xpuKernelLoopGroupRange(n, local_range);
+          auto global_range = (n - 1) / local_range + 1;
           sycl_kernel_submit(
               global_range * local_range,
               local_range,
@@ -1147,7 +1147,7 @@ void conv_depthwise2d_backward_kernel(
               dilationW,
               dilationH);
           int64_t local_range = syclMaxWorkGroupSize(kfn);
-          auto global_range = xpuKernelLoopGroupRange(n, local_range);
+          auto global_range = (n - 1) / local_range + 1;
           sycl_kernel_submit(
               global_range * local_range,
               local_range,
@@ -1175,7 +1175,7 @@ void conv_depthwise2d_backward_kernel(
               dilationW,
               dilationH);
           int64_t local_range = syclMaxWorkGroupSize(kfn);
-          auto global_range = xpuKernelLoopGroupRange(n, local_range);
+          auto global_range = (n - 1) / local_range + 1;
           sycl_kernel_submit(
               global_range * local_range,
               local_range,

--- a/src/ATen/native/xpu/sycl/DepthwiseConv3dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/DepthwiseConv3dKernels.cpp
@@ -563,7 +563,8 @@ void conv_depthwise_shape_check(
         (dilh),                                                                \
         (dilw)>;                                                               \
     int64_t local_range = 256;                                                 \
-    int64_t global_range = xpuKernelLoopGroupRange(num_outputs, local_range);  \
+    int64_t global_range =                                                     \
+        std::min((num_outputs - 1) / local_range + 1, (int64_t)65536);         \
     auto kfn = KernelClass(                                                    \
         input_.packed_accessor32<const scalar_t, 5>(),                         \
         output_.packed_accessor32<scalar_t, 5>(),                              \
@@ -581,36 +582,37 @@ void conv_depthwise_shape_check(
     sycl_kernel_submit(                                                        \
         global_range* local_range, local_range, getCurrentSYCLQueue(), kfn);   \
   } else
-#define DWCONV3D_FORWARD_DISPATCH_OTHERS                                      \
-  {                                                                           \
-    using accscalar_t = acc_type<scalar_t, true>;                             \
-    using KernelClass = ConvDepthwise3dXpuFunctor<                            \
-        scalar_t,                                                             \
-        accscalar_t,                                                          \
-        -1,                                                                   \
-        -1,                                                                   \
-        -1,                                                                   \
-        -1,                                                                   \
-        -1,                                                                   \
-        -1>;                                                                  \
-    int64_t local_range = 256;                                                \
-    int64_t global_range = xpuKernelLoopGroupRange(num_outputs, local_range); \
-    auto kfn = KernelClass(                                                   \
-        input_.packed_accessor32<const scalar_t, 5>(),                        \
-        output_.packed_accessor32<scalar_t, 5>(),                             \
-        weight_.packed_accessor32<const scalar_t, 5>(),                       \
-        bias_ptr,                                                             \
-        stride[0],                                                            \
-        stride[1],                                                            \
-        stride[2],                                                            \
-        padding[0],                                                           \
-        padding[1],                                                           \
-        padding[2],                                                           \
-        dilation[0],                                                          \
-        dilation[1],                                                          \
-        dilation[2]);                                                         \
-    sycl_kernel_submit(                                                       \
-        global_range* local_range, local_range, getCurrentSYCLQueue(), kfn);  \
+#define DWCONV3D_FORWARD_DISPATCH_OTHERS                                     \
+  {                                                                          \
+    using accscalar_t = acc_type<scalar_t, true>;                            \
+    using KernelClass = ConvDepthwise3dXpuFunctor<                           \
+        scalar_t,                                                            \
+        accscalar_t,                                                         \
+        -1,                                                                  \
+        -1,                                                                  \
+        -1,                                                                  \
+        -1,                                                                  \
+        -1,                                                                  \
+        -1>;                                                                 \
+    int64_t local_range = 256;                                               \
+    int64_t global_range =                                                   \
+        std::min((num_outputs - 1) / local_range + 1, (int64_t)65536);       \
+    auto kfn = KernelClass(                                                  \
+        input_.packed_accessor32<const scalar_t, 5>(),                       \
+        output_.packed_accessor32<scalar_t, 5>(),                            \
+        weight_.packed_accessor32<const scalar_t, 5>(),                      \
+        bias_ptr,                                                            \
+        stride[0],                                                           \
+        stride[1],                                                           \
+        stride[2],                                                           \
+        padding[0],                                                          \
+        padding[1],                                                          \
+        padding[2],                                                          \
+        dilation[0],                                                         \
+        dilation[1],                                                         \
+        dilation[2]);                                                        \
+    sycl_kernel_submit(                                                      \
+        global_range* local_range, local_range, getCurrentSYCLQueue(), kfn); \
   }
 
 Tensor conv_depthwise3d_kernel(
@@ -859,7 +861,7 @@ std::tuple<Tensor&, Tensor&, Tensor&> _depthwise_3d_backward_kernel(
           int64_t num_inputs = grad_input_.numel();
           int64_t local_range = 256;
           int64_t global_range =
-              xpuKernelLoopGroupRange(num_inputs, local_range);
+              std::min((num_inputs - 1) / local_range + 1, (int64_t)65536);
 
           // Range check to avoid overflow in XPU kernels.
           TORCH_CHECK(

--- a/src/ATen/native/xpu/sycl/KernelUtils.h
+++ b/src/ATen/native/xpu/sycl/KernelUtils.h
@@ -10,9 +10,8 @@
 
 #pragma once
 
-#include <ATen/ceil_div.h>
-#include <comm/DeviceProperties.h>
-#include <algorithm>
+#include <c10/util/Exception.h>
+#include <limits>
 
 #define XPU_KERNEL_LOOP_TYPE(item, i, n, index_type)                      \
   int64_t _i_n_d_e_x =                                                    \
@@ -23,14 +22,19 @@
 
 #define XPU_KERNEL_LOOP(item, i, n) XPU_KERNEL_LOOP_TYPE(item, i, n, int)
 
-// Returns the number of work groups needed to cover `nelem` elements with the
-// given work-group size, capped so grid-strided loop kernels (XPU_KERNEL_LOOP)
-// do not launch more work items than the device can keep resident. The default
-// cap is syclMaxWorkItemsPerTile(); pass a custom `candidate` to override.
-inline int64_t xpuKernelLoopGroupRange(
-    int64_t nelem,
-    int64_t group_size = xpu::sycl::syclDeviceMaxWorkGroupSize(),
-    int64_t candidate = xpu::sycl::syclMaxWorkItemsPerTile()) {
-  int64_t work_items = std::min(nelem, candidate);
-  return at::ceil_div(work_items, group_size);
+constexpr int SYCL_NUM_THREADS = 1024;
+
+inline int GET_GROUPS(
+    const int64_t N,
+    const int64_t max_threads_per_group = SYCL_NUM_THREADS) {
+  TORCH_INTERNAL_ASSERT(
+      N > 0, "XPU kernel launch blocks must be positive, but got N=", N);
+  constexpr int64_t max_int = std::numeric_limits<int>::max();
+
+  // Round up division for positive number that cannot cause integer overflow
+  auto group_num = (N - 1) / max_threads_per_group + 1;
+  TORCH_INTERNAL_ASSERT(
+      group_num <= max_int, "Can't schedule too many blocks on XPU device");
+
+  return static_cast<int>(group_num);
 }

--- a/src/ATen/native/xpu/sycl/LossNLLKernel.cpp
+++ b/src/ATen/native/xpu/sycl/LossNLLKernel.cpp
@@ -444,8 +444,8 @@ void nll_loss_forward_kernel(
                         n_classes,
                         ignore_index);
                 sycl_kernel_submit(
-                    xpuKernelLoopGroupRange(batch_size, 1024) * 1024,
-                    1024,
+                    GET_GROUPS(batch_size) * SYCL_NUM_THREADS,
+                    SYCL_NUM_THREADS,
                     getCurrentSYCLQueue(),
                     kfn);
               });
@@ -580,8 +580,8 @@ void nll_loss_backward_kernel(
                         n_classes,
                         ignore_index);
                 sycl_kernel_submit(
-                    xpuKernelLoopGroupRange(batch_size, 1024) * 1024,
-                    1024,
+                    GET_GROUPS(batch_size) * SYCL_NUM_THREADS,
+                    SYCL_NUM_THREADS,
                     getCurrentSYCLQueue(),
                     kfn);
               });

--- a/src/ATen/native/xpu/sycl/MaxUnpoolingKernels.cpp
+++ b/src/ATen/native/xpu/sycl/MaxUnpoolingKernels.cpp
@@ -178,8 +178,7 @@ Tensor& max_unpooling2d_forward_kernel(
                       output.mutable_data_ptr<scalar_t>());
 
                   int64_t group_size = syclMaxWorkItemsPerSubSlice();
-                  int64_t num_groups =
-                      xpuKernelLoopGroupRange(count, group_size);
+                  int64_t num_groups = (count + group_size - 1) / group_size;
                   sycl_kernel_submit(
                       num_groups * group_size,
                       group_size,
@@ -200,8 +199,7 @@ Tensor& max_unpooling2d_forward_kernel(
                       owidth,
                       output.mutable_data_ptr<scalar_t>());
                   int64_t group_size = syclMaxWorkItemsPerSubSlice();
-                  int64_t num_groups =
-                      xpuKernelLoopGroupRange(count, group_size);
+                  int64_t num_groups = (count + group_size - 1) / group_size;
                   sycl_kernel_submit(
                       num_groups * group_size,
                       group_size,
@@ -411,7 +409,7 @@ void max_unpooling3d_cl_forward_template(
       output);
 
   int64_t group_size = syclMaxWorkItemsPerSubSlice();
-  int64_t num_groups = xpuKernelLoopGroupRange(numInputElements, group_size);
+  int64_t num_groups = (numInputElements + group_size - 1) / group_size;
   int64_t total_items = num_groups * group_size;
   sycl_kernel_submit(total_items, group_size, getCurrentSYCLQueue(), kfn);
 }

--- a/src/ATen/native/xpu/sycl/PhiloxKeySplitKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PhiloxKeySplitKernels.cpp
@@ -145,8 +145,7 @@ Tensor _philox_key_split_xpu(const Tensor& key, int64_t num_splits) {
   const int64_t total_elements = num_keys * num_splits;
   constexpr int64_t work_group_size =
       256; // TODO: wg_size 256 on performance of XPU remains to be investigated
-  const int64_t work_group_num =
-      xpuKernelLoopGroupRange(total_elements, work_group_size);
+  const int64_t work_group_num = at::ceil_div(total_elements, work_group_size);
   auto key_contig = key.contiguous();
   auto functor = PhiloxKeySplitFunctor(
       key_contig.data_ptr<uint64_t>(),
@@ -181,8 +180,7 @@ Tensor _philox_key_fold_in_xpu(const Tensor& key, int64_t data) {
 
   constexpr int64_t work_group_size =
       256; // TODO: wg_size 256 on performance of XPU remains to be investigated
-  const int64_t work_group_num =
-      xpuKernelLoopGroupRange(num_keys, work_group_size);
+  const int64_t work_group_num = at::ceil_div(num_keys, work_group_size);
   auto key_contig = key.contiguous();
   auto functor = PhiloxKeyFoldInFunctor(
       key_contig.data_ptr<uint64_t>(),

--- a/src/ATen/native/xpu/sycl/PsRoiAlignKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PsRoiAlignKernels.cpp
@@ -421,8 +421,9 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_align_kernel(
       at::zeros(output.sizes(), input.options().dtype(at::kInt));
 
   auto output_size = output.numel();
-  int64_t global_range =
-      xpuKernelLoopGroupRange(static_cast<int64_t>(output_size), 512);
+  int64_t global_range = std::min(
+      ceil_div(static_cast<int64_t>(output_size), static_cast<int64_t>(512)),
+      static_cast<int64_t>(4096));
   int64_t local_range = 512;
 
   if (output.numel() == 0) {
@@ -470,8 +471,9 @@ Tensor ps_roi_align_backward_kernel(
     int64_t width) {
   at::Tensor grad_input =
       at::zeros({batch_size, channels, height, width}, grad.options());
-  int64_t global_range =
-      xpuKernelLoopGroupRange(static_cast<int64_t>(grad.numel()), 512);
+  int64_t global_range = std::min(
+      ceil_div(static_cast<int64_t>(grad.numel()), static_cast<int64_t>(512)),
+      static_cast<int64_t>(4096));
   int64_t local_range = 512;
 
   // handle possibly empty gradients

--- a/src/ATen/native/xpu/sycl/PsRoiPoolKernels.cpp
+++ b/src/ATen/native/xpu/sycl/PsRoiPoolKernels.cpp
@@ -150,8 +150,9 @@ std::tuple<Tensor, Tensor> ps_roi_pool_kernel(
       at::zeros(output.sizes(), input.options().dtype(at::kInt));
 
   auto output_size = output.numel();
-  int64_t global_range =
-      xpuKernelLoopGroupRange(static_cast<int64_t>(output_size), 512);
+  int64_t global_range = std::min(
+      ceil_div(static_cast<int64_t>(output_size), static_cast<int64_t>(512)),
+      static_cast<int64_t>(4096));
   int64_t local_range = 512;
 
   if (output_size == 0) {
@@ -295,8 +296,9 @@ Tensor ps_roi_pool_backward_kernel(
     int64_t width) {
   at::Tensor grad_input =
       at::zeros({batch_size, channels, height, width}, grad.options());
-  int64_t global_range =
-      xpuKernelLoopGroupRange(static_cast<int64_t>(grad.numel()), 512);
+  int64_t global_range = std::min(
+      ceil_div(static_cast<int64_t>(grad.numel()), static_cast<int64_t>(512)),
+      static_cast<int64_t>(4096));
   int64_t local_range = 512;
 
   // handle possibly empty gradients

--- a/src/ATen/native/xpu/sycl/RoiAlignKernels.cpp
+++ b/src/ATen/native/xpu/sycl/RoiAlignKernels.cpp
@@ -526,7 +526,7 @@ Tensor roi_align_backward_kernel(
   at::Tensor grad_input =
       at::zeros({batch_size, channels, height, width}, grad.options());
   int64_t global_range =
-      xpuKernelLoopGroupRange(static_cast<int64_t>(grad.numel()), 512);
+      ceil_div(static_cast<int64_t>(grad.numel()), static_cast<int64_t>(512));
   int64_t local_range = 512;
 
   // handle possibly empty gradients

--- a/src/ATen/native/xpu/sycl/RoiPoolKernels.cpp
+++ b/src/ATen/native/xpu/sycl/RoiPoolKernels.cpp
@@ -144,7 +144,7 @@ std::tuple<Tensor, Tensor> roi_pool_kernel(
 
   auto output_size = num_rois * pooled_height * pooled_width * channels;
   int64_t global_range =
-      xpuKernelLoopGroupRange(static_cast<int64_t>(output_size), 512);
+      ceil_div(static_cast<int64_t>(output_size), static_cast<int64_t>(512));
   int64_t local_range = 512;
 
   if (output.numel() == 0) {
@@ -269,8 +269,9 @@ Tensor roi_pool_backward_kernel(
     int64_t width) {
   at::Tensor grad_input =
       at::zeros({batch_size, channels, height, width}, grad.options());
-  int64_t global_range =
-      xpuKernelLoopGroupRange(static_cast<int64_t>(grad.numel()), 512);
+  int64_t global_range = std::min(
+      ceil_div(static_cast<int64_t>(grad.numel()), static_cast<int64_t>(512)),
+      static_cast<int64_t>(4096));
   int64_t local_range = 512;
 
   // handle possibly empty gradients


### PR DESCRIPTION
## Summary

Reverts #4722 due to regression reported in #5061.

- Fixes #5061