### PR TITLE
[1/N] Add experimental skill ut-refactor-review

### DIFF
--- a/.claude/skills/ut-refactor-review/SKILL.md
+++ b/.claude/skills/ut-refactor-review/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: ut-refactor-review
+description: Review PyTorch upstream unit-test (UT) PRs that enable Intel GPU (XPU) on existing tests. Use when reviewing PRs under test/ that port device-generic tests to XPU, add allow_xpu=True, generalize CUDA-hardcoded tests, or add XPU skips/xfails/tolerance overrides in OpInfo.
+---
+
+# XPU UT Refactor Review Skill
+
+Review PyTorch (`pytorch/pytorch`) pull requests that **enable XPU on existing
+upstream unit tests**. These PRs almost never add new operator logic; they make
+existing tests device-agnostic and opt XPU into them. The review must focus on
+what CI cannot check: whether the generalization preserves the original test
+intent, whether device gating is precise, and whether every skip/xfail is
+justified and traceable.
+
+## Scope: when this skill applies
+
+Use this skill (instead of the generic [`pr-review`](https://github.com/pytorch/pytorch/blob/main/.claude/skills/pr-review/SKILL.md)
+skill in `pytorch/pytorch`) when the diff is predominantly:
+- `test/**` changes that swap CUDA-hardcoded constructs for device-generic ones
+- `instantiate_device_type_tests(..., allow_xpu=True)` additions
+- `onlyAccelerator` / `onlyNativeDeviceTypesAnd([...])` decorator migrations
+- XPU entries in OpInfo (`common_methods_invocations.py`, `opinfo/definitions/*`):
+  `DecorateInfo(... device_type='xpu' ...)`, `toleranceOverride`, skips, xfails
+- New `TestXxxDevice` classes split out from a device-agnostic `TestXxx`
+
+If the PR also changes operator kernels or `native_functions.yaml`, hand those
+files to the [`pr-review`](https://github.com/pytorch/pytorch/blob/main/.claude/skills/pr-review/SKILL.md)
+skill and apply this skill only to the test files.
+
+## Usage Modes
+
+### No Argument
+
+If invoked with no arguments, **do not review**. Ask:
+
+> What would you like me to review?
+> - A PR number or URL (e.g., `159118` or the full PR URL)
+> - A local branch
+
+### PR Mode
+
+```
+/ut-refactor-review 159118
+/ut-refactor-review https://github.com/pytorch/pytorch/pull/159118
+/ut-refactor-review 159118 detailed
+```
+
+Obtain the PR title, description, diff, changed-file list, and existing review
+comments before reviewing. If the command does not name a repo, default to
+fetching the PR from `pytorch/pytorch`.
+
+Suggested fetch commands (CLI environments with `gh`):
+
+    gh pr view <PR_NUMBER> --repo pytorch/pytorch --json title,body,author,baseRefName,headRefName,files,additions,deletions,commits
+    gh pr diff <PR_NUMBER> --repo pytorch/pytorch
+    gh pr view <PR_NUMBER> --repo pytorch/pytorch --json comments,reviews
+
+### Local Branch Mode
+
+```
+/ut-refactor-review branch
+/ut-refactor-review branch detailed
+```
+
+Review the current branch's changes relative to `main` (diff, commit log, and
+changed-file list). Use the branch name in the review header instead of a PR
+number.
+
+## Review Philosophy
+
+Go through **every changed line** against
+[references/xpu-ut-review-checklist.md](references/xpu-ut-review-checklist.md).
+For anything this skill does not address, defer to the
+[`pr-review`](https://github.com/pytorch/pytorch/blob/main/.claude/skills/pr-review/SKILL.md)
+skill in `pytorch/pytorch`.
+
+## Files to Reference
+
+- [references/xpu-ut-review-checklist.md](references/xpu-ut-review-checklist.md) — the line-by-line checklist
+- `torch/testing/_internal/common_device_type.py` — `instantiate_device_type_tests`, `onlyAccelerator`, `allow_xpu`, `only_for`
+- `torch/testing/_internal/common_utils.py` — `TEST_XPU`, `TEST_CUDA`, `TEST_HPU`, `xfailIf`, `HardwareClassification`
+- `torch/testing/_internal/common_methods_invocations.py`, `torch/testing/_internal/opinfo/definitions/*` — OpInfo `DecorateInfo`, `toleranceOverride`

--- a/.claude/skills/ut-refactor-review/references/xpu-ut-review-checklist.md
+++ b/.claude/skills/ut-refactor-review/references/xpu-ut-review-checklist.md
@@ -1,0 +1,32 @@
+# XPU UT Refactor Review Checklist
+
+Evaluate every changed line against these patterns. Each row gives a code
+pattern to look for, what it means (the defect and the correct form), and a
+severity. Severities follow this scale:
+
+- **Blocker** — XPU gets wrong or zero test execution (the test never
+  instantiates, runs on the wrong device, silently runs the wrong dtype/skip
+  gating, risks an unguarded OOM/crash), or the change breaks another backend.
+  Must fix before merge.
+- **Major** — coverage or scope is silently wrong (a dropped/weakened assertion
+  or case, a mismatched or missing skip/xfail, a behavior-changing "refactor").
+  Fix before merge.
+- **Minor** — tuning- or convention-level issue (tolerance, over-broad skip
+  scope, naming/classification mismatch, stale skip). Fix or justify.
+- **Info** — no direct action required; guidance, or a pattern with no XPU
+  equivalent. Note and move on.
+
+Rows are grouped by area and roughly ordered by how often they surfaced as real
+review comments across the studied PRs.
+
+This checklist focuses on the XPU-specific and distributed concerns of a test
+refactor. Generic test-refactoring checks (classification, naming, API
+replacement, `HardwareClassification` tagging, instantiation mechanism) are out
+of scope here.
+
+## 1. Device gating precision (blanket-skip anti-pattern)
+
+| Code Pattern | What It Means | Severity |
+| --- | --- | --- |
+| `if device_type == "xpu": self.skipTest(...)` inside a test the PR enables on XPU | May be an over-skip: disables the whole XPU test to dodge one CUDA-specific check, hiding the real predicate. If so, gate only that check on its true condition and name the device to keep the rest of coverage for XPU. A genuinely CUDA-only test not being enabled on XPU should keep its CUDA scoping untouched, not gain an XPU skip. | Major |
+| `@unittest.skipIf(not SM70OrLater, ...)` (device-agnostic arch gate) | A CUDA arch check left device-agnostic wrongly skips XPU and every non-CUDA device. Scope it: `@skipCUDAIf(not SM70OrLater, ...)`. Gate the XPU side on its own capability constant (`PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU`, an `Xe*OrLater`-style flag), not the CUDA `SM*` predicate. | Blocker |

--- a/.claude/skills/ut-refactor-review/references/xpu-ut-review-checklist.md
+++ b/.claude/skills/ut-refactor-review/references/xpu-ut-review-checklist.md
@@ -29,4 +29,4 @@ of scope here.
 | Code Pattern | What It Means | Severity |
 | --- | --- | --- |
 | `if device_type == "xpu": self.skipTest(...)` inside a test the PR enables on XPU | May be an over-skip: disables the whole XPU test to dodge one CUDA-specific check, hiding the real predicate. Human review required. | Info |
-| `@unittest.skipIf(not SM70OrLater, ...)` | Decorators like @unittest.skipIf(not SM70OrLater, ...) used in non-CUDA specific test files will erroneously skip XPU and other active devices. Replace generic decorators with a conditional check like @skipCUDAIf(not SM70OrLater, ...) | Blocker |
+| `@unittest.skipIf(not SM70OrLater, ...)` | Decorators like `@unittest.skipIf(not SM70OrLater, ...)` used in non-CUDA specific test classes will erroneously skip XPU and other active devices. | Blocker |

--- a/.claude/skills/ut-refactor-review/references/xpu-ut-review-checklist.md
+++ b/.claude/skills/ut-refactor-review/references/xpu-ut-review-checklist.md
@@ -29,4 +29,4 @@ of scope here.
 | Code Pattern | What It Means | Severity |
 | --- | --- | --- |
 | `if device_type == "xpu": self.skipTest(...)` inside a test the PR enables on XPU | May be an over-skip: disables the whole XPU test to dodge one CUDA-specific check, hiding the real predicate. Human review required. | Info |
-| `@unittest.skipIf(not SM70OrLater, ...)` | A CUDA arch check left device-agnostic wrongly skips XPU and every non-CUDA device. Scope: `@skipCUDAIf(not SM70OrLater, ...)`. Gate the XPU side on its own capability constant (`PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU`, an `Xe*OrLater`-style flag), not the CUDA `SM*` predicate. Only applied to non CUDA specific test cases. | Blocker |
+| `@unittest.skipIf(not SM70OrLater, ...)` | Decorators like @unittest.skipIf(not SM70OrLater, ...) used in non-CUDA specific test files will erroneously skip XPU and other active devices. Replace generic decorators with a conditional check like @skipCUDAIf(not SM70OrLater, ...) | Blocker |

--- a/.claude/skills/ut-refactor-review/references/xpu-ut-review-checklist.md
+++ b/.claude/skills/ut-refactor-review/references/xpu-ut-review-checklist.md
@@ -28,5 +28,5 @@ of scope here.
 
 | Code Pattern | What It Means | Severity |
 | --- | --- | --- |
-| `if device_type == "xpu": self.skipTest(...)` inside a test the PR enables on XPU | May be an over-skip: disables the whole XPU test to dodge one CUDA-specific check, hiding the real predicate. If so, gate only that check on its true condition and name the device to keep the rest of coverage for XPU. A genuinely CUDA-only test not being enabled on XPU should keep its CUDA scoping untouched, not gain an XPU skip. | Major |
+| `if device_type == "xpu": self.skipTest(...)` inside a test the PR enables on XPU | May be an over-skip: disables the whole XPU test to dodge one CUDA-specific check, hiding the real predicate. Human review required. | Info |
 | `@unittest.skipIf(not SM70OrLater, ...)` (device-agnostic arch gate) | A CUDA arch check left device-agnostic wrongly skips XPU and every non-CUDA device. Scope it: `@skipCUDAIf(not SM70OrLater, ...)`. Gate the XPU side on its own capability constant (`PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU`, an `Xe*OrLater`-style flag), not the CUDA `SM*` predicate. | Blocker |

--- a/.claude/skills/ut-refactor-review/references/xpu-ut-review-checklist.md
+++ b/.claude/skills/ut-refactor-review/references/xpu-ut-review-checklist.md
@@ -29,4 +29,4 @@ of scope here.
 | Code Pattern | What It Means | Severity |
 | --- | --- | --- |
 | `if device_type == "xpu": self.skipTest(...)` inside a test the PR enables on XPU | May be an over-skip: disables the whole XPU test to dodge one CUDA-specific check, hiding the real predicate. Human review required. | Info |
-| `@unittest.skipIf(not SM70OrLater, ...)` (device-agnostic arch gate) | A CUDA arch check left device-agnostic wrongly skips XPU and every non-CUDA device. Scope it: `@skipCUDAIf(not SM70OrLater, ...)`. Gate the XPU side on its own capability constant (`PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU`, an `Xe*OrLater`-style flag), not the CUDA `SM*` predicate. | Blocker |
+| `@unittest.skipIf(not SM70OrLater, ...)` | A CUDA arch check left device-agnostic wrongly skips XPU and every non-CUDA device. Scope: `@skipCUDAIf(not SM70OrLater, ...)`. Gate the XPU side on its own capability constant (`PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU`, an `Xe*OrLater`-style flag), not the CUDA `SM*` predicate. Only applied to non CUDA specific test cases. | Blocker |


### PR DESCRIPTION
This PR introduces a new skill for reviewing PyTorch upstream unit-test (UT) pull requests that enable Intel GPU (XPU) on existing tests. It also adds a comprehensive checklist to guide reviewers in ensuring correctness and coverage when porting tests to XPU. 

**Key additions:**

**1. New Skill Documentation and Workflow**
- Adds `.claude/skills/ut-refactor-review/SKILL.md`, which defines the "ut-refactor-review" skill. This document details when and how to use the skill and the review philosophy.

**2. Comprehensive XPU UT Review Checklist**
- Introduces `.claude/skills/ut-refactor-review/references/xpu-ut-review-checklist.md`, a detailed checklist for reviewers.