### PR TITLE
[sycl-free-function] migrate TensorApply kernels to sycl free function (#145)

### DIFF
--- a/src/ATen/native/xpu/sycl/TensorApplyUtils.h
+++ b/src/ATen/native/xpu/sycl/TensorApplyUtils.h
@@ -232,11 +232,11 @@ void pointwiseApply2Kernel(
     const Op op) {
   auto item = syclext::this_work_item::get_nd_item<1>();
   for (IndexType linearIndex = (item.get_group(0) * item.get_local_range(0) +
-                                  item.get_local_id(0)) *
-            step;
-        linearIndex < totalElements;
-        linearIndex +=
-        item.get_group_range(0) * item.get_local_range(0) * step) {
+                                item.get_local_id(0)) *
+           step;
+       linearIndex < totalElements;
+       linearIndex +=
+       item.get_group_range(0) * item.get_local_range(0) * step) {
     ApplyOp2<Op, scalar1, scalar2, IndexType, step>::apply(
         item,
         a,
@@ -329,7 +329,8 @@ inline bool tensor_apply2(
     bInfo.collapseDims();
 
     using index_t = unsigned int;
-    constexpr auto fn = pointwiseApply2Kernel<Op, scalar1, scalar2, index_t, step>;
+    constexpr auto fn =
+        pointwiseApply2Kernel<Op, scalar1, scalar2, index_t, step>;
     sycl_kernel_submit<fn>(
         group_count * threads_per_group,
         threads_per_group,
@@ -348,7 +349,8 @@ inline bool tensor_apply2(
     bInfo.collapseDims();
 
     using index_t = uint64_t;
-    constexpr auto fn = pointwiseApply2Kernel<Op, scalar1, scalar2, index_t, step>;
+    constexpr auto fn =
+        pointwiseApply2Kernel<Op, scalar1, scalar2, index_t, step>;
     sycl_kernel_submit<fn>(
         group_count * threads_per_group,
         threads_per_group,

--- a/src/ATen/native/xpu/sycl/TensorApplyUtils.h
+++ b/src/ATen/native/xpu/sycl/TensorApplyUtils.h
@@ -224,36 +224,28 @@ template <
     typename scalar2,
     typename IndexType,
     int step>
-struct PointwiseApply2Functor {
-  void operator()(sycl::nd_item<1> item) const {
-    for (IndexType linearIndex = (item.get_group(0) * item.get_local_range(0) +
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
+void pointwiseApply2Kernel(
+    TensorInfo<scalar1, IndexType> a,
+    TensorInfo<scalar2, IndexType> b,
+    IndexType totalElements,
+    const Op op) {
+  auto item = syclext::this_work_item::get_nd_item<1>();
+  for (IndexType linearIndex = (item.get_group(0) * item.get_local_range(0) +
                                   item.get_local_id(0)) *
-             step;
-         linearIndex < totalElements_;
-         linearIndex +=
-         item.get_group_range(0) * item.get_local_range(0) * step) {
-      ApplyOp2<Op, scalar1, scalar2, IndexType, step>::apply(
-          item,
-          a_,
-          b_,
-          op_,
-          std::min(step, static_cast<int>(totalElements_ - linearIndex)),
-          linearIndex);
-    }
+            step;
+        linearIndex < totalElements;
+        linearIndex +=
+        item.get_group_range(0) * item.get_local_range(0) * step) {
+    ApplyOp2<Op, scalar1, scalar2, IndexType, step>::apply(
+        item,
+        a,
+        b,
+        op,
+        std::min(step, static_cast<int>(totalElements - linearIndex)),
+        linearIndex);
   }
-  PointwiseApply2Functor(
-      TensorInfo<scalar1, IndexType> a,
-      TensorInfo<scalar2, IndexType> b,
-      IndexType totalElements,
-      const Op op)
-      : a_(a), b_(b), totalElements_(totalElements), op_(op) {}
-
- private:
-  TensorInfo<scalar1, IndexType> a_;
-  TensorInfo<scalar2, IndexType> b_;
-  IndexType totalElements_;
-  const Op op_;
-};
+}
 
 template <int step = 1>
 inline uint64_t get_apply_group_count(
@@ -337,13 +329,16 @@ inline bool tensor_apply2(
     bInfo.collapseDims();
 
     using index_t = unsigned int;
-    auto fn = PointwiseApply2Functor<Op, scalar1, scalar2, index_t, step>(
-        aInfo, bInfo, static_cast<index_t>(totalElements), op);
-    sycl_kernel_submit(
+    constexpr auto fn = pointwiseApply2Kernel<Op, scalar1, scalar2, index_t, step>;
+    sycl_kernel_submit<fn>(
         group_count * threads_per_group,
         threads_per_group,
         getCurrentSYCLQueue(),
-        fn);
+        0,
+        aInfo,
+        bInfo,
+        static_cast<index_t>(totalElements),
+        op);
   } else {
     TensorInfo<scalar1, uint64_t> aInfo = getTensorInfo<scalar1, uint64_t>(a);
 
@@ -353,13 +348,16 @@ inline bool tensor_apply2(
     bInfo.collapseDims();
 
     using index_t = uint64_t;
-    auto fn = PointwiseApply2Functor<Op, scalar1, scalar2, index_t, step>(
-        aInfo, bInfo, static_cast<index_t>(totalElements), op);
-    sycl_kernel_submit(
+    constexpr auto fn = pointwiseApply2Kernel<Op, scalar1, scalar2, index_t, step>;
+    sycl_kernel_submit<fn>(
         group_count * threads_per_group,
         threads_per_group,
         getCurrentSYCLQueue(),
-        fn);
+        0,
+        aInfo,
+        bInfo,
+        static_cast<index_t>(totalElements),
+        op);
   }
 
   if (oldA.defined()) {


### PR DESCRIPTION
* migrate TensorApply kernels to sycl free function
Test results (installed missing  scipy  test dependency, then ran via pytest from  third_party/torch-xpu-ops/test/xpu/ ):                               
                                                                                                                                                             
      -  test_distributions_xpu.py -k "poisson_gpu_sample or gamma_gpu_shape or beta_underflow_gpu or gamma_gpu_sample"  → 4 passed                          
      -  test_distributions_xpu.py -k "gamma or dirichlet or poisson"  → 27 passed                                                                           
      -  test_distributions_xpu.py -k "bernoulli"  → 17 passed                                                                                               
      -  test_torch_xpu.py -k "bernoulli"  → 13 passed, 3 skipped (pre-existing, unrelated to this diff)                                                     
                                                                                                                                                             
     All 61 relevant tests pass — the TensorApply free-function migration works correctly for poisson, gamma/dirichlet, and bernoulli-tensor-probability     
     kernels on XPU. 