### PR TITLE
Disable output vectorization for complex reductions

### DIFF
--- a/src/ATen/native/xpu/sycl/Reduce.h
+++ b/src/ATen/native/xpu/sycl/Reduce.h
@@ -20,6 +20,7 @@
 #include <ATen/native/xpu/sycl/OffsetCalculator.h>
 #include <c10/core/Allocator.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/complex_utils.h>
 #include <comm/DeviceProperties.h>
 #include <comm/SYCLContext.h>
 #include <comm/XPUPair.h>
@@ -1155,6 +1156,12 @@ class AccumulationBuffer {
 inline constexpr int DEFAULT_OUTPUT_VEC_SIZE = 4;
 template <typename scalar_t, int vt1>
 int get_output_vec_size(at::TensorIterator& iter) {
+  // The vectorized aligned_vector store below corrupts a complex value's
+  // real/imaginary components; keep those scalar.
+  if constexpr (c10::is_complex<scalar_t>::value) {
+    return 1;
+  }
+
   int vec_size = DEFAULT_OUTPUT_VEC_SIZE;
   auto update_vec_size = [&vec_size](uint64_t n) {
     while (n % vec_size != 0) {


### PR DESCRIPTION
get_output_vec_size unconditionally considered vector widths up to DEFAULT_OUTPUT_VEC_SIZE (4), even for complex scalar_t. The vectorized store treats output_vec_size adjacent elements as a raw aligned_vector, which corrupts a complex value's real/imaginary components; scalar output processing is unaffected. Complex reductions now always use a scalar (vec_size 1) output; real types' vectorization is untouched.

Test Plan: no XPU device available where this was written; offered for CI. The complex64/complex128 sum and mean shape matrix should be checked against CPU references (e.g. `test_consistency_mean_xpu_complex128` in complex_tensor/test_complex_tensor_xpu.py).

This PR was authored with the assistance of an AI coding assistant.