### PR TITLE
[xccl] Mark isInitialized as override

### DIFF
--- a/src/xccl/ProcessGroupXCCL.hpp
+++ b/src/xccl/ProcessGroupXCCL.hpp
@@ -199,7 +199,7 @@ class TORCH_API ProcessGroupXCCL : public Backend {
     options_->timeout = timeout;
   }
 
-  bool isInitialized();
+  bool isInitialized() override;
 
   void setEnableNanCheck(bool enableNanCheck);
 


### PR DESCRIPTION
pytorch/pytorch made Backend::isInitialized virtual so that split() callers can check whether a lazily initialized backend already has its parent communicator. 