### PR TITLE
bot: make the fix pipeline's session comment reliable

### DIFF
--- a/.claude/skills/issue-handler/references/execution-modes.md
+++ b/.claude/skills/issue-handler/references/execution-modes.md
@@ -105,8 +105,11 @@ gh api "/repos/$OWNER/$REPO/issues/comments/$SESSION_COMMENT_ID" \
   --jq .body > session_comment.md
 cat next_block.md >> session_comment.md
 gh api --method PATCH "/repos/$OWNER/$REPO/issues/comments/$SESSION_COMMENT_ID" \
-  -f body=@session_comment.md
+  -F body=@session_comment.md
 ```
+
+`-F`, not `-f`: only `--field` reads a value from `@file`; `--raw-field`
+would post the literal string `@session_comment.md` as the comment.
 
 Keep the accumulating body under 65000 chars (the GitHub limit is 65536,
 and a PATCH over it fails outright): if the diff in the implement block

--- a/.claude/skills/issue-handler/references/execution-modes.md
+++ b/.claude/skills/issue-handler/references/execution-modes.md
@@ -108,8 +108,8 @@ gh api --method PATCH "/repos/$OWNER/$REPO/issues/comments/$SESSION_COMMENT_ID" 
   -F body=@session_comment.md
 ```
 
-`-F`, not `-f`: only `--field` reads a value from `@file`; `--raw-field`
-would post the literal string `@session_comment.md` as the comment.
+`--raw-field` would post the literal string `@session_comment.md` as the
+comment; only `--field` reads the value from a file.
 
 Keep the accumulating body under 65000 chars (the GitHub limit is 65536,
 and a PATCH over it fails outright): if the diff in the implement block

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1296,7 +1296,7 @@ jobs:
             id `$SESSION_COMMENT_ID` on the issue is yours, so edit it in place
             at every stage (`gh api --method PATCH
             /repos/${{ github.repository }}/issues/comments/$SESSION_COMMENT_ID
-            -f body=@file`) and never create a second comment. It is public and
+            -F body=@file`) and never create a second comment. It is public and
             not retractable (edit history stays visible), so it carries your
             stage reports only -- never raw command output, env, or credentials.
             End by appending your summary to it and reporting the branch name.

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1366,6 +1366,41 @@ jobs:
             done
           done <<< "$SECRETS"
 
+      # The prompt cannot guarantee the pipeline actually updated its session
+      # comment -- an earlier run left the issue with nothing but the "Starting"
+      # placeholder. Backfill only when the comment carries no
+      # `<!-- agent:session -->` marker (never written, or written wrong): a
+      # partially filled comment is the pipeline's and is left alone. Runs after
+      # redaction because result.result is agent free text going to a public
+      # issue.
+      - name: Backfill session comment
+        if: always() && steps.redact.outcome == 'success' && steps.ai-fix.outputs.execution_file
+        uses: actions/github-script@v9
+        env:
+          SESSION_COMMENT_ID: ${{ steps.start-comment.outputs.comment_id }}
+        with:
+          github-token: ${{ secrets.MERGE_TOKEN }}
+          script: |
+            const id = Number(process.env.SESSION_COMMENT_ID);
+            if (!id) return;
+            const current = await github.rest.issues.getComment({
+              owner: context.repo.owner, repo: context.repo.repo, comment_id: id
+            });
+            if ((current.data.body || '').includes('<!-- agent:session -->')) return;
+            const fs = require('fs');
+            const file = '${{ steps.ai-fix.outputs.execution_file }}';
+            if (!fs.existsSync(file)) return;
+            const result = JSON.parse(fs.readFileSync(file, 'utf8'))
+              .filter(e => e.type === 'result').pop();
+            if (!result || result.is_error || !result.result) return;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const footer = `\n\n---\n_The [\`fix\` job](${runUrl}) did not update this comment itself, so this is the agent's closing summary only._`;
+            let body = `<!-- agent:session -->\n\n${result.result}${footer}`;
+            if (body.length > 65000) body = body.slice(0, 64800 - footer.length) + `\n\n_(truncated -- full output in the job artifacts)_` + footer;
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner, repo: context.repo.repo, comment_id: id, body
+            });
+
       - name: "Verify: AI fix succeeded"
         if: always()
         uses: actions/github-script@v9


### PR DESCRIPTION
Two follow-ups to #5161, which made the `fix` pipeline the sole owner of its issue comment.

### 1. Wrong `gh api` flag (the comment body became a literal `@filename`)

`-f/--raw-field` does **not** interpret a leading `@` as a filename -- only `-F/--field` does. So the PATCH posted the string `@session_comment.md` as the comment body. First run on the new path shows it: https://github.com/intel/torch-xpu-ops/issues/5126#issuecomment-5489603018

Verified with the real binary, using the markdown API as an echo:

```console
$ printf 'hello **world**' > t.md
$ gh api -X POST /markdown -f text=@t.md
<p>@t.md</p>
$ gh api -X POST /markdown -F text=@t.md
<p>hello <strong>world</strong></p>
```

The read half of the recipe was already correct (`--jq .body` prints the raw string).

### 2. Nothing enforced that the comment gets written at all

The prompt asks the pipeline to update the comment; nothing checks that it did. #5079 posted no stage reports at all, and the flag bug above wrote garbage -- both leave the issue showing only `Starting automated fix on this issue`, with the run's outcome reachable only from the job log.

New `Backfill session comment` step: after the agent exits, if the comment carries no `<!-- agent:session -->` marker, overwrite it with the agent's closing summary (`result.result` -- the text the deleted `Post result comment` step used to post).

- The marker is the first thing the pipeline writes, so a comment it filled even partially (triage only, then the job timed out) keeps its stage reports and is left alone.
- Still one comment per run: it edits the id the pipeline was given, never creates a second.
- Runs after `Redact secrets` for the same reason the old step did: `result.result` is agent free text going to a public issue.

Worst case now degrades to the pre-#5161 behaviour (one summary) instead of a bare placeholder.

### Test plan

```bash
# gate + body assembly + size clamp
node -e '
function backfill(bodyNow, resultText){
  if ((bodyNow || "").includes("<!-- agent:session -->")) return null;
  const footer = "\n\n---\n_footer_";
  let body = "<!-- agent:session -->\n\n" + resultText + footer;
  if (body.length > 65000) body = body.slice(0, 64800 - footer.length) + "\n\n_(truncated)_" + footer;
  return body;
}
console.log(backfill("Starting automated fix on this issue.", "S") !== null);  // true
console.log(backfill("@session_comment.md", "S") !== null);                    // true
console.log(backfill("<!-- agent:session -->\n<!-- agent:triage -->", "S"));   // null
console.log(backfill("placeholder", "S".repeat(200000)).length <= 65536);      // true
'

# step order
python3 -c "
import yaml
names = [s.get('name') for s in yaml.safe_load(open('.github/workflows/bot.yml'))['jobs']['fix']['steps']]
assert names.index('Backfill session comment') > names.index('Redact secrets from agent artifacts')
"

lintrunner -m origin/main
```

The `@torchxpubot fix` run in flight on #5126 keeps the old prompt, so its comment stays broken; re-run it after this lands.

Authored with the assistance of an AI coding agent (opencode).
