### PR TITLE
[sycl free function] migrate TensorCompare kernels to sycl free function (#147)

### DIFF
--- a/src/ATen/native/xpu/sycl/TensorCompareKernels.cpp
+++ b/src/ATen/native/xpu/sycl/TensorCompareKernels.cpp
@@ -188,58 +188,37 @@ struct Msg {
 
 // SYCL_KERNEL_ASSERT_MSG is not ready
 template <typename scalar_t>
-struct AssertAsyncKernelFunctor1 {
-  void operator()(sycl::nd_item<1> item) const {
-    SYCL_KERNEL_ASSERT(input_[0] != 0);
-  }
-  AssertAsyncKernelFunctor1(const scalar_t* input, Msg msg)
-      : input_(input), msg_(msg) {}
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
+void assert_async_kernel1(const scalar_t* input, Msg msg) {
+  SYCL_KERNEL_ASSERT(input[0] != 0);
+}
 
- private:
-  const scalar_t* input_;
-  Msg msg_;
-};
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
+void assert_async_kernel2(const c10::complex<float>* input, Msg msg) {
+  SYCL_KERNEL_ASSERT(input[0] != c10::complex<float>(0, 0));
+}
 
-struct AssertAsyncKernelFunctor2 {
-  void operator()(sycl::nd_item<1> item) const {
-    SYCL_KERNEL_ASSERT(input_[0] != c10::complex<float>(0, 0));
-  }
-  AssertAsyncKernelFunctor2(const c10::complex<float>* input, Msg msg)
-      : input_(input), msg_(msg) {}
-
- private:
-  const c10::complex<float>* input_;
-  Msg msg_;
-};
-
-struct AssertAsyncKernelFunctor3 {
-  void operator()(sycl::nd_item<1> item) const {
-    SYCL_KERNEL_ASSERT(input_[0] != c10::complex<double>(0, 0));
-  }
-  AssertAsyncKernelFunctor3(const c10::complex<double>* input, Msg msg)
-      : input_(input), msg_(msg) {}
-
- private:
-  const c10::complex<double>* input_;
-  Msg msg_;
-};
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
+void assert_async_kernel3(const c10::complex<double>* input, Msg msg) {
+  SYCL_KERNEL_ASSERT(input[0] != c10::complex<double>(0, 0));
+}
 
 template <typename scalar_t>
 void launch_assert_async_kernel(const scalar_t* input, Msg msg) {
-  AssertAsyncKernelFunctor1<scalar_t> kfn(input, msg);
-  sycl_kernel_submit(1, 1, getCurrentSYCLQueue(), kfn);
+  constexpr auto kernelFunc = assert_async_kernel1<scalar_t>;
+  sycl_kernel_submit<kernelFunc>(1, 1, getCurrentSYCLQueue(), 0, input, msg);
 }
 
 template <>
 void launch_assert_async_kernel(const c10::complex<float>* input, Msg msg) {
-  AssertAsyncKernelFunctor2 kfn(input, msg);
-  sycl_kernel_submit(1, 1, getCurrentSYCLQueue(), kfn);
+  constexpr auto kernelFunc = assert_async_kernel2;
+  sycl_kernel_submit<kernelFunc>(1, 1, getCurrentSYCLQueue(), 0, input, msg);
 }
 
 template <>
 void launch_assert_async_kernel(const c10::complex<double>* input, Msg msg) {
-  AssertAsyncKernelFunctor3 kfn(input, msg);
-  sycl_kernel_submit(1, 1, getCurrentSYCLQueue(), kfn);
+  constexpr auto kernelFunc = assert_async_kernel3;
+  sycl_kernel_submit<kernelFunc>(1, 1, getCurrentSYCLQueue(), 0, input, msg);
 }
 
 void _assert_async_msg_kernel(


### PR DESCRIPTION
* migrate TensorCompare kernels to sycl free function

 Test results:                                                                                                                                             
                                                                                                                                                             
   • Manual direct checks of  torch._assert_async  on  xpu  device for  int ,  float ,  bool ,  complex64 ,  complex128  (nonzero and zero cases) — all pass 
     correctly (nonzero: no error; zero: kernel assertion fires as expected).                                                                                
   •  test_torch_xpu.py::TestTorch::test_assert_async  — PASSED.                                                                                             
   •  test_indexing_xpu.py  — 192 passed, 4 skipped, 2 failed. The 2 failures ( test_index_add_smem_stage_alignment_regression_xpu_* ) are                   
     pre-existing/unrelated: they call  torch.cuda.get_device_properties(0)  in a CUDA-specific regression test that isn't guarded for XPU-only builds —     
     unrelated to the  TensorCompareKernels.cpp  change. 