### PR TITLE
Use FunctionSchema::name() instead of OperatorName::name field

### DIFF
--- a/src/ATen/native/xpu/XPUFallback.cpp
+++ b/src/ATen/native/xpu/XPUFallback.cpp
@@ -36,7 +36,7 @@ static void check_device_consistency(
         " and ",
         cur_device,
         "! (Operator ",
-        op.schema().operator_name().name,
+        op.schema().name(),
         ")");
   };
 
@@ -253,9 +253,9 @@ static bool lazy_registration_and_redispatch(
 
   bool need_redispatch_after_lazy_registration =
       torchvision_ops_dispatching_table_.end() !=
-      torchvision_ops_dispatching_table_.find(op.schema().operator_name().name);
+      torchvision_ops_dispatching_table_.find(op.schema().name());
   bool is_cpu_fallback = need_redispatch_after_lazy_registration
-      ? torchvision_ops_dispatching_table_[op.schema().operator_name().name]
+      ? torchvision_ops_dispatching_table_[op.schema().name()]
       : true;
 
   if (need_redispatch_after_lazy_registration) {


### PR DESCRIPTION
```
OperatorName::name is expected to become a private field behind a
name() accessor in a future PyTorch release, so
op.schema().operator_name().name will stop compiling once that lands.

FunctionSchema already exposes its own name() (a thin wrapper over the
same underlying string) as a stable public API independent of that
internal change, so op.schema().name() works identically before and
after the change - it's also one hop shorter.
```

Drafted with AI assistance (Claude Code).