### PR TITLE
Drop dead c10/util/Optional.h include from UpSample.h

### DIFF
--- a/src/ATen/native/xpu/UpSample.h
+++ b/src/ATen/native/xpu/UpSample.h
@@ -17,7 +17,6 @@
 #include <ATen/native/xpu/sycl/Atomics.h>
 
 #include <c10/util/ArrayRef.h>
-#include <c10/util/Optional.h>
 #include <c10/util/OptionalArrayRef.h>
 #include <c10/util/SmallVector.h>
 


### PR DESCRIPTION
## Summary
UpSample.h already uses `std::optional` exclusively (no `c10::optional` usages), so the `#include <c10/util/Optional.h>` was dead. `std::optional` remains available transitively via `c10/util/OptionalArrayRef.h`, which already includes `<optional>`, so no replacement include is needed.

Test: none (dead include removal, no behavior change; verified with `grep -n "optional" src/ATen/native/xpu/UpSample.h`)

This PR was authored with the assistance of an AI (Claude Code).

https://claude.ai/code/session_01Qv4y9gGiWgvsKnJntF7BEj