### PR TITLE
[sycl-free-function] Refactor Multinomial by free function

### DIFF
--- a/src/ATen/native/xpu/sycl/MultinomialKernel.cpp
+++ b/src/ATen/native/xpu/sycl/MultinomialKernel.cpp
@@ -65,35 +65,13 @@ inline void renormRowsL1(
 }
 
 template <typename scalar_t>
-struct RenormRowsKernelFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
-  void operator()(sycl::nd_item<1> item) const {
-    renormRowsL1<scalar_t>(
-        item,
-        t_ptr,
-        rows,
-        cols,
-        (unsigned char*)(smem.template get_multi_ptr<
-                                 sycl::access::decorated::no>()
-                             .get()));
-  }
-  void sycl_ker_config_convention(sycl::handler& cgh) {
-    smem = sycl_local_acc_t<scalar_t>(group_size_ / 8, cgh);
-    // We use the smallest subgroup size to ensure enough space
-  }
-  RenormRowsKernelFunctor(
-      int64_t rows_,
-      int64_t cols_,
-      scalar_t* t_ptr_,
-      int group_size)
-      : rows(rows_), cols(cols_), t_ptr(t_ptr_), group_size_(group_size) {}
-
- private:
-  int64_t rows;
-  int64_t cols;
-  scalar_t* t_ptr;
-  int group_size_;
-  sycl_local_acc_t<scalar_t> smem;
-};
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
+void renorm_rows_kernel(int64_t rows, int64_t cols, scalar_t* t_ptr) {
+  auto item = syclext::this_work_item::get_nd_item<1>();
+  unsigned char* smem =
+      (unsigned char*)syclexp::get_work_group_scratch_memory();
+  renormRowsL1<scalar_t>(item, t_ptr, rows, cols, smem);
+}
 
 inline void renormRows(Tensor& t) {
   TORCH_CHECK(t.dim() == 2);
@@ -114,10 +92,15 @@ inline void renormRows(Tensor& t) {
       "renormRows_xpu",
       [&] {
         auto t_ptr = t.data_ptr<scalar_t>();
-        auto kfn =
-            RenormRowsKernelFunctor<scalar_t>(rows, cols, t_ptr, group_size);
-        sycl_kernel_submit(
-            num_groups * group_size, group_size, sycl_queue, kfn);
+        int slm_sz = sizeof(scalar_t) * (group_size / 8);
+        sycl_kernel_submit<renorm_rows_kernel<scalar_t>>(
+            num_groups * group_size,
+            group_size,
+            sycl_queue,
+            slm_sz,
+            rows,
+            cols,
+            t_ptr);
       });
 }
 
@@ -211,219 +194,170 @@ inline void sampleMultinomialWithReplacement(
 }
 
 template <typename scalar_t>
-struct MultinomialWithReplacementKernelImplFunctor {
-  void operator()(sycl::nd_item<2> item) const {
-    sampleMultinomialWithReplacement(
-        item,
-        rng_engine_inputs,
-        n_sample,
-        result_ptr,
-        numDist,
-        numCategories,
-        prefixSum_ptr,
-        normDist_ptr);
-  }
-  MultinomialWithReplacementKernelImplFunctor(
-      PhiloxXpuState rng_engine_inputs_,
-      const int64_t n_sample_,
-      int64_t* result_ptr_,
-      int64_t numDist_,
-      int numCategories_,
-      scalar_t* prefixSum_ptr_,
-      scalar_t* normDist_ptr_)
-      : rng_engine_inputs(rng_engine_inputs_),
-        n_sample(n_sample_),
-        result_ptr(result_ptr_),
-        numDist(numDist_),
-        numCategories(numCategories_),
-        prefixSum_ptr(prefixSum_ptr_),
-        normDist_ptr(normDist_ptr_) {}
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<2>))
+void multinomial_with_replacement_kernel(
+    PhiloxXpuState rng_engine_inputs,
+    int totalSamples,
+    int64_t* result_ptr,
+    int64_t numDist,
+    int numCategories,
+    scalar_t* prefixSum_ptr,
+    scalar_t* normDist_ptr) {
+  auto item = syclext::this_work_item::get_nd_item<2>();
+  sampleMultinomialWithReplacement(
+      item,
+      rng_engine_inputs,
+      totalSamples,
+      result_ptr,
+      numDist,
+      numCategories,
+      prefixSum_ptr,
+      normDist_ptr);
+}
 
