### PR TITLE
[xccl] Support Float4_e2m1fn_x2 and Float8_e8m0fnu for non-reduction ops

### DIFF
--- a/src/xccl/NanCheck_XPU.cpp
+++ b/src/xccl/NanCheck_XPU.cpp
@@ -213,6 +213,12 @@ void checkForNan(const at::Tensor& tensor, at::xpu::XPUStream& stream) {
   if (!tensor.is_floating_point()) {
     return;
   }
+  // Both report as floating point but are moved as opaque bytes: fp4 has no
+  // NaN encoding at all, and e8m0 is absent from the dispatch below.
+  if (tensor.scalar_type() == at::kFloat4_e2m1fn_x2 ||
+      tensor.scalar_type() == at::kFloat8_e8m0fnu) {
+    return;
+  }
   if (tensor.numel() == 0) {
     return;
   }

--- a/src/xccl/xccl.h
+++ b/src/xccl/xccl.h
@@ -108,6 +108,10 @@ inline const std::map<at::ScalarType, onecclDataType_t> xcclDatatypes = {
     {at::kFloat8_e4m3fn, onecclDataType_t::onecclUint8},
     {at::kFloat8_e4m3fnuz, onecclDataType_t::onecclUint8},
     {at::kFloat8_e5m2fnuz, onecclDataType_t::onecclUint8},
+    // MX formats: fp4 is already x2-packed into a byte and e8m0 is the shared
+    // scale that comes with it, so both are one byte per element here.
+    {at::kFloat8_e8m0fnu, onecclDataType_t::onecclUint8},
+    {at::kFloat4_e2m1fn_x2, onecclDataType_t::onecclUint8},
 };
 
 namespace {
@@ -180,6 +184,11 @@ inline onecclDataType_t getXcclDataType(
     TORCH_CHECK(
         !isFloat8Type(type),
         "Float8 dtypes are not currently supported for XCCL reductions");
+    // Not covered by isFloat8Type. Reducing it as uint8 would let one element
+    // carry into the neighbour packed in the same byte.
+    TORCH_CHECK(
+        type != at::kFloat4_e2m1fn_x2,
+        "Float4 is not currently supported for XCCL reductions");
   }
   auto it = xcclDatatypes.find(type);
   TORCH_CHECK_WITH(

--- a/test/xpu/distributed/test_c10d_xccl.py
+++ b/test/xpu/distributed/test_c10d_xccl.py
@@ -769,6 +769,51 @@ class CommTest(MultiProcessTestCase):
 
     @requires_xccl()
     @skip_if_lt_x_gpu(2)
+    def test_all_gather_into_tensor_mx_dtypes(self):
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            "xccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+        )
+        device = "xpu"
+        # The two halves of an MX tensor: packed fp4 payload and its e8m0 scale.
+        for dtype in [torch.float4_e2m1fn_x2, torch.float8_e8m0fnu]:
+            # Neither dtype supports arithmetic or casting, so build the byte
+            # pattern as uint8 and reinterpret. Keeping the payload
+            # rank-dependent means an implementation that skips the transfer
+            # cannot pass.
+            tensor = torch.full(
+                (12, 12), self.rank + 1, dtype=torch.uint8, device=device
+            ).view(dtype)
+            output_tensor = torch.zeros(
+                self.world_size * 12, 12, dtype=torch.uint8, device=device
+            ).view(dtype)
+            dist.all_gather_into_tensor(output_tensor, tensor)
+            gathered = output_tensor.view(torch.uint8)
+            for i in range(self.world_size):
+                expected = torch.full((12, 12), i + 1, dtype=torch.uint8, device=device)
+                self.assertEqual(gathered[i * 12 : (i + 1) * 12], expected)
+
+    @requires_xccl()
+    @skip_if_lt_x_gpu(2)
+    def test_reduction_rejects_float4(self):
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            "xccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+        )
+        tensor = torch.zeros(12, 12, dtype=torch.uint8, device="xpu").view(
+            torch.float4_e2m1fn_x2
+        )
+        with self.assertRaisesRegex(RuntimeError, "Float4"):
+            dist.all_reduce(tensor)
+
+    @requires_xccl()
+    @skip_if_lt_x_gpu(2)
     def test_unwaited(self) -> None:
         # Verify that the process can terminate gracefully
         # even with unwaited tensors


### PR DESCRIPTION
These are the two halves of an MX tensor. torchao keeps them as separate tensors (MXTensor holds `qdata` plus `scale`), so a collective on an MX tensor is really two collectives.
Both are one byte per element -- fp4 packs two values into a byte and e8m0 is a bare 8-bit exponent -- so for ops that only move bytes they can map to onecclUint8 the same way the fp8 types already do. 