### PR TITLE
[sycl-free-function] migrate UnfoldBackward kernels to sycl free function (#152)

### DIFF
--- a/src/ATen/native/xpu/sycl/UnfoldBackwardKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UnfoldBackwardKernels.cpp
@@ -29,30 +29,21 @@ namespace at::native::xpu {
 constexpr int n_elems_per_work_item = 4; // UNROLLED_ELEM_PER_WORK_ITEM;
 
 template <int n_elems_per_work_item, typename func_t>
-struct UnfoldBackwardElementwiseKernelFunctor {
-  void operator()(sycl::item<1> item) const {
-    int idx = item.get_linear_id();
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
+void unfold_backward_elementwise_kernel(
+    int total_work_items,
+    int total_n_elems,
+    func_t f) {
+  auto item = syclext::this_work_item::get_nd_item<1>();
+  int idx = item.get_local_linear_id();
 #pragma unroll
-    for (int i = 0; i < n_elems_per_work_item; ++i) {
-      if (idx < total_n_elems_) {
-        f_(idx);
-        idx += total_work_items_;
-      }
+  for (int i = 0; i < n_elems_per_work_item; ++i) {
+    if (idx < total_n_elems) {
+      f(idx);
+      idx += total_work_items;
     }
   }
-  UnfoldBackwardElementwiseKernelFunctor(
-      int total_work_items,
-      int total_n_elems,
-      func_t f)
-      : total_work_items_(total_work_items),
-        total_n_elems_(total_n_elems),
-        f_(f) {}
-
- private:
-  int total_work_items_;
-  int total_n_elems_;
-  func_t f_;
-};
+}
 
 template <int n_elems_per_work_item, typename func_t>
 static void _launch_unfold_backward_kernel(int total_n_elems, func_t f) {
@@ -63,11 +54,18 @@ static void _launch_unfold_backward_kernel(int total_n_elems, func_t f) {
 
   int total_work_items =
       (total_n_elems + n_elems_per_work_item - 1) / n_elems_per_work_item;
-  UnfoldBackwardElementwiseKernelFunctor<n_elems_per_work_item, func_t> kfn(
-      total_work_items, total_n_elems, f);
+  constexpr auto kfn =
+      unfold_backward_elementwise_kernel<n_elems_per_work_item, func_t>;
   auto& queue = getCurrentSYCLQueue();
 
-  sycl_kernel_submit(sycl::range<1>(total_work_items), queue, kfn);
+  sycl_kernel_submit<kfn>(
+      sycl::range<1>(total_work_items),
+      sycl::range<1>(total_work_items),
+      queue,
+      0,
+      total_work_items,
+      total_n_elems,
+      f);
 }
 
 template <typename scalar_t, typename offset_calc_t>


### PR DESCRIPTION
 Test results (all passing):                                                                                                                            
                                                                                                                                                            
      -  test_unfold_backward_errors_cpu  — OK                                                                                                              
      -  test_unfold_backward_errors_xpu  — OK                                                                                                              
      -  test_ops_gradients_xpu.py -k unfold  — 30 tests, 12 ran OK, 18 skipped (expected: no inplace variant / no gradgrad support for those variants) —  covers  unfold ,  unfold_copy ,  nn.functional.unfold  for float64/complex128, exercising the migrated free-function kernel via  gradcheck/gradgradcheck.                                                                                     
      - Manual sanity check:  x.unfold(...).sum().backward()  on XPU matches CPU gradient exactly. 