### PR TITLE
[sycl-free-function] multi tensor apply related kernels

### DIFF
--- a/src/ATen/native/xpu/sycl/ForeachReduceKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ForeachReduceKernels.cpp
@@ -22,7 +22,8 @@
 
 namespace at::native::xpu {
 
-// WR (replace enum class) due to https://jira.devtools.intel.com/browse/CMPLRLLVM-72438
+// WR (replace enum class) due to
+// https://jira.devtools.intel.com/browse/CMPLRLLVM-72438
 const int NormType_L1 = 0;
 const int NormType_L2 = 1;
 const int NormType_LInf = 2;
@@ -39,7 +40,8 @@ template <
     int r_args_depth = 1,
     int res_arg_index = 0>
 struct LpNormFunctor {
-  template <typename TLA, typename TLW> void operator()(
+  template <typename TLA, typename TLW>
+  void operator()(
       const int64_t chunk_size,
       TLA tlAddress,
       TLW tlWGMeta,
@@ -72,9 +74,9 @@ struct LpNormFunctor {
 #pragma unroll
         for (int ii = 0; ii < kILP; ii++) {
           opmath_t next = static_cast<opmath_t>(r_x[ii]);
-          if constexpr (norm_type == NormType::LInf) {
+          if constexpr (norm_type == NormType_LInf) {
             vals[ii] = max_impl(vals[ii], sycl::fabs((opmath_t)next));
-          } else if constexpr (norm_type == NormType::L1) {
+          } else if constexpr (norm_type == NormType_L1) {
             vals[ii] += static_cast<opmath_t>(sycl::fabs((opmath_t)next));
           } else {
             vals[ii] += static_cast<opmath_t>(next * next);
@@ -89,10 +91,10 @@ struct LpNormFunctor {
           int i = i_start + item_idx + ii * item_range;
           if (i < n && i < chunk_size) {
             opmath_t next = static_cast<opmath_t>(x[i]);
-            if constexpr (norm_type == NormType::LInf) {
+            if constexpr (norm_type == NormType_LInf) {
               vals[ii] =
                   max_impl(vals[ii], sycl::fabs(sycl::fabs((opmath_t)next)));
-            } else if constexpr (norm_type == NormType::L1) {
+            } else if constexpr (norm_type == NormType_L1) {
               vals[ii] += static_cast<opmath_t>(sycl::fabs((opmath_t)next));
             } else {
               vals[ii] += static_cast<opmath_t>(next * next);
@@ -111,14 +113,14 @@ struct LpNormFunctor {
       }
     }
 
-    opmath_t sum_val;
-    if constexpr (norm_type == NormType::L1 || norm_type == NormType::L2) {
-      sum_val =
-          GroupReduceSumWithoutBroadcast<opmath_t, SIMD>(item_id, val, shared_);
-    } else {
-      sum_val =
-          GroupReduceMaxWithoutBroadcast<opmath_t, SIMD>(item_id, val, shared_);
-    }
+    constexpr int slm_size = get_group_reduce_group_size(SIMD);
+    syclexp::work_group_static<opmath_t[slm_size]> shared_;
+
+    auto sum_val = norm_type == NormType_L1 || norm_type == NormType_L2
+        ? GroupReduceSumWithoutBroadcast_StaticSlm<opmath_t, SIMD, slm_size>(
+              item_id, val, shared_)
+        : GroupReduceMaxWithoutBroadcast_StaticSlm<opmath_t, SIMD, slm_size>(
+              item_id, val, shared_);
 
     if (item_idx == 0) {
       output_per_tensor[tensor_loc * max_chunks_per_tensor + chunk_idx] =
@@ -129,40 +131,39 @@ struct LpNormFunctor {
 
 template <typename out_t, int norm_type, typename opmath_t, int SIMD, bool apply_root = true>
 struct lpnormChunkReduceKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
-SYCL_REQD_SUB_GROUP_SIZE(SIMD)
-void operator()(
-    sycl::nd_item<1> item_id) const {
-  auto lid = item_id.get_local_linear_id();
-  auto group_id = item_id.get_group(0);
+  SYCL_REQD_SUB_GROUP_SIZE(SIMD)
+  void operator()(sycl::nd_item<1> item_id) const {
+    auto lid = item_id.get_local_linear_id();
+    auto group_id = item_id.get_group(0);
 
-  const opmath_t* output_this_tensor =
-      output_per_tensor_ + group_id * max_chunks_per_tensor_;
-  opmath_t val = 0;
-  for (int i = lid; i < max_chunks_per_tensor_; i += wg_size_) {
-    if constexpr (norm_type == NormType_LInf) {
-      val = max_impl(val, output_this_tensor[i]);
+    const opmath_t* output_this_tensor =
+        output_per_tensor_ + group_id * max_chunks_per_tensor_;
+    opmath_t val = 0;
+    for (int i = lid; i < max_chunks_per_tensor_; i += wg_size_) {
+      if constexpr (norm_type == NormType_LInf) {
+        val = max_impl(val, output_this_tensor[i]);
+      } else {
+        val += output_this_tensor[i];
+      }
+    }
+    opmath_t sum_val;
+    if constexpr (norm_type == NormType_L1 || norm_type == NormType_L2) {
+      sum_val =
+          GroupReduceSumWithoutBroadcast<opmath_t, SIMD>(item_id, val, shared_);
     } else {
-      val += output_this_tensor[i];
+      sum_val =
+          GroupReduceMaxWithoutBroadcast<opmath_t, SIMD>(item_id, val, shared_);
+    }
+    if (lid == 0) {
+      // L2 norm applies the final sqrt; powsum (apply_root == false) keeps the
+      // raw sum of squares. L1 and LInf never apply a root.
+      if constexpr (norm_type == NormType::L2 && apply_root) {
+        *(ret_per_tensor_[group_id]) = sycl::sqrt((opmath_t)sum_val);
+      } else {
+        *(ret_per_tensor_[group_id]) = sum_val;
+      }
     }
   }
-  opmath_t sum_val;
-  if constexpr (norm_type == NormType_L1 || norm_type == NormType_L2) {
-    sum_val =
-        GroupReduceSumWithoutBroadcast<opmath_t, SIMD>(item_id, val, shared_);
-  } else {
-    sum_val =
-        GroupReduceMaxWithoutBroadcast<opmath_t, SIMD>(item_id, val, shared_);
-  }
-  if (lid == 0) {
-    // L2 norm applies the final sqrt; powsum (apply_root == false) keeps the
-    // raw sum of squares. L1 and LInf never apply a root.
-    if constexpr (norm_type == NormType::L2 && apply_root) {
-      *(ret_per_tensor_[group_id]) = sycl::sqrt((opmath_t)sum_val);
-    } else {
-      *(ret_per_tensor_[group_id]) = sum_val;
-    }
-  }
-}
 
 lpnormChunkReduceKernelFunctor(
     const opmath_t* output_per_tensor,
@@ -532,7 +533,8 @@ std::vector<Tensor> foreach_powsum_kernel(
 
 template <typename T, int SIMD>
 struct LpMaxFunctor {
-  template <typename TLA, typename TLW> void operator()(
+  template <typename TLA, typename TLW>
+  void operator()(
       int64_t chunk_size,
       TLA tlAddressMeta,
       TLW tlWGMeta,
@@ -588,8 +590,8 @@ struct LpMaxFunctor {
     for (int i = 0; i < kILP; i++) {
       val = max_impl(val, vals[i]);
     }
-    auto final_val =
-        GroupReduceMaxWithoutBroadcast_StaticSlm<T, SIMD, SIMD>(item, val, shared_);
+    auto final_val = GroupReduceMaxWithoutBroadcast_StaticSlm<T, SIMD, SIMD>(
+        item, val, shared_);
 
     if (item_id == 0) {
       output_per_tensor_ptr[tensor_loc * max_chunks_per_tensor + chunk_idx] =
@@ -601,8 +603,7 @@ struct LpMaxFunctor {
 template <typename T, int SIMD>
 struct LpmaxChunkReduceKernelFunctor {
   SYCL_REQD_SUB_GROUP_SIZE(SIMD)
-  void operator()(
-      sycl::nd_item<1> item_id) const {
+  void operator()(sycl::nd_item<1> item_id) const {
     auto local_range = item_id.get_local_range(0);
     auto lid = item_id.get_local_linear_id();
     auto group_id = item_id.get_group(0);
@@ -615,8 +616,8 @@ struct LpmaxChunkReduceKernelFunctor {
       val = max_impl(val, output_this_tensor[i]);
     }
     syclexp::work_group_static<T[SIMD]> shared_;
-    T final_value =
-        GroupReduceMaxWithoutBroadcast_StaticSlm<T, SIMD, SIMD>(item_id, val, shared_);
+    T final_value = GroupReduceMaxWithoutBroadcast_StaticSlm<T, SIMD, SIMD>(
+        item_id, val, shared_);
     if (lid == 0) {
       *(ret_per_tensor_[group_id]) = final_value;
     }

--- a/src/ATen/native/xpu/sycl/ForeachReduceKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ForeachReduceKernels.cpp
@@ -129,7 +129,12 @@ struct LpNormFunctor {
   }
 };
 
-template <typename out_t, int norm_type, typename opmath_t, int SIMD, bool apply_root = true>
+template <
+    typename out_t,
+    int norm_type,
+    typename opmath_t,
+    int SIMD,
+    bool apply_root = true>
 struct lpnormChunkReduceKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
   SYCL_REQD_SUB_GROUP_SIZE(SIMD)
   void operator()(sycl::nd_item<1> item_id) const {
@@ -157,7 +162,7 @@ struct lpnormChunkReduceKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
     if (lid == 0) {
       // L2 norm applies the final sqrt; powsum (apply_root == false) keeps the
       // raw sum of squares. L1 and LInf never apply a root.
-      if constexpr (norm_type == NormType::L2 && apply_root) {
+      if constexpr (norm_type == NormType_L2 && apply_root) {
         *(ret_per_tensor_[group_id]) = sycl::sqrt((opmath_t)sum_val);
       } else {
         *(ret_per_tensor_[group_id]) = sum_val;
@@ -165,25 +170,35 @@ struct lpnormChunkReduceKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
     }
   }
 
-lpnormChunkReduceKernelFunctor(
-    const opmath_t* output_per_tensor,
-    out_t** ret_per_tensor,
-    int max_chunks_per_tensor,
-    int wg_size)
-    : output_per_tensor_(output_per_tensor),
-      ret_per_tensor_(ret_per_tensor),
-      max_chunks_per_tensor_(max_chunks_per_tensor),
-      wg_size_(wg_size) {}
+  void sycl_ker_config_convention(sycl::handler& cgh) {
+    shared_ =
+        sycl_local_acc_t<opmath_t>(get_group_reduce_group_size(SIMD), cgh);
+  }
 
-private:
-const opmath_t* output_per_tensor_;
-out_t** ret_per_tensor_;
-int max_chunks_per_tensor_;
-int wg_size_;
-sycl_local_acc_t<opmath_t> shared_;
+  lpnormChunkReduceKernelFunctor(
+      const opmath_t* output_per_tensor,
+      out_t** ret_per_tensor,
+      int max_chunks_per_tensor,
+      int wg_size)
+      : output_per_tensor_(output_per_tensor),
+        ret_per_tensor_(ret_per_tensor),
+        max_chunks_per_tensor_(max_chunks_per_tensor),
+        wg_size_(wg_size) {}
+
+ private:
+  const opmath_t* output_per_tensor_;
+  out_t** ret_per_tensor_;
+  int max_chunks_per_tensor_;
+  int wg_size_;
+  sycl_local_acc_t<opmath_t> shared_;
 };
 
-template <typename out_t, int norm_type, typename out_opmath_t, int SIMD, bool apply_root = true>
+template <
+    typename out_t,
+    int norm_type,
+    typename out_opmath_t,
+    int SIMD,
+    bool apply_root = true>
 void launch_lpnorm_chunk_reduce_kernel(
     const out_opmath_t* output_per_tensor,
     out_t** ret_per_tensor,

--- a/src/ATen/native/xpu/sycl/ForeachReduceKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ForeachReduceKernels.cpp
@@ -22,21 +22,24 @@
 
 namespace at::native::xpu {
 
-enum class NormType { L1, L2, LInf };
+// WR (replace enum class) due to https://jira.devtools.intel.com/browse/CMPLRLLVM-72438
+const int NormType_L1 = 0;
+const int NormType_L2 = 1;
+const int NormType_LInf = 2;
+
 #define SIMD16 16
 #define SIMD32 32
 
 template <
     typename T,
-    NormType norm_type,
+    int norm_type,
     typename opmath_t,
     int SIMD,
     int depth = 1,
     int r_args_depth = 1,
     int res_arg_index = 0>
-struct LpNormFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
-  template <typename TLA, typename TLW>
-  void operator()(
+struct LpNormFunctor {
+  template <typename TLA, typename TLW> void operator()(
       const int64_t chunk_size,
       TLA tlAddress,
       TLW tlWGMeta,
@@ -101,7 +104,7 @@ struct LpNormFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
 
     auto val = opmath_t(0);
     for (int i = 0; i < kILP; i++) {
-      if constexpr (norm_type == NormType::LInf) {
+      if constexpr (norm_type == NormType_LInf) {
         val = max_impl(val, vals[i]);
       } else {
         val += vals[i];
@@ -122,83 +125,64 @@ struct LpNormFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
           sum_val;
     }
   }
-  void sycl_ker_config_convention(sycl::handler& cgh) {
-    shared_ =
-        sycl_local_acc_t<opmath_t>(get_group_reduce_group_size(SIMD), cgh);
-  }
-
- private:
-  sycl_local_acc_t<opmath_t> shared_;
 };
 
-template <
-    typename out_t,
-    NormType norm_type,
-    typename opmath_t,
-    int SIMD,
-    bool apply_root = true>
+template <typename out_t, int norm_type, typename opmath_t, int SIMD, bool apply_root = true>
 struct lpnormChunkReduceKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
-  SYCL_REQD_SUB_GROUP_SIZE(SIMD)
-  void operator()(sycl::nd_item<1> item_id) const {
-    auto lid = item_id.get_local_linear_id();
-    auto group_id = item_id.get_group(0);
+SYCL_REQD_SUB_GROUP_SIZE(SIMD)
+void operator()(
+    sycl::nd_item<1> item_id) const {
+  auto lid = item_id.get_local_linear_id();
+  auto group_id = item_id.get_group(0);
 
-    const opmath_t* output_this_tensor =
-        output_per_tensor_ + group_id * max_chunks_per_tensor_;
-    opmath_t val = 0;
-    for (int i = lid; i < max_chunks_per_tensor_; i += wg_size_) {
-      if constexpr (norm_type == NormType::LInf) {
-        val = max_impl(val, output_this_tensor[i]);
-      } else {
-        val += output_this_tensor[i];
-      }
-    }
-    opmath_t sum_val;
-    if constexpr (norm_type == NormType::L1 || norm_type == NormType::L2) {
-      sum_val =
-          GroupReduceSumWithoutBroadcast<opmath_t, SIMD>(item_id, val, shared_);
+  const opmath_t* output_this_tensor =
+      output_per_tensor_ + group_id * max_chunks_per_tensor_;
+  opmath_t val = 0;
+  for (int i = lid; i < max_chunks_per_tensor_; i += wg_size_) {
+    if constexpr (norm_type == NormType_LInf) {
+      val = max_impl(val, output_this_tensor[i]);
     } else {
-      sum_val =
-          GroupReduceMaxWithoutBroadcast<opmath_t, SIMD>(item_id, val, shared_);
-    }
-    if (lid == 0) {
-      // L2 norm applies the final sqrt; powsum (apply_root == false) keeps the
-      // raw sum of squares. L1 and LInf never apply a root.
-      if constexpr (norm_type == NormType::L2 && apply_root) {
-        *(ret_per_tensor_[group_id]) = sycl::sqrt((opmath_t)sum_val);
-      } else {
-        *(ret_per_tensor_[group_id]) = sum_val;
-      }
+      val += output_this_tensor[i];
     }
   }
-  void sycl_ker_config_convention(sycl::handler& cgh) {
-    shared_ =
-        sycl_local_acc_t<opmath_t>(get_group_reduce_group_size(SIMD), cgh);
+  opmath_t sum_val;
+  if constexpr (norm_type == NormType_L1 || norm_type == NormType_L2) {
+    sum_val =
+        GroupReduceSumWithoutBroadcast<opmath_t, SIMD>(item_id, val, shared_);
+  } else {
+    sum_val =
+        GroupReduceMaxWithoutBroadcast<opmath_t, SIMD>(item_id, val, shared_);
   }
-  lpnormChunkReduceKernelFunctor(
-      const opmath_t* output_per_tensor,
-      out_t** ret_per_tensor,
-      int max_chunks_per_tensor,
-      int wg_size)
-      : output_per_tensor_(output_per_tensor),
-        ret_per_tensor_(ret_per_tensor),
-        max_chunks_per_tensor_(max_chunks_per_tensor),
-        wg_size_(wg_size) {}
+  if (lid == 0) {
+    // L2 norm applies the final sqrt; powsum (apply_root == false) keeps the
+    // raw sum of squares. L1 and LInf never apply a root.
+    if constexpr (norm_type == NormType::L2 && apply_root) {
+      *(ret_per_tensor_[group_id]) = sycl::sqrt((opmath_t)sum_val);
+    } else {
+      *(ret_per_tensor_[group_id]) = sum_val;
+    }
+  }
+}
 
- private:
-  const opmath_t* output_per_tensor_;
-  out_t** ret_per_tensor_;
-  int max_chunks_per_tensor_;
-  int wg_size_;
-  sycl_local_acc_t<opmath_t> shared_;
+lpnormChunkReduceKernelFunctor(
+    const opmath_t* output_per_tensor,
+    out_t** ret_per_tensor,
+    int max_chunks_per_tensor,
+    int wg_size)
+    : output_per_tensor_(output_per_tensor),
+      ret_per_tensor_(ret_per_tensor),
+      max_chunks_per_tensor_(max_chunks_per_tensor),
+      wg_size_(wg_size) {}
+
+private:
+const opmath_t* output_per_tensor_;
+out_t** ret_per_tensor_;
+int max_chunks_per_tensor_;
+int wg_size_;
+sycl_local_acc_t<opmath_t> shared_;
 };
 
-template <
-    typename out_t,
-    NormType norm_type,
-    typename out_opmath_t,
-    int SIMD,
-    bool apply_root = true>
+template <typename out_t, int norm_type, typename out_opmath_t, int SIMD, bool apply_root = true>
 void launch_lpnorm_chunk_reduce_kernel(
     const out_opmath_t* output_per_tensor,
     out_t** ret_per_tensor,
@@ -318,7 +302,7 @@ std::vector<Tensor> foreach_norm_kernel_impl(
                       tensor_lists,
                       LpNormFunctor<
                           scalar_t,
-                          NormType::L1,
+                          NormType_L1,
                           out_opmath_t,
                           SIMD32>(),
                       output_per_tensor.mutable_data_ptr<out_opmath_t>(),
@@ -328,7 +312,7 @@ std::vector<Tensor> foreach_norm_kernel_impl(
                       tensor_lists,
                       LpNormFunctor<
                           scalar_t,
-                          NormType::L1,
+                          NormType_L1,
                           out_opmath_t,
                           SIMD16>(),
                       output_per_tensor.mutable_data_ptr<out_opmath_t>(),
@@ -350,7 +334,7 @@ std::vector<Tensor> foreach_norm_kernel_impl(
                 if (simd == SIMD32) {
                   launch_lpnorm_chunk_reduce_kernel<
                       out_t,
-                      NormType::L1,
+                      NormType_L1,
                       out_opmath_t,
                       SIMD32,
                       apply_root>(
@@ -362,7 +346,7 @@ std::vector<Tensor> foreach_norm_kernel_impl(
                 } else {
                   launch_lpnorm_chunk_reduce_kernel<
                       out_t,
-                      NormType::L1,
+                      NormType_L1,
                       out_opmath_t,
                       SIMD16,
                       apply_root>(
@@ -389,7 +373,7 @@ std::vector<Tensor> foreach_norm_kernel_impl(
                       tensor_lists,
                       LpNormFunctor<
                           scalar_t,
-                          NormType::L2,
+                          NormType_L2,
                           out_opmath_t,
                           SIMD32>(),
                       output_per_tensor.mutable_data_ptr<out_opmath_t>(),
@@ -399,7 +383,7 @@ std::vector<Tensor> foreach_norm_kernel_impl(
                       tensor_lists,
                       LpNormFunctor<
                           scalar_t,
-                          NormType::L2,
+                          NormType_L2,
                           out_opmath_t,
                           SIMD16>(),
                       output_per_tensor.mutable_data_ptr<out_opmath_t>(),
@@ -421,7 +405,7 @@ std::vector<Tensor> foreach_norm_kernel_impl(
                 if (simd == SIMD32) {
                   launch_lpnorm_chunk_reduce_kernel<
                       out_t,
-                      NormType::L2,
+                      NormType_L2,
                       out_opmath_t,
                       SIMD32,
                       apply_root>(
@@ -433,7 +417,7 @@ std::vector<Tensor> foreach_norm_kernel_impl(
                 } else {
                   launch_lpnorm_chunk_reduce_kernel<
                       out_t,
-                      NormType::L2,
+                      NormType_L2,
                       out_opmath_t,
                       SIMD16,
                       apply_root>(
@@ -460,7 +444,7 @@ std::vector<Tensor> foreach_norm_kernel_impl(
                       tensor_lists,
                       LpNormFunctor<
                           scalar_t,
-                          NormType::LInf,
+                          NormType_LInf,
                           out_opmath_t,
                           SIMD32>(),
                       output_per_tensor.mutable_data_ptr<out_opmath_t>(),
@@ -470,7 +454,7 @@ std::vector<Tensor> foreach_norm_kernel_impl(
                       tensor_lists,
                       LpNormFunctor<
                           scalar_t,
-                          NormType::LInf,
+                          NormType_LInf,
                           out_opmath_t,
                           SIMD16>(),
                       output_per_tensor.mutable_data_ptr<out_opmath_t>(),
@@ -492,7 +476,7 @@ std::vector<Tensor> foreach_norm_kernel_impl(
                 if (simd == SIMD32) {
                   launch_lpnorm_chunk_reduce_kernel<
                       out_t,
-                      NormType::LInf,
+                      NormType_LInf,
                       out_opmath_t,
                       SIMD32,
                       apply_root>(
@@ -504,7 +488,7 @@ std::vector<Tensor> foreach_norm_kernel_impl(
                 } else {
                   launch_lpnorm_chunk_reduce_kernel<
                       out_t,
-                      NormType::LInf,
+                      NormType_LInf,
                       out_opmath_t,
                       SIMD16,
                       apply_root>(
@@ -547,9 +531,8 @@ std::vector<Tensor> foreach_powsum_kernel(
 }
 
 template <typename T, int SIMD>
-struct LpMaxFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
-  template <typename TLA, typename TLW>
-  void operator()(
+struct LpMaxFunctor {
+  template <typename TLA, typename TLW> void operator()(
       int64_t chunk_size,
       TLA tlAddressMeta,
       TLW tlWGMeta,
@@ -599,31 +582,27 @@ struct LpMaxFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
       }
     }
 
+    syclexp::work_group_static<T[SIMD]> shared_;
+
     auto val = T(std::numeric_limits<T>::lowest());
     for (int i = 0; i < kILP; i++) {
       val = max_impl(val, vals[i]);
     }
     auto final_val =
-        GroupReduceMaxWithoutBroadcast<T, SIMD>(item, val, shared_);
+        GroupReduceMaxWithoutBroadcast_StaticSlm<T, SIMD, SIMD>(item, val, shared_);
 
     if (item_id == 0) {
       output_per_tensor_ptr[tensor_loc * max_chunks_per_tensor + chunk_idx] =
           final_val;
     }
   }
-
-  void sycl_ker_config_convention(sycl::handler& cgh) {
-    shared_ = sycl_local_acc_t<T>(SIMD, cgh);
-  }
-
- private:
-  sycl_local_acc_t<T> shared_;
 };
 
 template <typename T, int SIMD>
-struct LpmaxChunkReduceKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
+struct LpmaxChunkReduceKernelFunctor {
   SYCL_REQD_SUB_GROUP_SIZE(SIMD)
-  void operator()(sycl::nd_item<1> item_id) const {
+  void operator()(
+      sycl::nd_item<1> item_id) const {
     auto local_range = item_id.get_local_range(0);
     auto lid = item_id.get_local_linear_id();
     auto group_id = item_id.get_group(0);
@@ -635,15 +614,12 @@ struct LpmaxChunkReduceKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
     for (int i = lid; i < chunks_this_tensor; i += local_range) {
       val = max_impl(val, output_this_tensor[i]);
     }
+    syclexp::work_group_static<T[SIMD]> shared_;
     T final_value =
-        GroupReduceMaxWithoutBroadcast<T, SIMD>(item_id, val, shared_);
+        GroupReduceMaxWithoutBroadcast_StaticSlm<T, SIMD, SIMD>(item_id, val, shared_);
     if (lid == 0) {
       *(ret_per_tensor_[group_id]) = final_value;
     }
-  }
-
-  void sycl_ker_config_convention(sycl::handler& cgh) {
-    shared_ = sycl_local_acc_t<T>(SIMD, cgh);
   }
 
   LpmaxChunkReduceKernelFunctor(
@@ -661,7 +637,6 @@ struct LpmaxChunkReduceKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
   T** ret_per_tensor_;
   int* chunks_per_tensor_;
   int max_chunks_per_tensor_;
-  sycl_local_acc_t<T> shared_;
 };
 
 template <typename T, int SIMD>

--- a/src/ATen/native/xpu/sycl/FusedAdamAmsgradKernels.cpp
+++ b/src/ATen/native/xpu/sycl/FusedAdamAmsgradKernels.cpp
@@ -53,7 +53,7 @@ void fused_adam_amsgrad_kernel(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ORIGINAL, true>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE_ORIGINAL, true>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -104,7 +104,7 @@ void fused_adam_amsgrad_kernel(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ORIGINAL, true>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE_ORIGINAL, true>(),
             lr_ptr,
             1.0f, // unused
             beta1,

--- a/src/ATen/native/xpu/sycl/FusedAdamKernels.cpp
+++ b/src/ATen/native/xpu/sycl/FusedAdamKernels.cpp
@@ -48,7 +48,7 @@ void fused_adam_kernel(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ORIGINAL, false>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE_ORIGINAL, false>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -94,7 +94,7 @@ void fused_adam_kernel(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ORIGINAL, false>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE_ORIGINAL, false>(),
             lr_ptr,
             1.0f, // unused
             beta1,

--- a/src/ATen/native/xpu/sycl/FusedAdamUtils.h
+++ b/src/ATen/native/xpu/sycl/FusedAdamUtils.h
@@ -20,7 +20,8 @@
 
 namespace at::native::xpu {
 
-// WR (replace enum class) due to https://jira.devtools.intel.com/browse/CMPLRLLVM-72438
+// WR (replace enum class) due to
+// https://jira.devtools.intel.com/browse/CMPLRLLVM-72438
 const int ADAM_MODE_ORIGINAL = 0;
 const int ADAM_MODE_ADAMW = 1;
 

--- a/src/ATen/native/xpu/sycl/FusedAdamUtils.h
+++ b/src/ATen/native/xpu/sycl/FusedAdamUtils.h
@@ -20,7 +20,9 @@
 
 namespace at::native::xpu {
 
-enum class ADAM_MODE : uint8_t { ORIGINAL = 0, ADAMW = 1 };
+// WR (replace enum class) due to https://jira.devtools.intel.com/browse/CMPLRLLVM-72438
+const int ADAM_MODE_ORIGINAL = 0;
+const int ADAM_MODE_ADAMW = 1;
 
 // index in TensorList for params
 constexpr uint8_t kParamIdx = 0;
@@ -33,7 +35,7 @@ template <
     typename scalar_type,
     typename opmath_t,
     int depth,
-    ADAM_MODE adam_mode,
+    int adam_mode,
     bool amsgrad>
 inline void adam_math(
     scalar_type r_args[depth][kILP],
@@ -64,9 +66,9 @@ inline void adam_math(
     opmath_t exp_avg_sq = static_cast<opmath_t>(r_args[kExpAvgSqIdx][ii]);
     // Update param, grad, 1st and 2nd order momentum.
     if (weight_decay != 0) {
-      if constexpr (adam_mode == ADAM_MODE::ORIGINAL) {
+      if constexpr (adam_mode == ADAM_MODE_ORIGINAL) {
         grad += param * weight_decay;
-      } else if constexpr (adam_mode == ADAM_MODE::ADAMW) {
+      } else if constexpr (adam_mode == ADAM_MODE_ADAMW) {
         param -= lr * weight_decay * param;
       }
     }
@@ -95,7 +97,7 @@ inline void adam_math(
   }
 }
 
-template <typename scalar_type, int depth, ADAM_MODE adam_mode, bool amsgrad>
+template <typename scalar_type, int depth, int adam_mode, bool amsgrad>
 struct FusedAdamMathFunctor {
   static_assert(
       depth == 4 || depth == 5,

--- a/src/ATen/native/xpu/sycl/FusedAdamWAmsgradKernels.cpp
+++ b/src/ATen/native/xpu/sycl/FusedAdamWAmsgradKernels.cpp
@@ -53,7 +53,7 @@ void fused_adamw_amsgrad_kernel(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ADAMW, true>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE_ADAMW, true>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -104,7 +104,7 @@ void fused_adamw_amsgrad_kernel(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ADAMW, true>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE_ADAMW, true>(),
             lr_ptr,
             1.0f, // unused
             beta1,

--- a/src/ATen/native/xpu/sycl/FusedAdamWKernels.cpp
+++ b/src/ATen/native/xpu/sycl/FusedAdamWKernels.cpp
@@ -48,7 +48,7 @@ void fused_adamw_kernel(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ADAMW, false>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE_ADAMW, false>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -94,7 +94,7 @@ void fused_adamw_kernel(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ADAMW, false>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE_ADAMW, false>(),
             lr_ptr,
             1.0f, // unused
             beta1,

--- a/src/ATen/native/xpu/sycl/GroupReduceUtils.h
+++ b/src/ATen/native/xpu/sycl/GroupReduceUtils.h
@@ -23,7 +23,7 @@ namespace at {
 namespace native {
 namespace xpu {
 
-inline int get_group_reduce_group_size(int simd) {
+constexpr inline int get_group_reduce_group_size(int simd) {
   // Limited by group reduce implementation. We use two sub group shuffles,
   // The second sub group shuffle only could handle simd size elements.
   return std::min(512, simd * simd);
@@ -82,6 +82,35 @@ inline T& GroupReduceSumWithoutBroadcast(
   return val;
 }
 
+template <typename T, int SIMD, int SLM_SIZE, int DIM>
+inline T& GroupReduceSumWithoutBroadcast_StaticSlm(
+    sycl::nd_item<DIM>& item,
+    T& val,
+    syclexp::work_group_static<T[SLM_SIZE]>& shared) {
+  auto sg = item.get_sub_group();
+  int sg_tid = sg.get_local_linear_id();
+  int sg_id = sg.get_group_linear_id();
+  int n_sg = get_local_linear_range<DIM>(item) / SIMD;
+  val = SubgroupReduceSumWithoutBroadcast<T, SIMD, DIM>(item, val);
+  sycl::group_barrier(item.get_group()); // prevent races when GroupReduceSum are
+                                  // called in a row.
+  if (n_sg == 1) {
+    return val;
+  }
+  if (sg_tid == 0) {
+    shared[sg_id] = val;
+  }
+  sycl::group_barrier(item.get_group());
+  val = 0;
+  if (sg_id == 0) {
+    for (int i = sg_tid; i < n_sg; i += SIMD) {
+      val += shared[i];
+    }
+    val = SubgroupReduceSumWithoutBroadcast<T, SIMD, DIM>(item, val);
+  }
+  return val;
+}
+
 // Keep max_impl below: sycl::maximum under reduce_over_group can drop a NaN,
 // which torch.max/amax must not.
 template <typename T, int SIMD, int DIM>
@@ -110,6 +139,33 @@ inline T& GroupReduceMaxWithoutBroadcast(
   val = SubgroupReduceMaxWithoutBroadcast<T, SIMD, DIM>(item, val);
   sycl::group_barrier(item.get_group()); // prevent races when GroupReduceSum
                                          // are called in a row.
+  if (n_sg == 1) {
+    return val;
+  }
+  if (sg_tid == 0) {
+    shared[sg_id] = val;
+  }
+  sycl::group_barrier(item.get_group());
+  if (sg_id == 0) {
+    for (int i = 1; i < n_sg; i++) {
+      val = max_impl(val, shared[i]);
+    }
+  }
+  return val;
+}
+
+template <typename T, int SIMD, int SLM_SIZE, int DIM>
+inline T& GroupReduceMaxWithoutBroadcast_StaticSlm(
+    sycl::nd_item<DIM>& item,
+    T& val,
+    syclexp::work_group_static<T[SLM_SIZE]>& shared) {
+  auto sg = item.get_sub_group();
+  int sg_tid = sg.get_local_linear_id();
+  int sg_id = sg.get_group_linear_id();
+  int n_sg = get_local_linear_range<DIM>(item) / SIMD;
+  val = SubgroupReduceMaxWithoutBroadcast<T, SIMD, DIM>(item, val);
+  sycl::group_barrier(item.get_group()); // prevent races when GroupReduceSum are
+                                  // called in a row.
   if (n_sg == 1) {
     return val;
   }

--- a/src/ATen/native/xpu/sycl/GroupReduceUtils.h
+++ b/src/ATen/native/xpu/sycl/GroupReduceUtils.h
@@ -92,8 +92,8 @@ inline T& GroupReduceSumWithoutBroadcast_StaticSlm(
   int sg_id = sg.get_group_linear_id();
   int n_sg = get_local_linear_range<DIM>(item) / SIMD;
   val = SubgroupReduceSumWithoutBroadcast<T, SIMD, DIM>(item, val);
-  sycl::group_barrier(item.get_group()); // prevent races when GroupReduceSum are
-                                  // called in a row.
+  sycl::group_barrier(item.get_group()); // prevent races when GroupReduceSum
+                                         // are called in a row.
   if (n_sg == 1) {
     return val;
   }
@@ -164,8 +164,8 @@ inline T& GroupReduceMaxWithoutBroadcast_StaticSlm(
   int sg_id = sg.get_group_linear_id();
   int n_sg = get_local_linear_range<DIM>(item) / SIMD;
   val = SubgroupReduceMaxWithoutBroadcast<T, SIMD, DIM>(item, val);
-  sycl::group_barrier(item.get_group()); // prevent races when GroupReduceSum are
-                                  // called in a row.
+  sycl::group_barrier(item.get_group()); // prevent races when GroupReduceSum
+                                         // are called in a row.
   if (n_sg == 1) {
     return val;
   }

--- a/src/ATen/native/xpu/sycl/MultiTensorApply.h
+++ b/src/ATen/native/xpu/sycl/MultiTensorApply.h
@@ -82,39 +82,13 @@ static inline int64_t multi_tensor_apply_fused_kernel_get_chunk_size() {
   return max_wg_size * kILP;
 }
 
-#ifndef _WIN32
-template <typename T, typename Y, typename U, typename... ArgTypes>
-SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
-void multi_tensor_apply_kernel(
-    int64_t kChunkSize,
-    T tlAddressMeta,
-    Y tlWGMeta,
-    U callable,
-    ArgTypes... args) {
-  auto item = syclext::this_work_item::get_nd_item<1>();
-  callable(kChunkSize, tlAddressMeta, tlWGMeta, item, args...);
-}
-#else
-// Windows-only workaround for an Intel oneAPI DPC++ (icx) SYCL integration
-// header generation bug when the host compiler is MSVC (cl.exe, i.e.
-// -fsycl-host-compiler=cl). For a variadic free function kernel, icx emits a
-// `KernelInfo` specialization keyed on
-//   NdRangeFreeFunctionKernelWrapper<&multi_tensor_apply_kernel<T, Y, U,
-//   ArgTypes...>, ...>
-// where the kernel pointer is used as an uncast non-type template argument.
-// The MSVC front-end cannot convert that variadic template-id to the expected
-// `auto*` pointer type and fails with:
-//   error C2440: 'specialization': cannot convert from 'overloaded-function'
-//   to 'void (__cdecl *)(...)'
-//
-// To avoid a variadic kernel signature entirely, the kernel below is
-// non-variadic (multi_tensor_apply_kernel<T, Y, U>): the trailing kernel
-// arguments are folded, together with the callable, into a single
-// non-variadic, device-copyable functor (MultiTensorApplyCallableWrapper).
-// The emitted template-id is then non-variadic and MSVC resolves the pointer
-// correctly.
-//
-// Remove this workaround once the icx integration-header generator is fixed.
+#ifdef _WIN32
+// Windows-only workaround for an icx SYCL integration-header bug with MSVC as
+// host compiler: a variadic free-function kernel makes icx emit a KernelInfo
+// specialization whose non-type template argument (the kernel pointer) MSVC
+// cannot convert (error C2440). Fold the extra args into a single non-variadic,
+// device-copyable functor so the emitted template-id is non-variadic.
+// TODO: remove once the icx integration-header generator is fixed [CMPLRLLVM-77173]
 template <typename T, typename Y, typename U>
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
 void multi_tensor_apply_kernel(
@@ -141,20 +115,20 @@ struct MultiTensorApplyCallableWrapper {
         args);
   }
 };
-} // namespace at::native::xpu
-
-// Opt MultiTensorApplyCallableWrapper into SYCL device-copyability. std::tuple
-// is not implicitly device-copyable, so declare the wrapper copyable whenever
-// its callable and bound argument types are.
-template <typename U, typename... ArgTypes>
-struct sycl::is_device_copyable<
-    ::at::native::xpu::MultiTensorApplyCallableWrapper<U, ArgTypes...>>
-    : std::bool_constant<(
-          sycl::is_device_copyable_v<U> && ... &&
-          sycl::is_device_copyable_v<ArgTypes>)> {};
-
-namespace at::native::xpu {
+#else
+template <typename T, typename Y, typename U, typename... ArgTypes>
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
+void multi_tensor_apply_kernel(
+    int64_t kChunkSize,
+    T tlAddressMeta,
+    Y tlWGMeta,
+    U callable,
+    ArgTypes... args) {
+  auto item = syclext::this_work_item::get_nd_item<1>();
+  callable(kChunkSize, tlAddressMeta, tlWGMeta, item, args...);
+}
 #endif // _WIN32
+
 template <
     bool fused_kernel,
     typename T,
@@ -455,3 +429,17 @@ void multi_tensor_apply_for_fused_optimizer(
 }
 
 } // namespace at::native::xpu
+
+#ifdef _WIN32
+// Opt MultiTensorApplyCallableWrapper into SYCL device-copyability. std::tuple
+// is not implicitly device-copyable, so declare the wrapper copyable whenever
+// its callable and bound argument types are.
+// TODO: remove once the icx integration-header generator is fixed [CMPLRLLVM-77173]
+template <typename U, typename... ArgTypes>
+struct sycl::is_device_copyable<
+    ::at::native::xpu::MultiTensorApplyCallableWrapper<U, ArgTypes...>>
+    : std::bool_constant<(
+          sycl::is_device_copyable_v<U> && ... &&
+          sycl::is_device_copyable_v<ArgTypes>)> {};
+#endif // _WIN32
+

--- a/src/ATen/native/xpu/sycl/MultiTensorApply.h
+++ b/src/ATen/native/xpu/sycl/MultiTensorApply.h
@@ -88,7 +88,8 @@ static inline int64_t multi_tensor_apply_fused_kernel_get_chunk_size() {
 // specialization whose non-type template argument (the kernel pointer) MSVC
 // cannot convert (error C2440). Fold the extra args into a single non-variadic,
 // device-copyable functor so the emitted template-id is non-variadic.
-// TODO: remove once the icx integration-header generator is fixed [CMPLRLLVM-77173]
+// TODO: remove once the icx integration-header generator is fixed
+// [CMPLRLLVM-77173]
 template <typename T, typename Y, typename U>
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
 void multi_tensor_apply_kernel(
@@ -434,7 +435,8 @@ void multi_tensor_apply_for_fused_optimizer(
 // Opt MultiTensorApplyCallableWrapper into SYCL device-copyability. std::tuple
 // is not implicitly device-copyable, so declare the wrapper copyable whenever
 // its callable and bound argument types are.
-// TODO: remove once the icx integration-header generator is fixed [CMPLRLLVM-77173]
+// TODO: remove once the icx integration-header generator is fixed
+// [CMPLRLLVM-77173]
 template <typename U, typename... ArgTypes>
 struct sycl::is_device_copyable<
     ::at::native::xpu::MultiTensorApplyCallableWrapper<U, ArgTypes...>>
@@ -442,4 +444,3 @@ struct sycl::is_device_copyable<
           sycl::is_device_copyable_v<U> && ... &&
           sycl::is_device_copyable_v<ArgTypes>)> {};
 #endif // _WIN32
-

--- a/src/ATen/native/xpu/sycl/MultiTensorApply.h
+++ b/src/ATen/native/xpu/sycl/MultiTensorApply.h
@@ -18,6 +18,11 @@
 #include <ATen/native/xpu/sycl/MemoryAccessUtils.h>
 #include <comm/SYCLContext.h>
 
+#ifdef _WIN32
+#include <tuple>
+#include <utility>
+#endif
+
 namespace at::native::xpu {
 
 // Instruction level Parallelism, namely vec size
@@ -77,6 +82,7 @@ static inline int64_t multi_tensor_apply_fused_kernel_get_chunk_size() {
   return max_wg_size * kILP;
 }
 
+#ifndef _WIN32
 template <typename T, typename Y, typename U, typename... ArgTypes>
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
 void multi_tensor_apply_kernel(
@@ -88,7 +94,70 @@ void multi_tensor_apply_kernel(
   auto item = syclext::this_work_item::get_nd_item<1>();
   callable(kChunkSize, tlAddressMeta, tlWGMeta, item, args...);
 }
+#else
+// Windows-only workaround for an Intel oneAPI DPC++ (icx) SYCL integration
+// header generation bug when the host compiler is MSVC (cl.exe, i.e.
+// -fsycl-host-compiler=cl). For a variadic free function kernel, icx emits a
+// `KernelInfo` specialization keyed on
+//   NdRangeFreeFunctionKernelWrapper<&multi_tensor_apply_kernel<T, Y, U,
+//   ArgTypes...>, ...>
+// where the kernel pointer is used as an uncast non-type template argument.
+// The MSVC front-end cannot convert that variadic template-id to the expected
+// `auto*` pointer type and fails with:
+//   error C2440: 'specialization': cannot convert from 'overloaded-function'
+//   to 'void (__cdecl *)(...)'
+//
+// To avoid a variadic kernel signature entirely, the kernel below is
+// non-variadic (multi_tensor_apply_kernel<T, Y, U>): the trailing kernel
+// arguments are folded, together with the callable, into a single
+// non-variadic, device-copyable functor (MultiTensorApplyCallableWrapper).
+// The emitted template-id is then non-variadic and MSVC resolves the pointer
+// correctly.
+//
+// Remove this workaround once the icx integration-header generator is fixed.
+template <typename T, typename Y, typename U>
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
+void multi_tensor_apply_kernel(
+    int64_t kChunkSize,
+    T tlAddressMeta,
+    Y tlWGMeta,
+    U callable) {
+  auto item = syclext::this_work_item::get_nd_item<1>();
+  callable(kChunkSize, tlAddressMeta, tlWGMeta, item);
+}
 
+template <typename U, typename... ArgTypes>
+struct MultiTensorApplyCallableWrapper {
+  U callable;
+  std::tuple<ArgTypes...> args;
+
+  template <typename T, typename Y, typename Item>
+  void operator()(
+      int64_t kChunkSize,
+      T tlAddressMeta,
+      Y tlWGMeta,
+      Item item) const {
+    std::apply(
+        [&](const ArgTypes&... unpacked) {
+          callable(kChunkSize, tlAddressMeta, tlWGMeta, item, unpacked...);
+        },
+        args);
+  }
+};
+} // namespace at::native::xpu
+
+// Opt MultiTensorApplyCallableWrapper into SYCL device-copyability. std::tuple
+// is not implicitly device-copyable, so declare the wrapper copyable whenever
+// its callable and bound argument types are.
+template <typename U, typename... ArgTypes>
+struct sycl::is_device_copyable<
+    ::at::native::xpu::MultiTensorApplyCallableWrapper<U, ArgTypes...>>
+    : std::bool_constant<
+          (sycl::is_device_copyable_v<U> && ... &&
+           sycl::is_device_copyable_v<ArgTypes>)> {};
+
+namespace at::native::xpu {
+#endif // _WIN32
 template <
     bool fused_kernel,
     typename T,
@@ -111,6 +180,25 @@ void launch_multi_tensor_apply_kernel(
     kChunkSize = multi_tensor_apply_fused_kernel_get_chunk_size();
   }
 
+#ifdef _WIN32
+  // See MultiTensorApplyCallableWrapper above: fold extra args into a
+  // non-variadic, device-copyable callable so the kernel template-id emitted in
+  // the SYCL integration header is non-variadic (works around MSVC C2440).
+  using WrappedCallable = MultiTensorApplyCallableWrapper<U, ArgTypes...>;
+  WrappedCallable wrapped{callable, std::tuple<ArgTypes...>(args...)};
+
+  constexpr auto kfn = multi_tensor_apply_kernel<T, Y, WrappedCallable>;
+
+  sycl_kernel_submit<kfn>(
+      sycl::range<1>(num_wg * max_wg_size),
+      sycl::range<1>(max_wg_size),
+      q,
+      0,
+      kChunkSize,
+      tlAddressMeta,
+      tlWGMeta,
+      wrapped);
+#else
   constexpr auto kfn = multi_tensor_apply_kernel<T, Y, U, ArgTypes...>;
 
   sycl_kernel_submit<kfn>(
@@ -123,6 +211,7 @@ void launch_multi_tensor_apply_kernel(
       tlWGMeta,
       callable,
       args...);
+#endif // _WIN32
 }
 
 template <int depth, typename scalar_t, typename T, typename... ArgTypes>

--- a/src/ATen/native/xpu/sycl/MultiTensorApply.h
+++ b/src/ATen/native/xpu/sycl/MultiTensorApply.h
@@ -89,7 +89,6 @@ static inline int64_t multi_tensor_apply_fused_kernel_get_chunk_size() {
 // cannot convert (error C2440). Fold the extra args into a single non-variadic,
 // device-copyable functor so the emitted template-id is non-variadic.
 // TODO: remove once the icx integration-header generator is fixed
-// [CMPLRLLVM-77173]
 template <typename T, typename Y, typename U>
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
 void multi_tensor_apply_kernel(
@@ -436,7 +435,6 @@ void multi_tensor_apply_for_fused_optimizer(
 // is not implicitly device-copyable, so declare the wrapper copyable whenever
 // its callable and bound argument types are.
 // TODO: remove once the icx integration-header generator is fixed
-// [CMPLRLLVM-77173]
 template <typename U, typename... ArgTypes>
 struct sycl::is_device_copyable<
     ::at::native::xpu::MultiTensorApplyCallableWrapper<U, ArgTypes...>>

--- a/src/ATen/native/xpu/sycl/MultiTensorApply.h
+++ b/src/ATen/native/xpu/sycl/MultiTensorApply.h
@@ -79,19 +79,14 @@ static inline int64_t multi_tensor_apply_fused_kernel_get_chunk_size() {
 
 template <typename T, typename Y, typename U, typename... ArgTypes>
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
-void multiTensorApplyKernel(
+void multi_tensor_apply_kernel(
     int64_t kChunkSize,
     T tlAddressMeta,
     Y tlWGMeta,
     U callable,
     ArgTypes... args) {
   auto item = syclext::this_work_item::get_nd_item<1>();
-  callable(
-        kChunkSize,
-        tlAddressMeta,
-        tlWGMeta,
-        item,
-        args...);
+  callable(kChunkSize, tlAddressMeta, tlWGMeta, item, args...);
 }
 
 template <
@@ -116,14 +111,18 @@ void launch_multi_tensor_apply_kernel(
     kChunkSize = multi_tensor_apply_fused_kernel_get_chunk_size();
   }
 
-  constexpr auto kfn = multiTensorApplyKernel<T, Y, U, ArgTypes...>;
+  constexpr auto kfn = multi_tensor_apply_kernel<T, Y, U, ArgTypes...>;
 
   sycl_kernel_submit<kfn>(
       sycl::range<1>(num_wg * max_wg_size),
       sycl::range<1>(max_wg_size),
       q,
       0,
-      kChunkSize, tlAddressMeta, tlWGMeta, callable, args...);
+      kChunkSize,
+      tlAddressMeta,
+      tlWGMeta,
+      callable,
+      args...);
 }
 
 template <int depth, typename scalar_t, typename T, typename... ArgTypes>

--- a/src/ATen/native/xpu/sycl/MultiTensorApply.h
+++ b/src/ATen/native/xpu/sycl/MultiTensorApply.h
@@ -18,10 +18,8 @@
 #include <ATen/native/xpu/sycl/MemoryAccessUtils.h>
 #include <comm/SYCLContext.h>
 
-#ifdef _WIN32
 #include <tuple>
 #include <utility>
-#endif
 
 namespace at::native::xpu {
 
@@ -82,13 +80,9 @@ static inline int64_t multi_tensor_apply_fused_kernel_get_chunk_size() {
   return max_wg_size * kILP;
 }
 
-#ifdef _WIN32
-// Windows-only workaround for an icx SYCL integration-header bug with MSVC as
-// host compiler: a variadic free-function kernel makes icx emit a KernelInfo
-// specialization whose non-type template argument (the kernel pointer) MSVC
-// cannot convert (error C2440). Fold the extra args into a single non-variadic,
-// device-copyable functor so the emitted template-id is non-variadic.
-// TODO: remove once the icx integration-header generator is fixed
+// functions marked with `nd_range_kernel` cannot be variadic.
+// For the variadic kernel template, fold the extra args into
+// a single non-variadic, device-copyable functor
 template <typename T, typename Y, typename U>
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
 void multi_tensor_apply_kernel(
@@ -115,19 +109,6 @@ struct MultiTensorApplyCallableWrapper {
         args);
   }
 };
-#else
-template <typename T, typename Y, typename U, typename... ArgTypes>
-SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
-void multi_tensor_apply_kernel(
-    int64_t kChunkSize,
-    T tlAddressMeta,
-    Y tlWGMeta,
-    U callable,
-    ArgTypes... args) {
-  auto item = syclext::this_work_item::get_nd_item<1>();
-  callable(kChunkSize, tlAddressMeta, tlWGMeta, item, args...);
-}
-#endif // _WIN32
 
 template <
     bool fused_kernel,
@@ -151,10 +132,8 @@ void launch_multi_tensor_apply_kernel(
     kChunkSize = multi_tensor_apply_fused_kernel_get_chunk_size();
   }
 
-#ifdef _WIN32
   // See MultiTensorApplyCallableWrapper above: fold extra args into a
-  // non-variadic, device-copyable callable so the kernel template-id emitted in
-  // the SYCL integration header is non-variadic (works around MSVC C2440).
+  // non-variadic, device-copyable callable
   using WrappedCallable = MultiTensorApplyCallableWrapper<U, ArgTypes...>;
   WrappedCallable wrapped{callable, std::tuple<ArgTypes...>(args...)};
 
@@ -169,20 +148,6 @@ void launch_multi_tensor_apply_kernel(
       tlAddressMeta,
       tlWGMeta,
       wrapped);
-#else
-  constexpr auto kfn = multi_tensor_apply_kernel<T, Y, U, ArgTypes...>;
-
-  sycl_kernel_submit<kfn>(
-      sycl::range<1>(num_wg * max_wg_size),
-      sycl::range<1>(max_wg_size),
-      q,
-      0,
-      kChunkSize,
-      tlAddressMeta,
-      tlWGMeta,
-      callable,
-      args...);
-#endif // _WIN32
 }
 
 template <int depth, typename scalar_t, typename T, typename... ArgTypes>
@@ -430,15 +395,12 @@ void multi_tensor_apply_for_fused_optimizer(
 
 } // namespace at::native::xpu
 
-#ifdef _WIN32
 // Opt MultiTensorApplyCallableWrapper into SYCL device-copyability. std::tuple
 // is not implicitly device-copyable, so declare the wrapper copyable whenever
 // its callable and bound argument types are.
-// TODO: remove once the icx integration-header generator is fixed
 template <typename U, typename... ArgTypes>
 struct sycl::is_device_copyable<
     ::at::native::xpu::MultiTensorApplyCallableWrapper<U, ArgTypes...>>
     : std::bool_constant<(
           sycl::is_device_copyable_v<U> && ... &&
           sycl::is_device_copyable_v<ArgTypes>)> {};
-#endif // _WIN32

--- a/src/ATen/native/xpu/sycl/MultiTensorApply.h
+++ b/src/ATen/native/xpu/sycl/MultiTensorApply.h
@@ -132,11 +132,8 @@ struct MultiTensorApplyCallableWrapper {
   std::tuple<ArgTypes...> args;
 
   template <typename T, typename Y, typename Item>
-  void operator()(
-      int64_t kChunkSize,
-      T tlAddressMeta,
-      Y tlWGMeta,
-      Item item) const {
+  void operator()(int64_t kChunkSize, T tlAddressMeta, Y tlWGMeta, Item item)
+      const {
     std::apply(
         [&](const ArgTypes&... unpacked) {
           callable(kChunkSize, tlAddressMeta, tlWGMeta, item, unpacked...);
@@ -152,9 +149,9 @@ struct MultiTensorApplyCallableWrapper {
 template <typename U, typename... ArgTypes>
 struct sycl::is_device_copyable<
     ::at::native::xpu::MultiTensorApplyCallableWrapper<U, ArgTypes...>>
-    : std::bool_constant<
-          (sycl::is_device_copyable_v<U> && ... &&
-           sycl::is_device_copyable_v<ArgTypes>)> {};
+    : std::bool_constant<(
+          sycl::is_device_copyable_v<U> && ... &&
+          sycl::is_device_copyable_v<ArgTypes>)> {};
 
 namespace at::native::xpu {
 #endif // _WIN32

--- a/src/ATen/native/xpu/sycl/MultiTensorApply.h
+++ b/src/ATen/native/xpu/sycl/MultiTensorApply.h
@@ -78,48 +78,21 @@ static inline int64_t multi_tensor_apply_fused_kernel_get_chunk_size() {
 }
 
 template <typename T, typename Y, typename U, typename... ArgTypes>
-struct MultiTensorApplyKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
-  void operator()(sycl::nd_item<1> item_id) const {
-    // Expand the tuple elements manually and call the callable
-    expandAndCall(item_id, std::index_sequence_for<ArgTypes...>());
-  }
-  MultiTensorApplyKernelFunctor(
-      int64_t kChunkSize_,
-      T tlAddressMeta_,
-      Y tlWGMeta_,
-      U callable_,
-      ArgTypes... args_)
-      : kChunkSize(kChunkSize_),
-        tlAddressMeta(tlAddressMeta_),
-        tlWGMeta(tlWGMeta_),
-        callable(callable_),
-        args(std::make_tuple(args_...)) {}
-
-  void sycl_ker_config_convention(sycl::handler& cgh) {
-    if constexpr (std::is_base_of_v<__SYCL_KER_CONFIG_CONVENTION__, U>) {
-      callable.sycl_ker_config_convention(cgh);
-    }
-  }
-
- private:
-  template <std::size_t... Indices>
-  void expandAndCall(sycl::nd_item<1> item_id, std::index_sequence<Indices...>)
-      const {
-    // Call the callable with expanded tuple elements
-    callable(
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
+void multiTensorApplyKernel(
+    int64_t kChunkSize,
+    T tlAddressMeta,
+    Y tlWGMeta,
+    U callable,
+    ArgTypes... args) {
+  auto item = syclext::this_work_item::get_nd_item<1>();
+  callable(
         kChunkSize,
         tlAddressMeta,
         tlWGMeta,
-        item_id,
-        std::get<Indices>(args)...);
-  }
-
-  int64_t kChunkSize;
-  T tlAddressMeta;
-  Y tlWGMeta;
-  U callable;
-  std::tuple<ArgTypes...> args;
-};
+        item,
+        args...);
+}
 
 template <
     bool fused_kernel,
@@ -143,14 +116,14 @@ void launch_multi_tensor_apply_kernel(
     kChunkSize = multi_tensor_apply_fused_kernel_get_chunk_size();
   }
 
-  MultiTensorApplyKernelFunctor<T, Y, U, ArgTypes...> kfn(
-      kChunkSize, tlAddressMeta, tlWGMeta, callable, args...);
+  constexpr auto kfn = multiTensorApplyKernel<T, Y, U, ArgTypes...>;
 
-  sycl_kernel_submit(
+  sycl_kernel_submit<kfn>(
       sycl::range<1>(num_wg * max_wg_size),
       sycl::range<1>(max_wg_size),
       q,
-      kfn);
+      0,
+      kChunkSize, tlAddressMeta, tlWGMeta, callable, args...);
 }
 
 template <int depth, typename scalar_t, typename T, typename... ArgTypes>


### PR DESCRIPTION

UT reruns (same suites as before):                                                                                                                     
                                                                                                                                                             
      -  test/test_foreach.py -k xpu : 3746 tests, OK (skipped=42, expected failures=53) — includes all  _foreach_norm / _foreach_max  reduce-kernel tests  exercising the refactored  MultiTensorApply / GroupReduceUtils  code.                                                                                   
      -  torch-xpu-ops/test/xpu/test_optim_xpu.py -k fused : 60 passed / 16 skipped / 10 errors — identical error set as before the rebase: all 10 are test_fused_mixed_precision_*  (CUDA-only master-weight mixed-precision feature that XPU's  FusedAdam.cpp / FusedAdamW.cpp  doesn't support yet, unrelated to this branch's changes). All core fused-optimizer tests ( test_fused_matches_forloop ,  test_fused_large_tensor ,  test_fused_does_not_step_if_foundinf ,  test_fused_error_on_params_on_meta ,  test_fused_cpu_matches_device ,  test_fused_cpu_load_state_dict_impl ) passed
    