### PR TITLE
[test/xpu] Stop test/xpu/functorch shadowing the installed functorch package

### DIFF
--- a/test/xpu/functorch/test_aot_joint_with_descriptors_xpu.py
+++ b/test/xpu/functorch/test_aot_joint_with_descriptors_xpu.py
@@ -13,17 +13,25 @@
 # Owner(s): ["module: intel"]
 # ruff: noqa: F401
 
+import sys
 import unittest
+from pathlib import Path
 
 import torch
 import torch.fx.traceback as fx_traceback
 from torch.nn.attention.flex_attention import create_block_mask, flex_attention
 from torch.testing._internal.common_utils import run_tests, TEST_CUDA, TEST_XPU
 
-try:
-    from .xpu_test_utils import XPUImportCtx
-except Exception:
-    from ..xpu_test_utils import XPUImportCtx
+# Do NOT add a test/xpu/functorch/__init__.py to use a relative import here.
+# op_ut runs pytest with cwd=test/xpu, so a regular package named `functorch` in
+# that directory shadows the installed one in every `python -c` subprocess an
+# upstream test spawns, breaking `from functorch.compile import ...` inside
+# torch/_dynamo/backends/debugging.py (#4831, #4728).
+xpu_test_dir = Path(__file__).resolve().parents[1]
+if str(xpu_test_dir) not in sys.path:
+    sys.path.insert(0, str(xpu_test_dir))
+
+from xpu_test_utils import XPUImportCtx
 
 with XPUImportCtx(False):
     from test_aot_joint_with_descriptors import (

--- a/test/xpu/functorch/test_control_flow_xpu.py
+++ b/test/xpu/functorch/test_control_flow_xpu.py
@@ -1,7 +1,9 @@
 # Owner(s): ["module: functorch"]
 import contextlib
 import functools
+import sys
 import unittest
+from pathlib import Path
 
 import torch
 import torch.utils._pytree as pytree
@@ -38,10 +40,16 @@ from torch.testing._internal.common_utils import (
     TestCase,
 )
 
-try:
-    from .xpu_test_utils import XPUImportCtx
-except Exception:
-    from ..xpu_test_utils import XPUImportCtx
+# Do NOT add a test/xpu/functorch/__init__.py to use a relative import here.
+# op_ut runs pytest with cwd=test/xpu, so a regular package named `functorch` in
+# that directory shadows the installed one in every `python -c` subprocess an
+# upstream test spawns, breaking `from functorch.compile import ...` inside
+# torch/_dynamo/backends/debugging.py (#4831, #4728).
+xpu_test_dir = Path(__file__).resolve().parents[1]
+if str(xpu_test_dir) not in sys.path:
+    sys.path.insert(0, str(xpu_test_dir))
+
+from xpu_test_utils import XPUImportCtx
 
 with XPUImportCtx(False):
     from test_control_flow import (


### PR DESCRIPTION
Deleting a 0-byte file. That's the whole fix for #4831 and #4728.

### What's broken

`test/xpu/functorch/__init__.py` is empty, but its presence makes
`test/xpu/functorch/` a real Python package named `functorch`.

`op_ut` runs pytest from `test/xpu` (`linux-uttest/action.yml:61`). pytest itself is
fine, but some upstream tests shell out with `python -c`, and `python -c` puts the cwd
on `sys.path[0]`. So those subprocesses import our empty package,
`torch/_dynamo/backends/debugging.py:34` can't do `from functorch.compile import ...`,
the subprocess exits 1, and the parent test fails on `assertEqual(returncode, 0)`.

That's why #4831 looked like a DebugMode bug and #4728 like a `PYTHONOPTIMIZE` bug,
and why it only fails when you run from `test/xpu`:

```console
$ cd test/xpu && python -c "import functorch; print(functorch.__file__)"
.../test/xpu/functorch/__init__.py     # should have been the installed one
```

### The fix

Delete the file. Without `__init__.py` the directory is only a PEP 420 namespace
portion, so Python keeps scanning `sys.path` and finds the installed `functorch`.

The two import edits are forced by the deletion, not cleanup: #4354 added the
`__init__.py` on purpose so these files could do `from ..xpu_test_utils import ...`.
They now use the `sys.path` insert that
`test/xpu/export/test_export_training_ir_to_run_decomp_xpu.py` already uses, with a
comment saying why the `__init__.py` must not come back.

### Checked

- `functorch` is the only collision — ran `find_spec` on all 6 `__init__.py`
  directories under `test/xpu`.
- Skip-list keys and junit classnames are path-based, so CI reporting doesn't move.
- The other 6 files in the directory use `sys.path.append("../../../../test/functorch")`,
  unaffected by the directory no longer being a package.

Worth a look: the two changed files now put `test/xpu` on `sys.path[0]`, which the
relative import didn't need. Only one file in the repo used this pattern before.

### How to check

```bash
cd pytorch/third_party/torch-xpu-ops/test/xpu

PYTORCH_TEST_WITH_SLOW=1 pytest -sv --timeout 600 \
  "../../../../test/dynamo/test_dynamic_shapes.py::DynamicShapesMiscTests::test_debugmode_respects_custom_op_aliasing_env_override_dynamic_shapes"

PYTORCH_TEST_WITH_SLOW=1 pytest -sv --timeout 600 \
  "dynamo/test_export_xpu.py::ExportTestsSubprocess::test_strict_export_under_pythonoptimize"

PYTORCH_TEST_WITH_SLOW=1 pytest --collect-only -q functorch/
```

The #4831 case and one test from each changed file passed in the fix session
(collect: 1486 and 21, no errors). The 8-file sweep is new — leaving it to CI.

No skip added; this removes two failures. #4728 isn't in `skip_list_common.py`, so
just re-validate and close it.

Fixes #4831
Fixes #4728
