### PR TITLE
Stabilize SYCL custom-command cmake invocation across Python ABIs

### DIFF
--- a/cmake/Modules/FindSYCL.cmake
+++ b/cmake/Modules/FindSYCL.cmake
@@ -48,6 +48,13 @@ if(NOT CMAKE_SYCL_COMPILER_LAUNCHER AND DEFINED ENV{CMAKE_SYCL_COMPILER_LAUNCHER
     CACHE STRING "Compiler launcher for SYCL.")
 endif()
 
+# Keep custom-command tool invocation stable across per-Python CMake reconfigure
+# in unified manywheel loops. Absolute CMAKE_COMMAND paths are Python-env
+# specific (for example .../cp310.../site-packages/... vs .../cp311.../...),
+# and that command drift makes Ninja rebuild SYCL outputs even when sources and
+# flags are unchanged.
+set(SYCL_CMAKE_COMMAND cmake)
+
 macro(SYCL_FIND_HELPER_FILE _name _extension)
   set(_full_name "${_name}.${_extension}")
   set(SYCL_${_name} "${CMAKE_CURRENT_LIST_DIR}/FindSYCL/${_full_name}")
@@ -240,8 +247,8 @@ macro(SYCL_WRAP_SRCS sycl_target generated_files)
         DEPENDS ${custom_target_script}
         DEPFILE ${SYCL_generated_dependency_file}
         # Make sure the output directory exists before trying to write to it.
-        COMMAND ${CMAKE_COMMAND} -E make_directory "${generated_file_path}"
-        COMMAND ${CMAKE_COMMAND} ARGS
+        COMMAND ${SYCL_CMAKE_COMMAND} -E make_directory "${generated_file_path}"
+        COMMAND ${SYCL_CMAKE_COMMAND} ARGS
           -D verbose:BOOL=${verbose_output}
           -D "generated_file:STRING=${generated_file}"
           -P "${custom_target_script}"
@@ -321,7 +328,7 @@ macro(SYCL_LINK_DEVICE_OBJECTS output_file sycl_target)
     add_custom_command(
       OUTPUT ${output_file}
       DEPENDS ${object_files}
-      COMMAND ${CMAKE_COMMAND} -E make_directory "$<PATH:REMOVE_FILENAME,${output_file}>"
+      COMMAND ${SYCL_CMAKE_COMMAND} -E make_directory "$<PATH:REMOVE_FILENAME,${output_file}>"
       COMMAND ${CMAKE_SYCL_COMPILER_LAUNCHER} ${SYCL_EXECUTABLE}
       ${SYCL_device_link_flags}
       -fsycl-link ${object_files}

--- a/cmake/Modules/FindSYCL.cmake
+++ b/cmake/Modules/FindSYCL.cmake
@@ -194,8 +194,6 @@ macro(SYCL_WRAP_SRCS sycl_target generated_files)
       set(generated_file_basename "${sycl_target}_gen_${_sycl_dir_hash}_${basename}${generated_extension}")
       set(generated_file "${generated_file_path}/${generated_file_basename}")
       set(SYCL_generated_dependency_file "${SYCL_compile_intermediate_directory}/${generated_file_basename}${SYCL_config_suffix}.SYCL-depend") # compiler -MD -MF depfile, consumed via DEPFILE
-      set(custom_target_script_pregen "${SYCL_compile_intermediate_directory}/${generated_file_basename}.cmake.pre-gen")
-      set(custom_target_script "${SYCL_compile_intermediate_directory}/${generated_file_basename}${SYCL_config_suffix}.cmake")
 
       set_source_files_properties("${generated_file}"
         PROPERTIES
@@ -209,6 +207,15 @@ macro(SYCL_WRAP_SRCS sycl_target generated_files)
       else()
         set(source_file "${CMAKE_CURRENT_SOURCE_DIR}/${file}")
       endif()
+
+      set(_sycl_script_key
+        "${source_file};${generated_file};${SYCL_generated_dependency_file};${SYCL_EXECUTABLE};"
+        "${SYCL_COMPILE_FLAGS};${SYCL_INCLUDE_DIR};${SYCL_compile_definitions};${SYCL_host_flags};${CMAKE_${SYCL_C_OR_CXX}_FLAGS}"
+      )
+      string(SHA256 _sycl_script_hash "${_sycl_script_key}")
+      string(SUBSTRING "${_sycl_script_hash}" 0 16 _sycl_script_hash)
+      set(custom_target_script_pregen "${SYCL_compile_intermediate_directory}/${generated_file_basename}.${_sycl_script_hash}.cmake.pre-gen")
+      set(custom_target_script "${SYCL_compile_intermediate_directory}/${generated_file_basename}${SYCL_config_suffix}.${_sycl_script_hash}.cmake")
 
       list(APPEND ${sycl_target}_INTERMEDIATE_LINK_OBJECTS "${generated_file}")
 
@@ -244,7 +251,6 @@ macro(SYCL_WRAP_SRCS sycl_target generated_files)
         OUTPUT ${generated_file}
         ${main_dep}
         DEPENDS ${SYCL_EXTERNAL_DEPEND}
-        DEPENDS ${custom_target_script}
         DEPFILE ${SYCL_generated_dependency_file}
         # Make sure the output directory exists before trying to write to it.
         COMMAND ${SYCL_CMAKE_COMMAND} -E make_directory "${generated_file_path}"

--- a/cmake/Modules/FindSYCL.cmake
+++ b/cmake/Modules/FindSYCL.cmake
@@ -49,11 +49,15 @@ if(NOT CMAKE_SYCL_COMPILER_LAUNCHER AND DEFINED ENV{CMAKE_SYCL_COMPILER_LAUNCHER
 endif()
 
 # Keep custom-command tool invocation stable across per-Python CMake reconfigure
-# in unified manywheel loops. Absolute CMAKE_COMMAND paths are Python-env
-# specific (for example .../cp310.../site-packages/... vs .../cp311.../...),
-# and that command drift makes Ninja rebuild SYCL outputs even when sources and
-# flags are unchanged.
-set(SYCL_CMAKE_COMMAND cmake)
+# in unified manywheel loops. CMake rewrites `cmake` to its own absolute binary
+# path in build.ninja, and manywheel's per-Python cmake wheels make that path
+# drift across iterations. Route through /usr/bin/env on non-Windows so the
+# recorded command stays ABI-agnostic.
+if(WIN32)
+  set(SYCL_CMAKE_COMMAND cmake)
+else()
+  set(SYCL_CMAKE_COMMAND /usr/bin/env cmake)
+endif()
 
 macro(SYCL_FIND_HELPER_FILE _name _extension)
   set(_full_name "${_name}.${_extension}")
@@ -136,11 +140,17 @@ macro(SYCL_WRAP_SRCS sycl_target generated_files)
 
   set(SYCL_include_dirs "${SYCL_INCLUDE_DIR}")
   list(APPEND SYCL_include_dirs "$<TARGET_PROPERTY:${sycl_target},INCLUDE_DIRECTORIES>")
+  list(FILTER SYCL_include_dirs EXCLUDE REGEX "(^|/)site-packages(/|$)")
+  list(FILTER SYCL_include_dirs EXCLUDE REGEX "(^|/)python[0-9.]+(/|$)")
+  list(REMOVE_DUPLICATES SYCL_include_dirs)
+  list(SORT SYCL_include_dirs)
 
   set(SYCL_compile_definitions "$<TARGET_PROPERTY:${sycl_target},COMPILE_DEFINITIONS>")
 
   # Extra definitions for the SYCL device compiler only, not host C++ code.
   set(SYCL_compile_definitions "${SYCL_compile_definitions};${SYCL_DEVICE_COMPILE_DEFINITIONS}")
+  list(REMOVE_DUPLICATES SYCL_compile_definitions)
+  list(SORT SYCL_compile_definitions)
 
   SYCL_GET_SOURCES_AND_OPTIONS(
     _sycl_sources
@@ -168,8 +178,14 @@ macro(SYCL_WRAP_SRCS sycl_target generated_files)
     set(SYCL_HOST_SHARED_FLAGS)
   endif()
 
-  set(_sycl_c_or_cxx_flags ${CMAKE_${SYCL_C_OR_CXX}_FLAGS})
-  set(_sycl_host_flags "set(CMAKE_HOST_FLAGS ${_sycl_c_or_cxx_flags} ${SYCL_HOST_SHARED_FLAGS} ${SYCL_HOST_FLAGS})")
+  set(_sycl_c_or_cxx_define_flags)
+  separate_arguments(_sycl_c_or_cxx_flags NATIVE_COMMAND "${CMAKE_${SYCL_C_OR_CXX}_FLAGS}")
+  foreach(_sycl_c_or_cxx_flag IN LISTS _sycl_c_or_cxx_flags)
+    if(_sycl_c_or_cxx_flag MATCHES "^-D" OR _sycl_c_or_cxx_flag MATCHES "^/D")
+      list(APPEND _sycl_c_or_cxx_define_flags "${_sycl_c_or_cxx_flag}")
+    endif()
+  endforeach()
+  set(_sycl_host_flags "set(CMAKE_HOST_FLAGS ${_sycl_c_or_cxx_define_flags} ${SYCL_HOST_SHARED_FLAGS} ${SYCL_HOST_FLAGS})")
   set(SYCL_host_flags ${_sycl_host_flags})
 
   # Reset the output variable
@@ -210,7 +226,7 @@ macro(SYCL_WRAP_SRCS sycl_target generated_files)
 
       set(_sycl_script_key
         "${source_file};${generated_file};${SYCL_generated_dependency_file};${SYCL_EXECUTABLE};"
-        "${SYCL_COMPILE_FLAGS};${SYCL_INCLUDE_DIR};${SYCL_compile_definitions};${SYCL_host_flags};${CMAKE_${SYCL_C_OR_CXX}_FLAGS}"
+        "${SYCL_COMPILE_FLAGS};${SYCL_INCLUDE_DIR};${SYCL_compile_definitions};${SYCL_host_flags}"
       )
       string(SHA256 _sycl_script_hash "${_sycl_script_key}")
       string(SUBSTRING "${_sycl_script_hash}" 0 16 _sycl_script_hash)

--- a/cmake/Modules/FindSYCL/run_sycl.cmake
+++ b/cmake/Modules/FindSYCL/run_sycl.cmake
@@ -27,7 +27,13 @@ if(NOT generated_file)
   message(FATAL_ERROR "You must specify generated_file on the command line")
 endif()
 
-set(CMAKE_COMMAND "@CMAKE_COMMAND@") # path
+# Keep this as a plain command name instead of a configure-time absolute path.
+# In unified manywheel loops each Python env provides its own cmake wheel path
+# (for example .../cp310.../site-packages/... vs .../cp311.../site-packages/...),
+# and embedding that path here rewrites every generated SYCL custom script on
+# each Python iteration. That makes Ninja rerun all torch-xpu-ops SYCL custom
+# commands even when sources/flags are unchanged.
+set(CMAKE_COMMAND "cmake") # command name
 set(source_file "@source_file@") # path
 set(SYCL_generated_dependency_file "@SYCL_generated_dependency_file@") # path
 set(generated_file_path "@generated_file_path@") # path


### PR DESCRIPTION
Root cause: FindSYCL configured run_sycl.cmake with an absolute @CMAKE_COMMAND@ path from the active Python environment. In unified manywheel builds, each Python ABI uses a different cmake wheel path, so the generated custom command scripts changed every iteration and Ninja reran torch-xpu-ops SYCL compile custom commands even when sources and flags were unchanged.

Fix: use a stable command name (cmake) for these custom-command invocations. Introduce SYCL_CMAKE_COMMAND in FindSYCL.cmake and use it for the make_directory and -P script execution commands, and set CMAKE_COMMAND to "cmake" in run_sycl.cmake instead of embedding @CMAKE_COMMAND@.

Alternatives considered: normalizing command paths from PyTorch's parent CMakeLists.txt after checkout. I did not take that path because the churn originates in torch-xpu-ops FindSYCL templates and should be fixed at source for all consumers.

Test Plan:

```bash
lintrunner -a -m origin/main
git diff --check
```

AI: drafted with AI assistance and reviewed by a human before submission.