### PR TITLE
Use `check_mm_shapes` in `addmm_out_sparse_compressed_xpu`

### DIFF
--- a/src/ATen/native/sparse/xpu/SparseCsrTensorMath.cpp
+++ b/src/ATen/native/sparse/xpu/SparseCsrTensorMath.cpp
@@ -11,6 +11,7 @@
 #include <ATen/ExpandUtils.h>
 #include <ATen/SparseCsrTensorUtils.h>
 #include <ATen/TensorOperators.h>
+#include <ATen/native/LinearAlgebraUtils.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/sparse/SparseCsrTensorMath.h>
 #include <ATen/native/sparse/SparseStubs.h>
@@ -229,20 +230,7 @@ Tensor& addmm_out_sparse_compressed_xpu(
 
   // Same checks as in TORCH_META_FUNC(addmm) at
   // aten/src/ATen/native/LinearAlgebra.cpp
-  sparse::impl::_check_dim(mat1, 2, "mat1");
-  sparse::impl::_check_dim(mat2, 2, "mat2");
-
-  TORCH_CHECK(
-      mat1.size(1) == mat2.size(0),
-      "mat1 and mat2 shapes cannot be multiplied (",
-      mat1.size(0),
-      "x",
-      mat1.size(1),
-      " and ",
-      mat2.sizes()[0],
-      "x",
-      mat2.sizes()[1],
-      ")");
+  check_mm_shapes(mat1, mat2, "addmm");
 
   std::array<int64_t, 2> result_shape = {mat1.size(0), mat2.size(1)};
 


### PR DESCRIPTION
The expected error messages differed between CPU/CUDA and XPU for the `addmm` kernel, i.e., in the `addmm_out_sparse_compressed_xpu` function the `TORCH_CHECK` and `_check_dim` calls are replaced with a single `check_mm_shapes` call to math CPU/CUDA behaviour.

Partially fixes https://github.com/intel/torch-xpu-ops/issues/4999
- test_sparse_csr_xpu.TestSparseCSRXPU,test_addmm_errors_xpu_float32
- test_sparse_csr_xpu.TestSparseCSRXPU,test_mm_errors_xpu_float32