### PR TITLE
[sycl-free-function] Refactor WeightInt4Pack by free function

### DIFF
--- a/src/ATen/native/xpu/sycl/WeightInt4PackKernel.cpp
+++ b/src/ATen/native/xpu/sycl/WeightInt4PackKernel.cpp
@@ -16,38 +16,32 @@
 
 namespace at::native::xpu {
 
-struct WeightToInt4PackKernelFunctor {
-  void operator()(sycl::item<1> item) const {
-    auto idx = item.get_linear_id();
-    int K_div_2 = K_ / 2;
-    int K_div_8 = K_ / 8;
-    int out_y = idx / K_div_8;
-    int out_x = idx % K_div_8;
-    int in_y = out_y;
-    int in_x = out_x * 4;
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
+void weight_to_int4_pack_sub_kernel(
+    uint32_t* weight_packed,
+    const uint8_t* weight,
+    int K,
+    int total) {
+  auto item = syclext::this_work_item::get_nd_item<1>();
+  auto idx = item.get_global_linear_id();
+  if (idx >= static_cast<size_t>(total))
+    return;
 
-    weight_packed_[out_y * K_div_8 + out_x] = 0x00000000;
-    for (int i = 0; i < 4; i++) {
-      uint32_t low = weight_[in_y * K_div_2 + in_x + i] & 0x0000000F;
-      uint32_t high = weight_[in_y * K_div_2 + in_x + i] >> 4;
-      uint32_t ele_i = (low) | (high << 4);
-      weight_packed_[out_y * K_div_8 + out_x] |= ele_i << (i * 8);
-    }
+  int K_div_2 = K / 2;
+  int K_div_8 = K / 8;
+  int out_y = idx / K_div_8;
+  int out_x = idx % K_div_8;
+  int in_y = out_y;
+  int in_x = out_x * 4;
+
+  weight_packed[out_y * K_div_8 + out_x] = 0x00000000;
+  for (int i = 0; i < 4; i++) {
+    uint32_t low = weight[in_y * K_div_2 + in_x + i] & 0x0000000F;
+    uint32_t high = weight[in_y * K_div_2 + in_x + i] >> 4;
+    uint32_t ele_i = (low) | (high << 4);
+    weight_packed[out_y * K_div_8 + out_x] |= ele_i << (i * 8);
   }
-
-  WeightToInt4PackKernelFunctor(
-      uint32_t* weight_packed,
-      const uint8_t* weight,
-      int N,
-      int K)
-      : weight_packed_(weight_packed), weight_(weight), N_(N), K_(K) {}
-
- private:
-  uint32_t* weight_packed_;
-  const uint8_t* weight_;
-  int N_;
-  int K_;
-};
+}
 
 void weight_to_int4pack_kernel(
     const Tensor& weight_packed,
@@ -58,10 +52,20 @@ void weight_to_int4pack_kernel(
       reinterpret_cast<uint32_t*>(weight_packed.data_ptr());
   const auto weight_data = weight.const_data_ptr<uint8_t>();
   int K_div_8 = K / 8;
-  size_t global_range = N * K_div_8;
-  auto fn =
-      WeightToInt4PackKernelFunctor(weight_packed_data, weight_data, N, K);
-  sycl_kernel_submit(sycl::range<1>(global_range), getCurrentSYCLQueue(), fn);
+  int total = N * K_div_8;
+  constexpr auto kptr = weight_to_int4_pack_sub_kernel;
+  int64_t local_range = syclMaxWorkGroupSize<kptr>();
+  int64_t num_groups = (total + local_range - 1) / local_range;
+  int64_t global_range = num_groups * local_range;
+  sycl_kernel_submit<kptr>(
+      sycl::range<1>(global_range),
+      sycl::range<1>(local_range),
+      getCurrentSYCLQueue(),
+      0,
+      weight_packed_data,
+      weight_data,
+      K,
+      total);
 }
 
 } // namespace at::native::xpu


### PR DESCRIPTION
 pytorch/test/xpu/test_gemm.py -k test__int4_mm  (4 params, exercises _convert_weight_to_int4pack  +  _weight_int4pack_mm_with_scales_and_zeros )        4 ran, OK
 torch-xpu-ops/test/regressions/test_int4pack.py::test_convert_weight_to_int4pack  (pack/unpack roundtrip, directly targets the changed kernel)          1 ran, PASSED
 torch-xpu-ops/test/xpu/test_linalg_xpu.py -k int4_mm  ( test__int4_mm  + test_compile_int4_mm , monkeypatched onto upstream  TestLinalg )               test__int4_mm : 168/168 ok;  test_compile_int4_mm : 8 errors, all  TritonMissing  (torch.compile/inductor backend has no Triton in this env — unrelated to the kernel change)