### PR TITLE
fix: suppress -Wswitch warning in LoadWithCastFP

### DIFF
--- a/src/ATen/native/xpu/sycl/MemoryAccessUtils.h
+++ b/src/ATen/native/xpu/sycl/MemoryAccessUtils.h
@@ -143,6 +143,8 @@ struct LoadWithCastFP {
           return c10::convert<float>(c10::load<c10::Half>(ptr));
         case at::ScalarType::BFloat16:
           return c10::convert<float>(c10::load<c10::BFloat16>(ptr));
+        default:
+          break;
       }
     }
     // Satisfy compiler for non-float scalar_t instantiations that never run.


### PR DESCRIPTION
## Summary

Follow-up to #5005/#5034. The `LoadWithCastFP::load` switch only handles `Float/Half/BFloat16`, and the SYCL compiler emits `-Wswitch` warnings listing all other `ScalarType` values as unhandled.

Fix by adding a `default: break;` to the switch. The unreachable default falls through to the existing trailing `return scalar_t{};`.

Co-authored-by: OpenCode (AI assistant)