### PR TITLE
Reject a mismatched out= dtype in histc instead of casting silently

### DIFF
--- a/src/ATen/native/xpu/SummaryOps.cpp
+++ b/src/ATen/native/xpu/SummaryOps.cpp
@@ -55,6 +55,14 @@ Tensor& _histc_out_xpu(
     const Scalar& min,
     const Scalar& max,
     Tensor& result) {
+  // Checked before resize_output so a rejected call leaves result untouched.
+  TORCH_CHECK(
+      self.dtype() == result.dtype(),
+      "torch.histogram: input tensor and hist tensor should",
+      " have the same dtype, but got input ",
+      self.dtype(),
+      " and hist ",
+      result.dtype());
   auto ret = _histc_xpu(self, bins, min, max);
   at::native::resize_output(result, ret.sizes());
   result.copy_(ret);

--- a/test/regressions/test_histc.py
+++ b/test/regressions/test_histc.py
@@ -1,0 +1,36 @@
+# Copyright 2020-2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Owner(s): ["module: intel"]
+import torch
+from torch.testing._internal.common_utils import TestCase
+
+xpu_device = torch.device("xpu")
+
+
+class TestHistc(TestCase):
+    def test_histc_out_rejects_mismatched_dtype(self):
+        """out= must not be cast into silently.
+
+        _histc_out_xpu computed into a tensor of the input dtype and finished
+        with result.copy_(ret), so a float histogram written into an integral
+        out= came back truncated with no error. CPU rejects the same call from
+        histogramdd_prepare_out, which the XPU out variant does not go through.
+        """
+        x = torch.linspace(1, 8, 8, device=xpu_device, dtype=torch.float32)
+        out = torch.empty(4, device=xpu_device, dtype=torch.int64)
+
+        with self.assertRaisesRegex(RuntimeError, "should have the same dtype"):
+            torch.histc(x, bins=4, min=0, max=8, out=out)
+
+    def test_histc_out_matching_dtype_still_works(self):
+        x = torch.linspace(1, 8, 8, device=xpu_device, dtype=torch.float32)
+        out = torch.empty(0, device=xpu_device, dtype=torch.float32)
+
+        torch.histc(x, bins=4, min=0, max=8, out=out)
+        self.assertEqual(out, torch.histc(x, bins=4, min=0, max=8))

--- a/test/xpu/skip_list_common.py
+++ b/test/xpu/skip_list_common.py
@@ -180,7 +180,6 @@ skip_dict = {
         # Exception: The supported dtypes for linalg.multi_dot on device type xpu are incorrect!
         "test_dtypes_linalg_multi_dot_xpu",
         # For CUDA it's skipped explicitly in common_methods_invocations.py in upstream. We can skip it here
-        "test_out_histc_xpu_float32",
         "test_out_mean_xpu_float32",
         # FakeTensor mismatch in outputs_alias_inputs for aten.view.default
         # Known upstream issue: https://github.com/pytorch/pytorch/issues/159150

--- a/test/xpu/xpu_test_utils.py
+++ b/test/xpu/xpu_test_utils.py
@@ -1071,6 +1071,23 @@ class XPUPatchForImport(XPUImportCtx):
                             wrapper.device_type = "xpu"
                             replaced = True
                     elif (
+                        isinstance(wrapper.device_type, (list, tuple))
+                        and "xpu" in wrapper.device_type
+                        and unittest.expectedFailure in wrapper.decorators
+                        and (op_name, wrapper.test_name) in _cuda_xfail_xpu_pass
+                    ):
+                        # Upstream may scope one xfail to several devices at
+                        # once (device_type=("cuda", "xpu")). The "cuda" branch
+                        # above only matches the plain string, so drop XPU from
+                        # the scope here.
+                        replaced = True
+                        new_wrapper = copy.copy(wrapper)
+                        new_wrapper.device_type = tuple(
+                            d for d in wrapper.device_type if d != "xpu"
+                        )
+                        wrapper_xpu.append(new_wrapper)
+                        continue
+                    elif (
                         wrapper.device_type is None
                         and unittest.expectedFailure in wrapper.decorators
                         and (op_name, wrapper.test_name) in _none_device_xfail_xpu_pass


### PR DESCRIPTION
`_histc_out_xpu` computes into a fresh tensor of the input dtype and then does `result.copy_(ret)`. `copy_` converts, so a float64 input written into an int64 `out=` yields a silently truncated histogram and no error. CPU raises here; its check lives in `histogramdd_prepare_out`, which the XPU out variant does not go through. The functional form allocates its own output and is unaffected.

The check goes before `resize_output` so a rejected call does not resize the caller's tensor on its way to raising, and reuses the CPU message verbatim.

`test_out_histc_xpu_float32` comes off the skip list, and needs one more change to pass: `align_db_decorators` matched `device_type == "cuda"` as a bare string, but this test's upstream xfail is scoped to the tuple `("cuda", "xpu")`, so it stayed live on XPU and the fixed test would report an unexpected success. The new branch drops only `"xpu"` from the scope and stays gated on `_cuda_xfail_xpu_pass`, which already lists `("histc", "test_out")`.

`test/regressions/test_histc.py` adds a direct case plus a matching-dtype positive control. Against the current released binary (`torch 2.12.1+xpu`, Max 1100) the rejection case fails as expected -- `RuntimeError not raised` -- and the control passes.

pytorch/pytorch#196100 adds the same check to CUDA. This neither depends on nor conflicts with it; once it lands, the tuple xfail should be dropped upstream rather than de-scoped here.

Fixes #5237.

## Post-fix XPU result

The Linux XPU `op_regression` artifact for PR head `b6601b2545e32f6e4773091820a5dcf2b8b24900` in [CI run 34858234020](https://github.com/intel/torch-xpu-ops/actions/runs/34858234020) records:

```text
test_histc_out_rejects_mismatched_dtype       PASSED
test_histc_out_matching_dtype_still_works     PASSED
2 passed, 0 failed
```

The fixed path rejects a mismatched `out=` dtype and preserves the matching-dtype positive control.
