### PR TITLE
[1/2] Migrating DeviceProperties.h to ATen/xpu/XPUContext.h for 1:1 API mappings

### DIFF
--- a/src/ATen/native/nested/xpu/sycl/NestedTensorTransformerFunctionKernels.cpp
+++ b/src/ATen/native/nested/xpu/sycl/NestedTensorTransformerFunctionKernels.cpp
@@ -14,6 +14,7 @@
 #include <ATen/native/StridedRandomAccessor.h>
 #include <ATen/native/nested/NestedTensorUtils.h>
 #include <ATen/native/nested/xpu/sycl/NestedTensorTransformerFunctionKernels.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/SYCLContext.h>
 
 // keep align with cuda, global range0 is set to output_batch_size, global_range
@@ -214,7 +215,7 @@ void remove_padding_kernel(
         output_sizes,
         output_dim,
         batch_size);
-    int64_t max_wg_size = syclMaxWorkGroupSize(kfn);
+    int64_t max_wg_size = at::xpu::getKernelMaxWorkGroupSize(kfn);
     sycl::range<2> global_range(GRID_DIM_Y, batch_size * max_wg_size);
     sycl::range<2> local_range(1, max_wg_size);
     sycl_kernel_submit(global_range, local_range, queue, kfn);
@@ -227,7 +228,7 @@ void remove_padding_kernel(
         output_sizes,
         output_dim,
         batch_size);
-    int64_t max_wg_size = syclMaxWorkGroupSize(kfn);
+    int64_t max_wg_size = at::xpu::getKernelMaxWorkGroupSize(kfn);
     sycl::range<2> global_range(GRID_DIM_Y, batch_size * max_wg_size);
     sycl::range<2> local_range(1, max_wg_size);
     sycl_kernel_submit(global_range, local_range, queue, kfn);
@@ -257,7 +258,7 @@ void remove_padding_transform0213_kernel(
       output_dim,
       batch_size);
 
-  int64_t max_wg_size = syclMaxWorkGroupSize(kfn);
+  int64_t max_wg_size = at::xpu::getKernelMaxWorkGroupSize(kfn);
   sycl::range<2> global_range(GRID_DIM_Y, batch_size * max_wg_size);
   sycl::range<2> local_range(1, max_wg_size);
 
@@ -567,7 +568,7 @@ void add_padding_kernel_impl(
         input_dim,
         output_sizes[1],
         batch_size);
-    int64_t max_wg_size = syclMaxWorkGroupSize(kfn);
+    int64_t max_wg_size = at::xpu::getKernelMaxWorkGroupSize(kfn);
     sycl::range<2> global_range(GRID_DIM_Y, output_batch_size * max_wg_size);
     sycl::range<2> local_range(1, max_wg_size);
     sycl_kernel_submit(global_range, local_range, queue, kfn);
@@ -583,7 +584,7 @@ void add_padding_kernel_impl(
         output_sizes[1],
         output_sizes[2],
         batch_size);
-    int64_t max_wg_size = syclMaxWorkGroupSize(kfn);
+    int64_t max_wg_size = at::xpu::getKernelMaxWorkGroupSize(kfn);
     sycl::range<2> global_range(GRID_DIM_Y, output_batch_size * max_wg_size);
     sycl::range<2> local_range(1, max_wg_size);
     sycl_kernel_submit(global_range, local_range, queue, kfn);
@@ -600,7 +601,7 @@ void add_padding_kernel_impl(
         output_sizes[2],
         output_sizes[3],
         batch_size);
-    int64_t max_wg_size = syclMaxWorkGroupSize(kfn);
+    int64_t max_wg_size = at::xpu::getKernelMaxWorkGroupSize(kfn);
     sycl::range<2> global_range(GRID_DIM_Y, output_batch_size * max_wg_size);
     sycl::range<2> local_range(1, max_wg_size);
     sycl_kernel_submit(global_range, local_range, queue, kfn);

--- a/src/ATen/native/sparse/xpu/sycl/SparseCsrTensorMathKernels.cpp
+++ b/src/ATen/native/sparse/xpu/sycl/SparseCsrTensorMathKernels.cpp
@@ -24,6 +24,7 @@
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/SparseTensorUtils.h>
+#include <ATen/xpu/XPUContext.h>
 #include <algorithm>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -133,7 +134,8 @@ Tensor reduce_sparse_csr_dim0_xpu_template(
             index_t,
             ReductionOp,
             acc_t>;
