### PR TITLE
Add C10D_XCCL_CHECK macro to check oneCCL return code

### DIFF
--- a/src/xccl/ProcessGroupXCCL.cpp
+++ b/src/xccl/ProcessGroupXCCL.cpp
@@ -34,27 +34,6 @@ bool checkSameSize(const std::vector<at::Tensor>& input_tensors) {
   return true;
 }
 
-struct OnecclGroupGuard {
-  OnecclGroupGuard() {
-    xccl::oneccl_group_start();
-  }
-
-  ~OnecclGroupGuard() noexcept {
-    // Ensure the group is always closed, even if a prior call threw.
-    // Suppress any exception here so that none can escape this noexcept
-    // destructor and trigger std::terminate during stack unwinding.
-    try {
-      xccl::oneccl_group_end();
-    } catch (...) {
-    }
-  }
-
-  OnecclGroupGuard(const OnecclGroupGuard&) = delete;
-  OnecclGroupGuard& operator=(const OnecclGroupGuard&) = delete;
-  OnecclGroupGuard(OnecclGroupGuard&&) = delete;
-  OnecclGroupGuard& operator=(OnecclGroupGuard&&) = delete;
-};
-
 void checkSingleTensor(
     const at::Tensor& tensor,
     const bool p2p = false // whether operation is a P2P operation
@@ -609,7 +588,7 @@ std::shared_ptr<onecclComm_t> ProcessGroupXCCL::initXCCLComm(
 
   onecclUniqueId xcclID;
   if (rank_ == 0 || (singleP2POp && p2pRank == 0)) {
-    onecclGetUniqueId(&xcclID);
+    C10D_XCCL_CHECK(onecclGetUniqueId(&xcclID), nullptr);
   }
   broadcastUniqueXCCLID(
       &xcclID,
@@ -620,16 +599,8 @@ std::shared_ptr<onecclComm_t> ProcessGroupXCCL::initXCCLComm(
       rank_,
       store_.get());
   onecclComm_t comm = nullptr;
-  TORCH_CHECK(
-      onecclSetDevice(device.index()) == onecclSuccess,
-      "xccl: onecclSetDevice(",
-      (int)device.index(),
-      ") failed");
-  auto initR = onecclCommInitRank(&comm, numRanks, xcclID, rank);
-  TORCH_CHECK(
-      initR == onecclSuccess,
-      "xccl: onecclCommInitRank failed with code ",
-      (int)initR);
+  C10D_XCCL_CHECK(onecclSetDevice(device.index()), nullptr);
+  C10D_XCCL_CHECK(onecclCommInitRank(&comm, numRanks, xcclID, rank), nullptr);
   XCCLComm = std::make_shared<onecclComm_t>(comm);
 
   RECORD_PARAM_COMMS(
@@ -1028,7 +999,7 @@ c10::intrusive_ptr<Work> ProcessGroupXCCL::pointToPoint(
       tensor.storage().data_ptr(), stream);
 
   if (!batchP2P) {
-    OnecclGroupGuard group_guard;
+    xccl::OnecclGroupGuard group_guard;
     fn(tensor, *comm, stream, p2pTargetRank);
   } else {
     fn(tensor, *comm, stream, p2pTargetRank);
@@ -2113,7 +2084,7 @@ c10::intrusive_ptr<Work> ProcessGroupXCCL::alltoall(
           at::Tensor& /* unused */,
           onecclComm_t& comm,
           at::xpu::XPUStream& stream) {
-        xccl::oneccl_group_start();
+        xccl::OnecclGroupGuard group_guard;
         for (const int r :
              c10::irange(static_cast<int>(outputTensors.size()))) {
           at::Tensor& input = inputTensors[r];
@@ -2125,7 +2096,6 @@ c10::intrusive_ptr<Work> ProcessGroupXCCL::alltoall(
             xccl::onecclRecv(output, comm, r, stream);
           }
         }
-        xccl::oneccl_group_end();
         return;
       },
       OpType::ALLTOALL,

--- a/src/xccl/xccl.cpp
+++ b/src/xccl/xccl.cpp
@@ -14,11 +14,11 @@ namespace c10d {
 namespace xccl {
 
 void oneccl_group_start() {
-  onecclGroupStart();
+  C10D_XCCL_CHECK(onecclGroupStart(), nullptr);
 }
 
 void oneccl_group_end() {
-  onecclGroupEnd();
+  C10D_XCCL_CHECK(onecclGroupEnd(), nullptr);
 }
 
 void onecclAllReduce(
@@ -29,14 +29,16 @@ void onecclAllReduce(
     at::xpu::XPUStream& stream) {
   auto xcclDataType = getXcclDataType(input.scalar_type(), true);
   auto xcclReduceOp = getXcclReduceOp(reduceOp, input, xcclDataType, comm);
-  onecclAllReduce(
-      input.data_ptr(),
-      output.data_ptr(),
-      (size_t)input.numel(),
-      xcclDataType,
-      xcclReduceOp,
-      comm,
-      &stream.queue());
+  C10D_XCCL_CHECK(
+      onecclAllReduce(
+          input.data_ptr(),
+          output.data_ptr(),
+          (size_t)input.numel(),
+          xcclDataType,
+          xcclReduceOp,
+          comm,
+          &stream.queue()),
+      comm);
 }
 
 void onecclReduce(
@@ -48,15 +50,17 @@ void onecclReduce(
     at::xpu::XPUStream& stream) {
   auto xcclDataType = getXcclDataType(input.scalar_type(), true);
   auto xcclReduceOp = getXcclReduceOp(reduceOp, input, xcclDataType, comm);
-  onecclReduce(
-      input.data_ptr(),
-      output.data_ptr(),
-      (size_t)input.numel(),
-      xcclDataType,
-      xcclReduceOp,
-      root,
-      comm,
-      &stream.queue());
+  C10D_XCCL_CHECK(
+      onecclReduce(
+          input.data_ptr(),
+          output.data_ptr(),
+          (size_t)input.numel(),
+          xcclDataType,
+          xcclReduceOp,
+          root,
+          comm,
+          &stream.queue()),
+      comm);
 }
 
 void onecclBroadcast(
@@ -66,14 +70,16 @@ void onecclBroadcast(
     const int root,
     at::xpu::XPUStream& stream) {
   auto xcclDataType = getXcclDataType(input.scalar_type(), false);
-  onecclBroadcast(
-      input.data_ptr(),
-      output.data_ptr(),
-      (size_t)input.numel(),
-      xcclDataType,
-      root,
-      comm,
-      &stream.queue());
+  C10D_XCCL_CHECK(
+      onecclBroadcast(
+          input.data_ptr(),
+          output.data_ptr(),
+          (size_t)input.numel(),
+          xcclDataType,
+          root,
+          comm,
+          &stream.queue()),
+      comm);
 }
 
 void onecclReduceScatter(
@@ -84,14 +90,16 @@ void onecclReduceScatter(
     at::xpu::XPUStream& stream) {
   auto xcclDataType = getXcclDataType(input.scalar_type(), true);
   auto xcclReduceOp = getXcclReduceOp(reduceOp, input, xcclDataType, comm);
-  onecclReduceScatter(
-      input.data_ptr(),
-      output.data_ptr(),
-      (size_t)output.numel(),
-      xcclDataType,
-      xcclReduceOp,
-      comm,
-      &stream.queue());
+  C10D_XCCL_CHECK(
+      onecclReduceScatter(
+          input.data_ptr(),
+          output.data_ptr(),
+          (size_t)output.numel(),
+          xcclDataType,
+          xcclReduceOp,
+          comm,
+          &stream.queue()),
+      comm);
 }
 
 void onecclAllGather(
@@ -100,13 +108,15 @@ void onecclAllGather(
     onecclComm_t& comm,
     at::xpu::XPUStream& stream) {
   auto xcclDataType = getXcclDataType(input.scalar_type(), false);
-  onecclAllGather(
-      input.data_ptr(),
-      output.data_ptr(),
-      (size_t)input.numel(),
-      xcclDataType,
-      comm,
-      &stream.queue());
+  C10D_XCCL_CHECK(
+      onecclAllGather(
+          input.data_ptr(),
+          output.data_ptr(),
+          (size_t)input.numel(),
+          xcclDataType,
+          comm,
+          &stream.queue()),
+      comm);
 }
 
 void onecclSend(
@@ -115,13 +125,15 @@ void onecclSend(
     const int dstRank,
     at::xpu::XPUStream& stream) {
   auto xcclDataType = getXcclDataType(input.scalar_type(), false);
-  onecclSend(
-      input.data_ptr(),
-      (size_t)input.numel(),
-      xcclDataType,
-      dstRank,
-      comm,
-      &stream.queue());
+  C10D_XCCL_CHECK(
+      onecclSend(
+          input.data_ptr(),
+          (size_t)input.numel(),
+          xcclDataType,
+          dstRank,
+          comm,
+          &stream.queue()),
+      comm);
 }
 
 void onecclRecv(
@@ -130,13 +142,15 @@ void onecclRecv(
     const int srcRank,
     at::xpu::XPUStream& stream) {
   auto xcclDataType = getXcclDataType(output.scalar_type(), false);
-  onecclRecv(
-      output.data_ptr(),
-      (size_t)output.numel(),
-      xcclDataType,
-      srcRank,
-      comm,
-      &stream.queue());
+  C10D_XCCL_CHECK(
+      onecclRecv(
+          output.data_ptr(),
+          (size_t)output.numel(),
+          xcclDataType,
+          srcRank,
+          comm,
+          &stream.queue()),
+      comm);
 }
 
 void onecclGather(
@@ -148,24 +162,32 @@ void onecclGather(
   size_t count = inputs.numel();
   auto xcclDataType = getXcclDataType(inputs.scalar_type(), false);
   int numranks = 0, cur_rank = 0;
-  onecclCommCount(comm, &numranks);
-  onecclCommUserRank(comm, &cur_rank);
-  onecclGroupStart();
+  C10D_XCCL_CHECK(onecclCommCount(comm, &numranks), comm);
+  C10D_XCCL_CHECK(onecclCommUserRank(comm, &cur_rank), comm);
+  OnecclGroupGuard group_guard;
   if (cur_rank == root) {
     for (const auto r : c10::irange(numranks)) {
       if (r != root) {
         auto* recvbuff = reinterpret_cast<char*>(outputs[r].data_ptr());
-        onecclRecv(recvbuff, count, xcclDataType, r, comm, &stream.queue());
+        C10D_XCCL_CHECK(
+            onecclRecv(recvbuff, count, xcclDataType, r, comm, &stream.queue()),
+            comm);
       } else {
         // on its own rank, simply copy from the input
         outputs[r].copy_(inputs);
       }
     }
   } else {
-    onecclSend(
-        inputs.data_ptr(), count, xcclDataType, root, comm, &stream.queue());
+    C10D_XCCL_CHECK(
+        onecclSend(
+            inputs.data_ptr(),
+            count,
+            xcclDataType,
+            root,
+            comm,
+            &stream.queue()),
+        comm);
   }
-  onecclGroupEnd();
 }
 
 void onecclScatter(
@@ -176,20 +198,22 @@ void onecclScatter(
     at::xpu::XPUStream& stream) {
   auto xcclDataType = getXcclDataType(outputs.scalar_type(), false);
   int numranks = 0, cur_rank = 0;
-  onecclCommCount(comm, &numranks);
-  onecclCommUserRank(comm, &cur_rank);
-  onecclGroupStart();
+  C10D_XCCL_CHECK(onecclCommCount(comm, &numranks), comm);
+  C10D_XCCL_CHECK(onecclCommUserRank(comm, &cur_rank), comm);
+  OnecclGroupGuard group_guard;
   if (cur_rank == root) {
     for (const auto r : c10::irange(numranks)) {
       if (r != root) {
         size_t send_count = inputs[r].numel();
-        onecclSend(
-            inputs[r].data_ptr(),
-            send_count,
-            xcclDataType,
-            r,
-            comm,
-            &stream.queue());
+        C10D_XCCL_CHECK(
+            onecclSend(
+                inputs[r].data_ptr(),
+                send_count,
+                xcclDataType,
+                r,
+                comm,
+                &stream.queue()),
+            comm);
       } else {
         // on its own rank, simply copy from the input
         outputs.copy_(inputs[r]);
@@ -197,15 +221,16 @@ void onecclScatter(
     }
   } else {
     size_t recv_count = outputs.numel();
-    onecclRecv(
-        outputs.data_ptr(),
-        recv_count,
-        xcclDataType,
-        root,
-        comm,
-        &stream.queue());
+    C10D_XCCL_CHECK(
+        onecclRecv(
+            outputs.data_ptr(),
+            recv_count,
+            xcclDataType,
+            root,
+            comm,
+            &stream.queue()),
+        comm);
   }
-  onecclGroupEnd();
 }
 
 static std::pair<bool, size_t> checkUniformAllToAll(
@@ -244,41 +269,51 @@ void onecclAllToAll(
     at::xpu::XPUStream& stream) {
   auto xcclDataType = getXcclDataType(dataType, false);
   int numranks = 0;
-  onecclCommCount(comm, &numranks);
+  C10D_XCCL_CHECK(onecclCommCount(comm, &numranks), comm);
 
   auto [isUniform, uniformCount] = checkUniformAllToAll(
       sendcounts, senddispls, recvcounts, recvdispls, numranks);
 
   if (isUniform) {
     // Use native onecclAllToAll for uniform case
-    onecclAllToAll(
-        sendbuff, recvbuff, uniformCount, xcclDataType, comm, &stream.queue());
+    C10D_XCCL_CHECK(
+        onecclAllToAll(
+            sendbuff,
+            recvbuff,
+            uniformCount,
+            xcclDataType,
+            comm,
+            &stream.queue()),
+        comm);
     return;
   }
 
   // Fallback to send/recv based implementation for non-uniform case
-  xccl::oneccl_group_start();
+  OnecclGroupGuard group_guard;
   for (const auto r : c10::irange(numranks)) {
     if (sendcounts[r] != 0) {
-      onecclSend(
-          ((char*)sendbuff) + senddispls[r] * size,
-          sendcounts[r],
-          xcclDataType,
-          r,
-          comm,
-          &stream.queue());
+      C10D_XCCL_CHECK(
+          onecclSend(
+              ((char*)sendbuff) + senddispls[r] * size,
+              sendcounts[r],
+              xcclDataType,
+              r,
+              comm,
+              &stream.queue()),
+          comm);
     }
     if (recvcounts[r] != 0) {
-      onecclRecv(
-          ((char*)recvbuff) + recvdispls[r] * size,
-          recvcounts[r],
-          xcclDataType,
-          r,
-          comm,
-          &stream.queue());
+      C10D_XCCL_CHECK(
+          onecclRecv(
+              ((char*)recvbuff) + recvdispls[r] * size,
+              recvcounts[r],
+              xcclDataType,
+              r,
+              comm,
+              &stream.queue()),
+          comm);
     }
   }
-  xccl::oneccl_group_end();
 }
 
 } // namespace xccl

--- a/src/xccl/xccl.h
+++ b/src/xccl/xccl.h
@@ -83,6 +83,43 @@ inline const std::string& getVersionString() {
   return versionString;
 }
 
+inline std::string getXcclErrorDetailStr(
+    onecclResult_t result,
+    onecclComm_t comm) {
+  std::string detail = c10::str(
+      "oneCCL error ",
+      static_cast<int>(result),
+      " '",
+      onecclGetErrorString(result),
+      "', oneCCL version ",
+      getVersionString());
+  // The result code alone does not say which argument or stage failed; oneCCL's
+  // own logging records that message here. It is never cleared, so a stale
+  // message can outlive the call that produced it.
+  const char* lastError = comm != nullptr ? onecclGetLastError(comm) : nullptr;
+  if (lastError != nullptr && *lastError != '\0') {
+    detail += c10::str("\nLast error reported by oneCCL: ", lastError);
+  }
+  return detail;
+}
+
+// oneCCL reports failures only through the return code, so an ignored code
+// turns a failed collective into a silent no-op. Every oneCCL call goes through
+// this macro. Pass nullptr for `comm` when the call takes no communicator.
+// The failing call is identified by the source location TORCH_CHECK_WITH
+// already attaches.
+#define C10D_XCCL_CHECK(cmd, comm)                    \
+  do {                                                \
+    onecclResult_t xcclResult = (cmd);                \
+    if (xcclResult != onecclSuccess) {                \
+      TORCH_CHECK_WITH(                               \
+          DistBackendError,                           \
+          false,                                      \
+          "XCCL error: ",                             \
+          getXcclErrorDetailStr(xcclResult, (comm))); \
+    }                                                 \
+  } while (0)
+
 namespace c10d {
 
 const std::map<c10d::ReduceOp, onecclRedOp_t> xcclOps = {
@@ -163,11 +200,13 @@ inline xcclRedOpRAII unpackPreMulSum(
       ? preMulSupplement->tensor_factor.const_data_ptr<T>()
       : nullptr;
   T scalar_factor = T(preMulSupplement->double_factor);
-  onecclRedOpCreatePreMulSum(
-      &preMulSum,
-      /*scalar=*/has_tensor ? const_cast<T*>(ptr_factor) : &scalar_factor,
-      dataType,
-      residence,
+  C10D_XCCL_CHECK(
+      onecclRedOpCreatePreMulSum(
+          &preMulSum,
+          /*scalar=*/has_tensor ? const_cast<T*>(ptr_factor) : &scalar_factor,
+          dataType,
+          residence,
+          comm),
       comm);
   return xcclRedOpRAII(preMulSum, comm);
 }
@@ -299,6 +338,28 @@ namespace xccl {
 
 void oneccl_group_start();
 void oneccl_group_end();
+
+struct OnecclGroupGuard {
+  OnecclGroupGuard() {
+    oneccl_group_start();
+  }
+
+  ~OnecclGroupGuard() noexcept {
+    // Ensure the group is always closed, even if a prior call threw. Suppress
+    // any exception here so that none can escape this noexcept destructor and
+    // trigger std::terminate during stack unwinding.
+    try {
+      oneccl_group_end();
+    } catch (...) {
+    }
+  }
+
+  OnecclGroupGuard(const OnecclGroupGuard&) = delete;
+  OnecclGroupGuard& operator=(const OnecclGroupGuard&) = delete;
+  OnecclGroupGuard(OnecclGroupGuard&&) = delete;
+  OnecclGroupGuard& operator=(OnecclGroupGuard&&) = delete;
+};
+
 void onecclAllReduce(
     at::Tensor& input,
     at::Tensor& output,

--- a/src/xccl/xccl.h
+++ b/src/xccl/xccl.h
@@ -93,9 +93,6 @@ inline std::string getXcclErrorDetailStr(
       onecclGetErrorString(result),
       "', oneCCL version ",
       getVersionString());
-  // The result code alone does not say which argument or stage failed; oneCCL's
-  // own logging records that message here. It is never cleared, so a stale
-  // message can outlive the call that produced it.
   const char* lastError = comm != nullptr ? onecclGetLastError(comm) : nullptr;
   if (lastError != nullptr && *lastError != '\0') {
     detail += c10::str("\nLast error reported by oneCCL: ", lastError);
@@ -103,11 +100,6 @@ inline std::string getXcclErrorDetailStr(
   return detail;
 }
 
-// oneCCL reports failures only through the return code, so an ignored code
-// turns a failed collective into a silent no-op. Every oneCCL call goes through
-// this macro. Pass nullptr for `comm` when the call takes no communicator.
-// The failing call is identified by the source location TORCH_CHECK_WITH
-// already attaches.
 #define C10D_XCCL_CHECK(cmd, comm)                    \
   do {                                                \
     onecclResult_t xcclResult = (cmd);                \


### PR DESCRIPTION
This is to fix https://github.com/intel/torch-xpu-ops/issues/3623. After moving to v2 API, oneCCL return code is discarded so no exception will be raised for failures like this. The PR adds C10D_XCCL_CHECK macro and wraps oneCCL calls so that `DistBackendError` can be raised with the result code.