### PR TITLE
bot: run the redact step under bash

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1303,6 +1303,9 @@ jobs:
       - name: Redact secrets from agent artifacts
         id: redact
         if: always()
+        # Container jobs default to `sh -e {0}` regardless of the image having
+        # bash, and this script needs arrays / process substitution / herestring.
+        shell: bash
         env:
           TRANSCRIPT: ${{ steps.ai-fix.outputs.execution_file }}
           SECRETS: |


### PR DESCRIPTION
`@torchxpubot fix` runs finish the AI fix but post nothing: the `Redact secrets from agent artifacts` step dies before the gated hand-off steps.

```
/__w/_temp/xxx.sh: 3: Syntax error: "(" unexpected
##[error]Process completed with exit code 2
```

Root cause: with no `shell:` key, a `container:` job gets `sh -e {0}`. The runner sets `shellCommand = "sh"`, probes bash **on the host**, then execs the literal `shell*Command` inside the container (`fileName = isContainerStepHost ? shellCommand : commandPath` in `ScriptHandler.cs`), so the image having bash is irrelevant. Ubuntu's `/bin/sh` is dash, which rejects `targets=()`, `targets+=(...)`, `< <(...)` and `<<<`.

Fallout: `Post result comment`, `Upload agent transcript`, `Upload fix result metadata` and `Upload fix patch` are all gated on `steps.redact.outcome == 'success'` (deliberately, so nothing unredacted is published), so a 46-minute successful fix was discarded silently — see run 33347843431 on #3426.

Fix: `shell: bash` on that one step. It is the only step in this workflow with bashisms.

Verified by running the step's script verbatim: under `bash -e` it exits 0 and redacts the transcript, `fix_result.json` and the `.patch`, including the `base64("x-access-token:<token>")` form and tokens containing `+ . /`; empty-target and empty-secret paths also exit 0. Under `sh -e` it reproduces the exit-2 syntax error.