### PR TITLE
Fix `@torchxpubot revert` passing a flag gh does not have

### DIFF
--- a/.github/scripts/bot_revert.py
+++ b/.github/scripts/bot_revert.py
@@ -10,6 +10,7 @@ Usage:
 
 import argparse
 import json
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -41,7 +42,7 @@ def main():
     )
     pr = json.loads(pr_json)
 
-    # `merged` is not a gh pr view field; state is MERGED once the PR lands.
+    # state is MERGED once the PR lands.
     if pr["state"] != "MERGED":
         print(f"::error::PR #{args.pr_number} is not merged. Cannot revert.")
         # Post comment via gh
@@ -94,16 +95,13 @@ def main():
     # Push the revert branch
     run(f"git push origin {revert_branch}")
 
-    # Create the revert PR (use temp files to avoid shell injection)
+    # gh pr create has --body-file but no --title-file; quote the title instead.
     revert_title = f'Revert "{original_title}"'
     revert_body = (
         f"Reverts #{args.pr_number}\n\n"
         f"**Reason:** {args.reason}\n\n"
         f"Original PR: #{args.pr_number}"
     )
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as tf:
-        tf.write(revert_title)
-        title_file = tf.name
     with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as bf:
         bf.write(revert_body)
         body_file = bf.name
@@ -111,7 +109,7 @@ def main():
     pr_url = run(
         f"gh pr create --repo {args.repo} "
         f"--base {base_branch} --head {revert_branch} "
-        f"--title-file {title_file} "
+        f"--title {shlex.quote(revert_title)} "
         f"--body-file {body_file}"
     )
 


### PR DESCRIPTION
`@torchxpubot revert` has been failing at PR creation. From the [failed job](https://github.com/intel/torch-xpu-ops/actions/runs/32709805089/job/97378606378) on [#4722](https://github.com/intel/torch-xpu-ops/pull/4722#issuecomment-5393026245):

```
Command failed: gh pr create --repo intel/torch-xpu-ops --base main \
  --head revert-pr-4722 --title-file /tmp/tmpqx0jfluh.txt \
  --body-file /tmp/tmpvg7o7c_a.md
unknown flag: --title-file
```

`gh pr create` has `--body-file` but no `--title-file`; the script assumed the two were symmetric. The title now goes inline through `shlex.quote` -- which is what the tempfile existed to avoid needing -- and the body keeps its file.

Also softens a comment I added in #5021 claiming `merged` is not a `gh pr view` field. I inferred that from a local gh 2.72 rejecting it, but this failure shows the runner's newer gh accepted the old field list and got all the way to `gh pr create`. Using `state` is still correct; the reason I gave was not.

Test: none (CI script fix)

```bash
gh pr create --help | grep -E '^\s+-[a-zA-Z], --(title|body)'
python3 -c "import ast; ast.parse(open('.github/scripts/bot_revert.py').read())"
lintrunner --paths-cmd='git diff --name-only origin/main'
```

The first confirms `--title`, `--body`, and `--body-file` exist and `--title-file` does not. Title quoting was checked against titles containing a double quote, a backtick, and `$(...)`; each round-trips through `shlex.split` as a single argument.

The real check is a live re-run of `@torchxpubot revert -m "reason"` on a merged PR. Note it will reuse the `revert-pr-4722` branch already pushed by the failed run.

Authored with the assistance of an AI coding agent.