### PR TITLE
[bot] Keep the fix pipeline from stopping mid-run, and fail the job when it does

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1263,7 +1263,7 @@ jobs:
                 "Stop": [{
                   "hooks": [{
                     "type": "prompt",
-                    "prompt": "A headless /issue-handler pipeline is trying to end its turn: $ARGUMENTS. Nothing can resume it, so a turn that ends mid-run loses the whole build. ok=false unless BOTH hold: last_assistant_message reports a terminal outcome (IMPLEMENTING(fix_verified) / NEEDS_HUMAN(reason) / SKIPPED(reason), or an equivalent per-sub-item batch report), AND background_tasks is empty. Otherwise reason must tell it to continue in this session from the stage it stopped at -- waiting on a background task means polling that task in the foreground, and a sub-skill's output is never the final answer."
+                    "prompt": "$ARGUMENTS\n\nAllow the stop only if both are true:\n1. last_assistant_message contains an explicit exit status for the whole run -- a stated final outcome, not a progress update or a partial result\n2. background_tasks is empty\n\nIf both: {\"ok\": true}\nOtherwise: {\"ok\": false, \"reason\": \"Not finished. Keep working in this session. If a background task is running, poll it in the foreground.\"}"
                   }]
                 }]
               }
@@ -1425,20 +1425,20 @@ jobs:
             const outcome = process.env.AI_FIX_OUTCOME || 'skipped';
             const file = '${{ steps.ai-fix.outputs.execution_file }}';
 
-            let result = null;
+            let resultEvent = null;
             if (file && fs.existsSync(file)) {
               const data = JSON.parse(fs.readFileSync(file, 'utf8'));
-              result = data.filter(e => e.type === 'result').pop();
-              // Log only status fields, not result.result (agent free text that
+              resultEvent = data.filter(e => e.type === 'result').pop();
+              // Log only status fields, not resultEvent.result (agent free text that
               // may echo a token) into the job log.
-              if (result) console.log('Result status:', JSON.stringify({
-                is_error: result.is_error, total_cost_usd: result.total_cost_usd
+              if (resultEvent) console.log('Result status:', JSON.stringify({
+                is_error: resultEvent.is_error, total_cost_usd: resultEvent.total_cost_usd
               }));
             }
-            const reportedOutcome = /(?:^|\n)\s*(?:\*\*)?Done\b|\b(IMPLEMENTING\(fix_verified\)|NEEDS_HUMAN|SKIPPED|NOT_REPRODUCED|NO_REPRODUCER|CANNOT_VERIFY|ALREADY_FIXED|STALE_SKIP|FIXED|PASSED|FAILED)\b/
-              .test((result && result.result) || '');
-            if (outcome === 'success' && result && !result.is_error
-                && result.total_cost_usd > 0 && reportedOutcome) {
+            const reportedOutcome = /(?:^|\n)\s*(?:\*\*)?Done\b|\b(IMPLEMENTING\(fix_verified\)|NEEDS_HUMAN|SKIPPED|NOT_REPRODUCED|NO_REPRODUCER|CANNOT_VERIFY|ALREADY_FIXED|STALE_SKIP|FIXED|PASSED|FAILED)\b/i
+              .test((resultEvent && resultEvent.result) || '');
+            if (outcome === 'success' && resultEvent && !resultEvent.is_error
+                && resultEvent.total_cost_usd > 0 && reportedOutcome) {
               return;
             }
 
@@ -1449,9 +1449,9 @@ jobs:
               reason = 'the run was cancelled.';
             } else if (outcome === 'skipped') {
               reason = 'the environment setup failed before the agent started -- checkout, Python setup, or the nightly PyTorch-XPU install.';
-            } else if (result && result.is_error) {
+            } else if (resultEvent && resultEvent.is_error) {
               reason = 'the agent returned an error. This is usually a Bedrock or model failure; check AWS token validity.';
-            } else if (!result) {
+            } else if (!resultEvent) {
               reason = 'the agent produced no output. This is usually a Bedrock connectivity or credential failure; check AWS token validity.';
             } else if (!reportedOutcome) {
               reason = 'the pipeline exited before reporting a terminal outcome -- it dropped out mid-run instead of reaching stage 6. Re-run `@torchxpubot fix`: the re-run gate skips the stages that already completed.';

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1256,7 +1256,18 @@ jobs:
         with:
           use_bedrock: "true"
           github_token: ${{ secrets.MERGE_TOKEN }}
-          settings: '{"alwaysThinkingEnabled": true}'
+          settings: |
+            {
+              "alwaysThinkingEnabled": true,
+              "hooks": {
+                "Stop": [{
+                  "hooks": [{
+                    "type": "prompt",
+                    "prompt": "A headless /issue-handler pipeline is trying to end its turn: $ARGUMENTS. Nothing can resume it, so a turn that ends mid-run loses the whole build. ok=false unless BOTH hold: last_assistant_message reports a terminal outcome (IMPLEMENTING(fix_verified) / NEEDS_HUMAN(reason) / SKIPPED(reason), or an equivalent per-sub-item batch report), AND background_tasks is empty. Otherwise reason must tell it to continue in this session from the stage it stopped at -- waiting on a background task means polling that task in the foreground, and a sub-skill's output is never the final answer."
+                  }]
+                }]
+              }
+            }
           claude_args: "--model ${{ env.BEDROCK_MODEL }} --max-turns 200 --allowedTools ${{ env.CLAUDE_ALLOWED_TOOLS }},Write,Edit"
           prompt: |
             Use the /issue-handler skill in pipeline mode to fix issue
@@ -1424,7 +1435,10 @@ jobs:
                 is_error: result.is_error, total_cost_usd: result.total_cost_usd
               }));
             }