- private:
-  PhiloxXpuState rng_engine_inputs;
-  const int64_t n_sample;
-  int64_t* result_ptr;
-  int64_t numDist;
-  int numCategories;
-  scalar_t* prefixSum_ptr;
-  scalar_t* normDist_ptr;
-};
 template <typename scalar_t, typename accscalar_t>
-struct SampleMultinomialOnceFunctor : public __SYCL_KER_CONFIG_CONVENTION__ {
-  void operator()(sycl::nd_item<1> item) const {
-    accscalar_t* smem = reinterpret_cast<accscalar_t*>(
-        smem_.template get_multi_ptr<sycl::access::decorated::no>().get());
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
+void sample_multinomial_once_kernel(
+    int64_t* dest,
+    int64_t distributions,
+    int categories,
+    const scalar_t* sampled,
+    const scalar_t* dist,
+    int stride_dist,
+    int stride_categories,
+    int group_size) {
+  auto item = syclext::this_work_item::get_nd_item<1>();
 
-    accscalar_t accZero = static_cast<accscalar_t>(0);
-    scalar_t zero = static_cast<scalar_t>(0);
-    int local_id = item.get_local_id(0);
-    int local_range = item.get_local_range(0);
+  char* scratch = (char*)syclexp::get_work_group_scratch_memory();
+  accscalar_t* smem = reinterpret_cast<accscalar_t*>(scratch);
+  int* foundPos = (int*)(scratch + sizeof(accscalar_t) * group_size);
+  bool* found = (bool*)(foundPos + 1);
 
-    for (int64_t curDist = item.get_group(0); curDist < distributions_;
-         curDist += item.get_group_range(0)) {
-      // First pass, find the total sum of the distribution
-      accscalar_t sum = accZero;
-      scalar_t val;
-      for (int cat = item.get_local_id(0); cat < categories_;
-           cat += item.get_local_range(0)) {
-        val = dist_[curDist * stride_dist_ + cat * stride_categories_];
-        SYCL_KERNEL_ASSERT(!at::_isnan(val));
-        SYCL_KERNEL_ASSERT(!_isinf(val));
-        SYCL_KERNEL_ASSERT(!(val < zero));
-        sum = sum + static_cast<accscalar_t>(val);
-      }
+  accscalar_t accZero = static_cast<accscalar_t>(0);
+  scalar_t zero = static_cast<scalar_t>(0);
+  int local_id = item.get_local_id(0);
+  int local_range = item.get_local_range(0);
 
-      sum = GroupReduceSumSGSizeEqualstoNumSG(item, sum, smem);
+  for (int64_t curDist = item.get_group(0); curDist < distributions;
+       curDist += item.get_group_range(0)) {
+    // First pass, find the total sum of the distribution
+    accscalar_t sum = accZero;
+    scalar_t val;
+    for (int cat = item.get_local_id(0); cat < categories;
+         cat += item.get_local_range(0)) {
+      val = dist[curDist * stride_dist + cat * stride_categories];
+      SYCL_KERNEL_ASSERT(!at::_isnan(val));
+      SYCL_KERNEL_ASSERT(!_isinf(val));
+      SYCL_KERNEL_ASSERT(!(val < zero));
+      sum = sum + static_cast<accscalar_t>(val);
+    }
 
-      // Broadcast sum and sample value
-      if (item.get_local_id(0) == 0) {
-        // Make sure the sum of our distribution didn't overflow
-        SYCL_KERNEL_ASSERT(!_isinf(val));
-        SYCL_KERNEL_ASSERT(sum > accZero);
+    sum = GroupReduceSumSGSizeEqualstoNumSG(item, sum, smem);
 
-        foundPos_[0] = 0;
-        smem[0] = sum;
-        smem[1] = sampled_[curDist];
-      }
-      sycl::group_barrier(item.get_group());
+    // Broadcast sum and sample value
+    if (item.get_local_id(0) == 0) {
+      // Make sure the sum of our distribution didn't overflow
+      SYCL_KERNEL_ASSERT(!_isinf(val));
+      SYCL_KERNEL_ASSERT(sum > accZero);
 
-      sum = smem[0];
-      scalar_t sample = static_cast<scalar_t>(smem[1]);
-      sycl::group_barrier(item.get_group());
+      foundPos[0] = 0;
+      smem[0] = sum;
+      smem[1] = sampled[curDist];
+    }
+    sycl::group_barrier(item.get_group());
 
-      if (sum == accZero) {
-        // Choose the first element
-        if (local_id == 0) {
-          dest_[curDist] = 0;
-        }
+    sum = smem[0];
+    scalar_t sample = static_cast<scalar_t>(smem[1]);
+    sycl::group_barrier(item.get_group());
 
-        continue;
-      }
-
-      int chunks = (categories_ + (int)local_range - 1) / local_range;
-      accscalar_t prevHighProb = accZero;
-      found_[0] = false;
-
-      for (int chunk = 0; chunk < chunks && !found_[0]; ++chunk) {
-        // All threads in bounds load a value
-        int cat = chunk * local_range + local_id;
-
-        accscalar_t dist_val = cat < categories_
-            ? static_cast<accscalar_t>(
-                  dist_[curDist * stride_dist_ + cat * stride_categories_]) /
-                sum
-            : accZero;
-
-        smem[local_id] = dist_val;
-        sycl::group_barrier(item.get_group());
-
-        // Perform an inclusive prefix sum of the shared memory contents
-        for (int offset = 1; offset < local_range; offset *= 2) {
-          accscalar_t val = accZero;
-
-          if (local_id >= offset) {
-            val = smem[local_id - offset] + smem[local_id];
-          }
-
-          sycl::group_barrier(item.get_group());
-          if (local_id >= offset) {
-            smem[local_id] = val;
-          }
-          sycl::group_barrier(item.get_group());
-        }
-
-        // Each thread will check to see if the sample falls in its
-        // bucket
-        scalar_t curBucket =
-            static_cast<scalar_t>(smem[local_id] + prevHighProb);
-        scalar_t prevBucket = static_cast<scalar_t>(
-            local_id == 0 ? prevHighProb : smem[local_id - 1] + prevHighProb);
-        bool inBucket = (cat < categories_) &&
-            (!(sample >= curBucket) && (sample >= prevBucket) &&
-             (dist_val > zero));
-
-        if (inBucket) {
-          // We're done; we have the sample
-          // Torch indices are 1-based
-
-          atomicMax(
-              sycl_local_ptr<int>(
-                  foundPos_
-                      .template get_multi_ptr<sycl::access::decorated::no>()
-                      .get()),
-              cat);
-
-          found_[0] = true;
-        }
-
-        // Store the previous scan's high value for future use
-        prevHighProb = prevHighProb + smem[local_range - 1];
-
-        sycl::group_barrier(item.get_group());
-      }
-
+    if (sum == accZero) {
+      // Choose the first element
       if (local_id == 0) {
-        if (found_[0]) {
-          dest_[curDist] = foundPos_[0];
-        } else {
-          // This should address a rare bug where we don't select a valid index.
-          // This likely occurs when due to floating point arithmetic rounding
-          // errors, our cumulative sum does not add up to 1, but and our
-          // uniform sample is greater than this value. In this case we likely
-          // have unitialized memory in dest[curDist]. So basically we will loop
-          // through the distribution and pick the largest index where the
-          // distribution is non-zero. This is obviously terribly inefficient,
-          // but due to the rarity in which this occurs, this should not be an
-          // issue.
-          for (int cat = categories_ - 1; cat >= 0; --cat) {
-            if (dist_[curDist * stride_dist_ + cat * stride_categories_] >
-                zero) {
-              dest_[curDist] = cat;
-              break;
-            }
+        dest[curDist] = 0;
+      }
+
+      continue;
+    }
+
+    int chunks = (categories + (int)local_range - 1) / local_range;
+    accscalar_t prevHighProb = accZero;
+    found[0] = false;
+
+    for (int chunk = 0; chunk < chunks && !found[0]; ++chunk) {
+      // All threads in bounds load a value
+      int cat = chunk * local_range + local_id;
+
+      accscalar_t dist_val = cat < categories
+          ? static_cast<accscalar_t>(
+                dist[curDist * stride_dist + cat * stride_categories]) /
+              sum
+          : accZero;
+
+      smem[local_id] = dist_val;
+      sycl::group_barrier(item.get_group());
+
+      // Perform an inclusive prefix sum of the shared memory contents
+      for (int offset = 1; offset < local_range; offset *= 2) {
+        accscalar_t val = accZero;
+
+        if (local_id >= offset) {
+          val = smem[local_id - offset] + smem[local_id];
+        }
+
+        sycl::group_barrier(item.get_group());
+        if (local_id >= offset) {
+          smem[local_id] = val;
+        }
+        sycl::group_barrier(item.get_group());
+      }
+
+      // Each thread will check to see if the sample falls in its
+      // bucket
+      scalar_t curBucket = static_cast<scalar_t>(smem[local_id] + prevHighProb);
+      scalar_t prevBucket = static_cast<scalar_t>(
+          local_id == 0 ? prevHighProb : smem[local_id - 1] + prevHighProb);
+      bool inBucket = (cat < categories) &&
+          (!(sample >= curBucket) && (sample >= prevBucket) &&
+           (dist_val > zero));
+
+      if (inBucket) {
+        // We're done; we have the sample
+        // Torch indices are 1-based
+
+        atomicMax(sycl_local_ptr<int>(foundPos), cat);
+
+        found[0] = true;
+      }
+
+      // Store the previous scan's high value for future use
+      prevHighProb = prevHighProb + smem[local_range - 1];
+
+      sycl::group_barrier(item.get_group());
+    }
+
+    if (local_id == 0) {
+      if (found[0]) {
+        dest[curDist] = foundPos[0];
+      } else {
+        // This should address a rare bug where we don't select a valid index.
+        // This likely occurs when due to floating point arithmetic rounding
+        // errors, our cumulative sum does not add up to 1, but and our
+        // uniform sample is greater than this value. In this case we likely
+        // have unitialized memory in dest[curDist]. So basically we will loop
+        // through the distribution and pick the largest index where the
+        // distribution is non-zero. This is obviously terribly inefficient,
+        // but due to the rarity in which this occurs, this should not be an
+        // issue.
+        for (int cat = categories - 1; cat >= 0; --cat) {
+          if (dist[curDist * stride_dist + cat * stride_categories] > zero) {
+            dest[curDist] = cat;
+            break;
           }
         }
       }
     }
   }
-
-  void sycl_ker_config_convention(sycl::handler& cgh) {
-    smem_ = sycl_local_acc_t<scalar_t>(group_size_, cgh);
-    found_ = sycl_local_acc_t<bool>(1, cgh);
-    foundPos_ = sycl_local_acc_t<int>(1, cgh);
-  }
-
-  SampleMultinomialOnceFunctor(
-      int64_t* dest,
-      int64_t distributions,
-      int categories,
-      const scalar_t* sampled,
-      const scalar_t* dist,
-      int stride_dist, // dist->stride(0)
-      int stride_categories, // dist->stride(1)
-      int group_size)
-      : dest_(dest),
-        distributions_(distributions),
-        categories_(categories),
-        sampled_(sampled),
-        dist_(dist),
-        stride_dist_(stride_dist),
-        stride_categories_(stride_categories),
-        group_size_(group_size) {}
-
- private:
-  int64_t* dest_;
-  int64_t distributions_;
-  int categories_;
-  const scalar_t* sampled_;
-  const scalar_t* dist_;
-  int stride_dist_;
-  int stride_categories_;
-  int group_size_;
-  sycl_local_acc_t<scalar_t> smem_;
-  sycl_local_acc_t<bool> found_;
-  sycl_local_acc_t<int> foundPos_;
-};
+}
 
 void multinomial_kernel(
     Tensor& result,
@@ -450,8 +384,8 @@ void multinomial_kernel(
       "multinomial_kernel_xpu",
       [&] {
         using accscalar_t = acc_type_device<scalar_t, kXPU>;
-        using KernelClass = SampleMultinomialOnceFunctor<scalar_t, accscalar_t>;
-        int maxThreads = syclMaxWorkGroupSize<KernelClass>();
+        int maxThreads = syclMaxWorkGroupSize<
+            sample_multinomial_once_kernel<scalar_t, accscalar_t>>();
         int maxShared = syclLocalMemSize();
 
         int SubGroupSize = syclMinSubGroupSize();
@@ -468,18 +402,22 @@ void multinomial_kernel(
           at::native::uniform_(sampled, 0.0, 1.0, generator);
           int group_size = requiredThreads;
           int group_range = numDist;
-          auto kfn = KernelClass(
+          int slm_sz =
+              sizeof(scalar_t) * group_size + sizeof(int) + sizeof(bool);
+          sycl_kernel_submit<
+              sample_multinomial_once_kernel<scalar_t, accscalar_t>>(
+              group_range * group_size,
+              group_size,
+              sycl_queue,
+              slm_sz,
               result.mutable_data_ptr<int64_t>(),
               numDist,
               numCategories,
               sampled.const_data_ptr<scalar_t>(),
               self_v.const_data_ptr<scalar_t>(),
-              self_v.stride(0),
-              self_v.stride(1),
+              (int)self_v.stride(0),
+              (int)self_v.stride(1),
               group_size);
-
-          sycl_kernel_submit(
-              group_range * group_size, group_size, sycl_queue, kfn);
         } else {
           Tensor origDist = native::empty_like(
               self_v,
@@ -527,20 +465,18 @@ void multinomial_kernel(
           auto result_ptr = result.data_ptr<int64_t>();
           auto prefixSum_ptr = prefixSum.data_ptr<scalar_t>();
           auto normDist_ptr = normDist.data_ptr<scalar_t>();
-          auto kfn = MultinomialWithReplacementKernelImplFunctor<scalar_t>(
+          sycl_kernel_submit<multinomial_with_replacement_kernel<scalar_t>>(
+              sycl::range<2>(group_range_y, group_range_x * group_size),
+              sycl::range<2>(1, group_size),
+              sycl_queue,
+              0,
               rng_engine_inputs,
-              n_sample,
+              (int)n_sample,
               result_ptr,
               numDist,
               numCategories,
               prefixSum_ptr,
               normDist_ptr);
-
-          sycl_kernel_submit(
-              sycl::range<2>(group_range_y, group_range_x * group_size),
-              sycl::range<2>(1, group_size),
-              sycl_queue,
-              kfn);
         }
       });
 


### PR DESCRIPTION
     pytorch  test/test_ops.py -k multinomial  (XPU)                            │ 9 run, OK (7 skipped)  

     pytorch  test/test_torch.py -k multinomial  (CPU)                          │ 16 run, OK             

     xpu-ops  test_torch_xpu.py -k multinomial                                  │ 16 run, OK (2 slow-skipped)    

     xpu-ops slow:  multinomial_invalid_probs ,  multinomial_rng_state_advance  │ 2 run, OK              

     xpu-ops  test_ops_xpu.py -k multinomial                                    │ 17 run, OK (1 expected failure) 

     xpu-ops  extended/test_ops_xpu.py -k multinomial                           │ 16 run, OK             

     xpu-ops  test_distributions_xpu.py -k categorical                          │ 13 run, 1 error 


The one failure,  test_relaxed_one_hot_categorical_2d_xpu , is unrelated to this change: it is a  gradcheck  numerical instability of   
      RelaxedOneHotCategorical.log_prob  at temperature 0.25 (analytic grads ~1e8, numeric diff nan). That path uses Gumbel/softmax and never calls the   multinomial kernel; it fails deterministically across 3 reruns, i.e. a pre-existing XPU issue.