### PR TITLE
Reshape the layer_norm two-stage column reduction to the gradient shape

### DIFF
--- a/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
+++ b/src/ATen/native/xpu/sycl/LayerNormKernels.cpp
@@ -1316,9 +1316,10 @@ void layer_norm_backward_kernel_impl(
            static_cast<size_t>(tile_size_n < SIMD ? tile_size_n : SIMD)},
           getCurrentSYCLQueue(),
           kfn);
-      *dgamma = dgamma_blocks.sum(0);
+      // sum(0) is flat {N}; the gradient may be multi-dimensional.
+      *dgamma = dgamma_blocks.sum(0).view_as(*dgamma);
       if constexpr (!rms_norm) {
-        *dbeta = dbeta_blocks.sum(0);
+        *dbeta = dbeta_blocks.sum(0).view_as(*dbeta);
       }
     } else if (dgamma->defined() && !dbeta->defined()) {
       GammaBetaReduceFunctor<
@@ -1362,7 +1363,7 @@ void layer_norm_backward_kernel_impl(
            static_cast<size_t>(tile_size_n < SIMD ? tile_size_n : SIMD)},
           getCurrentSYCLQueue(),
           kfn);
-      *dgamma = dgamma_blocks.sum(0);
+      *dgamma = dgamma_blocks.sum(0).view_as(*dgamma);
     } else if (!dgamma->defined() && dbeta->defined()) {
       GammaBetaReduceFunctor<
           scalar_t,
@@ -1406,7 +1407,7 @@ void layer_norm_backward_kernel_impl(
           getCurrentSYCLQueue(),
           kfn);
       if constexpr (!rms_norm) {
-        *dbeta = dbeta_blocks.sum(0);
+        *dbeta = dbeta_blocks.sum(0).view_as(*dbeta);
       }
     } else {
       return;

--- a/test/regressions/test_layer_norm.py
+++ b/test/regressions/test_layer_norm.py
@@ -15,6 +15,17 @@ cpu_device = torch.device("cpu")
 xpu_device = torch.device("xpu")
 
 
+def _over_threshold_rows():
+    """Row count above the kernel's two-stage column-reduction threshold.
+
+    The kernel gates on `M > xe_core_count * 1024`, where its `xe_core_count` is
+    `gpu_eu_count / gpu_eu_count_per_subslice` -- the same quotient PyTorch
+    exposes as `gpu_subslice_count`. One extra tile of rows clears it.
+    """
+    xe_core_count = torch.xpu.get_device_properties(0).gpu_subslice_count
+    return xe_core_count * 1024 + 1024
+
+
 class TestLayerNorm(TestCase):
     def test_layer_norm_no_nan(self, dtype=torch.float):
         dim = [5]
@@ -26,3 +37,42 @@ class TestLayerNorm(TestCase):
         layernorm_xpu = nn.LayerNorm(dim).to(xpu_device)
         y_xpu = layernorm_xpu(x_xpu)
         self.assertEqual(y_cpu, y_xpu.to(cpu_device))
+
+    def test_layer_norm_backward_multidim_normalized_shape_large_rows(self):
+        """Weight and bias gradients keep normalized_shape above the threshold.
+
+        Above `xe_core_count * 1024` rows the backward takes a two-stage column
+        reduction whose accumulator is `{num_tile_m, N}` with N the flattened
+        normalized size, so `sum(0)` is a flat `{N}` and assigning it replaced
+        the gradient the caller had allocated from the parameter. Autograd then
+        saw `[8]` where it expected `[2, 4]`. A one-dimensional normalized_shape
+        hides it because `{N}` is already the right shape.
+        """
+        torch.manual_seed(42)
+        dim = [2, 4]
+        rows = _over_threshold_rows()
+
+        x_cpu = torch.randn(rows, *dim, dtype=torch.float32, requires_grad=True)
+        layernorm_cpu = nn.LayerNorm(dim, dtype=torch.float32)
+        layernorm_cpu(x_cpu).sum().backward()
+
+        x_xpu = x_cpu.detach().to(xpu_device).requires_grad_()
+        layernorm_xpu = nn.LayerNorm(dim, dtype=torch.float32).to(xpu_device)
+        layernorm_xpu.load_state_dict(layernorm_cpu.state_dict())
+        layernorm_xpu(x_xpu).sum().backward()
+
+        self.assertEqual(layernorm_xpu.weight.grad.shape, torch.Size(dim))
+        self.assertEqual(layernorm_xpu.bias.grad.shape, torch.Size(dim))
+        self.assertEqual(
+            layernorm_cpu.weight.grad,
+            layernorm_xpu.weight.grad.to(cpu_device),
+            atol=1e-1,
+            rtol=1e-3,
+        )
+        self.assertEqual(
+            layernorm_cpu.bias.grad,
+            layernorm_xpu.bias.grad.to(cpu_device),
+            atol=1e-1,
+            rtol=1e-3,
+        )
+        self.assertEqual(x_cpu.grad, x_xpu.grad.to(cpu_device))

--- a/test/regressions/test_rms_norm.py
+++ b/test/regressions/test_rms_norm.py
@@ -132,6 +132,28 @@ class TestRMSNorm(TestCase):
         self.assertEqual(grad_input.shape, x.shape)
         self.assertTrue(torch.isfinite(grad_input).all())
 
+    def test_rms_norm_backward_multidim_normalized_shape_large_rows(self):
+        """The weight gradient keeps normalized_shape above the threshold.
+
+        The two-stage accumulator is `{num_tile_m, N}` with N the flattened
+        normalized size, so `sum(0)` is a flat `{N}` and assigning it replaced
+        the gradient allocated from the parameter. Autograd then saw `[8]` where
+        it expected `[2, 4]`.
+        """
+        torch.manual_seed(42)
+        dim = [2, 4]
+        rows = _over_threshold_rows()
+
+        layer = nn.RMSNorm(dim, eps=1e-6, dtype=torch.float32).to(xpu_device)
+        x = torch.randn(
+            rows, *dim, device=xpu_device, dtype=torch.float32, requires_grad=True
+        )
+        layer(x).sum().backward()
+
+        self.assertEqual(layer.weight.grad.shape, torch.Size(dim))
+        self.assertTrue(torch.isfinite(layer.weight.grad).all())
+        self.assertEqual(x.grad.shape, x.shape)
+
     def test_layer_norm_backward_unaffected(self):
         """LayerNorm shares the impl and must keep producing a real dbeta.
 


### PR DESCRIPTION
## Background

The huge-row two-stage layer-norm reduction produces a flat `{N}` tensor. Assigning it directly to `dgamma` or `dbeta` replaces the caller-allocated multidimensional gradient shape, so autograd receives `[N]` instead of `normalized_shape` and raises.

## Upstream

- [pytorch/pytorch#193016](https://github.com/pytorch/pytorch/pull/193016) and its landed [commit 64417d6](https://github.com/pytorch/pytorch/commit/64417d6eb27cc17a97e8aa2172ffe60f7843fdc4) fix the analogous CUDA huge-M path and reshape the flat reduction with `view_as`. XPU carries an independent implementation of the same reduction.

## Fix

- apply `view_as` before rebinding all four `dgamma`/`dbeta` reduction results
- cover layer norm and RMS norm with multidimensional normalized shapes
- derive the test row threshold from the device Xe-core count

## Before and after

| Case | Before | After |
|---|---|---|
| Multidimensional `normalized_shape` | Flat `[N]` gradient and autograd error | Gradient retains the requested shape |
| One-dimensional shape | Works | Still works |

## Testing

Linux XPU `op_regression` in [CI run 34858228663](https://github.com/intel/torch-xpu-ops/actions/runs/34858228663): 8 passed, 0 failed.

Fixes #5235