-        int64_t work_group_size = syclMaxWorkGroupSize<kernel_func>();
+        int64_t work_group_size =
+            at::xpu::getKernelMaxWorkGroupSize<kernel_func>();
         int64_t work_group_num =
             (new_nnz + work_group_size - 1) / work_group_size;
         sycl_kernel_submit<kernel_func>(
@@ -233,7 +235,8 @@ Tensor reduce_sparse_csr_dim1_xpu_template(
             index_t,
             ReductionOp,
             acc_t>;
-        int64_t work_group_size = syclMaxWorkGroupSize<kernel_func>();
+        int64_t work_group_size =
+            at::xpu::getKernelMaxWorkGroupSize<kernel_func>();
         int64_t work_group_num =
             (nrows + work_group_size - 1) / work_group_size;
 
@@ -453,7 +456,7 @@ void launch_convert_indices_from_coo_to_csr_xpu_kernel(
 
   constexpr auto kernel_func =
       convert_indices_from_coo_to_csr_xpu_kernel<input_t, output_t>;
-  int64_t wgroup_size = syclMaxWorkGroupSize<kernel_func>();
+  int64_t wgroup_size = at::xpu::getKernelMaxWorkGroupSize<kernel_func>();
   int64_t ngroups = (numel + wgroup_size - 1) / wgroup_size;
   sycl::range<1> global_range(ngroups * wgroup_size);
   sycl::range<1> local_range(wgroup_size);
@@ -506,7 +509,7 @@ void launch_convert_indices_from_csr_to_coo_xpu_kernel(
 
   constexpr auto kernel_func =
       convert_indices_from_csr_to_coo_xpu_kernel<input_t, output_t>;
-  int64_t THREADS = syclMaxWorkGroupSize<kernel_func>();
+  int64_t THREADS = at::xpu::getKernelMaxWorkGroupSize<kernel_func>();
   int64_t GROUPS = (nrows * nbatches + THREADS) / THREADS;
 
   sycl::range<1> global_range(GROUPS * THREADS);

--- a/src/ATen/native/sparse/xpu/sycl/SparseTensorMathKernels.cpp
+++ b/src/ATen/native/sparse/xpu/sycl/SparseTensorMathKernels.cpp
@@ -21,6 +21,7 @@
 #include <ATen/native/SparseTensorUtils.h>
 #include <ATen/native/sparse/SparseTensorMath.h>
 #include <ATen/native/xpu/sycl/pstl/PSTLFunctions.h>
+#include <ATen/xpu/XPUContext.h>
 #include <ATen/xpu/XPUUtils.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -117,9 +118,10 @@ void sparse_elementwise_kernel(
 //     const IndexType nnz) {
 //   using KernelClass = SparseElementwiseKernellFunctor<Op, IndexType, Real>;
 //   auto& queue = getCurrentSYCLQueue();
-//   IndexType group_size = (IndexType)syclMaxWorkGroupSize<KernelClass>();
-//   IndexType target_global_size = (IndexType)syclMaxWorkItemsPerTile();
-//   auto max_work_group_num = target_global_size / group_size;
+//   IndexType group_size =
+//   (IndexType)at::xpu::getKernelMaxWorkGroupSize<KernelClass>(); IndexType
+//   target_global_size = (IndexType)at::xpu::getDeviceMaxWorkItems(); auto
+//   max_work_group_num = target_global_size / group_size;
 
 //   auto num_groups = CeilDiv(nnz, group_size);
 //   if (num_groups > max_work_group_num)
@@ -167,8 +169,8 @@ void sparse_elementwise_scalar_kernel(
 //     const IndexType nnz) {
 //   using KernelClass = SparseElementwiseKernelScalarFunctor<Op, IndexType,
 //   Real>; auto& queue = getCurrentSYCLQueue(); IndexType group_size =
-//   (IndexType)syclMaxWorkGroupSize<KernelClass>(); IndexType
-//   target_global_size = (IndexType)syclMaxWorkItemsPerTile(); auto
+//   (IndexType)at::xpu::getKernelMaxWorkGroupSize<KernelClass>(); IndexType
+//   target_global_size = (IndexType)at::xpu::getDeviceMaxWorkItems(); auto
 //   max_work_group_num = target_global_size / group_size;
 
 //   auto num_groups = CeilDiv(nnz * group_size, group_size);
@@ -242,7 +244,7 @@ Tensor& add_out_dense_sparse_kernel(
   }
 
   if (sparse.is_coalesced()) {
-    size_t target_global_size = syclMaxWorkItemsPerTile();
+    size_t target_global_size = at::xpu::getDeviceMaxWorkItems();
 
     if (sparse.dense_dim() == 0) {
       AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(
@@ -262,7 +264,8 @@ Tensor& add_out_dense_sparse_kernel(
             auto indices_info = I_INFO(indices);
             auto values_info = V_INFO(values);
             auto nnz_val = static_cast<uint64_t>(nnz);
-            size_t group_size = syclMaxWorkGroupSize<kernel_ptr>();
+            size_t group_size =
+                at::xpu::getKernelMaxWorkGroupSize<kernel_ptr>();
             size_t max_work_group_num = target_global_size / group_size;
             size_t num_groups = (nnz + group_size - 1) / group_size;
             if (num_groups > max_work_group_num)
@@ -299,7 +302,8 @@ Tensor& add_out_dense_sparse_kernel(
             auto indices_info = I_INFO(indices);
             auto values_info = V_INFO(values);
             auto nnz_val = static_cast<uint64_t>(nnz);
-            size_t group_size = syclMaxWorkGroupSize<kernel_ptr>();
+            size_t group_size =
+                at::xpu::getKernelMaxWorkGroupSize<kernel_ptr>();
             size_t max_work_group_num = target_global_size / group_size;
             size_t num_groups = (nnz + group_size - 1) / group_size;
             if (num_groups > max_work_group_num)
@@ -653,10 +657,11 @@ Tensor _sparse_sum_backward_kernel(
                 getTensorInfo<scalar_t, int64_t>(grad_input_values);
 
             constexpr auto kernel_ptr = sparse_sum_backward_kernel<scalar_t>;
-            size_t target_global_size = syclMaxWorkItemsPerTile();
+            size_t target_global_size = at::xpu::getDeviceMaxWorkItems();
             size_t group_size = std::min(
                 static_cast<size_t>(input_nnz),
-                static_cast<size_t>(syclMaxWorkGroupSize<kernel_ptr>()));
+                static_cast<size_t>(
+                    at::xpu::getKernelMaxWorkGroupSize<kernel_ptr>()));
             size_t max_work_group_num = target_global_size / group_size;
             size_t num_groups = (input_nnz + group_size - 1) / group_size;
             if (num_groups > max_work_group_num)

--- a/src/ATen/native/transformers/sycl/AttentionKernels.cpp
+++ b/src/ATen/native/transformers/sycl/AttentionKernels.cpp
@@ -18,6 +18,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/core/TensorAccessor.h>
 #include <ATen/native/nested/NestedTensorUtils.h>
+#include <ATen/xpu/XPUContext.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -399,7 +400,7 @@ void _transform_bias_rescale_qkv_kernel(
     int64_t T,
     int64_t D,
     int64_t dim_per_head) {
-  auto max_wg_size = syclDeviceMaxWorkGroupSize();
+  int64_t max_wg_size = at::xpu::getDeviceMaxWorkGroupSize();
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::Half,

--- a/src/ATen/native/xpu/sycl/ActivationGluKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ActivationGluKernels.cpp
@@ -11,6 +11,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/OpMathType.h>
 #include <ATen/TensorIterator.h>
+#include <ATen/xpu/XPUContext.h>
 
 #include <ATen/native/xpu/sycl/Loops.h>
 #include <comm/SYCLContext.h>
@@ -114,8 +115,8 @@ void launch_glu_backward_kernel(
     OffsetCalc offset_calculator,
     int64_t gI_byte_offset,
     int64_t I_byte_offset) {
-  const int64_t local_size =
-      syclMaxWorkGroupSize<glu_backward_kernel<scalar_t, OffsetCalc>>();
+  const int64_t local_size = at::xpu::getKernelMaxWorkGroupSize<
+      glu_backward_kernel<scalar_t, OffsetCalc>>();
   const int64_t num_wg = (numel + local_size - 1) / local_size;
   const int64_t global_size = num_wg * local_size;
 

--- a/src/ATen/native/xpu/sycl/AdaptiveAveragePooling2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/AdaptiveAveragePooling2dKernels.cpp
@@ -15,6 +15,7 @@
 #include <ATen/native/Pool.h>
 #include <ATen/native/xpu/sycl/LaunchUtils.h>
 #include <ATen/native/xpu/sycl/MemoryAccess.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/MemoryFormat.h>
 #include <comm/xpu_aten.h>
 #include <vector>
@@ -91,7 +92,8 @@ struct AdaptiveAvgPool2dBwdKernelFunctor {
         local_range_(syclMaxWorkItemsPerSubSlice()),
         gyacc_(gyacc),
         gxacc_(gxacc) {
-    int total_item = std::min(numel_, syclMaxWorkItemsPerTile());
+    int total_item =
+        std::min<int64_t>(numel_, at::xpu::getDeviceMaxWorkItems());
     global_range_ = total_item < local_range_
         ? local_range_
         : (total_item / local_range_) * local_range_;
@@ -204,11 +206,12 @@ struct AdaptiveAvgPool2dBwdSLMKernelFunctor
         oh_(gyacc.size(2)),
         ow_(gyacc.size(3)),
         numel_(static_cast<int64_t>(ib_) * ic_ * ih_ * iw_),
-        local_range_(
-            syclMaxWorkGroupSize<AdaptiveAvgPool2dBwdSLMKernelFunctor>()),
+        local_range_(at::xpu::getKernelMaxWorkGroupSize<
+                     AdaptiveAvgPool2dBwdSLMKernelFunctor>()),
         gyacc_(gyacc),
         gxacc_(gxacc) {
-    int total_item = std::min(numel_, syclMaxWorkItemsPerTile());
+    int total_item =
+        std::min<int64_t>(numel_, at::xpu::getDeviceMaxWorkItems());
     global_range_ = total_item < local_range_
         ? local_range_
         : (total_item / local_range_) * local_range_;
@@ -457,12 +460,13 @@ void adaptive_avg_pool2d_backward_kernel(
 
     int max_threads =
         std::min<int>(syclMaxWorkItemsPerSubSlice(), XPU_MAX_THREADS);
-    size_t sharedMemPerGroup = syclLocalMemSize();
+    size_t sharedMemPerGroup = at::xpu::getDeviceLocalMemSize();
 
     bool done = false;
     do {
       int group_x = std::max<int>(
-          std::min<int>(lastPow2(sizeC), syclMaxSubGroupSize()), 1);
+          std::min<int>(lastPow2(sizeC), at::xpu::getDeviceMaxSubGroupSize()),
+          1);
       int group_y = std::max<int>(
           std::min<int>(lastPow2(isizeW), max_threads / group_x), 1);
       int group_z = std::max<int>(
@@ -541,8 +545,8 @@ void adaptive_avg_pool2d_backward_kernel(
 
           int64_t ohw01_shared_size = ((isizeH + isizeW) * 2) * sizeof(int);
           int64_t ikhw_shared_size = (osizeH + osizeW) * sizeof(opmath_t);
-          bool using_shared =
-              syclLocalMemSize() >= ohw01_shared_size + ikhw_shared_size;
+          bool using_shared = at::xpu::getDeviceLocalMemSize() >=
+              ohw01_shared_size + ikhw_shared_size;
 
           auto& q = getCurrentSYCLQueue();
           if (using_shared) {
@@ -768,13 +772,13 @@ void launch_adaptive_avg_pool2d_kernel_cl(const Tensor& input, Tensor& output) {
        vec_size /= 2) {
     if (oc % vec_size != 0)
       continue;
-    if (2 * numel / vec_size > syclMaxWorkItemsPerTile()) {
+    if (2 * numel / vec_size > at::xpu::getDeviceMaxWorkItems()) {
       numel /= vec_size;
       break;
     }
   }
 
-  auto wg_size = syclDeviceMaxWorkGroupSize();
+  int64_t wg_size = at::xpu::getDeviceMaxWorkGroupSize();
   int64_t num_wg = (numel + wg_size - 1) / wg_size;
   switch (vec_size) {
     case 8:
@@ -867,7 +871,7 @@ void launch_adaptive_avg_pool2d_kernel(
   int ow = output.size(3);
 
   int64_t numel = ob * oc * oh * ow;
-  int total_item = std::min(numel, syclMaxWorkItemsPerTile());
+  int total_item = std::min<int64_t>(numel, at::xpu::getDeviceMaxWorkItems());
   int local_range = syclMaxWorkItemsPerSubSlice();
   int global_range = total_item < local_range
       ? local_range

--- a/src/ATen/native/xpu/sycl/AveragePool3dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/AveragePool3dKernels.cpp
@@ -12,6 +12,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <ATen/xpu/XPUContext.h>
 #include <comm/Macros.h>
 // clang-format off
 DISABLE_RETURN_TYPE_WARNING_BEGIN
@@ -173,9 +174,10 @@ void avg_pool3d_out_template(
       output_acc);
 
   // width size is fixed size = 32, height dim equals =
-  // syclMaxWorkGroupSize(kfn) / width_size
+  // at::xpu::getKernelMaxWorkGroupSize(kfn) / width_size
   index_t width_group_size = 32;
-  index_t height_group_size = syclMaxWorkGroupSize(kfn) / width_group_size;
+  index_t height_group_size =
+      at::xpu::getKernelMaxWorkGroupSize(kfn) / width_group_size;
   index_t width_group_range =
       ceil_div<index_t>(work_output.size(-1), width_group_size);
   index_t height_group_range =
@@ -384,9 +386,10 @@ void avg_pool3d_backward_stride1_template(
   AvgPool3dBackwardStride1KernelFunctor<scalar_t, accscalar_t, index_t> kfn(
       kT, kH, kW, normFactor, offsetZ, grad_output_acc, grad_input_acc);
   // width size is fixed size = 32, height dim equals =
-  // syclMaxWorkGroupSize(kfn) / width_size
+  // at::xpu::getKernelMaxWorkGroupSize(kfn) / width_size
   index_t width_group_size = 32;
-  index_t height_group_size = syclMaxWorkGroupSize(kfn) / width_group_size;
+  index_t height_group_size =
+      at::xpu::getKernelMaxWorkGroupSize(kfn) / width_group_size;
   index_t width_group_range =
       ceil_div<index_t>(grad_input.size(-1), width_group_size);
   index_t height_group_range =
@@ -546,9 +549,10 @@ void avg_pool3d_backward_atomic_template(
       grad_input_acc);
 
   // width size is fixed size = 32, height dim equals =
-  // syclMaxWorkGroupSize(kfn) / width_size
+  // at::xpu::getKernelMaxWorkGroupSize(kfn) / width_size
   index_t width_group_size = 32;
-  index_t height_group_size = syclMaxWorkGroupSize(kfn) / width_group_size;
+  index_t height_group_size =
+      at::xpu::getKernelMaxWorkGroupSize(kfn) / width_group_size;
   index_t width_group_range =
       ceil_div<index_t>(grad_output.size(-1), width_group_size);
   index_t height_group_range =
@@ -704,9 +708,10 @@ void avg_pool3d_backward_template(
       grad_input_acc);
 
   // width size is fixed size = 32, height dim equals =
-  // syclMaxWorkGroupSize(kfn) / width_size
+  // at::xpu::getKernelMaxWorkGroupSize(kfn) / width_size
   index_t width_group_size = 32;
-  index_t height_group_size = syclMaxWorkGroupSize(kfn) / width_group_size;
+  index_t height_group_size =
+      at::xpu::getKernelMaxWorkGroupSize(kfn) / width_group_size;
   index_t width_group_range =
       ceil_div<index_t>(grad_output.size(-1), width_group_size);
   index_t height_group_range =

--- a/src/ATen/native/xpu/sycl/BatchKernel.h
+++ b/src/ATen/native/xpu/sycl/BatchKernel.h
@@ -10,6 +10,9 @@
 
 #pragma once
 #include <comm/SYCLContext.h>
+
+// Keep XPUContext after the existing host-only SYCL warning suppression.
+#include <ATen/xpu/XPUContext.h>
 #include <algorithm>
 #include <bit>
 
@@ -149,7 +152,7 @@ class BatchKernelConfig {
       int64_t stride,
       bool problem_along_x,
       bool bypass_adaptive_policy = true) {
-    auto target_wi_num = syclMaxWorkItemsPerTile();
+    int64_t target_wi_num = at::xpu::getDeviceMaxWorkItems();
 
     if (!bypass_adaptive_policy && batch * problem * stride >= target_wi_num) {
       return Policy::pAdaptive;
@@ -163,7 +166,7 @@ class BatchKernelConfig {
         batch * stride,
         problem_along_x,
         Policy::pLoop,
-        syclDeviceMaxWorkGroupSize());
+        at::xpu::getDeviceMaxWorkGroupSize());
     size_t wg_num = (cfg_.glb_range_x_ / cfg_.wg_range_x_) *
         (cfg_.glb_range_y_ / cfg_.wg_range_y_);
     size_t wg_size = cfg_.wg_range_x_ * cfg_.wg_range_y_;
@@ -202,13 +205,13 @@ class BatchKernelConfig {
   template <class KernelClass>
   void build() {
     size_t wg_size;
-    size_t sg_size = syclMaxSubGroupSize();
+    size_t sg_size = at::xpu::getDeviceMaxSubGroupSize();
     // Caller takes responsibility of if work group size is valid or compatible.
     if (prefer_wg_size_ != 0 && prefer_wg_size_ % sg_size == 0 &&
-        prefer_wg_size_ <= syclDeviceMaxWorkGroupSize()) {
+        prefer_wg_size_ <= at::xpu::getDeviceMaxWorkGroupSize()) {
       wg_size = prefer_wg_size_;
     } else {
-      wg_size = syclMaxWorkGroupSize<KernelClass>();
+      wg_size = at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
     }
     wg_range_x_ = sg_size;
     wg_range_y_ = wg_size / wg_range_x_;
@@ -240,7 +243,7 @@ class BatchKernelConfig {
         wg_size / wg_range_x_, std::bit_ceil((uint64_t)range_bound_y));
 
     if ((uint8_t)policy_ & (uint8_t)Policy::pAdaptive) {
-      size_t target_glb_range = syclMaxWorkItemsPerTile() /
+      size_t target_glb_range = at::xpu::getDeviceMaxWorkItems() /
           (wg_range_x_ * wg_range_y_) * (wg_range_x_ * wg_range_y_);
       if (problem_along_x_) {
         glb_range_y_ = wg_range_y_;

--- a/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/BatchNormKernels.cpp
@@ -155,7 +155,7 @@ template <class KernelClass>
 int get_max_group_size(int simd = SIMD32) {
   // The max work group size required by batch_norm needs to ensure that the two
   // subgroup reduces can obtain correct results.
-  int max_size = syclMaxWorkGroupSize<KernelClass>();
+  int max_size = at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
   int shfl2_restricted_size = simd * simd;
   return max_size > shfl2_restricted_size ? shfl2_restricted_size : max_size;
 }
@@ -175,7 +175,7 @@ int get_num_threads(int nelem, int restricted_simd = SIMD32) {
 int get_dev_max_group_size(int simd = SIMD32) {
   // The max work group size required by batch_norm needs to ensure that the two
   // subgroup reduces can obtain correct results.
-  int max_size = syclDeviceMaxWorkGroupSize();
+  int max_size = at::xpu::getDeviceMaxWorkGroupSize();
   int shfl2_restricted_size = simd * simd;
   return max_size > shfl2_restricted_size ? shfl2_restricted_size : max_size;
 }
@@ -209,7 +209,7 @@ int get_prefer_simd(int numPlane, int nHw) {
   if (simd >= SIMD32 && nHw <= SIMD32)
     return SIMD32;
 
-  int64_t target_tile_size = syclMaxWorkItemsPerTile(dev_id);
+  int64_t target_tile_size = at::xpu::getDeviceMaxWorkItems(dev_id);
   // for work group barrier perf
   int64_t wg_size = syclMaxWorkItemsPerEU(dev_id);
   if (simd == SIMD32) {
@@ -389,7 +389,7 @@ std::tuple<sycl::range<2>, sycl::range<2>> get_adaptive_launch_config(
   int nwg_x = at::ceil_div(stride, group_x);
   int nwg_y = std::min(
       at::ceil_div(reduction, group_y * loops_per_item),
-      int(syclMaxWorkItemsPerTile()) / (nwg_x * group_x) / (group_y));
+      int(at::xpu::getDeviceMaxWorkItems()) / (nwg_x * group_x) / (group_y));
   nwg_y = std::max(nwg_y, 1);
 
   if (coop_flag) {
@@ -952,7 +952,7 @@ void batch_norm_stats_channels_last_template(
         ELEMENTS_PER_ITER>;
 
     auto config = get_adaptive_launch_config(
-        syclMaxWorkGroupSize<KernelT>(),
+        at::xpu::getKernelMaxWorkGroupSize<KernelT>(),
         reduction_size,
         stride,
         true,
@@ -1322,7 +1322,7 @@ void batch_norm_elemt_template(
       1,
       std::min<int>(
           (256 * 1024) / input.size(1), (input.size(0) + tb - 1) / tb));
-  nwg_y = std::min<int>(nwg_y, syclMaxWorkItemsPerTile() / (tf * tb));
+  nwg_y = std::min<int>(nwg_y, at::xpu::getDeviceMaxWorkItems() / (tf * tb));
   sycl::range<2> global_range(nwg_y * tb, nwg_x * tf);
 
   auto input_ptr = (char*)input_reshaped.const_data_ptr();
@@ -1632,7 +1632,7 @@ void batch_norm_elemt_channels_last_template(
                     stride,
                     fuse_relu);
             auto config_vec = get_adaptive_launch_config(
-                syclMaxWorkGroupSize(kfn),
+                at::xpu::getKernelMaxWorkGroupSize(kfn),
                 reduction_size,
                 stride / VEC_SIZE,
                 false,
@@ -1657,7 +1657,7 @@ void batch_norm_elemt_channels_last_template(
                 stride,
                 fuse_relu);
             auto config = get_adaptive_launch_config(
-                syclMaxWorkGroupSize(kfn),
+                at::xpu::getKernelMaxWorkGroupSize(kfn),
                 reduction_size,
                 stride,
                 false,
@@ -1714,7 +1714,7 @@ void batch_norm_elemt_channels_last_template(
                     stride,
                     fuse_relu);
             auto config_vec = get_adaptive_launch_config(
-                syclMaxWorkGroupSize(kfn),
+                at::xpu::getKernelMaxWorkGroupSize(kfn),
                 reduction_size,
                 stride / VEC_SIZE,
                 false,
@@ -1739,7 +1739,7 @@ void batch_norm_elemt_channels_last_template(
                 stride,
                 fuse_relu);
             auto config = get_adaptive_launch_config(
-                syclMaxWorkGroupSize(kfn),
+                at::xpu::getKernelMaxWorkGroupSize(kfn),
                 reduction_size,
                 stride,
                 false,
@@ -2937,7 +2937,7 @@ Tensor batch_norm_backward_elemt_template(
       1,
       std::min<int>(
           (256 * 1024) / input.size(1), (input.size(0) + tb - 1) / tb));
-  nwg_y = std::min<int>(nwg_y, syclMaxWorkItemsPerTile() / (tf * tb));
+  nwg_y = std::min<int>(nwg_y, at::xpu::getDeviceMaxWorkItems() / (tf * tb));
   auto reduction_size = input_.numel() / n_input;
   auto norm_fct = static_cast<stat_accscalar_t>(1.0 / reduction_size);
 
@@ -3047,7 +3047,7 @@ Tensor batch_norm_backward_elemt_template(
       1,
       std::min<int>(
           (256 * 1024) / input.size(1), (input.size(0) + tb - 1) / tb));
-  nwg_y = std::min<int>(nwg_y, syclMaxWorkItemsPerTile() / (tf * tb));
+  nwg_y = std::min<int>(nwg_y, at::xpu::getDeviceMaxWorkItems() / (tf * tb));
 
   sycl::range<2> local_range(tb, tf);
   sycl::range<2> global_range(nwg_y * tb, nwg_x * tf);
@@ -3401,7 +3401,7 @@ at::Tensor batch_norm_backward_elemt_channels_last_template(
                     reduction_size,
                     stride);
             auto config = get_adaptive_launch_config(
-                syclMaxWorkGroupSize(kfn),
+                at::xpu::getKernelMaxWorkGroupSize(kfn),
                 reduction_size,
                 stride / VEC_SIZE,
                 true,
@@ -3430,7 +3430,7 @@ at::Tensor batch_norm_backward_elemt_channels_last_template(
                     reduction_size,
                     stride);
             auto config = get_adaptive_launch_config(
-                syclMaxWorkGroupSize(kfn),
+                at::xpu::getKernelMaxWorkGroupSize(kfn),
                 reduction_size,
                 stride / VEC_SIZE,
                 true,
@@ -3458,7 +3458,7 @@ at::Tensor batch_norm_backward_elemt_channels_last_template(
                 reduction_size,
                 stride);
             auto config = get_adaptive_launch_config(
-                syclMaxWorkGroupSize(kfn),
+                at::xpu::getKernelMaxWorkGroupSize(kfn),
                 reduction_size,
                 stride,
                 true,
@@ -3484,7 +3484,7 @@ at::Tensor batch_norm_backward_elemt_channels_last_template(
                 reduction_size,
                 stride);
             auto config = get_adaptive_launch_config(
-                syclMaxWorkGroupSize(kfn),
+                at::xpu::getKernelMaxWorkGroupSize(kfn),
                 reduction_size,
                 stride,
                 true,
@@ -3549,7 +3549,7 @@ at::Tensor batch_norm_backward_elemt_channels_last_template(
                 count.const_data_ptr<int>(),
                 count.numel());
             auto config = get_adaptive_launch_config(
-                syclMaxWorkGroupSize(kfn),
+                at::xpu::getKernelMaxWorkGroupSize(kfn),
                 reduction_size,
                 stride,
                 false,
@@ -3580,7 +3580,7 @@ at::Tensor batch_norm_backward_elemt_channels_last_template(
                     count.const_data_ptr<int>(),
                     count.numel());
             auto config = get_adaptive_launch_config(
-                syclMaxWorkGroupSize(kfn),
+                at::xpu::getKernelMaxWorkGroupSize(kfn),
                 reduction_size,
                 stride / VEC_SIZE,
                 false,
@@ -3632,7 +3632,7 @@ at::Tensor batch_norm_backward_elemt_channels_last_template(
                 count.const_data_ptr<int>(),
                 count.numel());
             auto config = get_adaptive_launch_config(
-                syclMaxWorkGroupSize(kfn),
+                at::xpu::getKernelMaxWorkGroupSize(kfn),
                 reduction_size,
                 stride,
                 false,
@@ -3664,7 +3664,7 @@ at::Tensor batch_norm_backward_elemt_channels_last_template(
                     count.const_data_ptr<int>(),
                     count.numel());
             auto config = get_adaptive_launch_config(
-                syclMaxWorkGroupSize(kfn),
+                at::xpu::getKernelMaxWorkGroupSize(kfn),
                 reduction_size,
                 stride / VEC_SIZE,
                 false,

--- a/src/ATen/native/xpu/sycl/BucketizationKernels.cpp
+++ b/src/ATen/native/xpu/sycl/BucketizationKernels.cpp
@@ -14,6 +14,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/native/BucketizationUtils.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/SYCLContext.h>
 #include <comm/SYCLHelpers.h>
 
@@ -132,8 +133,8 @@ void searchsorted_template(
   auto data_out_data = result.mutable_data_ptr<output_t>();
 
   int64_t rng, grng, tile_size;
-  tile_size =
-      syclMaxWorkGroupSize<searchsorted_kernel_impl<input_t, output_t>>();
+  tile_size = at::xpu::getKernelMaxWorkGroupSize<
+      searchsorted_kernel_impl<input_t, output_t>>();
   rng = numel_in;
   if (rng == 0) {
     rng = static_cast<int64_t>(1);

--- a/src/ATen/native/xpu/sycl/CrossKernel.cpp
+++ b/src/ATen/native/xpu/sycl/CrossKernel.cpp
@@ -11,6 +11,7 @@
 #include <ATen/ATen.h>
 #include <ATen/TensorIterator.h>
 #include <ATen/native/xpu/sycl/OffsetCalculator.h>
+#include <ATen/xpu/XPUContext.h>
 #include <c10/core/WrapDimMinimal.h>
 #include <comm/SYCLContext.h>
 
@@ -74,7 +75,7 @@ void launch_cross_kernel(
       "cross_xpu",
       [&]() {
         int64_t work_group_size =
-            syclMaxWorkGroupSize<cross_ff_kernel<scalar_t>>();
+            at::xpu::getKernelMaxWorkGroupSize<cross_ff_kernel<scalar_t>>();
         int64_t work_group_num = (N + work_group_size - 1) / work_group_size;
         auto out = static_cast<scalar_t*>(iter.data_ptr(0));
         auto x1 = static_cast<const scalar_t*>(iter.data_ptr(1));

--- a/src/ATen/native/xpu/sycl/DepthwiseConv2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/DepthwiseConv2dKernels.cpp
@@ -20,6 +20,7 @@
 #include <ATen/native/xpu/sycl/DepthwiseConv2dKernels.h>
 #include <ATen/native/xpu/sycl/GroupReduceUtils.h>
 #include <ATen/native/xpu/sycl/KernelUtils.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/SYCLContext.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -682,7 +683,7 @@ void conv_depthwise2d_forward_kernel(
               padH,
               dilationW,
               dilationH);
-          int64_t local_range = syclMaxWorkGroupSize(kfn);
+          int64_t local_range = at::xpu::getKernelMaxWorkGroupSize(kfn);
           auto global_range = xpuKernelLoopGroupRange(n, local_range);
           sycl_kernel_submit(
               global_range * local_range,
@@ -711,7 +712,7 @@ void conv_depthwise2d_forward_kernel(
               padH,
               dilationW,
               dilationH);
-          int64_t local_range = syclMaxWorkGroupSize(kfn);
+          int64_t local_range = at::xpu::getKernelMaxWorkGroupSize(kfn);
           auto global_range = xpuKernelLoopGroupRange(n, local_range);
           sycl_kernel_submit(
               global_range * local_range,
@@ -740,7 +741,7 @@ void conv_depthwise2d_forward_kernel(
               padH,
               dilationW,
               dilationH);
-          int64_t local_range = syclMaxWorkGroupSize(kfn);
+          int64_t local_range = at::xpu::getKernelMaxWorkGroupSize(kfn);
           auto global_range = xpuKernelLoopGroupRange(n, local_range);
           sycl_kernel_submit(
               global_range * local_range,
@@ -769,7 +770,7 @@ void conv_depthwise2d_forward_kernel(
               padH,
               dilationW,
               dilationH);
-          int64_t local_range = syclMaxWorkGroupSize(kfn);
+          int64_t local_range = at::xpu::getKernelMaxWorkGroupSize(kfn);
           auto global_range = xpuKernelLoopGroupRange(n, local_range);
           sycl_kernel_submit(
               global_range * local_range,
@@ -861,7 +862,7 @@ void conv_depthwise2d_backward_kernel(
                 padH,
                 dilationW,
                 dilationH);
-            int64_t local_range = syclMaxWorkGroupSize(kfn);
+            int64_t local_range = at::xpu::getKernelMaxWorkGroupSize(kfn);
             auto global_range = xpuKernelLoopGroupRange(n, local_range);
             sycl_kernel_submit(
                 global_range * local_range,
@@ -889,7 +890,7 @@ void conv_depthwise2d_backward_kernel(
                 padH,
                 dilationW,
                 dilationH);
-            int64_t local_range = syclMaxWorkGroupSize(kfn);
+            int64_t local_range = at::xpu::getKernelMaxWorkGroupSize(kfn);
             auto global_range = xpuKernelLoopGroupRange(n, local_range);
             sycl_kernel_submit(
                 global_range * local_range,
@@ -917,7 +918,7 @@ void conv_depthwise2d_backward_kernel(
                 padH,
                 dilationW,
                 dilationH);
-            int64_t local_range = syclMaxWorkGroupSize(kfn);
+            int64_t local_range = at::xpu::getKernelMaxWorkGroupSize(kfn);
             auto global_range = xpuKernelLoopGroupRange(n, local_range);
             sycl_kernel_submit(
                 global_range * local_range,
@@ -947,7 +948,7 @@ void conv_depthwise2d_backward_kernel(
                 padH,
                 dilationW,
                 dilationH);
-            int64_t local_range = syclMaxWorkGroupSize(kfn);
+            int64_t local_range = at::xpu::getKernelMaxWorkGroupSize(kfn);
             auto global_range = xpuKernelLoopGroupRange(n, local_range);
             sycl_kernel_submit(
                 global_range * local_range,
@@ -975,7 +976,7 @@ void conv_depthwise2d_backward_kernel(
                 padH,
                 dilationW,
                 dilationH);
-            int64_t local_range = syclMaxWorkGroupSize(kfn);
+            int64_t local_range = at::xpu::getKernelMaxWorkGroupSize(kfn);
             auto global_range = xpuKernelLoopGroupRange(n, local_range);
             sycl_kernel_submit(
                 global_range * local_range,
@@ -1003,7 +1004,7 @@ void conv_depthwise2d_backward_kernel(
                 padH,
                 dilationW,
                 dilationH);
-            int64_t local_range = syclMaxWorkGroupSize(kfn);
+            int64_t local_range = at::xpu::getKernelMaxWorkGroupSize(kfn);
             auto global_range = xpuKernelLoopGroupRange(n, local_range);
             sycl_kernel_submit(
                 global_range * local_range,
@@ -1033,7 +1034,7 @@ void conv_depthwise2d_backward_kernel(
                 padH,
                 dilationW,
                 dilationH);
-            int64_t local_range = syclMaxWorkGroupSize(kfn);
+            int64_t local_range = at::xpu::getKernelMaxWorkGroupSize(kfn);
             auto global_range = xpuKernelLoopGroupRange(n, local_range);
             sycl_kernel_submit(
                 global_range * local_range,
@@ -1061,7 +1062,7 @@ void conv_depthwise2d_backward_kernel(
                 padH,
                 dilationW,
                 dilationH);
-            int64_t local_range = syclMaxWorkGroupSize(kfn);
+            int64_t local_range = at::xpu::getKernelMaxWorkGroupSize(kfn);
             auto global_range = xpuKernelLoopGroupRange(n, local_range);
             sycl_kernel_submit(
                 global_range * local_range,
@@ -1089,7 +1090,7 @@ void conv_depthwise2d_backward_kernel(
                 padH,
                 dilationW,
                 dilationH);
-            int64_t local_range = syclMaxWorkGroupSize(kfn);
+            int64_t local_range = at::xpu::getKernelMaxWorkGroupSize(kfn);
             auto global_range = xpuKernelLoopGroupRange(n, local_range);
             sycl_kernel_submit(
                 global_range * local_range,
@@ -1118,7 +1119,7 @@ void conv_depthwise2d_backward_kernel(
               padH,
               dilationW,
               dilationH);
-          int64_t local_range = syclMaxWorkGroupSize(kfn);
+          int64_t local_range = at::xpu::getKernelMaxWorkGroupSize(kfn);
           auto global_range = xpuKernelLoopGroupRange(n, local_range);
           sycl_kernel_submit(
               global_range * local_range,
@@ -1146,7 +1147,7 @@ void conv_depthwise2d_backward_kernel(
               padH,
               dilationW,
               dilationH);
-          int64_t local_range = syclMaxWorkGroupSize(kfn);
+          int64_t local_range = at::xpu::getKernelMaxWorkGroupSize(kfn);
           auto global_range = xpuKernelLoopGroupRange(n, local_range);
           sycl_kernel_submit(
               global_range * local_range,
@@ -1174,7 +1175,7 @@ void conv_depthwise2d_backward_kernel(
               padH,
               dilationW,
               dilationH);
-          int64_t local_range = syclMaxWorkGroupSize(kfn);
+          int64_t local_range = at::xpu::getKernelMaxWorkGroupSize(kfn);
           auto global_range = xpuKernelLoopGroupRange(n, local_range);
           sycl_kernel_submit(
               global_range * local_range,
@@ -1242,7 +1243,7 @@ void conv_depthwise2d_grad_weight_kernel(
 
         using KernelClass =
             ConvDepthwise2dGradWeightFunctor<scalar_t, acc_t, int, 32>;
-        int max_wg_size = syclMaxWorkGroupSize<KernelClass>();
+        int max_wg_size = at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
         // Make sure we have enough threads to perform the reduction, and use
         // this number to create the shared memory size for the reduction
         int64_t local_range = std::min(batchSize * C10_WARP_SIZE, max_wg_size);

--- a/src/ATen/native/xpu/sycl/DilatedMaxPool2d.cpp
+++ b/src/ATen/native/xpu/sycl/DilatedMaxPool2d.cpp
@@ -12,6 +12,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <ATen/xpu/XPUContext.h>
 #include <comm/Macros.h>
 // clang-format off
 DISABLE_RETURN_TYPE_WARNING_BEGIN
@@ -740,9 +741,9 @@ void launch_max_pool2d_kernel(
   int64_t stride = static_cast<int64_t>(numPlane) *
       static_cast<int64_t>(outputSizeH) * static_cast<int64_t>(outputSizeW);
   int vec_size = 1;
-  int thread_slots = syclGpuEuCount() * syclGpuHWThreadsPerEU();
+  int thread_slots = at::xpu::getDeviceHWThreads();
   int64_t num_sub_wg;
-  auto wg_size = syclDeviceMaxWorkGroupSize();
+  int64_t wg_size = at::xpu::getDeviceMaxWorkGroupSize();
   int64_t num_wg;
   if constexpr (is_channels_last) {
     for (vec_size =
@@ -752,7 +753,7 @@ void launch_max_pool2d_kernel(
       if (numPlane % vec_size != 0) {
         continue;
       }
-      num_sub_wg = outputSize / vec_size / syclMaxSubGroupSize();
+      num_sub_wg = outputSize / vec_size / at::xpu::getDeviceMaxSubGroupSize();
       if (2 * num_sub_wg > thread_slots) {
         int total_thread = outputSize / vec_size;
         num_wg = (total_thread + wg_size - 1) / wg_size;
@@ -970,9 +971,9 @@ void launch_max_pool2d_backward_kernel(
   // deterministic path.
 
   int vec_size = 1;
-  int thread_slots = syclGpuEuCount() * syclGpuHWThreadsPerEU();
+  int thread_slots = at::xpu::getDeviceHWThreads();
   int num_sub_wg;
-  auto wg_size = syclDeviceMaxWorkGroupSize();
+  int64_t wg_size = at::xpu::getDeviceMaxWorkGroupSize();
   int64_t num_wg;
   if constexpr (is_channels_last) {
     for (vec_size = std::min(
@@ -982,7 +983,8 @@ void launch_max_pool2d_backward_kernel(
       if (numPlane % vec_size != 0) {
         continue;
       }
-      num_sub_wg = gradInputSize / vec_size / syclMaxSubGroupSize();
+      num_sub_wg =
+          gradInputSize / vec_size / at::xpu::getDeviceMaxSubGroupSize();
       if (2 * num_sub_wg > thread_slots) {
         int total_thread = gradInputSize / vec_size;
         num_wg = (total_thread + wg_size - 1) / wg_size;

--- a/src/ATen/native/xpu/sycl/DistanceKernels.cpp
+++ b/src/ATen/native/xpu/sycl/DistanceKernels.cpp
@@ -13,6 +13,7 @@
 #include <ATen/native/xpu/sycl/BatchKernel.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/sum.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/SYCLContext.h>
 
 #include <ATen/native/xpu/sycl/DistanceKernels.h>
@@ -508,7 +509,8 @@ static void cdist_backward_kernel_impl(
     const int64_t r_size,
     const int64_t l1_size,
     const int64_t l2_size) {
-  auto wgroup_size = syclGpuHWThreadsPerEU() * syclMaxSubGroupSize();
+  int64_t wgroup_size =
+      syclGpuHWThreadsPerEU() * at::xpu::getDeviceMaxSubGroupSize();
   const int group_size_x = 256 > wgroup_size ? wgroup_size : 256;
   const int group_size_y = wgroup_size / group_size_x;
   const int group_num_x = (m + group_size_x * 32 - 1) / (group_size_x * 32);
@@ -731,9 +733,9 @@ static void pdist_kernel_impl(
     const double n2_squared_minus_1) {
   const auto ngroups = result.numel();
   using accscalar_t = acc_type_device<scalar_t, kXPU>;
-  auto min_sg_size = syclMinSubGroupSize();
-  auto wgroup_size =
-      syclMaxWorkGroupSize<pdist_kernel<scalar_t, F, accscalar_t>>();
+  int64_t min_sg_size = at::xpu::getDeviceMinSubGroupSize();
+  int64_t wgroup_size = at::xpu::getKernelMaxWorkGroupSize<
+      pdist_kernel<scalar_t, F, accscalar_t>>();
   while (wgroup_size >> 1 >= m && wgroup_size >> 1 >= 32 /* sg_size */) {
     wgroup_size >>= 1;
   }

--- a/src/ATen/native/xpu/sycl/DistributionTemplates.h
+++ b/src/ATen/native/xpu/sycl/DistributionTemplates.h
@@ -25,6 +25,7 @@
 #include <ATen/native/xpu/sycl/TensorApplyUtils.h>
 #include <ATen/ops/empty.h>
 #include <ATen/xpu/PhiloxXpuState.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/DeviceProperties.h>
 #include <comm/Runtime.h>
 
@@ -45,7 +46,7 @@ inline std::tuple<uint64_t, uint32_t, uint32_t> calc_execution_policy(
       syclMaxWorkItemsPerSubSlice(); // TODO: see
                                      // https://github.com/intel/torch-xpu-ops/issues/135
   auto num_groups = (total_elements + group_size - 1) / group_size;
-  auto hw_max_groups = syclMaxWorkItemsPerTile() / group_size;
+  int64_t hw_max_groups = at::xpu::getDeviceMaxWorkItems() / group_size;
   num_groups = num_groups > hw_max_groups ? hw_max_groups : num_groups;
   // Increment must be at least the number of 32-bit values consumed per
   // dist_func call. Our distribution functors consume one rand4-equivalent

--- a/src/ATen/native/xpu/sycl/EmbeddingBackwardKernel.h
+++ b/src/ATen/native/xpu/sycl/EmbeddingBackwardKernel.h
@@ -14,6 +14,7 @@
 #include <ATen/ceil_div.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/xpu/sycl/pstl/PSTLFunctions.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/SYCLContext.h>
 
 namespace at::native::xpu {
@@ -257,7 +258,7 @@ void compute_grad_weight_bags(
                          // buffer.
   auto segment_offsets_data = segment_offsets.const_data_ptr<index_t>();
 
-  int64_t max_sub_group_size = syclMaxSubGroupSize();
+  int64_t max_sub_group_size = at::xpu::getDeviceMaxSubGroupSize();
   int64_t stride_warped =
       at::ceil_div(stride, max_sub_group_size) * max_sub_group_size;
 
@@ -279,7 +280,7 @@ void compute_grad_weight_bags(
       per_sample_weights_data,
       segment_offsets_data);
 
-  int64_t work_group_size = syclMaxWorkGroupSize(kfn);
+  int64_t work_group_size = at::xpu::getKernelMaxWorkGroupSize(kfn);
   int64_t group_size = std::min(stride_warped, work_group_size);
   auto num_groups = at::ceil_div(num_of_segments * stride_warped, group_size);
   auto total_items = num_groups * group_size;
@@ -377,7 +378,7 @@ void compute_grad_weight(
       : indices_data; // use the indices_data handler as the dummy buffer.
   auto segment_offsets_data = segment_offsets.const_data_ptr<index_t>();
 
-  int64_t max_sub_group_size = syclMaxSubGroupSize();
+  int64_t max_sub_group_size = at::xpu::getDeviceMaxSubGroupSize();
   int64_t stride_warped =
       at::ceil_div(stride, max_sub_group_size) * max_sub_group_size;
 
@@ -393,7 +394,7 @@ void compute_grad_weight(
       count_data,
       segment_offsets_data);
 
-  int64_t work_group_size = syclMaxWorkGroupSize(kfn);
+  int64_t work_group_size = at::xpu::getKernelMaxWorkGroupSize(kfn);
   int64_t group_size = std::min(stride_warped, work_group_size);
   auto num_groups = at::ceil_div(num_of_segments * stride_warped, group_size);
   auto total_items = num_groups * group_size;
@@ -506,7 +507,7 @@ void sum_and_scatter(
       grad_weight_per_segment_data,
       segment_sizes_offsets_data);
 
-  int64_t work_group_size = syclMaxWorkGroupSize(kfn);
+  int64_t work_group_size = at::xpu::getKernelMaxWorkGroupSize(kfn);
   int64_t stride_warped =
       at::ceil_div(stride, work_group_size) * work_group_size;
   kfn.set_stride_warped(stride_warped);

--- a/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
+++ b/src/ATen/native/xpu/sycl/EmbeddingBag.cpp
@@ -8,6 +8,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <ATen/xpu/XPUContext.h>
 #include <comm/Macros.h>
 // clang-format off
 DISABLE_RETURN_TYPE_WARNING_BEGIN
@@ -82,7 +83,7 @@ void embedding_bag(
   vec_idx_t* max_idx_vec = reinterpret_cast<vec_idx_t*>(max_index);
 
   int vectorized_feature_dim = feature_dim / vec_size;
-  int64_t work_group_size = syclDeviceMaxWorkGroupSize();
+  int64_t work_group_size = at::xpu::getDeviceMaxWorkGroupSize();
   // TODO: we can set a smaller num_work_group and add for loop in kernel
   int64_t num_work_group = ceil_div(
       static_cast<int64_t>(bag_num * vectorized_feature_dim),
@@ -351,9 +352,9 @@ void embedding_bag_sum_template(
               int vec_size = memory::can_vectorize_up_to<scalar_t>(
                   (char*)weights.const_data_ptr());
               vec_size = feature_dim % vec_size == 0 ? vec_size : 1;
-              int num_sub_wg =
-                  bag_num * feature_dim / vec_size / syclMaxSubGroupSize();
-              int thread_slots = syclGpuEuCount() * syclGpuHWThreadsPerEU();
+              int num_sub_wg = bag_num * feature_dim / vec_size /
+                  at::xpu::getDeviceMaxSubGroupSize();
+              int thread_slots = at::xpu::getDeviceHWThreads();
               for (int v = vec_size; v != 1;
                    v = v / 2, num_sub_wg = num_sub_wg * 2) {
                 if (2 * num_sub_wg > thread_slots) {
@@ -431,9 +432,9 @@ void embedding_bag_mean_template(
               int vec_size = memory::can_vectorize_up_to<scalar_t>(
                   (char*)weights.const_data_ptr());
               vec_size = feature_dim % vec_size == 0 ? vec_size : 1;
-              int num_sub_wg =
-                  bag_num * feature_dim / vec_size / syclMaxSubGroupSize();
-              int thread_slots = syclGpuEuCount() * syclGpuHWThreadsPerEU();
+              int num_sub_wg = bag_num * feature_dim / vec_size /
+                  at::xpu::getDeviceMaxSubGroupSize();
+              int thread_slots = at::xpu::getDeviceHWThreads();
               for (int v = vec_size; v != 1;
                    v = v / 2, num_sub_wg = num_sub_wg * 2) {
                 if (2 * num_sub_wg > thread_slots) {
@@ -510,9 +511,9 @@ void embedding_bag_max_template(
               int vec_size = memory::can_vectorize_up_to<scalar_t>(
                   (char*)weights.const_data_ptr());
               vec_size = feature_dim % vec_size == 0 ? vec_size : 1;
-              int num_sub_wg =
-                  bag_num * feature_dim / vec_size / syclMaxSubGroupSize();
-              int thread_slots = syclGpuEuCount() * syclGpuHWThreadsPerEU();
+              int num_sub_wg = bag_num * feature_dim / vec_size /
+                  at::xpu::getDeviceMaxSubGroupSize();
+              int thread_slots = at::xpu::getDeviceHWThreads();
               for (int v = vec_size; v != 1;
                    v = v / 2, num_sub_wg = num_sub_wg * 2) {
                 if (2 * num_sub_wg > thread_slots) {
@@ -726,7 +727,7 @@ void _embedding_bag_per_sample_weights_backward_impl(
       index_t,
       accscalar_t>;
 
-  int64_t max_group_size = syclMaxWorkGroupSize<kfn>();
+  int64_t max_group_size = at::xpu::getKernelMaxWorkGroupSize<kfn>();
 
   int64_t num_group = (num_samples + max_group_size - 1) / max_group_size;
   auto global_range{num_group * max_group_size};

--- a/src/ATen/native/xpu/sycl/ForeachReduceKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ForeachReduceKernels.cpp
@@ -12,6 +12,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/OpMathType.h>
 #include <ATen/native/ForeachUtils.h>
+#include <ATen/xpu/XPUContext.h>
 
 #include <ATen/native/xpu/sycl/ForeachFunctors.h>
 #include <ATen/native/xpu/sycl/MultiTensorApply.h>
@@ -294,7 +295,7 @@ std::vector<Tensor> foreach_norm_kernel_impl(
   int64_t wg_size;
   int max_chunks_per_tensor;
   Tensor output_per_tensor;
-  int64_t simd = syclMaxSubGroupSize();
+  int64_t simd = at::xpu::getDeviceMaxSubGroupSize();
   foreach_norn_kernel_config(
       tensors,
       output_per_tensor_option,
@@ -709,7 +710,7 @@ std::vector<Tensor> foreach_max_kernel(TensorList tensors) {
   thunk_counts = (int*)thunk_counts_dptr.get();
 
   int max_chunks_per_tensor = -1;
-  int64_t simd = syclMaxSubGroupSize();
+  int64_t simd = at::xpu::getDeviceMaxSubGroupSize();
   int64_t kChunkSize = multi_tensor_apply_kernel_get_chunk_size(simd);
   for (const auto t : c10::irange(ntensors)) {
     int max_chunks_this_tensor =

--- a/src/ATen/native/xpu/sycl/GridSampler.cpp
+++ b/src/ATen/native/xpu/sycl/GridSampler.cpp
@@ -12,6 +12,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <ATen/xpu/XPUContext.h>
 #include <comm/Macros.h>
 // clang-format off
 DISABLE_RETURN_TYPE_WARNING_BEGIN
@@ -228,8 +229,8 @@ void grid_sampler_2d_forward_template(
   index_t out_sH = output.strides[2];
   index_t out_sW = output.strides[3];
 
-  const auto wgroup_size =
-      syclMaxWorkGroupSize<grid_sampler_2d_kernel_func<scalar_t, index_t>>();
+  const int64_t wgroup_size = at::xpu::getKernelMaxWorkGroupSize<
+      grid_sampler_2d_kernel_func<scalar_t, index_t>>();
   const auto ngroups = (nthreads + wgroup_size - 1) / wgroup_size;
   auto& queue = getCurrentSYCLQueue();
 
@@ -627,7 +628,7 @@ void grid_sampler_2d_backward_template(
   }
   index_t gGrid_sW = grad_grid.strides[2];
 
-  const auto wgroup_size = syclMaxWorkGroupSize<
+  const int64_t wgroup_size = at::xpu::getKernelMaxWorkGroupSize<
       grid_sampler_2d_backward_kernel_func<scalar_t, index_t>>();
   const auto ngroups = (nthreads + wgroup_size - 1) / wgroup_size;
   auto& queue = getCurrentSYCLQueue();
@@ -942,8 +943,8 @@ void grid_sampler_3d_forward_template(
   index_t out_sH = output.strides[3];
   index_t out_sW = output.strides[4];
 
-  const auto wgroup_size =
-      syclMaxWorkGroupSize<grid_sampler_3d_kernel_func<scalar_t, index_t>>();
+  const int64_t wgroup_size = at::xpu::getKernelMaxWorkGroupSize<
+      grid_sampler_3d_kernel_func<scalar_t, index_t>>();
   const auto ngroups = (nthreads + wgroup_size - 1) / wgroup_size;
   auto& queue = getCurrentSYCLQueue();
 
@@ -1428,7 +1429,7 @@ void grid_sampler_3d_backward_template(
   }
   index_t gGrid_sW = grad_grid.strides[3];
 
-  const auto wgroup_size = syclMaxWorkGroupSize<
+  const int64_t wgroup_size = at::xpu::getKernelMaxWorkGroupSize<
       grid_sampler_3d_backward_kernel_func<scalar_t, index_t>>();
   const auto ngroups = (nthreads + wgroup_size - 1) / wgroup_size;
   auto& queue = getCurrentSYCLQueue();

--- a/src/ATen/native/xpu/sycl/GroupNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/GroupNormKernels.cpp
@@ -17,6 +17,7 @@
 #include <ATen/native/xpu/sycl/IntegerDivider.h>
 #include <ATen/native/xpu/sycl/Loops.h>
 #include <ATen/native/xpu/sycl/SharedReduceOps.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/MemoryFormat.h>
 #include <comm/XPUMathCompat.h>
 #include <comm/xpu_aten.h>
@@ -1042,7 +1043,7 @@ void group_norm_kernel_impl(
   T* mean_data = mean.mutable_data_ptr<T>();
   T* rstd_data = rstd.mutable_data_ptr<T>();
   auto& queue = getCurrentSYCLQueue();
-  int64_t simd = syclMaxSubGroupSize();
+  int64_t simd = at::xpu::getDeviceMaxSubGroupSize();
 
   // --- Fused forward path: single kernel for Welford + normalization ---
   constexpr int FUSED_VEC_SIZE = 4;
@@ -1066,7 +1067,7 @@ void group_norm_kernel_impl(
     rstd_acc_data = rstd_acc.mutable_data_ptr<T_ACC>();
   }
 
-  int64_t thread_slots = syclGpuEuCount() * syclGpuHWThreadsPerEU();
+  int64_t thread_slots = at::xpu::getDeviceHWThreads();
 
   // Small-DS path: single vec4 per lane (covers DS where lanes <= SIMD).
   // WG = 1 SG, flat mapping over (N, G) with grid-stride loop.
@@ -1220,7 +1221,7 @@ void group_norm_kernel_impl(
       using index_t = decltype(index_tag);
       using K =
           GNFusedForwardFunctor<T, T_ACC, SIMD32, FUSED_VEC_SIZE, index_t>;
-      int64_t max_wg = syclMaxWorkGroupSize<K>();
+      int64_t max_wg = at::xpu::getKernelMaxWorkGroupSize<K>();
       int64_t ideal = (DS + kElemsPerWorkItem - 1) / kElemsPerWorkItem;
       int64_t min_wg_for_occ =
           ((thread_slots / 2 + n_groups - 1) / n_groups) * simd;
@@ -1234,12 +1235,12 @@ void group_norm_kernel_impl(
         }
       }
       // SLM budget: local_mem_size shared among concurrent WGs per Xe-core
-      int64_t eu_per_xc = syclGpuEUCountPerSubslice();
+      int64_t eu_per_xc = at::xpu::getDeviceEUCountPerXeCore();
       int64_t hw_thr = syclGpuHWThreadsPerEU();
       int64_t slots_per_xc = eu_per_xc * hw_thr;
       int64_t sgs_per_wg = wg_size / simd;
       int64_t concurrent_wgs = slots_per_xc / sgs_per_wg;
-      int64_t slm_per_wg = syclLocalMemSize() / concurrent_wgs;
+      int64_t slm_per_wg = at::xpu::getDeviceLocalMemSize() / concurrent_wgs;
       bool use_slm_coeff = (2 * D * (int64_t)sizeof(T_ACC) <= slm_per_wg);
       auto kfn =
           K(static_cast<index_t>(D),
@@ -1295,7 +1296,8 @@ void group_norm_kernel_impl(
     using KernelS32T =
         GNRowwiseMomentsVectorizedFunctor<T, T_ACC, SIMD32, VEC_SIZE>;
     auto max_size = std::min(
-        syclMaxWorkGroupSize<KernelS16T>(), syclMaxWorkGroupSize<KernelS32T>());
+        at::xpu::getKernelMaxWorkGroupSize<KernelS16T>(),
+        at::xpu::getKernelMaxWorkGroupSize<KernelS32T>());
     auto wg_size =
         get_adaptive_workgroup_size(prob_size / VEC_SIZE, simd, max_size);
     auto global_range = sycl::range<1>((stride / VEC_SIZE) * wg_size);
@@ -1316,7 +1318,8 @@ void group_norm_kernel_impl(
     using KernelS16T = GNRowwiseMomentsFunctor<T, T_ACC, SIMD16>;
     using KernelS32T = GNRowwiseMomentsFunctor<T, T_ACC, SIMD32>;
     auto max_size = std::min(
-        syclMaxWorkGroupSize<KernelS16T>(), syclMaxWorkGroupSize<KernelS32T>());
+        at::xpu::getKernelMaxWorkGroupSize<KernelS16T>(),
+        at::xpu::getKernelMaxWorkGroupSize<KernelS32T>());
     auto wg_size = get_adaptive_workgroup_size(prob_size, simd, max_size);
     auto global_range = sycl::range<1>(stride * wg_size);
     auto local_range = sycl::range<1>(wg_size);
@@ -1711,7 +1714,7 @@ void group_norm_1d_backward(
   const T* rstd_data = rstd.const_data_ptr<T>();
 
   auto& queue = getCurrentSYCLQueue();
-  int64_t simd = syclMaxSubGroupSize();
+  int64_t simd = at::xpu::getDeviceMaxSubGroupSize();
 
   if (dX.defined()) {
     const T* gamma_data = gamma.defined() ? gamma.const_data_ptr<T>() : nullptr;
@@ -2287,7 +2290,7 @@ void group_norm_backward_kernel_impl(
   }
 
   auto& queue = getCurrentSYCLQueue();
-  int64_t simd = syclMaxSubGroupSize();
+  int64_t simd = at::xpu::getDeviceMaxSubGroupSize();
 
   constexpr int VEC_SIZE = PREFERRED_VEC_SIZE;
   int64_t wg_size = 0;

--- a/src/ATen/native/xpu/sycl/HistogramddKernels.cpp
+++ b/src/ATen/native/xpu/sycl/HistogramddKernels.cpp
@@ -12,6 +12,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <ATen/xpu/XPUContext.h>
 #include <comm/Macros.h>
 // clang-format off
 DISABLE_RETURN_TYPE_WARNING_BEGIN
@@ -158,7 +159,7 @@ void histogramdd_template(
     const int64_t* num_bin_edges,
     const int64_t total_bin_size) {
   const int64_t max_wg_size =
-      syclMaxWorkGroupSize<histogramdd_kernel<scalar_t>>();
+      at::xpu::getKernelMaxWorkGroupSize<histogramdd_kernel<scalar_t>>();
   int64_t num_wg = input_size;
   int64_t batch_num = 1;
   int64_t batch_wg_size = max_wg_size;
@@ -253,7 +254,7 @@ void histogramdd_linear_template(
     int64_t input_dim,
     const int64_t* num_bin_edges) {
   const int64_t work_group_size =
-      syclMaxWorkGroupSize<histogramdd_linear_kernel<scalar_t>>();
+      at::xpu::getKernelMaxWorkGroupSize<histogramdd_linear_kernel<scalar_t>>();
   const int64_t num_wg = (input_size + work_group_size - 1) / work_group_size;
   sycl_kernel_submit<histogramdd_linear_kernel<scalar_t>>(
       num_wg * work_group_size,

--- a/src/ATen/native/xpu/sycl/Indexing.cpp
+++ b/src/ATen/native/xpu/sycl/Indexing.cpp
@@ -8,6 +8,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <ATen/xpu/XPUContext.h>
 #include <comm/Macros.h>
 // clang-format off
 DISABLE_RETURN_TYPE_WARNING_BEGIN
@@ -1400,7 +1401,8 @@ void index_reduce_add_xpu_template(
             } else {
               const bool indexIsMajor =
                   indexShouldBeMajor(selfInfo, selfAddDim);
-              uint64_t defaultMaxGroupThreads = syclDeviceMaxWorkGroupSize();
+              uint64_t defaultMaxGroupThreads =
+                  at::xpu::getDeviceMaxWorkGroupSize();
               size_t num_wg = std::min(
                   ceil_div(sourceTotalSize, (uint64_t)128),
                   (uint64_t)(ssc * 8));
@@ -1473,8 +1475,10 @@ void index_reduce_add_xpu_template(
 
             auto caller = LARGE_INDEX(
                 scalar_t, index_t, uint64_t, -1, -1, -1, true, func_t);
-            // uint64_t defaultMaxGroupThreads = syclMaxWorkGroupSize(caller);
-            uint64_t defaultMaxGroupThreads = syclDeviceMaxWorkGroupSize();
+            // uint64_t defaultMaxGroupThreads =
+            // at::xpu::getKernelMaxWorkGroupSize(caller);
+            uint64_t defaultMaxGroupThreads =
+                at::xpu::getDeviceMaxWorkGroupSize();
             size_t num_wg = std::min(
                 ceil_div(sourceTotalSize, (uint64_t)128), (uint64_t)(ssc * 8));
             size_t wg_size = (sourceTotalSize < defaultMaxGroupThreads)
@@ -1722,7 +1726,8 @@ void index_reduce_func_xpu_template(
                         -2,
                         true,
                         func_t);
-                    int defaultMaxGroupThreads = syclMaxWorkGroupSize(caller);
+                    int defaultMaxGroupThreads =
+                        at::xpu::getKernelMaxWorkGroupSize(caller);
                     size_t num_wg = std::min(
                         ceil_div(sourceTotalSize, (uint64_t)128),
                         (uint64_t)(ssc * 8));
@@ -1746,7 +1751,8 @@ void index_reduce_func_xpu_template(
                           -2,
                           true,
                           func_t);
-                      int defaultMaxGroupThreads = syclMaxWorkGroupSize(caller);
+                      int defaultMaxGroupThreads =
+                          at::xpu::getKernelMaxWorkGroupSize(caller);
                       size_t num_wg = std::min(
                           ceil_div(sourceTotalSize, (uint64_t)128),
                           (uint64_t)(ssc * 8));
@@ -1769,7 +1775,8 @@ void index_reduce_func_xpu_template(
                           -2,
                           false,
                           func_t);
-                      int defaultMaxGroupThreads = syclMaxWorkGroupSize(caller);
+                      int defaultMaxGroupThreads =
+                          at::xpu::getKernelMaxWorkGroupSize(caller);
                       size_t num_wg = std::min(
                           ceil_div(sourceTotalSize, (uint64_t)128),
                           (uint64_t)(ssc * 8));
@@ -1795,7 +1802,8 @@ void index_reduce_func_xpu_template(
                           -2,
                           true,
                           func_t);
-                      int defaultMaxGroupThreads = syclMaxWorkGroupSize(caller);
+                      int defaultMaxGroupThreads =
+                          at::xpu::getKernelMaxWorkGroupSize(caller);
                       size_t num_wg = std::min(
                           ceil_div(sourceTotalSize, (uint64_t)128),
                           (uint64_t)(ssc * 8));
@@ -1818,7 +1826,8 @@ void index_reduce_func_xpu_template(
                           -2,
                           false,
                           func_t);
-                      int defaultMaxGroupThreads = syclMaxWorkGroupSize(caller);
+                      int defaultMaxGroupThreads =
+                          at::xpu::getKernelMaxWorkGroupSize(caller);
                       size_t num_wg = std::min(
                           ceil_div(sourceTotalSize, (uint64_t)128),
                           (uint64_t)(ssc * 8));
@@ -1842,7 +1851,8 @@ void index_reduce_func_xpu_template(
                         -1,
                         true,
                         func_t);
-                    int defaultMaxGroupThreads = syclMaxWorkGroupSize(caller);
+                    int defaultMaxGroupThreads =
+                        at::xpu::getKernelMaxWorkGroupSize(caller);
                     size_t num_wg = std::min(
                         ceil_div(sourceTotalSize, (uint64_t)128),
                         (uint64_t)(ssc * 8));
@@ -1883,7 +1893,8 @@ void index_reduce_func_xpu_template(
                 indexInfo.collapseDims();
                 auto caller = LARGE_INDEX(
                     scalar_t, index_t, uint64_t, -1, -1, -1, true, func_t);
-                int defaultMaxGroupThreads = syclMaxWorkGroupSize(caller);
+                int defaultMaxGroupThreads =
+                    at::xpu::getKernelMaxWorkGroupSize(caller);
                 size_t num_wg = std::min(
                     ceil_div(sourceTotalSize, (uint64_t)128),
                     (uint64_t)(ssc * 8));
@@ -2199,7 +2210,8 @@ void index_select_out_impl(
               getTensorInfo<const index_t, unsigned int>(index));
           indicesInfo.collapseDims();
 
-          uint64_t defaultMaxGroupThreads = syclDeviceMaxWorkGroupSize() / 2;
+          uint64_t defaultMaxGroupThreads =
+              at::xpu::getDeviceMaxWorkGroupSize() / 2;
           size_t num_wg = std::min(
               ceil_div(sliceSize, defaultMaxGroupThreads), (uint64_t)(ssc * 8));
           size_t wg_size = std::min(sliceSize, defaultMaxGroupThreads);

--- a/src/ATen/native/xpu/sycl/Indexing.h
+++ b/src/ATen/native/xpu/sycl/Indexing.h
@@ -14,6 +14,7 @@
 #include <ATen/native/xpu/sycl/IndexKernelUtils.h>
 #include <ATen/native/xpu/sycl/Loops.h>
 #include <ATen/native/xpu/sycl/MemoryAccess.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/TensorInfo.h>
 
 using namespace at::xpu::detail;
@@ -537,7 +538,7 @@ void small_index_kernel(
   auto group_numel = group_index_iter * indices_size;
   auto group_numel_tail = (group_index_iter - 1) * indices_size;
 
-  auto wgroup_size = syclMaxWorkGroupSize<KernelClass>();
+  int64_t wgroup_size = at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
   wgroup_size = std::min(decltype(wgroup_size)(group_numel), wgroup_size);
   auto global_size = max_group_num * wgroup_size;
 
@@ -753,14 +754,14 @@ void _index_kernel(
     using KernelClass = SmallIndexKernelFunctor<func_t, index_buf_type>;
 
     int64_t max_group_num = syclMaxDSSNum();
-    auto wgroup_size = syclMaxWorkGroupSize<KernelClass>();
+    int64_t wgroup_size = at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
     auto indices_size = iter.tensor(2).size(-1);
     auto total_index_iter = numel / indices_size;
     auto local_index = numel / max_group_num;
 
     // the max_local_mem_size = 65536B (64KB)
     // TODO: Is this right?
-    auto max_local_mem_size = syclLocalMemSize();
+    int64_t max_local_mem_size = at::xpu::getDeviceLocalMemSize();
     auto indice_table_size = indices_size * sizeof(int64_t);
 
     // check whether the current case satisfying conditions 2,3,4

--- a/src/ATen/native/xpu/sycl/KernelUtils.h
+++ b/src/ATen/native/xpu/sycl/KernelUtils.h
@@ -12,6 +12,9 @@
 
 #include <ATen/ceil_div.h>
 #include <comm/DeviceProperties.h>
+
+// Keep XPUContext after the existing host-only SYCL warning suppression.
+#include <ATen/xpu/XPUContext.h>
 #include <algorithm>
 
 #define XPU_KERNEL_LOOP_TYPE(item, i, n, index_type)                      \
@@ -26,11 +29,12 @@
 // Returns the number of work groups needed to cover `nelem` elements with the
 // given work-group size, capped so grid-strided loop kernels (XPU_KERNEL_LOOP)
 // do not launch more work items than the device can keep resident. The default
-// cap is syclMaxWorkItemsPerTile(); pass a custom `candidate` to override.
+// cap is at::xpu::getDeviceMaxWorkItems(); pass a custom `candidate` to
+// override.
 inline int64_t xpuKernelLoopGroupRange(
     int64_t nelem,
-    int64_t group_size = xpu::sycl::syclDeviceMaxWorkGroupSize(),
-    int64_t candidate = xpu::sycl::syclMaxWorkItemsPerTile()) {
+    int64_t group_size = at::xpu::getDeviceMaxWorkGroupSize(),
+    int64_t candidate = at::xpu::getDeviceMaxWorkItems()) {
   int64_t work_items = std::min(nelem, candidate);
   return at::ceil_div(work_items, group_size);
 }

--- a/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
@@ -14,6 +14,7 @@
 #include <ATen/native/Math.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/xpu/sycl/GroupReduceUtils.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/xpu_aten.h>
 
 #include <ATen/native/xpu/sycl/Loops.h>
@@ -614,7 +615,7 @@ int64_t layer_norm_wg_size_select(
     return wg_size;
 
   // (XeCore count * EUs per XeCore) * HW threads per EU
-  int64_t total_hw_threads = syclGpuEuCount() * syclGpuHWThreadsPerEU();
+  int64_t total_hw_threads = at::xpu::getDeviceHWThreads();
   // Only use preferred_wg_size when less than 50% HW threads would be left idle
   if (M * threads_per_wg > total_hw_threads / 2)
     return preferred_wg_size;
@@ -635,7 +636,7 @@ void launch_vectorized_layer_norm_kernel(
     T_ACC* rstd_data) {
   using KernelClass = VectorizedLayerNormKernelFunctor<T, T_ACC, rms_norm>;
   auto wg_size = layer_norm_wg_size_select(
-      syclMaxWorkGroupSize<KernelClass>(), M, N / vec_size);
+      at::xpu::getKernelMaxWorkGroupSize<KernelClass>(), M, N / vec_size);
   KernelClass kfn(
       N,
       eps,
@@ -1203,16 +1204,17 @@ void layer_norm_backward_kernel_impl(
   auto config_w = NormConfig(M, N, 0, sizeof(scalar_t));
   auto norm_config_global_size =
       config_w.workgroup_num * config_w.block_row * config_w.workgroup_size;
-  int thread_slots = syclGpuEuCount() * syclGpuHWThreadsPerEU();
+  int thread_slots = at::xpu::getDeviceHWThreads();
   // use two stage col reduction if norm config occupancy < 50%
   // TODO: we can relax this restriction in future for better perf
   bool use_two_stage_col_reduction =
       (dY.dtype() == kFloat || dY.dtype() == kBFloat16 ||
        dY.dtype() == kHalf) &&
-      norm_config_global_size / syclMaxSubGroupSize() * 2 <= thread_slots;
+      norm_config_global_size / at::xpu::getDeviceMaxSubGroupSize() * 2 <=
+          thread_slots;
   // cuda uses condition M > 64 * 1024 && N / 32 < sm_count / 2 to parallelize
   // in the M dimension
-  int xe_core_count = syclGpuEuCount() / syclGpuEUCountPerSubslice();
+  int xe_core_count = at::xpu::getDeviceXeCoreCount();
   int tile_n = N / 32;
   if (use_two_stage_col_reduction && M > xe_core_count * 1024 &&
       tile_n < xe_core_count * 2) {
@@ -1233,7 +1235,7 @@ void layer_norm_backward_kernel_impl(
     for (auto i = 0; i < 3; i++) {
       // occupancy <= 50%
       if (num_tile_m * num_tile_n * local_size_x * SIMD /
-              syclMaxSubGroupSize() * 2 <=
+              at::xpu::getDeviceMaxSubGroupSize() * 2 <=
           thread_slots) {
         if (adjust_m) {
           tile_size_m /= 2;

--- a/src/ATen/native/xpu/sycl/Loops.h
+++ b/src/ATen/native/xpu/sycl/Loops.h
@@ -16,6 +16,7 @@
 #include <ATen/detail/FunctionTraits.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/TensorIteratorDynamicCasting.h>
+#include <ATen/xpu/XPUContext.h>
 #include <c10/core/DeviceGuard.h>
 
 #include <ATen/native/xpu/sycl/ElementwiseInvoke.h>
@@ -340,7 +341,7 @@ static void launch_legacy_global_range_kernel(int64_t N, const func_t& f) {
 
   int64_t wg_sz = syclMaxWorkItemsPerSubSlice();
   int64_t num_wg = ceil_div<int64_t>(N, wg_sz);
-  int64_t hw_max_num_wg = syclMaxWorkItemsPerTile() / wg_sz;
+  int64_t hw_max_num_wg = at::xpu::getDeviceMaxWorkItems() / wg_sz;
   num_wg = num_wg > hw_max_num_wg ? hw_max_num_wg : num_wg;
   sycl_kernel_submit(wg_sz * num_wg, wg_sz, getCurrentSYCLQueue(), ker);
 }

--- a/src/ATen/native/xpu/sycl/LossCTCKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LossCTCKernels.cpp
@@ -21,6 +21,7 @@
  * log_probs (also calling them inputs)
  */
 
+#include <ATen/xpu/XPUContext.h>
 #include <comm/Macros.h>
 // clang-format off
 DISABLE_RETURN_TYPE_WARNING_BEGIN
@@ -403,7 +404,7 @@ std::tuple<Tensor, Tensor> ctc_loss_kernel_template(
 
   using CTCLossLogAlphaKernel =
       CTCLossLogAlphaKernelFunctor<scalar_t, target_t>;
-  int max_threads = syclMaxWorkGroupSize<CTCLossLogAlphaKernel>();
+  int max_threads = at::xpu::getKernelMaxWorkGroupSize<CTCLossLogAlphaKernel>();
 
   int threads_target = max_threads;
   while (threads_target / 2 >= 2 * max_target_length + 1) {
@@ -1048,7 +1049,8 @@ Tensor ctc_loss_backward_kernel_template(
 
   using CTCLossBackwardLogBetaKernel =
       CTCLossBackwardLogBetaKernelFunctor<scalar_t, target_t>;
-  int max_threads = syclMaxWorkGroupSize<CTCLossBackwardLogBetaKernel>();
+  int max_threads =
+      at::xpu::getKernelMaxWorkGroupSize<CTCLossBackwardLogBetaKernel>();
   int threads_target = max_threads;
   while (threads_target / 2 >= 2 * max_target_length + 1) {
     threads_target /= 2;
@@ -1126,7 +1128,8 @@ Tensor ctc_loss_backward_kernel_template(
 
     using CTCLossBackwardCollectNonblankKernel =
         CTCLossBackwardCollectNonblankKernelFunctor<scalar_t, target_t>;
-    max_threads = syclMaxWorkGroupSize<CTCLossBackwardCollectNonblankKernel>();
+    max_threads = at::xpu::getKernelMaxWorkGroupSize<
+        CTCLossBackwardCollectNonblankKernel>();
     int threads_target = max_threads;
     while (threads_target / 2 >= max_target_length && threads_target > 1) {
       threads_target /= 2;
@@ -1170,7 +1173,8 @@ Tensor ctc_loss_backward_kernel_template(
   } else { // small problem, use naive algorithm
     using CTCLossBackwardCollectKernel =
         CTCLossBackwardCollectKernelFunctor<scalar_t, target_t>;
-    max_threads = syclMaxWorkGroupSize<CTCLossBackwardCollectKernel>();
+    max_threads =
+        at::xpu::getKernelMaxWorkGroupSize<CTCLossBackwardCollectKernel>();
     int threads_input = max_threads;
     while (threads_input / 2 >= log_probs.size(0) && threads_input > 1) {
       threads_input /= 2;
@@ -1220,7 +1224,8 @@ Tensor ctc_loss_backward_kernel_template(
   {
     using CTCLossZeroPaddedGradientsKernel =
         CTCLossZeroPaddedGradients<scalar_t>;
-    max_threads = syclMaxWorkGroupSize<CTCLossZeroPaddedGradientsKernel>();
+    max_threads =
+        at::xpu::getKernelMaxWorkGroupSize<CTCLossZeroPaddedGradientsKernel>();
     int threads_input = max_threads;
     while (threads_input / 2 >= log_probs.size(0)) {
       threads_input /= 2;

--- a/src/ATen/native/xpu/sycl/LossNLL2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LossNLL2dKernels.cpp
@@ -8,6 +8,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <ATen/xpu/XPUContext.h>
 #include <comm/Macros.h>
 // clang-format off
 DISABLE_RETURN_TYPE_WARNING_BEGIN
@@ -226,7 +227,7 @@ void nll_loss2d_forward_kernel(
               output.packed_accessor64<scalar_t, 3>(),
               optional_data<scalar_t>(weight_),
               ignore_index);
-          int64_t local_range = syclMaxWorkGroupSize(kfn);
+          int64_t local_range = at::xpu::getKernelMaxWorkGroupSize(kfn);
           auto global_range = (count + local_range - 1) / local_range;
           sycl_kernel_submit(
               global_range * local_range,
@@ -490,7 +491,7 @@ void nll_loss2d_backward_kernel(
               grad_input.packed_accessor64<scalar_t, 4>(),
               optional_data<scalar_t>(weight_),
               ignore_index);
-          int64_t local_range = syclMaxWorkGroupSize(kfn);
+          int64_t local_range = at::xpu::getKernelMaxWorkGroupSize(kfn);
           auto global_range = (count + local_range - 1) / local_range;
           sycl_kernel_submit(
               global_range * local_range,
@@ -516,7 +517,8 @@ void nll_loss2d_backward_kernel(
           auto weight_ = optional_contiguous(weight);
           int64_t map_nelem = target_numel / batch_size;
           using KernelClass = NllLoss2dBackwardKernelFunctor<scalar_t>;
-          int64_t max_work_group_size = syclMaxWorkGroupSize<KernelClass>();
+          int64_t max_work_group_size =
+              at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
           int blocks_per_sample =
               (map_nelem + max_work_group_size - 1) / max_work_group_size / 128;
           blocks_per_sample = (blocks_per_sample == 0) ? 1 : blocks_per_sample;

--- a/src/ATen/native/xpu/sycl/MultiMarginLossKernels.cpp
+++ b/src/ATen/native/xpu/sycl/MultiMarginLossKernels.cpp
@@ -14,6 +14,7 @@
 #include <ATen/native/LossMulti.h>
 #include <ATen/native/Resize.h>
 #include <ATen/ops/sum.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/SYCLContext.h>
 
 #include <ATen/native/xpu/sycl/MultiMarginLossKernels.h>
@@ -245,7 +246,8 @@ Tensor& multi_margin_loss_kernel(
           if (p == 1) {
             using KernelClass =
                 MultiMarginLossForwardKernelFunctor<1, scalar_t, accscalar_t>;
-            int64_t local_size = syclMaxWorkGroupSize<KernelClass>();
+            int64_t local_size =
+                at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
             auto kfn = KernelClass(
                 out.mutable_data_ptr<scalar_t>(),
                 input.const_data_ptr<scalar_t>(),
@@ -262,7 +264,8 @@ Tensor& multi_margin_loss_kernel(
           } else if (p == 2) {
             using KernelClass =
                 MultiMarginLossForwardKernelFunctor<2, scalar_t, accscalar_t>;
-            int64_t local_size = syclMaxWorkGroupSize<KernelClass>();
+            int64_t local_size =
+                at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
             auto kfn = KernelClass(
                 out.mutable_data_ptr<scalar_t>(),
                 input.const_data_ptr<scalar_t>(),
@@ -289,7 +292,8 @@ Tensor& multi_margin_loss_kernel(
             if (p == 1) {
               using KernelClass =
                   MultiMarginLossForwardKernelFunctor<1, scalar_t, accscalar_t>;
-              int64_t local_size = syclMaxWorkGroupSize<KernelClass>();
+              int64_t local_size =
+                  at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
               auto kfn = KernelClass(
                   out.mutable_data_ptr<scalar_t>(),
                   input.const_data_ptr<scalar_t>(),
@@ -306,7 +310,8 @@ Tensor& multi_margin_loss_kernel(
             } else if (p == 2) {
               using KernelClass =
                   MultiMarginLossForwardKernelFunctor<2, scalar_t, accscalar_t>;
-              int64_t local_size = syclMaxWorkGroupSize<KernelClass>();
+              int64_t local_size =
+                  at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
               auto kfn = KernelClass(
                   out.mutable_data_ptr<scalar_t>(),
                   input.const_data_ptr<scalar_t>(),
@@ -326,7 +331,8 @@ Tensor& multi_margin_loss_kernel(
             if (p == 1) {
               using KernelClass =
                   MultiMarginLossForwardKernelFunctor<1, scalar_t, accscalar_t>;
-              int64_t local_size = syclMaxWorkGroupSize<KernelClass>();
+              int64_t local_size =
+                  at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
               auto kfn = KernelClass(
                   tmp_output.mutable_data_ptr<scalar_t>(),
                   input.const_data_ptr<scalar_t>(),
@@ -344,7 +350,8 @@ Tensor& multi_margin_loss_kernel(
             } else if (p == 2) {
               using KernelClass =
                   MultiMarginLossForwardKernelFunctor<2, scalar_t, accscalar_t>;
-              int64_t local_size = syclMaxWorkGroupSize<KernelClass>();
+              int64_t local_size =
+                  at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
               auto kfn = KernelClass(
                   tmp_output.mutable_data_ptr<scalar_t>(),
                   input.const_data_ptr<scalar_t>(),
@@ -419,7 +426,8 @@ Tensor& multi_margin_loss_backward_kernel(
           if (p == 1) {
             using KernelClass =
                 MultiMarginLossBackwardKernelFunctor<1, scalar_t, accscalar_t>;
-            int64_t local_size = syclMaxWorkGroupSize<KernelClass>();
+            int64_t local_size =
+                at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
             auto kfn = KernelClass(
                 grad_input.mutable_data_ptr<scalar_t>(),
                 grad_output.const_data_ptr<scalar_t>(),
@@ -439,7 +447,8 @@ Tensor& multi_margin_loss_backward_kernel(
           } else if (p == 2) {
             using KernelClass =
                 MultiMarginLossBackwardKernelFunctor<2, scalar_t, accscalar_t>;
-            int64_t local_size = syclMaxWorkGroupSize<KernelClass>();
+            int64_t local_size =
+                at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
             auto kfn = KernelClass(
                 grad_input.mutable_data_ptr<scalar_t>(),
                 grad_output.const_data_ptr<scalar_t>(),
@@ -467,7 +476,8 @@ Tensor& multi_margin_loss_backward_kernel(
           if (p == 1) {
             using KernelClass =
                 MultiMarginLossBackwardKernelFunctor<1, scalar_t, accscalar_t>;
-            int64_t local_size = syclMaxWorkGroupSize<KernelClass>();
+            int64_t local_size =
+                at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
             auto kfn = KernelClass(
                 grad_input.mutable_data_ptr<scalar_t>(),
                 grad_output.const_data_ptr<scalar_t>(),
@@ -490,7 +500,8 @@ Tensor& multi_margin_loss_backward_kernel(
           } else if (p == 2) {
             using KernelClass =
                 MultiMarginLossBackwardKernelFunctor<2, scalar_t, accscalar_t>;
-            int64_t local_size = syclMaxWorkGroupSize<KernelClass>();
+            int64_t local_size =
+                at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
             auto kfn = KernelClass(
                 grad_input.mutable_data_ptr<scalar_t>(),
                 grad_output.const_data_ptr<scalar_t>(),

--- a/src/ATen/native/xpu/sycl/MultiTensorApply.h
+++ b/src/ATen/native/xpu/sycl/MultiTensorApply.h
@@ -9,6 +9,7 @@
  */
 
 #pragma once
+#include <ATen/xpu/XPUContext.h>
 #include <c10/core/ScalarType.h>
 #include <comm/xpu_aten.h>
 #include <vector>
@@ -134,7 +135,7 @@ void launch_multi_tensor_apply_kernel(
     int num_wg,
     ArgTypes... args) {
   auto& q = getCurrentSYCLQueue();
-  int64_t simd = syclMaxSubGroupSize();
+  int64_t simd = at::xpu::getDeviceMaxSubGroupSize();
   int64_t max_wg_size = multi_tensor_apply_kernel_get_wg_size(simd);
   int64_t kChunkSize = multi_tensor_apply_kernel_get_chunk_size(simd);
 
@@ -166,7 +167,7 @@ void multi_tensor_apply(
   size_t n_tensors = tensor_lists[0].size();
 
   auto& q = getCurrentSYCLQueue();
-  int64_t simd = syclMaxSubGroupSize();
+  int64_t simd = at::xpu::getDeviceMaxSubGroupSize();
   int64_t kChunkSize = multi_tensor_apply_kernel_get_chunk_size(simd);
 
   auto addressStorage = at::empty(
@@ -248,7 +249,7 @@ void multi_tensor_apply(
   size_t n_tensors = tensor_lists[0].size();
 
   auto& q = getCurrentSYCLQueue();
-  int64_t simd = syclMaxSubGroupSize();
+  int64_t simd = at::xpu::getDeviceMaxSubGroupSize();
   int64_t kChunkSize = multi_tensor_apply_kernel_get_chunk_size(simd);
 
   auto addressStorage = at::empty(

--- a/src/ATen/native/xpu/sycl/MultinomialKernel.cpp
+++ b/src/ATen/native/xpu/sycl/MultinomialKernel.cpp
@@ -8,6 +8,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <ATen/xpu/XPUContext.h>
 #include <comm/Macros.h>
 // clang-format off
 DISABLE_RETURN_TYPE_WARNING_BEGIN
@@ -99,11 +100,11 @@ inline void renormRows(Tensor& t) {
   TORCH_CHECK(t.dim() == 2);
   int64_t rows = t.size(0);
   int64_t cols = t.size(1);
-  int subgroup_size = syclMaxSubGroupSize();
+  int subgroup_size = at::xpu::getDeviceMaxSubGroupSize();
   int group_size = std::min(
       int(syclMaxWorkItemsPerSubSlice()), subgroup_size * subgroup_size);
   int num_groups = (rows + group_size - 1) / group_size;
-  int hw_max_groups = syclMaxWorkItemsPerTile() / group_size;
+  int hw_max_groups = at::xpu::getDeviceMaxWorkItems() / group_size;
   num_groups = num_groups > hw_max_groups ? hw_max_groups : num_groups;
 
   auto& sycl_queue = at::xpu::getCurrentSYCLQueue();
@@ -451,10 +452,10 @@ void multinomial_kernel(
       [&] {
         using accscalar_t = acc_type_device<scalar_t, kXPU>;
         using KernelClass = SampleMultinomialOnceFunctor<scalar_t, accscalar_t>;
-        int maxThreads = syclMaxWorkGroupSize<KernelClass>();
-        int maxShared = syclLocalMemSize();
+        int maxThreads = at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
+        int maxShared = at::xpu::getDeviceLocalMemSize();
 
-        int SubGroupSize = syclMinSubGroupSize();
+        int SubGroupSize = at::xpu::getDeviceMinSubGroupSize();
         int requiredSubGroups = at::ceil_div(numCategories, SubGroupSize);
         int requiredThreads =
             std::min(maxThreads, requiredSubGroups * SubGroupSize);

--- a/src/ATen/native/xpu/sycl/NonzeroKernel.cpp
+++ b/src/ATen/native/xpu/sycl/NonzeroKernel.cpp
@@ -11,6 +11,7 @@
 #include <ATen/Dispatch_v2.h>
 #include <ATen/ceil_div.h>
 #include <ATen/core/Tensor.h>
+#include <ATen/xpu/XPUContext.h>
 
 #include <ATen/native/xpu/sycl/pstl/PSTLFunctions.h>
 #include <comm/Memory.h>
@@ -258,7 +259,8 @@ void nonzero_template(const Tensor& self_, Tensor& out) {
           idx_flat_begin,
           divisor,
           sizes);
-      const auto wg_sz = std::min(syclMaxWorkGroupSize(kfn), total);
+      const auto wg_sz =
+          std::min<int64_t>(at::xpu::getKernelMaxWorkGroupSize(kfn), total);
       const auto num_wg = at::ceil_div(total, wg_sz);
       sycl_kernel_submit(wg_sz * num_wg, wg_sz, queue, kfn);
     }
@@ -276,7 +278,8 @@ void nonzero_template(const Tensor& self_, Tensor& out) {
 
   // ---- Pass 1: count nonzeros per chunk via work-group reduction ----
   using CountFunctor = CountNonzerosKernelFunctor<scalar_t>;
-  const auto count_wg_size = syclMaxWorkGroupSize<CountFunctor>();
+  const int64_t count_wg_size =
+      at::xpu::getKernelMaxWorkGroupSize<CountFunctor>();
 
   // Pre-allocate a single device buffer wide enough to hold every WG's partial
   // sum for every chunk. All count kernels are enqueued without blocking so

--- a/src/ATen/native/xpu/sycl/Norm.h
+++ b/src/ATen/native/xpu/sycl/Norm.h
@@ -14,6 +14,7 @@
 #include <ATen/core/Array.h>
 #include <ATen/detail/FunctionTraits.h>
 #include <ATen/native/xpu/sycl/MemoryAccess.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/SYCLContext.h>
 #include <comm/XPUMathCompat.h>
 #include <comm/xpu_aten.h>
@@ -283,7 +284,7 @@ class NormConfig {
   }
 
   void get_max_vec_size() {
-    int64_t total_resource = syclMaxWorkItemsPerTile();
+    int64_t total_resource = at::xpu::getDeviceMaxWorkItems();
 
     constexpr int float4_size = sizeof(float) * 4;
     max_vec_size = float4_size / element_size_bytes;
@@ -297,8 +298,8 @@ class NormConfig {
   // get resource size for Reduce problem [batch_size, problem_size]
   // the reduce is performed on problem_size dimension
   void get_workgroup_size() {
-    int max_workgroup_size = syclDeviceMaxWorkGroupSize();
-    int total_resource = syclMaxWorkItemsPerTile();
+    int max_workgroup_size = at::xpu::getDeviceMaxWorkGroupSize();
+    int total_resource = at::xpu::getDeviceMaxWorkItems();
     workgroup_num = total_resource / max_workgroup_size;
     int max_workgroup_num_foreach = 1;
     workgroup_size = max_workgroup_size;
@@ -330,8 +331,8 @@ class NormConfig {
 
   void get_workgroup_size_row() {
     // enlarge the occupancy, compute the least workgroup_num
-    int max_workgroup_size = syclDeviceMaxWorkGroupSize();
-    int total_resource = syclMaxWorkItemsPerTile();
+    int max_workgroup_size = at::xpu::getDeviceMaxWorkGroupSize();
+    int total_resource = at::xpu::getDeviceMaxWorkItems();
     workgroup_num = total_resource / max_workgroup_size;
 
     int max_block_row = max_workgroup_size / SIMD;

--- a/src/ATen/native/xpu/sycl/RNNKernels.cpp
+++ b/src/ATen/native/xpu/sycl/RNNKernels.cpp
@@ -16,6 +16,7 @@
 #include <ATen/TensorIterator.h>
 #include <ATen/core/TensorAccessor.h>
 #include <ATen/native/CanUse32BitIndexMath.h>
+#include <ATen/xpu/XPUContext.h>
 #include <c10/util/generic_math.h>
 #include <comm/SYCLContext.h>
 #include <comm/TensorInfo.h>
@@ -38,7 +39,8 @@ std::tuple<int64_t, int64_t> rnn_get_launch_config(
     int64_t numel) {
   int64_t num_groups =
       (numel + max_threads_per_group - 1) / max_threads_per_group;
-  auto hw_max_groups = syclMaxWorkItemsPerTile() / max_threads_per_group;
+  int64_t hw_max_groups =
+      at::xpu::getDeviceMaxWorkItems() / max_threads_per_group;
   num_groups = num_groups > hw_max_groups ? hw_max_groups : num_groups;
   return std::make_tuple(num_groups, max_threads_per_group);
 }
@@ -530,7 +532,7 @@ void lstm_forward_impl(
         workspaceI);
     using KernelT =
         LstmCellForwardFunctor<scalar_t, accscalar_t, index_type, 1>;
-    auto max_wg_size = syclMaxWorkGroupSize<KernelT>();
+    int64_t max_wg_size = at::xpu::getKernelMaxWorkGroupSize<KernelT>();
     auto config = rnn_get_launch_config(max_wg_size, numel);
     auto nwg = std::get<0>(config);
     auto local_range = std::get<1>(config);
@@ -550,7 +552,7 @@ void lstm_forward_impl(
   } else {
     using KernelT =
         LstmCellForwardFunctor<scalar_t, accscalar_t, index_type, 2>;
-    auto max_wg_size = syclMaxWorkGroupSize<KernelT>();
+    int64_t max_wg_size = at::xpu::getKernelMaxWorkGroupSize<KernelT>();
     auto config = rnn_get_launch_config(max_wg_size, numel);
     auto nwg = std::get<0>(config);
     auto local_range = std::get<1>(config);
@@ -600,7 +602,7 @@ void lstm_backward_impl(
         grad_hyI, grad_cyI, cxI, cyI, workspaceI, grad_gatesI, grad_cxI);
     using KernelT =
         LstmCellBackwardFunctor<scalar_t, accscalar_t, index_type, 1>;
-    auto max_wg_size = syclMaxWorkGroupSize<KernelT>();
+    int64_t max_wg_size = at::xpu::getKernelMaxWorkGroupSize<KernelT>();
     auto config = rnn_get_launch_config(max_wg_size, numel);
     auto nwg = std::get<0>(config);
     auto local_range = std::get<1>(config);
@@ -619,7 +621,7 @@ void lstm_backward_impl(
   } else {
     using KernelT =
         LstmCellBackwardFunctor<scalar_t, accscalar_t, index_type, 2>;
-    auto max_wg_size = syclMaxWorkGroupSize<KernelT>();
+    int64_t max_wg_size = at::xpu::getKernelMaxWorkGroupSize<KernelT>();
     auto config = rnn_get_launch_config(max_wg_size, numel);
     auto nwg = std::get<0>(config);
     auto local_range = std::get<1>(config);
@@ -679,7 +681,7 @@ void gru_forward_impl(
         hyI,
         workspaceI);
     using KernelT = GruCellForwardFunctor<scalar_t, accscalar_t, index_type, 1>;
-    auto max_wg_size = syclMaxWorkGroupSize<KernelT>();
+    int64_t max_wg_size = at::xpu::getKernelMaxWorkGroupSize<KernelT>();
     auto config = rnn_get_launch_config(max_wg_size, numel);
     auto nwg = std::get<0>(config);
     auto local_range = std::get<1>(config);
@@ -697,7 +699,7 @@ void gru_forward_impl(
         nwg * local_range, local_range, getCurrentSYCLQueue(), kfn);
   } else {
     using KernelT = GruCellForwardFunctor<scalar_t, accscalar_t, index_type, 2>;
-    auto max_wg_size = syclMaxWorkGroupSize<KernelT>();
+    int64_t max_wg_size = at::xpu::getKernelMaxWorkGroupSize<KernelT>();
     auto config = rnn_get_launch_config(max_wg_size, numel);
     auto nwg = std::get<0>(config);
     auto local_range = std::get<1>(config);
@@ -744,7 +746,7 @@ void gru_backward_impl(
         grad_hyI, workspaceI, grad_input_gatesI, grad_hidden_gatesI, grad_hxI);
     using KernelT =
         GruCellBackwardFunctor<scalar_t, accscalar_t, index_type, 1>;
-    auto max_wg_size = syclMaxWorkGroupSize<KernelT>();
+    int64_t max_wg_size = at::xpu::getKernelMaxWorkGroupSize<KernelT>();
     auto config = rnn_get_launch_config(max_wg_size, numel);
     auto nwg = std::get<0>(config);
     auto local_range = std::get<1>(config);
@@ -761,7 +763,7 @@ void gru_backward_impl(
   } else {
     using KernelT =
         GruCellBackwardFunctor<scalar_t, accscalar_t, index_type, 2>;
-    auto max_wg_size = syclMaxWorkGroupSize<KernelT>();
+    int64_t max_wg_size = at::xpu::getKernelMaxWorkGroupSize<KernelT>();
     auto config = rnn_get_launch_config(max_wg_size, numel);
     auto nwg = std::get<0>(config);
     auto local_range = std::get<1>(config);

--- a/src/ATen/native/xpu/sycl/RandpermKernel.cpp
+++ b/src/ATen/native/xpu/sycl/RandpermKernel.cpp
@@ -11,6 +11,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/native/xpu/sycl/Philox4x32.h>
 #include <ATen/native/xpu/sycl/SortingKernels.h>
+#include <ATen/xpu/XPUContext.h>
 #include <ATen/xpu/XPUGeneratorImpl.h>
 #include <comm/SYCLContext.h>
 #include <comm/xpu_aten.h>
@@ -89,8 +90,9 @@ void randperm_handle_duplicate_keys(
 
   T mask = static_cast<T>((1UL << bits) - 1);
 
-  auto local_range =
-      syclMaxWorkGroupSize<handle_duplicate_keys_kernel<T, scalar_t>>() / 2;
+  int64_t local_range = at::xpu::getKernelMaxWorkGroupSize<
+                            handle_duplicate_keys_kernel<T, scalar_t>>() /
+      2;
   auto num_wg = (n + local_range - 1) / local_range;
   auto global_range = num_wg * local_range;
 

--- a/src/ATen/native/xpu/sycl/Reduce.h
+++ b/src/ATen/native/xpu/sycl/Reduce.h
@@ -18,9 +18,9 @@
 #include <ATen/native/xpu/sycl/MemoryAccess.h>
 #include <ATen/native/xpu/sycl/MemoryAccessUtils.h>
 #include <ATen/native/xpu/sycl/OffsetCalculator.h>
+#include <ATen/xpu/XPUContext.h>
 #include <c10/core/Allocator.h>
 #include <c10/macros/Macros.h>
-#include <comm/DeviceProperties.h>
 #include <comm/SYCLContext.h>
 #include <comm/XPUPair.h>
 #include <comm/xpu_aten.h>
@@ -288,14 +288,15 @@ struct ReduceConfig {
 
   template <typename T, class KernelClass>
   void set_group_dimension(int64_t dim0, int64_t dim1) {
-    auto max_wg_sz = syclMaxWorkGroupSize<KernelClass>();
+    int64_t max_wg_sz = at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
     // Bypass reduction on SLM by sparing workload to other SGs. As the
     // result, reduction of small shape input only requires some shift
     // operations in side of SG. It is functional WA. We got case failures on
     // some platforms supporting SIMD8.
     // https://github.com/intel/torch-xpu-ops/issues/698
-    auto max_sg_sz = syclMinSubGroupSize() == 8 ? syclMinSubGroupSize()
-                                                : syclMaxSubGroupSize();
+    int64_t max_sg_sz = at::xpu::getDeviceMinSubGroupSize() == 8
+        ? at::xpu::getDeviceMinSubGroupSize()
+        : at::xpu::getDeviceMaxSubGroupSize();
     const int max_num_items = max_wg_sz / output_vec_size;
     int dim0_pow2 = dim0 < max_num_items ? static_cast<int>(last_pow2(dim0))
                                          : max_num_items;
@@ -1407,8 +1408,8 @@ inline void gpu_reduce_kernel(
   constexpr int min_values_per_item = 16;
   constexpr int max_values_per_item = 256;
 
-  const auto target_group_range =
-      syclMaxWorkItemsPerTile() / (group_height * group_width);
+  const int64_t target_group_range =
+      at::xpu::getDeviceMaxWorkItems() / (group_height * group_width);
   // outputs after spliting to work group
   int reset_output = config.n_groups()[1];
   if (config.input_mult[1] != 0 &&

--- a/src/ATen/native/xpu/sycl/RepeatKernel.cpp
+++ b/src/ATen/native/xpu/sycl/RepeatKernel.cpp
@@ -11,6 +11,7 @@
 #include <ATen/ATen.h>
 #include <ATen/native/Repeat.h>
 #include <ATen/native/xpu/sycl/RepeatKernel.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/SYCLContext.h>
 
 namespace at::native::xpu {
@@ -49,8 +50,8 @@ static void compute_xpu(
   if (size == 0)
     return;
 
-  int64_t wg_size =
-      syclMaxWorkGroupSize<repeat_interleave_kernel_implement<index_t>>();
+  int64_t wg_size = at::xpu::getKernelMaxWorkGroupSize<
+      repeat_interleave_kernel_implement<index_t>>();
 
   int64_t local_range = size < wg_size ? size : wg_size;
   int64_t global_range = ((size + local_range - 1) / local_range) * local_range;

--- a/src/ATen/native/xpu/sycl/ReplicationPaddingKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ReplicationPaddingKernels.cpp
@@ -8,6 +8,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <ATen/xpu/XPUContext.h>
 #include <comm/Macros.h>
 // clang-format off
 DISABLE_RETURN_TYPE_WARNING_BEGIN
@@ -59,8 +60,8 @@ void parallel_replication_pad1d(
   auto queue = getCurrentSYCLQueue();
   int64_t output_plane_size = output.size(2);
 
-  int64_t work_group_size =
-      syclMaxWorkGroupSize<parallel_replication_pad_1d_kernel_func<
+  int64_t work_group_size = at::xpu::getKernelMaxWorkGroupSize<
+      parallel_replication_pad_1d_kernel_func<
           input_scalar_t,
           output_scalar_t,
           F>>();
@@ -179,8 +180,8 @@ void parallel_replication_pad2d(
   auto queue = getCurrentSYCLQueue();
   int64_t output_plane_size = output.size(2) * output.size(3);
 
-  int64_t work_group_size =
-      syclMaxWorkGroupSize<parallel_replication_pad_2d_kernel_func<
+  int64_t work_group_size = at::xpu::getKernelMaxWorkGroupSize<
+      parallel_replication_pad_2d_kernel_func<
           input_scalar_t,
           output_scalar_t,
           F>>();
@@ -316,8 +317,8 @@ void parallel_replication_pad3d(
   auto queue = getCurrentSYCLQueue();
   int64_t output_plane_size = output.size(2) * output.size(3) * output.size(4);
 
-  int64_t work_group_size =
-      syclMaxWorkGroupSize<parallel_replication_pad_3d_kernel_func<
+  int64_t work_group_size = at::xpu::getKernelMaxWorkGroupSize<
+      parallel_replication_pad_3d_kernel_func<
           input_scalar_t,
           output_scalar_t,
           F>>();

--- a/src/ATen/native/xpu/sycl/RoiAlignKernels.cpp
+++ b/src/ATen/native/xpu/sycl/RoiAlignKernels.cpp
@@ -12,6 +12,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <ATen/xpu/XPUContext.h>
 #include <comm/Macros.h>
 // clang-format off
 DISABLE_RETURN_TYPE_WARNING_BEGIN
@@ -477,8 +478,8 @@ Tensor roi_align_kernel(
       input.scalar_type(),
       "roi_align_forward_kernel_xpu",
       [&] {
-        int64_t local_range =
-            syclMaxWorkGroupSize<RoiAlignForwardKernel<scalar_t>>();
+        int64_t local_range = at::xpu::getKernelMaxWorkGroupSize<
+            RoiAlignForwardKernel<scalar_t>>();
         int items_per_roi = pooled_height * pooled_width * channels;
         if (items_per_roi < local_range) {
           constexpr int simd_len = 32;

--- a/src/ATen/native/xpu/sycl/ScanUtils.h
+++ b/src/ATen/native/xpu/sycl/ScanUtils.h
@@ -16,6 +16,7 @@
 #include <ATen/native/Math.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/xpu/sycl/BatchKernel.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/SYCLContext.h>
 #include <comm/TensorInfo.h>
 #include <comm/TensorOptions.h>
@@ -348,7 +349,7 @@ class LoopScanConfig {
         wg_range_y_(0) {
     size_t wg_size = syclMaxWorkItemsPerSubSlice();
     wg_range_y_ = wg_size / wg_range_x_;
-    const auto target_global_size = syclMaxWorkItemsPerTile();
+    const int64_t target_global_size = at::xpu::getDeviceMaxWorkItems();
     ;
     const size_t max_work_group_num = target_global_size / wg_size;
     const size_t wg_number =

--- a/src/ATen/native/xpu/sycl/ScatterGatherKernels.cpp
+++ b/src/ATen/native/xpu/sycl/ScatterGatherKernels.cpp
@@ -8,6 +8,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <ATen/xpu/XPUContext.h>
 #include <comm/Macros.h>
 // clang-format off
 DISABLE_RETURN_TYPE_WARNING_BEGIN
@@ -183,11 +184,11 @@ static void launch_scatter_gather_kernel(int64_t N, const func_t& f) {
     return;
   }
 
-  int64_t max_wg_size =
-      syclMaxWorkGroupSize<scatter_gather_elementwise_kernel<func_t>>();
+  int64_t max_wg_size = at::xpu::getKernelMaxWorkGroupSize<
+      scatter_gather_elementwise_kernel<func_t>>();
   int outputSize = N;
   int work_group_size = outputSize > max_wg_size ? max_wg_size : outputSize;
-  const auto target_global_size = syclMaxWorkItemsPerTile();
+  const int64_t target_global_size = at::xpu::getDeviceMaxWorkItems();
   // Each work group size is work_group_size, one full device launch is
   // target_global_size, so we can calculate max work group num as below
   const int max_work_group_num = target_global_size / work_group_size;

--- a/src/ATen/native/xpu/sycl/SegmentReduceKernels.cpp
+++ b/src/ATen/native/xpu/sycl/SegmentReduceKernels.cpp
@@ -15,6 +15,7 @@
 #include <ATen/core/Scalar.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/native/ReductionType.h>
+#include <ATen/xpu/XPUContext.h>
 #include <optional>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -172,7 +173,7 @@ void segment_reduce_forward_kernel(
     const int64_t lengths_cumsum_stride_axis) {
   const int64_t size = outer_offset * segment_count * inner_offset;
   using Kernel = SegmentReduceForwardKernelFunctor<scalar_t, index_t>;
-  const int64_t work_group_size = syclMaxWorkGroupSize<Kernel>();
+  const int64_t work_group_size = at::xpu::getKernelMaxWorkGroupSize<Kernel>();
   const int64_t work_group_num = (size + work_group_size - 1) / work_group_size;
   Kernel kfn(
       reduction,
@@ -504,7 +505,7 @@ void segment_reduce_backward_kernel(
     const int64_t lengths_cumsum_stride_axis) {
   const int64_t size = outer_offset * segment_count * inner_offset;
   using Kernel = SegmentReduceBackwardKernelFunctor<scalar_t, index_t>;
-  const int64_t work_group_size = syclMaxWorkGroupSize<Kernel>();
+  const int64_t work_group_size = at::xpu::getKernelMaxWorkGroupSize<Kernel>();
   const int64_t work_group_num = (size + work_group_size - 1) / work_group_size;
 
   Kernel kfn(

--- a/src/ATen/native/xpu/sycl/Shape.cpp
+++ b/src/ATen/native/xpu/sycl/Shape.cpp
@@ -18,6 +18,7 @@
 #include <ATen/native/TensorShape.h>
 #include <ATen/native/TypeProperties.h>
 #include <ATen/native/xpu/sycl/MemoryAccessUtils.h>
+#include <ATen/xpu/XPUContext.h>
 #include <c10/core/MemoryFormat.h>
 #include <c10/util/SmallVector.h>
 #include <comm/SYCLContext.h>
@@ -63,8 +64,8 @@ inline std::tuple<sycl::range<2>, sycl::range<2>> getCatRange(
   // One wave is enough to saturate the tile. The kernel is grid-strided, so
   // additional groups do not increase parallelism and can increase idle work
   // for smaller tensors in the batch.
-  const unsigned int max_item_groups =
-      static_cast<unsigned int>(syclMaxWorkItemsPerTile() / items_per_group);
+  const unsigned int max_item_groups = static_cast<unsigned int>(
+      at::xpu::getDeviceMaxWorkItems() / items_per_group);
   item_groups = std::min(max_item_groups, item_groups);
 
   sycl::range<2> global_range(
@@ -85,8 +86,8 @@ inline std::tuple<sycl::range<2>, sycl::range<2>> getCatRangeContig(
   unsigned int max_items = ceil_div(max_elements_per_tensor, elements_per_item);
   unsigned int item_groups = ceil_div(max_items, items_per_group);
 
-  const unsigned int max_item_groups =
-      static_cast<unsigned int>(syclMaxWorkItemsPerTile() / items_per_group);
+  const unsigned int max_item_groups = static_cast<unsigned int>(
+      at::xpu::getDeviceMaxWorkItems() / items_per_group);
   item_groups = std::min(max_item_groups, item_groups);
 
   sycl::range<2> global_range(

--- a/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
+++ b/src/ATen/native/xpu/sycl/SoftMaxKernels.cpp
@@ -15,7 +15,6 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/xpu/sycl/Loops.h>
 #include <ATen/xpu/XPUContext.h>
-#include <comm/DeviceProperties.h>
 #include <comm/SYCLContext.h>
 #include <comm/xpu_aten.h>
 
@@ -146,7 +145,7 @@ static inline int get_wgroup_size(
     int& global_size_row,
     int& local_size_row,
     int& local_size_col) {
-  int maxWGSize = syclMaxWorkGroupSize<KernelClass>();
+  int maxWGSize = at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
 
   int local_size = (dim_size + NUM * vec_size - 1) / (NUM * vec_size);
   local_size = std::min(local_size, maxWGSize);
@@ -190,8 +189,8 @@ static inline void get_wgroup_size_spatial(
     int inner_size,
     int& GroupSize,
     int& GroupRow) {
-  int maxWGSize = syclMaxWorkGroupSize<KernelClass>();
-  int total_resource = syclMaxWorkItemsPerTile();
+  int maxWGSize = at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
+  int total_resource = at::xpu::getDeviceMaxWorkItems();
 
   // set the GroupSize smaller to ensure larger group number
   // smaller GroupSize is friendly to the tail case
@@ -723,7 +722,7 @@ void softmax_forward_kernel(
 
   int local_size = std::min(
       (dim_size + vec_size - 1) / vec_size,
-      int(syclMaxWorkGroupSize<KernelClass>()));
+      int(at::xpu::getKernelMaxWorkGroupSize<KernelClass>()));
   int64_t local_range{local_size};
   int64_t global_range{local_size * outer_size};
 
@@ -1384,7 +1383,7 @@ void softmax_backward_kernel(
 
   int64_t local_size = std::min(
       (dim_size + vec_size - 1) / vec_size,
-      int64_t(syclMaxWorkGroupSize<KernelClass>()));
+      int64_t(at::xpu::getKernelMaxWorkGroupSize<KernelClass>()));
   int64_t local_range{local_size};
   int64_t global_range{local_size * outer_size};
 

--- a/src/ATen/native/xpu/sycl/Sorting.cpp
+++ b/src/ATen/native/xpu/sycl/Sorting.cpp
@@ -8,6 +8,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <ATen/xpu/XPUContext.h>
 #include <comm/Macros.h>
 // clang-format off
 DISABLE_RETURN_TYPE_WARNING_BEGIN
@@ -411,7 +412,7 @@ void gatherMedian(
       in_data,
       values_data,
       indices_data);
-  int64_t local_size = syclMaxWorkGroupSize(kfn);
+  int64_t local_size = at::xpu::getKernelMaxWorkGroupSize(kfn);
   sycl_kernel_submit(
       numInputSlices * local_size, local_size, getCurrentSYCLQueue(), kfn);
 }
@@ -444,7 +445,7 @@ void gatherKthValue(
       in_data,
       values_data,
       indices_data);
-  int64_t local_size = syclMaxWorkGroupSize(kfn);
+  int64_t local_size = at::xpu::getKernelMaxWorkGroupSize(kfn);
   sycl_kernel_submit(
       numInputSlices * local_size, local_size, getCurrentSYCLQueue(), kfn);
 }

--- a/src/ATen/native/xpu/sycl/TensorApplyUtils.h
+++ b/src/ATen/native/xpu/sycl/TensorApplyUtils.h
@@ -13,6 +13,7 @@
 #include <ATen/native/CanUse32BitIndexMath.h>
 #include <ATen/native/Copy.h>
 #include <ATen/native/xpu/sycl/IndexUtils.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/SYCLContext.h>
 #include <comm/TensorInfo.h>
 #include <cmath>
@@ -264,7 +265,7 @@ inline uint64_t get_apply_group_count(
   uint64_t num_groups =
       (total_elements + numel_per_thread - 1) / numel_per_thread;
   uint64_t estimated_max_groups_per_tile =
-      syclMaxWorkItemsPerTile() / threads_per_group;
+      at::xpu::getDeviceMaxWorkItems() / threads_per_group;
   if (num_groups > estimated_max_groups_per_tile)
     num_groups = estimated_max_groups_per_tile;
   return num_groups;

--- a/src/ATen/native/xpu/sycl/TensorFactoriesKernels.cpp
+++ b/src/ATen/native/xpu/sycl/TensorFactoriesKernels.cpp
@@ -13,8 +13,8 @@
 #include <ATen/native/xpu/sycl/ScanUtils.h>
 #include <ATen/native/xpu/sycl/TensorFactoriesKernels.h>
 #include <ATen/xpu/EmptyTensor.h>
+#include <ATen/xpu/XPUContext.h>
 #include <c10/core/TensorOptions.h>
-#include <comm/DeviceProperties.h>
 #include <comm/SYCLHelpers.h>
 
 namespace at::native::xpu {
@@ -138,7 +138,7 @@ void triu_indices_kernel_template(
     int64_t rectangle_size,
     int64_t triu_size) {
   using Kernel = TriuIndicesKernelFunctor<scalar_t>;
-  int64_t group_size = syclMaxWorkGroupSize<Kernel>();
+  int64_t group_size = at::xpu::getKernelMaxWorkGroupSize<Kernel>();
   auto totalElements = triu_size;
   auto num_groups = at::ceil_div(totalElements, group_size);
   auto total_items = num_groups * group_size;
@@ -216,7 +216,7 @@ void tril_indices_kernel_template(
     int64_t trapezoid_size,
     int64_t tril_size) {
   using Kernel = TrilIndicesKernelFunctor<scalar_t>;
-  int64_t group_size = syclMaxWorkGroupSize<Kernel>();
+  int64_t group_size = at::xpu::getKernelMaxWorkGroupSize<Kernel>();
   auto totalElements = tril_size;
   auto num_groups = at::ceil_div(totalElements, group_size);
   auto total_items = num_groups * group_size;

--- a/src/ATen/native/xpu/sycl/TensorShapeKernels.cpp
+++ b/src/ATen/native/xpu/sycl/TensorShapeKernels.cpp
@@ -14,6 +14,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/TensorShape.h>
+#include <ATen/xpu/XPUContext.h>
 #include <c10/util/TypeCast.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -678,7 +679,7 @@ void split_with_sizes_copy_out_xpu_contiguous_no_cast(
     num_groups += at::ceil_div(split_chunk_size, GROUP_SIZE * BYTES_PER_THREAD);
   }
 
-  int64_t tile_size = syclMaxWorkItemsPerTile();
+  int64_t tile_size = at::xpu::getDeviceMaxWorkItems();
   const int64_t max_groups = tile_size / GROUP_SIZE * 2.0;
 
   // Make each thread process BYTES_PER_THREAD * iter_factor bytes to regulate

--- a/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TensorTopKSbtopkKernel.cpp
@@ -21,7 +21,7 @@
 #include <ATen/native/xpu/sycl/TensorTopKSbtopkKernel.h>
 #include <ATen/native/xpu/sycl/TensorTopKSbtopkKernelImpl.h>
 #include <ATen/native/xpu/sycl/TensorTopKSingleWgKernel.h>
-#include <comm/DeviceProperties.h>
+#include <ATen/xpu/XPUContext.h>
 
 #include <bit>
 
@@ -101,8 +101,7 @@ SbtopkResult sbtopk_try_launch(
   //   thread_slots/4 is the conservative cutoff.
   //
   // On B580: thread_slots = 160 EU * 8 HW threads = 1280, threshold = 320.
-  int64_t thread_slots =
-      ::xpu::sycl::syclGpuEuCount() * ::xpu::sycl::syclGpuHWThreadsPerEU();
+  int64_t thread_slots = at::xpu::getDeviceHWThreads();
   int64_t sg_threshold = thread_slots / 4;
   if (k <= 8 && nsegments >= sg_threshold) {
     if (subgroup_topk_try_launch(

--- a/src/ATen/native/xpu/sycl/TensorTransformationsKernels.cpp
+++ b/src/ATen/native/xpu/sycl/TensorTransformationsKernels.cpp
@@ -13,6 +13,7 @@
 #include <ATen/WrapDimUtilsMulti.h>
 #include <ATen/native/xpu/sycl/MemoryAccess.h>
 #include <ATen/native/xpu/sycl/OffsetCalculator.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/SYCLContext.h>
 #include <comm/xpu_aten.h>
 
@@ -59,8 +60,8 @@ void elementwise_kernel(int total_n_elems, func_t f) {
   using KernelClass = ElementwiseKernelFunctor<func_t>;
 
   auto& queue = getCurrentSYCLQueue();
-  int64_t max_wg_size = syclMaxWorkGroupSize<KernelClass>();
-  const auto target_global_size = syclMaxWorkItemsPerTile();
+  int64_t max_wg_size = at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
+  const int64_t target_global_size = at::xpu::getDeviceMaxWorkItems();
   int work_group_size =
       total_n_elems > max_wg_size ? max_wg_size : total_n_elems;
   const int max_work_group_num = target_global_size / work_group_size;
@@ -226,9 +227,9 @@ void roll_template(
   auto start_offset = start * stride;
   auto total_offset = size * stride;
 
-  auto local_range = syclMaxWorkGroupSize<KernelClass>();
-  const auto target_global_range =
-      syclMaxWorkItemsPerTile() / local_range * local_range;
+  int64_t local_range = at::xpu::getKernelMaxWorkGroupSize<KernelClass>();
+  const int64_t target_global_range =
+      at::xpu::getDeviceMaxWorkItems() / local_range * local_range;
   int global_range = (N + local_range - 1) / local_range * local_range;
   auto val_of_work_item =
       (global_range + target_global_range - 1) / target_global_range;

--- a/src/ATen/native/xpu/sycl/TransposeKernel.cpp
+++ b/src/ATen/native/xpu/sycl/TransposeKernel.cpp
@@ -11,6 +11,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/native/TensorIterator.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/SYCLContext.h>
 #include <comm/xpu_aten.h>
 
@@ -322,12 +323,12 @@ static bool detect_batch_transpose(
       int64_t num_tiles_y = (r + TILE_DIM - 1) / TILE_DIM;
       int64_t total_wgs = b * num_tiles_y * num_tiles_x;
 
-      int64_t simd = syclMaxSubGroupSize();
+      int64_t simd = at::xpu::getDeviceMaxSubGroupSize();
       int64_t sgs_per_wg = WG_SIZE / simd;
       int64_t total_sgs = total_wgs * sgs_per_wg;
 
       // 1) Total subgroups must fill all GPU thread slots
-      int64_t thread_slots = syclGpuEuCount() * syclGpuHWThreadsPerEU();
+      int64_t thread_slots = at::xpu::getDeviceHWThreads();
       if (total_sgs < thread_slots)
         return false;
 
@@ -337,11 +338,12 @@ static bool detect_batch_transpose(
       int64_t slm_pad = (elem_size <= 2) ? 2 : 1;
       int64_t slm_per_wg = TILE_DIM * (TILE_DIM + slm_pad) * elem_size;
 
-      int64_t eu_per_xc = syclGpuEUCountPerSubslice();
+      int64_t eu_per_xc = at::xpu::getDeviceEUCountPerXeCore();
       int64_t hw_thr = syclGpuHWThreadsPerEU();
       int64_t slots_per_xc = eu_per_xc * hw_thr;
       int64_t concurrent_wgs = slots_per_xc / sgs_per_wg;
-      int64_t slm_per_wg_upbound = syclLocalMemSize() / concurrent_wgs;
+      int64_t slm_per_wg_upbound =
+          at::xpu::getDeviceLocalMemSize() / concurrent_wgs;
       if (slm_per_wg > slm_per_wg_upbound)
         return false;
 

--- a/src/ATen/native/xpu/sycl/UpSampleBicubic2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleBicubic2dKernels.cpp
@@ -8,6 +8,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <ATen/xpu/XPUContext.h>
 #include <comm/Macros.h>
 // clang-format off
 DISABLE_RETURN_TYPE_WARNING_BEGIN
@@ -127,8 +128,8 @@ static void launch_upsample_bicubic2d_out_kernel(
     bool align_corners,
     const accscalar_t height_scale,
     const accscalar_t width_scale) {
-  int64_t wg_size =
-      syclMaxWorkGroupSize<upsample_bicubic2d_kernel<scalar_t, accscalar_t>>();
+  int64_t wg_size = at::xpu::getKernelMaxWorkGroupSize<
+      upsample_bicubic2d_kernel<scalar_t, accscalar_t>>();
   int64_t num_wg = at::ceil_div(onum, wg_size);
   auto queue = getCurrentSYCLQueue();
 
@@ -264,7 +265,7 @@ static void launch_upsample_bicubic2d_backward_out_kernel(
     const bool align_corners,
     PackedTensorAccessor64<scalar_t, 4> idata,
     const PackedTensorAccessor64<const scalar_t, 4> odata) {
-  int64_t wg_size = syclMaxWorkGroupSize<
+  int64_t wg_size = at::xpu::getKernelMaxWorkGroupSize<
       upsample_bicubic2d_backward_kernel<scalar_t, accscalar_t>>();
   int64_t num_wg = at::ceil_div(num_elements, wg_size);
   auto queue = getCurrentSYCLQueue();

--- a/src/ATen/native/xpu/sycl/UpSampleBilinear2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleBilinear2dKernels.cpp
@@ -8,6 +8,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <ATen/xpu/XPUContext.h>
 #include <comm/Macros.h>
 // clang-format off
 DISABLE_RETURN_TYPE_WARNING_BEGIN
@@ -93,8 +94,8 @@ void launch_upsample_bilinear2d_kernel(
     int64_t output_width,
     int64_t nbatch,
     int64_t channels) {
-  int64_t wg_size =
-      syclMaxWorkGroupSize<upsample_bilinear2d_kernel<scalar_t, accscalar_t>>();
+  int64_t wg_size = at::xpu::getKernelMaxWorkGroupSize<
+      upsample_bilinear2d_kernel<scalar_t, accscalar_t>>();
   int num_group = at::ceil_div(n, (int)wg_size);
   auto queue = getCurrentSYCLQueue();
 
@@ -199,7 +200,7 @@ void launch_upsample_bilinear2d_nhwc_kernel(
     const scalar_t* idata,
     scalar_t* odata,
     const int out_numel) {
-  int64_t wg_size = syclMaxWorkGroupSize<
+  int64_t wg_size = at::xpu::getKernelMaxWorkGroupSize<
       upsample_bilinear2d_nhwc_kernel<scalar_t, accscalar_t>>();
   int num_group = at::ceil_div(out_numel, (int)wg_size);
   auto queue = getCurrentSYCLQueue();
@@ -507,8 +508,8 @@ void launch_upsample_bilinear2d_backward_kernel(
       !std::is_same_v<scalar_t, double>;
   if (can_optimize) {
     if (align_corners) {
-      int64_t wg_size =
-          syclMaxWorkGroupSize<upsample_bilinear2d_backward_align_kernel<
+      int64_t wg_size = at::xpu::getKernelMaxWorkGroupSize<
+          upsample_bilinear2d_backward_align_kernel<
               scalar_t,
               accscalar_t,
               false>>();
@@ -532,8 +533,8 @@ void launch_upsample_bilinear2d_backward_kernel(
           (int)channels,
           i_numel);
     } else {
-      int64_t wg_size =
-          syclMaxWorkGroupSize<upsample_bilinear2d_backward_not_align_kernel<
+      int64_t wg_size = at::xpu::getKernelMaxWorkGroupSize<
+          upsample_bilinear2d_backward_not_align_kernel<
               scalar_t,
               accscalar_t,
               false>>();
@@ -561,7 +562,7 @@ void launch_upsample_bilinear2d_backward_kernel(
   } else {
     const size_t num_kernels = nc * output_width * output_height;
 
-    int64_t wg_size = syclMaxWorkGroupSize<
+    int64_t wg_size = at::xpu::getKernelMaxWorkGroupSize<
         upsample_bilinear2d_backward_kernel<scalar_t, accscalar_t>>();
     int num_group = at::ceil_div((int64_t)num_kernels, (int64_t)wg_size);
     auto queue = getCurrentSYCLQueue();
@@ -692,8 +693,8 @@ void launch_upsample_bilinear2d_backward_nhwc_kernel(
       !std::is_same_v<scalar_t, double>;
   if (can_optimize) {
     if (align_corners) {
-      int64_t wg_size =
-          syclMaxWorkGroupSize<upsample_bilinear2d_backward_align_kernel<
+      int64_t wg_size = at::xpu::getKernelMaxWorkGroupSize<
+          upsample_bilinear2d_backward_align_kernel<
               scalar_t,
               accscalar_t,
               true>>();
@@ -718,8 +719,8 @@ void launch_upsample_bilinear2d_backward_nhwc_kernel(
           i_numel);
 
     } else {
-      int64_t wg_size =
-          syclMaxWorkGroupSize<upsample_bilinear2d_backward_not_align_kernel<
+      int64_t wg_size = at::xpu::getKernelMaxWorkGroupSize<
+          upsample_bilinear2d_backward_not_align_kernel<
               scalar_t,
               accscalar_t,
               true>>();
@@ -745,7 +746,7 @@ void launch_upsample_bilinear2d_backward_nhwc_kernel(
     }
 
   } else {
-    int64_t wg_size = syclMaxWorkGroupSize<
+    int64_t wg_size = at::xpu::getKernelMaxWorkGroupSize<
         upsample_bilinear2d_backward_nhwc_kernel<scalar_t, accscalar_t>>();
     int num_group = at::ceil_div((int64_t)o_numel, (int64_t)wg_size);
     auto queue = getCurrentSYCLQueue();
@@ -1280,12 +1281,12 @@ void launch_upsample_gen2d_aa_kernel(
   const int interp_height = (int)ceilf(support_h) * 2 + 1;
   const int interp_width = (int)ceilf(support_w) * 2 + 1;
 
-  auto sharedMemPerBlock = syclLocalMemSize();
+  int64_t sharedMemPerBlock = at::xpu::getDeviceLocalMemSize();
   int maxThreadsPerBlock = std::min<int>(
-      syclMaxWorkGroupSize<
+      at::xpu::getKernelMaxWorkGroupSize<
           UpsampleGen2dAaKernelFunctor<scalar_t, accscalar_t, InterpFilter>>(),
       256); // 256 performs better
-  int block_x = syclMaxSubGroupSize();
+  int block_x = at::xpu::getDeviceMaxSubGroupSize();
 
   int numer =
       sharedMemPerBlock * 1.0 / sizeof(scalar_t) - interp_width * block_x;
@@ -1348,12 +1349,12 @@ void launch_upsample_gen2d_aa_backward_kernel(
     const accscalar_t support_w) {
   auto queue = getCurrentSYCLQueue();
 
-  auto sharedMemPerBlock = syclLocalMemSize();
+  int64_t sharedMemPerBlock = at::xpu::getDeviceLocalMemSize();
   int maxThreadsPerBlock = std::min<int>(
-      syclMaxWorkGroupSize<
+      at::xpu::getKernelMaxWorkGroupSize<
           UpsampleGen2dAaKernelFunctor<scalar_t, accscalar_t, InterpFilter>>(),
       256); // 256 performs better
-  int block_x = syclMaxSubGroupSize();
+  int block_x = at::xpu::getDeviceMaxSubGroupSize();
   int block_y = maxThreadsPerBlock / block_x;
 
   int grid_x = (output_width + block_x - 1) / block_x * block_x;

--- a/src/ATen/native/xpu/sycl/UpSampleLinear1dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleLinear1dKernels.cpp
@@ -8,6 +8,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <ATen/xpu/XPUContext.h>
 #include <comm/Macros.h>
 // clang-format off
 DISABLE_RETURN_TYPE_WARNING_BEGIN
@@ -101,7 +102,7 @@ void upsample_linear1d_kernel(
             input_width, output_width, align_corners, scales);
         const int num_kernels = output_width;
         constexpr auto kfn = upsample_linear1d_kernel<scalar_t, accscalar_t>;
-        const auto local_range = syclMaxWorkGroupSize<kfn>();
+        const int64_t local_range = at::xpu::getKernelMaxWorkGroupSize<kfn>();
         auto global_range =
             (num_kernels + local_range - 1) / local_range * local_range;
         sycl_kernel_submit<kfn>(
@@ -197,7 +198,7 @@ void upsample_linear1d_backward_kernel(
             input_width, output_width, align_corners, scales);
         constexpr auto kfn =
             upsample_linear1d_backward_kernel<scalar_t, accscalar_t>;
-        const auto local_range = syclMaxWorkGroupSize<kfn>();
+        const int64_t local_range = at::xpu::getKernelMaxWorkGroupSize<kfn>();
         auto global_range =
             (num_kernels + local_range - 1) / local_range * local_range;
         sycl_kernel_submit<kfn>(

--- a/src/ATen/native/xpu/sycl/UpSampleNearest2dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleNearest2dKernels.cpp
@@ -12,6 +12,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/native/xpu/sycl/LaunchUtils.h>
 #include <ATen/native/xpu/sycl/UpSampleNearest2dKernels.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/Runtime.h>
 #include <comm/SYCLContext.h>
 #include <comm/SYCLHelpers.h>
@@ -469,7 +470,7 @@ void upsample_nearest2d_channels_last_frame(
   auto work_group_size = syclMaxWorkItemsPerSubSlice();
   int64_t global_range =
       (out_numel + work_group_size - 1) / work_group_size * work_group_size;
-  int64_t max_groups = syclMaxWorkItemsPerTile() / work_group_size;
+  int64_t max_groups = at::xpu::getDeviceMaxWorkItems() / work_group_size;
   max_groups = std::max<int64_t>(1, max_groups);
   global_range = std::min<int64_t>(global_range, max_groups * work_group_size);
 

--- a/src/ATen/native/xpu/sycl/UpSampleNearest3dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleNearest3dKernels.cpp
@@ -8,6 +8,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <ATen/xpu/XPUContext.h>
 #include <comm/Macros.h>
 // clang-format off
 DISABLE_RETURN_TYPE_WARNING_BEGIN
@@ -89,7 +90,7 @@ void upsample_nearest3d_out_template(
     float width_scale,
     index_op_t index_op) {
   auto& queue = at::xpu::getCurrentSYCLQueue();
-  auto work_group_size = syclMaxWorkGroupSize<
+  int64_t work_group_size = at::xpu::getKernelMaxWorkGroupSize<
       upsample_nearest3d_kernel<scalar_t, index_t, index_op_t>>();
   int64_t work_group_num =
       at::ceil_div((unsigned int)n, (unsigned int)work_group_size);
@@ -289,8 +290,8 @@ void upsample_nearest3d_backward_template(
     float width_scale,
     index_bw_op_t index_bw_op) {
   auto& queue = at::xpu::getCurrentSYCLQueue();
-  auto work_group_size =
-      syclMaxWorkGroupSize<upsample_nearest3d_backward_kernel<
+  int64_t work_group_size =
+      at::xpu::getKernelMaxWorkGroupSize<upsample_nearest3d_backward_kernel<
           scalar_t,
           accscalar_t,
           index_t,

--- a/src/ATen/native/xpu/sycl/UpSampleTrilinear3dKernels.cpp
+++ b/src/ATen/native/xpu/sycl/UpSampleTrilinear3dKernels.cpp
@@ -8,6 +8,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <ATen/xpu/XPUContext.h>
 #include <comm/Macros.h>
 // clang-format off
 DISABLE_RETURN_TYPE_WARNING_BEGIN
@@ -140,7 +141,7 @@ void launch_upsample_trilinear3d_kernel(
   UpsampleTrilinear3dKernelFunctor<scalar_t, accscalar_t> kfn(
       n, rdepth, rheight, rwidth, align_corners, idata_acc, odata_acc);
 
-  int64_t wg_size = syclMaxWorkGroupSize(kfn);
+  int64_t wg_size = at::xpu::getKernelMaxWorkGroupSize(kfn);
   int num_group = at::ceil_div(n, (int)wg_size);
   auto queue = getCurrentSYCLQueue();
 
@@ -365,7 +366,7 @@ void launch_upsample_trilinear3d_backward_kernel(
       odata,
       idata_ptr);
 
-  int64_t wg_size = syclMaxWorkGroupSize(kfn);
+  int64_t wg_size = at::xpu::getKernelMaxWorkGroupSize(kfn);
   int num_group = at::ceil_div((int64_t)num_kernels, (int64_t)wg_size);
   auto queue = getCurrentSYCLQueue();
 

--- a/src/ATen/native/xpu/sycl/WelfordNorm.h
+++ b/src/ATen/native/xpu/sycl/WelfordNorm.h
@@ -13,6 +13,7 @@
 #include <ATen/ceil_div.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/xpu/sycl/MemoryAccess.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/SYCLContext.h>
 #include <comm/XPUMathCompat.h>
 
@@ -37,7 +38,8 @@ std::tuple<int, int, int, int> get_adaptive_config(
   int nwg_x = at::ceil_div(n_channels, group_size_x * vec_size);
   int nwg_y = std::min(
       at::ceil_div(reduction, group_size_y * loops_per_item),
-      int(syclMaxWorkItemsPerTile()) / (nwg_x * group_size_x) / (group_size_y));
+      int(at::xpu::getDeviceMaxWorkItems()) / (nwg_x * group_size_x) /
+          (group_size_y));
   nwg_y = std::max(nwg_y, 1);
 
   // it's not worth having reduction between work groups if the reduction
@@ -255,7 +257,7 @@ struct WelfordBatchNormStatChannelsLastVecKernelFunctor
         scalar_t,
         acc_t,
         VEC_SIZE>;
-    auto max_group_size = syclMaxWorkGroupSize<KernelT>();
+    int64_t max_group_size = at::xpu::getKernelMaxWorkGroupSize<KernelT>();
     std::tie(group_size_y_, group_size_x_, ngroups_y_, ngroups_x_) =
         get_adaptive_config(
             reduction_size_, n_channels_, VEC_SIZE, max_group_size);

--- a/src/ATen/native/xpu/sycl/pstl/PSTLFunctions.h
+++ b/src/ATen/native/xpu/sycl/pstl/PSTLFunctions.h
@@ -21,6 +21,7 @@
 #include <ATen/ops/zeros.h>
 #include <ATen/ops/zeros_like.h>
 #include <ATen/record_function.h>
+#include <ATen/xpu/XPUContext.h>
 #include <comm/SYCLContext.h>
 #include <comm/SYCLHelpers.h>
 #include <comm/TensorOptions.h>
@@ -277,7 +278,8 @@ static inline OutputIt _scan_kernel(
 
   const auto N = std::distance(first, last);
   auto& q = getCurrentSYCLQueue();
-  const auto kss_wgroup_size = syclMaxWorkGroupSize<KSScanKernel>();
+  const int64_t kss_wgroup_size =
+      at::xpu::getKernelMaxWorkGroupSize<KSScanKernel>();
 
   auto options = map_options<T>();
 
@@ -289,7 +291,8 @@ static inline OutputIt _scan_kernel(
     return d_first + N;
   }
 
-  const auto kssc_wgroup_size = syclMaxWorkGroupSize<KSScanWithCarrierKernel>();
+  const int64_t kssc_wgroup_size =
+      at::xpu::getKernelMaxWorkGroupSize<KSScanWithCarrierKernel>();
   const auto ngroups = (N + kssc_wgroup_size - 1) / kssc_wgroup_size;
   Tensor carry = at::empty({ngroups}, options);
   T* carry_ptr = carry.data_ptr<T>();
@@ -310,7 +313,7 @@ static inline OutputIt _scan_kernel(
   // Same work-group size as step 1: each item finds its carry by group id.
   ScanAccumulateKernelFunctor<OutputIt, T> kfn3(d_first, carry_ptr, N);
 
-  const auto sa_wgroup_size = syclMaxWorkGroupSize(kfn3);
+  const int64_t sa_wgroup_size = at::xpu::getKernelMaxWorkGroupSize(kfn3);
   TORCH_INTERNAL_ASSERT(
       kssc_wgroup_size <= sa_wgroup_size,
       "_scan_kernel: work group size doesn't match!");

--- a/src/xccl/NanCheck_XPU.cpp
+++ b/src/xccl/NanCheck_XPU.cpp
@@ -185,7 +185,8 @@ template <typename T>
 void checkfornan_impl_xpu(
     const at::Tensor& tensor,
     at::xpu::XPUStream& stream) {
-  int64_t maxNumThreadsPerBlock = syclMaxWorkGroupSize<checkForNaN<T>>();
+  int64_t maxNumThreadsPerBlock =
+      at::xpu::getKernelMaxWorkGroupSize<checkForNaN<T>>();
 
   constexpr int64_t maxNumBlocks = 24;
 

--- a/src/xccl/Signal.cpp
+++ b/src/xccl/Signal.cpp
@@ -55,7 +55,8 @@ void barrier_impl_xpu(
     int world_size,
     size_t timeout_ms,
     at::xpu::XPUStream& stream) {
-  int64_t maxNumThreadsPerBlock = syclMaxWorkGroupSize<barrierKernel>();
+  int64_t maxNumThreadsPerBlock =
+      at::xpu::getKernelMaxWorkGroupSize<barrierKernel>();
   const size_t numThreadsPerBlock =
       std::min<size_t>(maxNumThreadsPerBlock, std::max(32, world_size));
 
@@ -116,7 +117,8 @@ void put_signal_impl_xpu(
     int world_size,
     size_t timeout_ms,
     at::xpu::XPUStream& stream) {
-  int64_t maxNumThreadsPerBlock = syclMaxWorkGroupSize<putSignalKernel>();
+  int64_t maxNumThreadsPerBlock =
+      at::xpu::getKernelMaxWorkGroupSize<putSignalKernel>();
   const size_t numThreadsPerBlock = std::min<size_t>(maxNumThreadsPerBlock, 32);
 
   if (!(numThreadsPerBlock > 0)) {
@@ -178,7 +180,8 @@ void wait_signal_impl_xpu(
     int world_size,
     size_t timeout_ms,
     at::xpu::XPUStream& stream) {
-  int64_t maxNumThreadsPerBlock = syclMaxWorkGroupSize<waitSignalKernel>();
+  int64_t maxNumThreadsPerBlock =
+      at::xpu::getKernelMaxWorkGroupSize<waitSignalKernel>();
   const size_t numThreadsPerBlock = std::min<size_t>(maxNumThreadsPerBlock, 32);
 
   if (!(numThreadsPerBlock > 0)) {


### PR DESCRIPTION
This is the first task for RFC in https://github.com/intel/torch-xpu-ops/issues/5245 .It  is intended to migrate the usage of `DeviceProperties.h` to `ATen/xpu/XPUContext.h`'s definitions, and finally, will remove the torch-xpu-ops `DeviceProperties.h`. 

To keep the reviewing efforts simple, this PR does the 1:1 API mappings, so basically every API change is mapped correspondingly.

Authored with AI assistance.