### PR TITLE
[SYCL free func][sparse] Refactor SparseSoftmaxKernels by free function

### DIFF
--- a/src/ATen/native/sparse/xpu/sycl/SparseSoftmaxKernels.cpp
+++ b/src/ATen/native/sparse/xpu/sycl/SparseSoftmaxKernels.cpp
@@ -71,42 +71,30 @@
 namespace at::native::xpu {
 
 template <typename T, class InputIt1, class InputIt2, class OutputIt>
-struct MaxRowKernelFunctor {
-  void operator()(sycl::item<1> item_id) const {
-    int64_t curr_pool_size = pool_sizes_ptr[item_id];
-    auto mx_row = mx_buffer_ptr + static_cast<int64_t>(item_id * nvalues);
-    int64_t offset = pool_offsets_ptr[item_id];
-    for (int64_t p = 0; p < curr_pool_size; p++) {
-      int64_t i = *(sorted_indices_ptr + offset + p);
-      auto values_row = values_accessor[i].data();
-      for (int64_t j = 0; j < nvalues; j++) {
-        mx_row[j] = std::max(mx_row[j], values_row[j]);
-      }
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
+void max_row_kernel(
+    int64_t numel,
+    InputIt1 pool_sizes_ptr,
+    InputIt2 values_accessor,
+    InputIt1 sorted_indices_ptr,
+    InputIt1 pool_offsets_ptr,
+    OutputIt mx_buffer_ptr,
+    T nvalues) {
+  auto item_id = syclext::this_work_item::get_nd_item<1>();
+  int64_t index = item_id.get_global_id(0);
+  if (index >= numel)
+    return;
+  int64_t curr_pool_size = pool_sizes_ptr[index];
+  auto mx_row = mx_buffer_ptr + static_cast<int64_t>(index * nvalues);
+  int64_t offset = pool_offsets_ptr[index];
+  for (int64_t p = 0; p < curr_pool_size; p++) {
+    int64_t i = *(sorted_indices_ptr + offset + p);
+    auto values_row = values_accessor[i].data();
+    for (int64_t j = 0; j < nvalues; j++) {
+      mx_row[j] = std::max(mx_row[j], values_row[j]);
     }
   }
-
-  MaxRowKernelFunctor(
-      InputIt1 pool_sizes_ptr,
-      InputIt2 values_accessor,
-      InputIt1 sorted_indices_ptr,
-      InputIt1 pool_offsets_ptr,
-      OutputIt mx_buffer_ptr,
-      T nvalues)
-      : pool_sizes_ptr(pool_sizes_ptr),
-        values_accessor(values_accessor),
-        sorted_indices_ptr(sorted_indices_ptr),
-        pool_offsets_ptr(pool_offsets_ptr),
-        mx_buffer_ptr(mx_buffer_ptr),
-        nvalues(nvalues) {}
-
- private:
-  InputIt1 pool_sizes_ptr;
-  InputIt2 values_accessor;
-  InputIt1 sorted_indices_ptr;
-  InputIt1 pool_offsets_ptr;
-  OutputIt mx_buffer_ptr;
-  T nvalues;
-};
+}
 
 template <typename T, class InputIt1, class InputIt2, class OutputIt>
 OutputIt max_row(
@@ -121,14 +109,22 @@ OutputIt max_row(
   const auto N = std::distance(pool_sizes_first, pool_sizes_last);
   auto& q = getCurrentSYCLQueue();
 
-  MaxRowKernelFunctor<T, InputIt1, InputIt2, OutputIt> mfn(
+  auto wg_size =
+      syclMaxWorkGroupSize<max_row_kernel<T, InputIt1, InputIt2, OutputIt>>();
+  sycl::range<1> local_range(wg_size);
+  sycl::range<1> global_range(((N + wg_size - 1) / wg_size) * wg_size);
+  sycl_kernel_submit<max_row_kernel<T, InputIt1, InputIt2, OutputIt>>(
+      global_range,
+      local_range,
+      q,
+      0,
+      static_cast<int64_t>(N),
       pool_sizes_first,
       values_accessor,
       sorted_indices_ptr,
       pool_offsets_ptr,
       mx_buffer_ptr,
       nvalues);
-  sycl_kernel_submit(sycl::range<1>(N), q, mfn);
 
   return mx_buffer_ptr;
 }
@@ -182,195 +178,143 @@ struct ReducePred {
 };
 
 template <typename scalar_t, bool LogSoftMax>
-struct SparseCooSoftmaxFunctor {
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
+void sparse_coo_softmax_kernel(
+    int64_t* sorted_pool_indices,
+    int64_t pool_size,
+    int64_t* pool_sizes,
+    int64_t* pool_offsets,
+    int64_t nvalues,
+    scalar_t* mx_rows,
+    GenericPackedTensorAccessor<scalar_t, 2> input_values_acc,
+    GenericPackedTensorAccessor<scalar_t, 2> output_values_acc) {
   /*
     See ATen/native/sparse/SoftMax.cpp:cpu_sparse_coo_softmax for the CPU
     implementation of the sparse softmax algorithm that this implementation is
     based on.
   */
-  void operator()(sycl::nd_item<1> item) const {
-    int tid = item.get_local_id(0);
-    int blkid = item.get_group(0);
-    int blksz = item.get_local_range(0);
-    int gridsz = item.get_group_range(0);
+  auto item = syclext::this_work_item::get_nd_item<1>();
+  int tid = item.get_local_id(0);
+  int blkid = item.get_group(0);
+  int blksz = item.get_local_range(0);
+  int gridsz = item.get_group_range(0);
 
-    int index = tid + blkid * blksz;
-    int step = blksz * gridsz;
+  int index = tid + blkid * blksz;
+  int step = blksz * gridsz;
 
-    while (index < pool_size) {
-      int64_t offset = pool_offsets[index];
-      const int64_t* pool_indices = sorted_pool_indices + offset;
-      int64_t pool_indices_size = pool_sizes[index];
-      const scalar_t* mx_row = mx_rows + index * nvalues;
+  while (index < pool_size) {
+    int64_t offset = pool_offsets[index];
+    int64_t* pool_indices = sorted_pool_indices + offset;
+    int64_t pool_indices_size = pool_sizes[index];
+    scalar_t* mx_row = mx_rows + index * nvalues;
 
-      for (int64_t j = 0; j < nvalues; j++) {
-        scalar_t exp_sums = 0;
-        for (int64_t p = 0; p < pool_indices_size; p++) {
-          auto i = pool_indices[p];
-          auto values_row = input_values_acc[i];
-          auto out_values_row = output_values_acc[i];
-
-          auto v = sycl::exp(values_row[j] - mx_row[j]);
-          if (!LogSoftMax) {
-            out_values_row[j] = v;
-          }
-          exp_sums += v;
+    for (int64_t j = 0; j < nvalues; j++) {
+      scalar_t exp_sums = 0;
+      for (int64_t p = 0; p < pool_indices_size; p++) {
+        auto i = pool_indices[p];
+        auto values_row = input_values_acc[i];
+        auto out_values_row = output_values_acc[i];
+        auto v = std::exp(values_row[j] - mx_row[j]);
+        if (!LogSoftMax) {
+          out_values_row[j] = v;
         }
-        for (int64_t p = 0; p < pool_indices_size; p++) {
-          auto i = pool_indices[p];
-          auto values_row = input_values_acc[i];
-          auto out_values_row = output_values_acc[i];
-
-          if constexpr (LogSoftMax) {
-            out_values_row[j] = values_row[j] - mx_row[j] - sycl::log(exp_sums);
-          } else {
-            out_values_row[j] *= 1.0 / exp_sums;
-          }
+        exp_sums += v;
+      }
+      for (int64_t p = 0; p < pool_indices_size; p++) {
+        auto i = pool_indices[p];
+        auto values_row = input_values_acc[i];
+        auto out_values_row = output_values_acc[i];
+        if (LogSoftMax) {
+          out_values_row[j] = values_row[j] - mx_row[j] - std::log(exp_sums);
+        } else {
+          out_values_row[j] *= 1.0 / exp_sums;
         }
       }
-      index += step;
     }
+    index += step;
   }
-
-  SparseCooSoftmaxFunctor(
-      const int64_t* sorted_pool_indices,
-      int64_t pool_size,
-      const int64_t* pool_sizes,
-      const int64_t* pool_offsets,
-      int64_t nvalues,
-      const scalar_t* mx_rows,
-      GenericPackedTensorAccessor<scalar_t, 2> input_values_acc,
-      GenericPackedTensorAccessor<scalar_t, 2> output_values_acc)
-      : sorted_pool_indices(sorted_pool_indices),
-        pool_size(pool_size),
-        pool_sizes(pool_sizes),
-        pool_offsets(pool_offsets),
-        nvalues(nvalues),
-        mx_rows(mx_rows),
-        input_values_acc(input_values_acc),
-        output_values_acc(output_values_acc) {}
-
- private:
-  const int64_t* sorted_pool_indices;
-  int64_t pool_size;
-  const int64_t* pool_sizes;
-  const int64_t* pool_offsets;
-  int64_t nvalues;
-  const scalar_t* mx_rows;
-  GenericPackedTensorAccessor<scalar_t, 2> input_values_acc;
-  GenericPackedTensorAccessor<scalar_t, 2> output_values_acc;
-};
+}
 
 template <typename scalar_t, bool LogSoftMax>
-struct SparseCooSoftmaxbBackwardFunctor {
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
+void sparse_coo_softmax_backward_kernel(
+    int64_t* sorted_pool_indices,
+    int64_t size,
+    int64_t* pool_sizes,
+    int64_t* pool_offsets,
+    int64_t nvalues,
+    int64_t grad_nnz,
+    int64_t* grad_offsets,
+    int64_t* out_offsets,
+    int64_t* lower_bound_values,
+    GenericPackedTensorAccessor<scalar_t, 2> values_accessor,
+    GenericPackedTensorAccessor<scalar_t, 2> out_values_accessor,
+    GenericPackedTensorAccessor<scalar_t, 2> grad_values_accessor) {
   /*
     See ATen/native/sparse/SoftMax.cpp:cpu_sparse_coo_softmax_backward for
     the CPU implementation of the sparse softmax backward algorithm that this
     implementation is based on.
   */
-  void operator()(sycl::nd_item<1> item) const {
-    int tid = item.get_local_id(0);
-    int blkid = item.get_group(0);
-    int blksz = item.get_local_range(0);
-    int gridsz = item.get_group_range(0);
+  auto item = syclext::this_work_item::get_nd_item<1>();
+  int tid = item.get_local_id(0);
+  int blkid = item.get_group(0);
+  int blksz = item.get_local_range(0);
+  int gridsz = item.get_group_range(0);
 
-    int index = tid + blkid * blksz;
-    int step = blksz * gridsz;
+  int index = tid + blkid * blksz;
+  int step = blksz * gridsz;
 
-    while (index < size) {
-      int64_t offset = pool_offsets[index];
-      const int64_t* pool_indices = sorted_pool_indices + offset;
-      int64_t pool_indices_size = pool_sizes[index];
+  while (index < size) {
+    int64_t offset = pool_offsets[index];
+    int64_t* pool_indices = sorted_pool_indices + offset;
+    int64_t pool_indices_size = pool_sizes[index];
 
-      for (int64_t k = 0; k < nvalues; k++) {
-        scalar_t tmp_row{0};
+    for (int64_t k = 0; k < nvalues; k++) {
+      scalar_t tmp_row{0};
 
-        /* Compute tmp = - sum_j output_j * grad_j */
-        for (int64_t p = 0; p < pool_indices_size; p++) {
-          auto i = pool_indices[p];
-          auto out_values_row = out_values_accessor[i];
-          auto j = lower_bound_values[i];
-
-          /* Update `tmp_row` accumulator only when limits and pools are valid
-           */
-          if (j < grad_nnz && (out_offsets[i] == grad_offsets[j])) {
-            auto grad_values_row = grad_values_accessor[j];
-            if constexpr (LogSoftMax) {
-              tmp_row -= grad_values_row[k];
-            } else {
-              tmp_row -= out_values_row[k] * grad_values_row[k];
-            }
-          }
-        }
-
-        /* Compute grad_input = output * (grad + tmp)*/
-        for (int64_t p = 0; p < pool_indices_size; p++) {
-          auto i = pool_indices[p];
-          auto out_values_row = out_values_accessor[i];
-          auto values_row = values_accessor[i];
-          auto j = lower_bound_values[i];
-          if (j < grad_nnz && (out_offsets[i] == grad_offsets[j])) {
-            auto grad_values_row = grad_values_accessor[j];
-            if constexpr (LogSoftMax) {
-              values_row[k] =
-                  grad_values_row[k] + sycl::exp(out_values_row[k]) * tmp_row;
-            } else {
-              values_row[k] =
-                  out_values_row[k] * (grad_values_row[k] + tmp_row);
-            }
+      /* Compute tmp = - sum_j output_j * grad_j */
+      for (int64_t p = 0; p < pool_indices_size; p++) {
+        auto i = pool_indices[p];
+        auto out_values_row = out_values_accessor[i];
+        auto j = lower_bound_values[i];
+        /* Update `tmp_row` accumulator only when limits and pools are valid
+         */
+        if (j < grad_nnz && (out_offsets[i] == grad_offsets[j])) {
+          auto grad_values_row = grad_values_accessor[j];
+          if (LogSoftMax) {
+            tmp_row -= grad_values_row[k];
           } else {
-            if constexpr (LogSoftMax) {
-              values_row[k] = sycl::exp(out_values_row[k]) * tmp_row;
-            } else {
-              values_row[k] = out_values_row[k] * tmp_row;
-            }
+            tmp_row -= out_values_row[k] * grad_values_row[k];
           }
         }
       }
-      index += step;
+
+      /* Compute grad_input = output * (grad + tmp)*/
+      for (int64_t p = 0; p < pool_indices_size; p++) {
+        auto i = pool_indices[p];
+        auto out_values_row = out_values_accessor[i];
+        auto values_row = values_accessor[i];
+        auto j = lower_bound_values[i];
+        if (j < grad_nnz && (out_offsets[i] == grad_offsets[j])) {
+          auto grad_values_row = grad_values_accessor[j];
+          if (LogSoftMax) {
+            values_row[k] =
+                grad_values_row[k] + std::exp(out_values_row[k]) * tmp_row;
+          } else {
+            values_row[k] = out_values_row[k] * (grad_values_row[k] + tmp_row);
+          }
+        } else {
+          if (LogSoftMax) {
+            values_row[k] = std::exp(out_values_row[k]) * tmp_row;
+          } else {
+            values_row[k] = out_values_row[k] * tmp_row;
+          }
+        }
+      }
     }
+    index += step;
   }
-
-  SparseCooSoftmaxbBackwardFunctor(
-      const int64_t* sorted_pool_indices,
-      int64_t size,
-      const int64_t* pool_sizes,
-      const int64_t* pool_offsets,
-      int64_t nvalues,
-      int64_t grad_nnz,
-      const int64_t* grad_offsets,
-      const int64_t* out_offsets,
-      const int64_t* lower_bound_values,
-      GenericPackedTensorAccessor<scalar_t, 2> values_accessor,
-      GenericPackedTensorAccessor<scalar_t, 2> out_values_accessor,
-      GenericPackedTensorAccessor<scalar_t, 2> grad_values_accessor)
-      : sorted_pool_indices(sorted_pool_indices),
-        size(size),
-        pool_sizes(pool_sizes),
-        pool_offsets(pool_offsets),
-        nvalues(nvalues),
-        grad_nnz(grad_nnz),
-        grad_offsets(grad_offsets),
-        out_offsets(out_offsets),
-        lower_bound_values(lower_bound_values),
-        values_accessor(values_accessor),
-        out_values_accessor(out_values_accessor),
-        grad_values_accessor(grad_values_accessor) {}
-
- private:
-  const int64_t* sorted_pool_indices;
-  int64_t size;
-  const int64_t* pool_sizes;
-  const int64_t* pool_offsets;
-  int64_t nvalues;
-  int64_t grad_nnz;
-  const int64_t* grad_offsets;
-  const int64_t* out_offsets;
-  const int64_t* lower_bound_values;
-  GenericPackedTensorAccessor<scalar_t, 2> values_accessor;
-  GenericPackedTensorAccessor<scalar_t, 2> out_values_accessor;
-  GenericPackedTensorAccessor<scalar_t, 2> grad_values_accessor;
-};
+}
 
 Tensor get_offsets(
     const Tensor& indices,
@@ -539,8 +483,12 @@ void xpu_sparse_coo_softmax(
   // Further, they will be invalid configuration parameters for the launch. So
   // let's not launch a kernel unless both are non-zero.
   if (nvalues > 0 && pool_size > 0) {
-    auto kfn = SparseCooSoftmaxFunctor<scalar_t, LogSoftMax>(
-        sorted_indices.template const_data_ptr<int64_t>(),
+    sycl_kernel_submit<sparse_coo_softmax_kernel<scalar_t, LogSoftMax>>(
+        global_range,
+        local_range,
+        getCurrentSYCLQueue(),
+        0,
+        sorted_indices.template data_ptr<int64_t>(),
         pool_size,
         pool_sizes.template const_data_ptr<int64_t>(),
         pool_offsets.template const_data_ptr<int64_t>(),
@@ -548,7 +496,6 @@ void xpu_sparse_coo_softmax(
         mx_buffer.template const_data_ptr<scalar_t>(),
         values_accessor,
         out_values_accessor);
-    sycl_kernel_submit(global_range, local_range, getCurrentSYCLQueue(), kfn);
   }
 }
 
@@ -668,8 +615,13 @@ void xpu_sparse_coo_softmax_backward(
   sycl::range<1> local_range(block_size);
 
   if (nvalues > 0 && pool_size > 0) {
-    auto kfn = SparseCooSoftmaxbBackwardFunctor<scalar_t, LogSoftMax>(
-        sorted_indices.template const_data_ptr<int64_t>(),
+    sycl_kernel_submit<
+        sparse_coo_softmax_backward_kernel<scalar_t, LogSoftMax>>(
+        global_range,
+        local_range,
+        getCurrentSYCLQueue(),
+        0,
+        sorted_indices.template data_ptr<int64_t>(),
         pool_size,
         pool_sizes.template const_data_ptr<int64_t>(),
         pool_offsets.template const_data_ptr<int64_t>(),
@@ -681,7 +633,6 @@ void xpu_sparse_coo_softmax_backward(
         values_accessor,
         out_values_accessor,
         grad_values_accessor);
-    sycl_kernel_submit(global_range, local_range, getCurrentSYCLQueue(), kfn);
   }
 }
 


### PR DESCRIPTION
Migrate the SparseSoftmaxKernels SYCL kernels to free function style.

Changes:
- Convert the max-row kernel to an `nd_range_kernel<1>` with bounds checking.
- Convert the sparse COO softmax forward and backward kernels to free functions.
- Keep non-kernel types (`PoolPred`, `SortFunctor`, and `ReducePred`) unchanged.

Changed-kernel related UTs:
- `pytest -vs test_sparse_xpu.py -k softmax`
- Result from the private PR: 12 passed.
