### PR TITLE
[bot] Fix the agent lifecycle label mapping and surface the SKIPPED reason

### DIFF
--- a/.claude/skills/issue-handler/references/execution-modes.md
+++ b/.claude/skills/issue-handler/references/execution-modes.md
@@ -69,8 +69,12 @@ Apply the matching GitHub label when advancing the marker:
 |----------|-------|
 | DISCOVERED, TRIAGING, REPRODUCING, IMPLEMENTING, VERIFYING | `agent:active` |
 | TRIAGED | `agent:triaged` |
-| DONE, SKIPPED | `agent:done` |
+| DONE | `agent:done` |
+| SKIPPED | `agent:skipped` |
 | NEEDS_HUMAN | `agent:needs-human` |
+
+Always exactly one of these five: swap the old one for the new one,
+never leave the issue with none.
 
 The `agent:active` label sticks across all in-progress stages so
 external filters (dashboards, CI monitors) can bucket "currently
@@ -96,7 +100,9 @@ stage completes, and never creates a second one:
   text it held.
 - Stages 3-5 (root-cause, implement, verify) each **append** their block
   to that same comment.
-- Stage 6 **appends** the closing summary: verdict, branch, caveats.
+- Stage 6 **appends** the closing summary: verdict, branch, caveats. Its
+  `**Outcome:**` line goes at the top instead, with the reason:
+  `SKIPPED(no_longer_reproduces)`, never bare `SKIPPED`.
 
 Edit in place by id — read the current body, append, PATCH it back:
 

--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -238,10 +238,10 @@ Field notes:
 
 `suggested_labels` is populated as follows:
 
-- If `reproduction_missing == true` → include `agent:reproduction-needed`.
 - If `handling == "needs-human"` → include `agent:needs-human`.
-- Empty array when neither applies (i.e. agent-fixable with a
-  reproducer).
+- Empty array otherwise. A missing reproducer needs no label of its
+  own: the orchestrator reports it as `SKIPPED(reproduction_missing)`
+  and applies `agent:skipped`.
 
 Scope and dependency values live in the JSON structure, not as labels.
 


### PR DESCRIPTION
Four label problems, found going through the 2026-09-07 fix batch.

**SKIPPED had the wrong label.** Table said `DONE, SKIPPED -> agent:done`, but `agent:skipped` exists and is what the agent applies. Split them: one means a patch is waiting, the other means the issue can be closed.

**Runs could end up with no label.** Nothing said to swap the old one out, or that there should always be one. #4455 dropped `agent:active` and had nothing to add, since `agent:done` didn't exist. Seven runs are unlabelled right now, and #5020 finished DONE but sits on `agent:needs-human`.

**The SKIPPED reason was buried.** It can mean not a bug, no reproducer, or no longer reproduces. The outcome line landed on line 4 in #4834 but line 48 in #5027, so Stage 6 now puts it at the top with its reason.

**`agent:reproduction-needed` was redundant** with `SKIPPED(reproduction_missing)`. Dropped it and deleted the label, nothing was using it.

Also created `agent:done` and `agent:triaged`, and rewrote the three terminal label descriptions.

Authored with the assistance of an AI coding agent.
