### PR TITLE
Align test_inspect_variable_redirect with upstream changes

### DIFF
--- a/test/xpu/dynamo/test_misc_xpu.py
+++ b/test/xpu/dynamo/test_misc_xpu.py
@@ -12724,13 +12724,13 @@ fn
         from torch._dynamo.variables.user_defined import InspectVariable
 
         redirected_attrs = []
-        original_getattro_impl = InspectVariable.getattro_impl
+        original_redirect = InspectVariable._redirect
 
-        def tracking_getattro_impl(self, tx, name):
+        def tracking_redirect(self, tx, name):
             redirects = self._PROPERTY_REDIRECTS.get(type(self.value), {})
             if name in redirects:
                 redirected_attrs.append(name)
-            return original_getattro_impl(self, tx, name)
+            return original_redirect(self, tx, name)
 
         def fn(x, gn):
             sig = inspect.signature(gn)
@@ -12742,7 +12742,7 @@ fn
             return a + b
 
         x = torch.randn(2, 3)
-        with patch.object(InspectVariable, "getattro_impl", tracking_getattro_impl):
+        with patch.object(InspectVariable, "_redirect", tracking_redirect):
             opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
             result = opt_fn(x, gn)
 


### PR DESCRIPTION
Fixes failing case reported in https://github.com/intel/torch-xpu-ops/issues/4916

Failing case:
`op_ut,third_party.torch-xpu-ops.test.xpu.dynamo.test_misc_xpu.MiscTests,test_inspect_variable_redirect`

Caused by: https://github.com/pytorch/pytorch/pull/189434:
`getattro_impl` method renamed to `_redirect`.