### PR TITLE
Remove now passing test_linalg cases from skip_list_common.py

### DIFF
--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -138,12 +138,6 @@ skip_dict = {
         "test_compile_dyn_quant_matmul_4bit_m_32_k_64_n_4096_xpu",
         "_tunableop_",
         "_tuning_tunableop_",
-        # BMG hang (>10 min) taking down the xdist worker
-        # https://github.com/intel/torch-xpu-ops/issues/4947
-        "test_lobpcg_ortho_xpu_float64",
-        "test_pca_lowrank_xpu",
-        "test_svd_lowrank_xpu_complex128",
-        "test_svd_lowrank_xpu_float64",
     ),
     "test_masked_xpu.py": None,
     "test_maskedtensor_xpu.py": None,


### PR DESCRIPTION
Issue: https://github.com/intel/torch-xpu-ops/issues/4109
Cases:
**`test_linalg_xpu.py` — TestLinalgXPU**
- `test_lobpcg_ortho_xpu_float64`
- `test_pca_lowrank_xpu`
- `test_svd_lowrank_xpu_complex128`
- `test_svd_lowrank_xpu_float64`

Now PASS due to changes to XPU kernels and XPU -> CPU fallback changes. More info in the linked task comment.