### PR TITLE
Fix -Wsometimes-uninitialized and -Wunknown-warning-option

### DIFF
--- a/.github/workflows/pull_dpclang.yml
+++ b/.github/workflows/pull_dpclang.yml
@@ -3,6 +3,7 @@
 
 name: pull dpclang
 
+# Trigger workflow
 on:
   pull_request:
     branches:

--- a/cmake/BuildFlags.cmake
+++ b/cmake/BuildFlags.cmake
@@ -80,6 +80,10 @@ macro(set_build_flags)
       -Wno-stringop-overflow
       -Wno-dangling-reference
       -Wno-error=dangling-reference)
+    CHECK_SYCL_FLAG("-Wno-maybe-uninitialized;-Werror=unknown-warning-option" SUPPORTS_NO_MAYBE_UNINITIALIZED)
+    if(NOT SUPPORTS_NO_MAYBE_UNINITIALIZED)
+      list(APPEND SYCL_HOST_FLAGS_EXCLUDED_FROM_SYCL -Wno-maybe-uninitialized)
+    endif()
     # Excluding warnings which flood the compilation output
     # TODO: fix warnings in the source code and then reenable them in compilation
     list(APPEND SYCL_HOST_FLAGS -Wno-sign-compare)

--- a/src/ATen/native/xpu/sycl/GridSampler.cpp
+++ b/src/ATen/native/xpu/sycl/GridSampler.cpp
@@ -615,10 +615,10 @@ void grid_sampler_2d_backward_template(
   index_t gOut_sW = grad_output.strides[3];
   // gInp_* are not really needed if input_requires_grad
   // is false.
-  index_t gInp_sN;
-  index_t gInp_sC;
-  index_t gInp_sH;
-  index_t gInp_sW;
+  index_t gInp_sN = 0;
+  index_t gInp_sC = 0;
+  index_t gInp_sH = 0;
+  index_t gInp_sW = 0;
   if (input_requires_grad) {
     gInp_sN = grad_input.strides[0];
     gInp_sC = grad_input.strides[1];

--- a/src/ATen/native/xpu/sycl/SegmentReduceKernels.cpp
+++ b/src/ATen/native/xpu/sycl/SegmentReduceKernels.cpp
@@ -269,7 +269,7 @@ Tensor _segment_reduce_lengths_offsets_xpu_kernel(
               auto* output_data_ptr = output.mutable_data_ptr<scalar_t>();
 
               // initialize starting value
-              scalar_t initial_value;
+              scalar_t initial_value = 0;
               if (initial.has_value()) {
                 initial_value = initial.value().to<scalar_t>();
               } else if (reduction == native::ReductionType::MAX) {


### PR DESCRIPTION
Changes:
* Drop `-Wno-maybe-uninitialized` when building device code with DPCLANG
* Fix `-Wsometimes-uninitialized` warnings building couple kernels

Warning fixes are required for DPCLANG build after recently merged https://github.com/intel/torch-xpu-ops/commit/6254016f01c9cb434b1106eb7758adda8ebb24f1 which modified set of flags being passed to the SYCL compiler. It occurs that ICPX and DPCLANG expose different set of warnings giving different behavior.

Fixes: https://github.com/intel/torch-xpu-ops/issues/5335
Fixes: 6254016f (Refactor SYCL flag handling for host and device compilation (#5062))

CC: @chunhuanMeng, @chuanqi129, @mengfei25 