-            if (outcome === 'success' && result && !result.is_error && result.total_cost_usd > 0) {
+            const reportedOutcome = /(?:^|\n)\s*(?:\*\*)?Done\b|\b(IMPLEMENTING\(fix_verified\)|NEEDS_HUMAN|SKIPPED|NOT_REPRODUCED|NO_REPRODUCER|CANNOT_VERIFY|ALREADY_FIXED|STALE_SKIP|FIXED|PASSED|FAILED)\b/
+              .test((result && result.result) || '');
+            if (outcome === 'success' && result && !result.is_error
+                && result.total_cost_usd > 0 && reportedOutcome) {
               return;
             }
 
@@ -1439,6 +1453,8 @@ jobs:
               reason = 'the agent returned an error. This is usually a Bedrock or model failure; check AWS token validity.';
             } else if (!result) {
               reason = 'the agent produced no output. This is usually a Bedrock connectivity or credential failure; check AWS token validity.';
+            } else if (!reportedOutcome) {
+              reason = 'the pipeline exited before reporting a terminal outcome -- it dropped out mid-run instead of reaching stage 6. Re-run `@torchxpubot fix`: the re-run gate skips the stages that already completed.';
             } else {
               reason = 'the agent exited without a usable result.';
             }


### PR DESCRIPTION
## Problem

Three of 19 `@torchxpubot fix` runs on 2026-09-07 finished all 26 steps green without completing the pipeline:

| Issue | Where it stopped | Cost |
|---|---|---|
| #3530 | ended the turn when the nested `issue-triage` skill returned, stage 1 of 6 | $0.50 |
| #5221 | started a `run_in_background` build, reported progress, ended the turn | $5.96 |
| #4732 | same, fix committed and left at `verdict=PENDING_VERIFY` | $12.99 |

All three exit with `stop_reason=end_turn`, `is_error=false` and a non-zero cost, which is what the verify gate accepted:

```js
outcome === 'success' && !result.is_error && result.total_cost_usd > 0
```

## Fix

Two changes in `bot.yml`.

**A `Stop` hook on the fix job.** The Stop event carries `last_assistant_message` and `background_tasks`, so the hook can refuse the stop until the run reports a final outcome with nothing left in flight. Blocking resumes the same session, so #4732's build does not start over. Claude Code caps consecutive blocks at 8, so a stuck run still ends.

**The verify step requires the same.** It matches the closing message for an outcome token. `fix_result*.json` cannot serve as the signal: a legitimate `SKIPPED` run writes none, while an abandoned one writes it at `PENDING_VERIFY`.

## Test

Pulled the transcript artifacts for all 20 runs in that batch, plus #3530's original $0.50 drop-out, and matched the pattern against each run's actual `result.result`:

- 18/18 completed runs match
- 3/3 drop-outs do not, and none of them contains any token from the list

No structured field separates the two groups. `stop_reason`, `terminal_reason` and `subtype` are identical across all 21 runs, and `num_turns` does not help either (#4732 dropped out after 138 turns). The issue-body `<!-- agent:status -->` marker is absent on all 20 issues, which are human-filed rather than created from the agent template.

Treating every intermediate assistant message as a hypothetical stopping point, 17 of 277 (6.1%) would still be let through. So the verify step is a backstop at roughly 94%. The Stop hook is the primary defense, and it reads `background_tasks` rather than vocabulary.

The hook itself only proves out on a live Stop event. #5221 and #4732 are the natural first targets, being known to stop at the build.

Authored with the assistance of an AI coding agent.
