### PR TITLE
[DO NOT MERGE] Fuse clamp.Tensor backward into a single XPU kernel

### DIFF
--- a/src/ATen/native/xpu/TensorCompare.cpp
+++ b/src/ATen/native/xpu/TensorCompare.cpp
@@ -20,6 +20,8 @@
 #include <ATen/native/xpu/sycl/TensorCompareKernels.h>
 #include <ATen/native/xpu/sycl/TensorModeKernel.h>
 
+#include <ATen/ops/_clamp_backward_tensor_native.h>
+#include <ATen/ops/empty_like.h>
 #include <ATen/ops/result_type_native.h>
 
 namespace at {
@@ -78,6 +80,24 @@ REGISTER_XPU_DISPATCH(clamp_stub, &xpu::clamp_kernel);
 REGISTER_XPU_DISPATCH(max_stub, &xpu::max_kernel_impl);
 REGISTER_XPU_DISPATCH(min_stub, &xpu::min_kernel_impl)
 REGISTER_XPU_DISPATCH(isin_default_stub, &xpu::isin_kernel);
+
+Tensor _clamp_backward_tensor_xpu(
+    const Tensor& grad_output,
+    const Tensor& self,
+    const Tensor& min,
+    const Tensor& max) {
+  Tensor result = at::empty_like(grad_output);
+  auto iter = at::TensorIteratorConfig()
+                  .add_output(result)
+                  .add_const_input(grad_output)
+                  .add_const_input(self)
+                  .add_const_input(min)
+                  .add_const_input(max)
+                  .promote_inputs_to_common_dtype(true)
+                  .build();
+  xpu::clamp_backward_kernel(iter);
+  return result;
+}
 
 void _assert_async_msg_xpu(
     const Tensor& self_tensor,

--- a/src/ATen/native/xpu/sycl/TensorCompareKernels.cpp
+++ b/src/ATen/native/xpu/sycl/TensorCompareKernels.cpp
@@ -63,6 +63,21 @@ struct ClampFunctor {
 };
 
 template <typename scalar_t>
+struct ClampBackwardFunctor {
+  using opmath_t = at::opmath_type<scalar_t>;
+  scalar_t operator()(scalar_t grad, scalar_t v, scalar_t lower, scalar_t upper)
+      const {
+    if (v < lower || v > upper) {
+      return scalar_t(0);
+    }
+    if ((v == lower || v == upper) && lower < upper) {
+      return static_cast<scalar_t>(static_cast<opmath_t>(grad) / opmath_t(2));
+    }
+    return grad;
+  }
+};
+
+template <typename scalar_t>
 struct ClampScalarFunctor {
   using opmath_t = at::opmath_type<scalar_t>;
   scalar_t operator()(scalar_t v) const {
@@ -127,6 +142,17 @@ void clamp_kernel(TensorIteratorBase& iter) {
       iter.common_dtype(),
       "clamp_xpu",
       AT_WRAP([&] { gpu_kernel(iter, ClampFunctor<scalar_t>()); }),
+      AT_EXPAND(AT_ALL_TYPES),
+      AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES),
+      kHalf,
+      kBFloat16);
+}
+
+void clamp_backward_kernel(TensorIteratorBase& iter) {
+  AT_DISPATCH_V2(
+      iter.common_dtype(),
+      "clamp_backward_xpu",
+      AT_WRAP([&] { gpu_kernel(iter, ClampBackwardFunctor<scalar_t>()); }),
       AT_EXPAND(AT_ALL_TYPES),
       AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES),
       kHalf,

--- a/src/ATen/native/xpu/sycl/TensorCompareKernels.h
+++ b/src/ATen/native/xpu/sycl/TensorCompareKernels.h
@@ -22,6 +22,8 @@ TORCH_XPU_API void isneginf_kernel(TensorIteratorBase& iter);
 
 TORCH_XPU_API void clamp_kernel(TensorIteratorBase& iter);
 
+TORCH_XPU_API void clamp_backward_kernel(TensorIteratorBase& iter);
+
 TORCH_XPU_API void clamp_scalar_kernel(
     TensorIteratorBase& iter,
     const Scalar& min,


### PR DESCRIPTION
- Problem: float16 training of the hf_T5_large model regressed on Arc B580. The two-sided clamp.Tensor backward runs as an 11-op element-wise composite, and the model issues 120 such calls per training step, independent of batch size. The composite's cost is nearly shape-independent from 8 up to 1e6 elements, meaning it is dominated by per-kernel launch overhead rather than by memory bandwidth, so the number of ops dispatched is what drives the cost.
- Root cause: pytorch/pytorch#191142 grew the two-sided clamp_backward(grad, self, Tensor min, Tensor max) formula from 5 to 11 element-wise ops so that the 1/2-gradient is split correctly at ties. The enw semantics are intentional and documented (minimum-norm subradient, 1/2 to each bound at a tie when lo < hi), so the correct response is to fuse the ops, not to revert them.
- Fix: implement _clamp_backward_tensor_xpu for the private op introduced by the corresponding PyTorch change.
  - ClampBackwardFunctor<scalar_t> applies the three-region rule in a
    single gpu_kernel pass: inactive -> 0, tie -> grad/2, interior ->
    grad. NaN comparisons are always false, which preserves NaN pass-through.
  - TensorIteratorConfig uses promote_inputs_to_common_dtype(true) so the bounds are compared in the promoted dtype instead of being narrowed to the activation dtype.
- Validation:
  - 68/68 semantics checks pass, bit-exact (atol=0) against both the 11-op composite on XPU and the same aten op on CPU: boundary cases including equal, reversed and reversed-at-min bounds and NaN self; float16, bfloat16, float32 and float64; mixed and reverse-mixed bound dtypes; a bound not representable in the activation dtype; broadcast 0-dim and row bounds; non-contiguous inputs; 4096 randomized elements per dtype in two dtypes, drawn so that exact tie are hit; gradcheck adn gradgradcheck
  - pytest test/test_binary_ufuncs.py -k "clamp and xpu": 486 passed
  - pytest test/test_ops.py -k "clamp and xpu": 90 passed
  - pytest test/xpu/test_binary_ufuncs_xpu.py -k clamp: 486 passed
  - microbenchmark of the backward op alone, at the shape and dtypes hf_T5_large actually uses ([2,128,1024] float16 activations, 0-dim float32 bounds), taking the current 11-op composite as the baseline:
      * the 5-op formula from before #191142: 79% faster than the baseline
      * this kernel: 86% faster than the baseline
  - end-to-end hf_T5_large float16 forward and backward: the step is 7.6% faster at batch size 1 and 7.5% faster at batch size 2.

Partially fixes: intel/torch-xpu-ops#5155
Recovers 16% of the reproted regression. The remaining has a different cause that is still being investigated.