### PR TITLE
[XPU] Fix test_foreach_xpu.py collection after upstream TestForeach rename

### DIFF
--- a/test/xpu/test_foreach_xpu.py
+++ b/test/xpu/test_foreach_xpu.py
@@ -48,7 +48,7 @@ def get_device_capability(device=None):
 torch.cuda.get_device_capability = get_device_capability
 
 with XPUPatchForImport(False):
-    from test_foreach import TestForeach
+    from test_foreach import TestForeachDevice
 
 
 @ops(
@@ -165,7 +165,7 @@ def _test_binary_op_list_slow_path(self, device, dtype, op):
     )
 
 
-TestForeach.test_binary_op_list_slow_path = _test_binary_op_list_slow_path
+TestForeachDevice.test_binary_op_list_slow_path = _test_binary_op_list_slow_path
 
 
 def _test_0dim_tensor_overload_cpu_ok(self):
@@ -180,7 +180,7 @@ def _test_0dim_tensor_overload_cpu_ok(self):
     self.assertEqual(actual, [t.div(scalar_cpu_tensor) for t in tensors])
 
 
-TestForeach.test_0dim_tensor_overload_cpu_ok = _test_0dim_tensor_overload_cpu_ok
+TestForeachDevice.test_0dim_tensor_overload_cpu_ok = _test_0dim_tensor_overload_cpu_ok
 
 
 def _test_div_reciprocal(self):
@@ -192,7 +192,7 @@ def _test_div_reciprocal(self):
     self.assertEqual(expect_e, actual_e)
 
 
-TestForeach.test_div_reciprocal = _test_div_reciprocal
+TestForeachDevice.test_div_reciprocal = _test_div_reciprocal
 
 
 def _test_0dim_tensor_overload_exception(self):
@@ -208,7 +208,9 @@ def _test_0dim_tensor_overload_exception(self):
         torch._foreach_add(tensors, torch.tensor([1.0, 1.0], device="xpu"))
 
 
-TestForeach.test_0dim_tensor_overload_exception = _test_0dim_tensor_overload_exception
+TestForeachDevice.test_0dim_tensor_overload_exception = (
+    _test_0dim_tensor_overload_exception
+)
 
 
 @serialTest()
@@ -223,7 +225,7 @@ def _test_foreach_copy_with_multi_dtypes_large_input(self):
     self.assertEqual(self_tensor, ref_out)
 
 
-TestForeach.test_foreach_copy_with_multi_dtypes_large_input = (
+TestForeachDevice.test_foreach_copy_with_multi_dtypes_large_input = (
     _test_foreach_copy_with_multi_dtypes_large_input
 )
 
@@ -239,7 +241,7 @@ def _test_foreach_copy_with_different_device_inputs(self, device, dtype, op):
     copy_ = op.ref_inplace
 
     def fn(self_tensor, src_tensor, non_blocking):
-        return foreach_copy(self_tensor, src_tensor, non_blocking)
+        return foreach_copy(self_tensor, src_tensor, non_blocking=non_blocking)
 
     fn = torch.compile(fn)
     for non_blocking in (False,):
@@ -263,7 +265,7 @@ def _test_foreach_copy_with_different_device_inputs(self, device, dtype, op):
             self.assertEqual(output2, ref_input_cpu)
 
 
-TestForeach.test_foreach_copy_with_different_device_inputs = (
+TestForeachDevice.test_foreach_copy_with_different_device_inputs = (
     _test_foreach_copy_with_different_device_inputs
 )
 
@@ -317,9 +319,11 @@ def _test_big_num_tensors(self, device, dtype, op, use_xpu_graph, w_empty):
         self.assertEqual(expect, actual, equal_nan=True)
 
 
-TestForeach.test_big_num_tensors = _test_big_num_tensors
+TestForeachDevice.test_big_num_tensors = _test_big_num_tensors
 
-instantiate_device_type_tests(TestForeach, globals(), only_for="xpu", allow_xpu=True)
+instantiate_device_type_tests(
+    TestForeachDevice, globals(), only_for="xpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Issue

Fixes https://github.com/intel/torch-xpu-ops/issues/5070

## Summary

Upstream PyTorch PR #195452 ("[Test] Refactor `test_foreach.py`", landed
2026-09-09) renamed `test/test_foreach.py`'s `TestForeach` class to
`TestForeachDevice`, and updated
`test_foreach_copy_with_different_device_inputs` to call
`foreach_copy(..., non_blocking=non_blocking)` as a keyword argument
(`torch.foreach.copy_`, introduced in #193607, declares `non_blocking`
keyword-only). `test/xpu/test_foreach_xpu.py` still imported the old
`TestForeach` name and called `foreach_copy` positionally, so it had
already drifted out of sync before the rename: it hit
`TypeError: copy_() takes 2 positional arguments but 3 were given`
(the error in the linked issue) and, after the rename landed, the whole
file now fails to even collect with
`ImportError: cannot import name 'TestForeach' from 'test_foreach'`.
This change resyncs the port: renames `TestForeach` to `TestForeachDevice`
everywhere it's referenced, and passes `non_blocking` as a keyword
argument in `_test_foreach_copy_with_different_device_inputs` to match
the current upstream body. No production/kernel code is touched.

## Test plan

```bash
cd third_party/torch-xpu-ops
python -m pytest test/xpu/test_foreach_xpu.py \
  -k "test_foreach_copy_with_different_device_inputs" -v --timeout=300
```

Before: `ERROR test/xpu/test_foreach_xpu.py` (collection error).
After: `12 passed, 4 skipped` (complex64/complex128 and the fp8 `*fnuz`
dtypes are skipped by the test itself). Ran 3x to rule out flakiness, and
ran `--collect-only` over the whole file (3780 items, no errors) to
confirm the rename didn't break any other test in it.

## Checklist

- [x] Passes lint (`lintrunner -a test/xpu/test_foreach_xpu.py`) — ran it; it
      reformatted a few lines that got longer because `TestForeachDevice` is
      longer than `TestForeach`, no other changes.
- [x] Added/updated tests — no new test needed; this fixes the porting of an
      existing upstream-mirrored test.
- [ ] Updated documentation (if applicable) — not applicable.
- [ ] Included benchmark results (for PRs impacting perf) — not applicable,
      test-only change.

## BC-breaking?

No.