### PR TITLE
Refine gamma/beta load for LayerNorm

### DIFF
--- a/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
@@ -498,34 +498,38 @@ struct VectorizedLayerNormKernelFunctor
       // Computation is performed in T_ACC, X is cast to T_ACC and result is
       // implicitly cast to T
       if (gamma_vec != nullptr && beta_vec != nullptr) {
+        vec_t gamma_data = gamma_vec[i];
+        vec_t beta_data = beta_vec[i];
 #pragma unroll
         for (int ii = 0; ii < vec_size; ii++) {
           if constexpr (!rms_norm) {
-            out.val[ii] = static_cast<T_ACC>(gamma_vec[i].val[ii]) *
+            out.val[ii] = static_cast<T_ACC>(gamma_data.val[ii]) *
                     (rstd_val * (static_cast<T_ACC>(data.val[ii]) - wd.mean)) +
-                static_cast<T_ACC>(beta_vec[i].val[ii]);
+                static_cast<T_ACC>(beta_data.val[ii]);
           } else {
-            out.val[ii] = static_cast<T_ACC>(gamma_vec[i].val[ii]) *
+            out.val[ii] = static_cast<T_ACC>(gamma_data.val[ii]) *
                 (rstd_val * static_cast<T_ACC>(data.val[ii]));
           }
         }
       } else if (gamma_vec != nullptr) {
+        vec_t gamma_data = gamma_vec[i];
 #pragma unroll
         for (int ii = 0; ii < vec_size; ii++) {
           if constexpr (!rms_norm) {
-            out.val[ii] = static_cast<T_ACC>(gamma_vec[i].val[ii]) *
+            out.val[ii] = static_cast<T_ACC>(gamma_data.val[ii]) *
                 (rstd_val * (static_cast<T_ACC>(data.val[ii]) - wd.mean));
           } else {
-            out.val[ii] = static_cast<T_ACC>(gamma_vec[i].val[ii]) *
+            out.val[ii] = static_cast<T_ACC>(gamma_data.val[ii]) *
                 (rstd_val * static_cast<T_ACC>(data.val[ii]));
           }
         }
       } else if (beta_vec != nullptr) {
+        vec_t beta_data = beta_vec[i];
 #pragma unroll
         for (int ii = 0; ii < vec_size; ii++) {
           out.val[ii] =
               (rstd_val * (static_cast<T_ACC>(data.val[ii]) - wd.mean)) +
-              static_cast<T_ACC>(beta_vec[i].val[ii]);
+              static_cast<T_ACC>(beta_data.val[ii]);
         }
       } else {
 #pragma unroll

--- a/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
@@ -499,14 +499,17 @@ struct VectorizedLayerNormKernelFunctor
       // implicitly cast to T
       if (gamma_vec != nullptr && beta_vec != nullptr) {
         vec_t gamma_data = gamma_vec[i];
-        vec_t beta_data = beta_vec[i];
+        if constexpr (!rms_norm) {
+          vec_t beta_data = beta_vec[i];
 #pragma unroll
-        for (int ii = 0; ii < vec_size; ii++) {
-          if constexpr (!rms_norm) {
+          for (int ii = 0; ii < vec_size; ii++) {
             out.val[ii] = static_cast<T_ACC>(gamma_data.val[ii]) *
                     (rstd_val * (static_cast<T_ACC>(data.val[ii]) - wd.mean)) +
                 static_cast<T_ACC>(beta_data.val[ii]);
-          } else {
+          }
+        } else {
+#pragma unroll
+          for (int ii = 0; ii < vec_size; ii++) {
             out.val[ii] = static_cast<T_ACC>(gamma_data.val[ii]) *
                 (rstd_val * static_cast<T_ACC>(data.val[ii]));
           }


### PR DESCRIPTION
This PR is to refine the vectorization for gamma/beta load in `VectorizedLayerNormKernelFunctor` to generate `load.ugm.d32x2.a64` instead of two `load.ugm.d32.a64`. The main change is the introduction of local variables to hold `gamma_vec[i]` and `beta_vec[i]` before entering the loop of gamma/beta processing.
Due to the usually low proportion of gamma/beta among all inputs, this issue has no significant impact on performance, but it should still be fixed.